### PR TITLE
Rename step types to simplify some more

### DIFF
--- a/src/helpers/error.rs
+++ b/src/helpers/error.rs
@@ -1,6 +1,6 @@
 use crate::error::BoxError;
 use crate::helpers::Identity;
-use crate::protocol::{RecordId, UniqueStepId};
+use crate::protocol::{RecordId, Step};
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
 
@@ -60,7 +60,7 @@ impl Error {
     #[must_use]
     pub fn serialization_error(
         record_id: RecordId,
-        step: &UniqueStepId,
+        step: &Step,
         inner: serde_json::Error,
     ) -> Error {
         Self::SerializationError {

--- a/src/helpers/fabric.rs
+++ b/src/helpers/fabric.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{error::Error, Identity};
-use crate::protocol::{RecordId, UniqueStepId};
+use crate::protocol::{RecordId, Step};
 use async_trait::async_trait;
 use futures::Stream;
 use std::fmt::{Debug, Formatter};
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Formatter};
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct ChannelId {
     pub identity: Identity,
-    pub step: UniqueStepId,
+    pub step: Step,
 }
 
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub trait Network: Sync {
 
 impl ChannelId {
     #[must_use]
-    pub fn new(identity: Identity, step: UniqueStepId) -> Self {
+    pub fn new(identity: Identity, step: Step) -> Self {
         Self { identity, step }
     }
 }

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -11,7 +11,7 @@ use crate::{
     helpers::error::Error,
     helpers::fabric::{ChannelId, MessageEnvelope, Network},
     helpers::Identity,
-    protocol::{RecordId, UniqueStepId},
+    protocol::{RecordId, Step},
 };
 
 use futures::SinkExt;
@@ -57,7 +57,7 @@ pub struct Gateway<N> {
 #[derive(Debug)]
 pub struct Mesh<'a, 'b, N> {
     gateway: &'a Gateway<N>,
-    step: &'b UniqueStepId,
+    step: &'b Step,
 }
 
 pub(super) struct ReceiveRequest {
@@ -194,7 +194,7 @@ impl<N: Network> Gateway<N> {
     /// This method makes no guarantee that the communication channel will actually be established
     /// between this helper and every other one. The actual connection may be created only when
     /// `Mesh::send` or `Mesh::receive` methods are called.
-    pub fn mesh<'a, 'b>(&'a self, step: &'b UniqueStepId) -> Mesh<'a, 'b, N> {
+    pub fn mesh<'a, 'b>(&'a self, step: &'b Step) -> Mesh<'a, 'b, N> {
         Mesh {
             gateway: self,
             step,

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -51,7 +51,7 @@ impl IterStep {
     }
 }
 
-impl crate::protocol::Step for IterStep {}
+impl crate::protocol::Substep for IterStep {}
 
 impl AsRef<str> for IterStep {
     fn as_ref(&self) -> &str {

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -20,7 +20,7 @@ enum Step {
     RevealR,
 }
 
-impl crate::protocol::Step for Step {}
+impl crate::protocol::Substep for Step {}
 
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use super::{
     prss::{IndexedSharedRandomness, SequentialSharedRandomness},
     securemul::SecureMul,
-    RecordId, Step, UniqueStepId,
+    RecordId, Step, Substep,
 };
 use crate::{
     helpers::{
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct ProtocolContext<'a, N> {
     role: Identity,
-    step: UniqueStepId,
+    step: Step,
     prss: &'a PrssEndpoint,
     gateway: &'a Gateway<N>,
 }
@@ -29,7 +29,7 @@ impl<'a, N> ProtocolContext<'a, N> {
     pub fn new(role: Identity, participant: &'a PrssEndpoint, gateway: &'a Gateway<N>) -> Self {
         Self {
             role,
-            step: UniqueStepId::default(),
+            step: Step::default(),
             prss: participant,
             gateway,
         }
@@ -43,14 +43,14 @@ impl<'a, N> ProtocolContext<'a, N> {
 
     /// A unique identifier for this stage of the protocol execution.
     #[must_use]
-    pub fn step(&self) -> &UniqueStepId {
+    pub fn step(&self) -> &Step {
         &self.step
     }
 
     /// Make a sub-context.
     /// Note that each invocation of this should use a unique value of `step`.
     #[must_use]
-    pub fn narrow<S: Step + ?Sized>(&self, step: &S) -> Self {
+    pub fn narrow<S: Substep + ?Sized>(&self, step: &S) -> Self {
         ProtocolContext {
             role: self.role,
             step: self.step.narrow(step),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -31,13 +31,13 @@ use std::{fmt::Debug, hash::Hash};
 ///
 /// Steps are therefore composed into a `UniqueStepIdentifier`, which collects the complete
 /// hierarchy of steps at each layer into a unique identifier.
-pub trait Step: AsRef<str> {}
+pub trait Substep: AsRef<str> {}
 
 // In test code, allow a string (or string reference) to be used as a `Step`.
 #[cfg(any(feature = "test-fixture", debug_assertions))]
-impl Step for String {}
+impl Substep for String {}
 #[cfg(any(feature = "test-fixture", debug_assertions))]
-impl Step for str {}
+impl Substep for str {}
 
 /// The representation of a unique step in protocol execution.
 ///
@@ -63,33 +63,33 @@ impl Step for str {}
 /// to be cloning this object all over the place.  Of course, a string is pretty useful
 /// from a debugging perspective.
 #[derive(Clone, Debug)]
-pub struct UniqueStepId {
+pub struct Step {
     id: String,
     /// This tracks the different values that have been provided to `narrow()`.
     #[cfg(debug_assertions)]
     used: Arc<Mutex<HashSet<String>>>,
 }
 
-impl Hash for UniqueStepId {
+impl Hash for Step {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         state.write(self.id.as_bytes());
     }
 }
 
-impl PartialEq for UniqueStepId {
+impl PartialEq for Step {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
-impl Eq for UniqueStepId {}
+impl Eq for Step {}
 
-impl UniqueStepId {
+impl Step {
     /// Narrow the scope of the step identifier.
     /// # Panics
     /// In a debug build, this checks that the same refine call isn't run twice and that the string
     /// value of the step doesn't include '/' (which would lead to a bad outcome).
     #[must_use]
-    pub fn narrow<S: Step + ?Sized>(&self, step: &S) -> Self {
+    pub fn narrow<S: Substep + ?Sized>(&self, step: &S) -> Self {
         #[cfg(debug_assertions)]
         {
             let s = String::from(step.as_ref());
@@ -110,7 +110,7 @@ impl UniqueStepId {
     }
 }
 
-impl Default for UniqueStepId {
+impl Default for Step {
     // TODO(mt): this should might be better if it were to be constructed from
     // a QueryId rather than using a default.
     fn default() -> Self {
@@ -122,7 +122,7 @@ impl Default for UniqueStepId {
     }
 }
 
-impl AsRef<str> for UniqueStepId {
+impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         self.id.as_str()
     }
@@ -139,7 +139,7 @@ pub enum IpaProtocolStep {
     Attribution,
 }
 
-impl Step for IpaProtocolStep {}
+impl Substep for IpaProtocolStep {}
 
 impl AsRef<str> for IpaProtocolStep {
     fn as_ref(&self) -> &str {

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -27,7 +27,7 @@ enum Step {
     BinaryReveal,
 }
 
-impl crate::protocol::Step for Step {}
+impl crate::protocol::Substep for Step {}
 
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {

--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -31,7 +31,7 @@ enum Step {
     Xor2,
 }
 
-impl crate::protocol::Step for Step {}
+impl crate::protocol::Substep for Step {}
 
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -84,12 +84,12 @@ pub mod stream {
 
     use crate::chunkscan::ChunkScan;
     use crate::helpers::fabric::Network;
-    use crate::protocol::{RecordId, Step};
+    use crate::protocol::{RecordId, Substep};
 
     #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
     pub struct StreamingStep;
 
-    impl Step for StreamingStep {}
+    impl Substep for StreamingStep {}
     impl AsRef<str> for StreamingStep {
         fn as_ref(&self) -> &str {
             "streaming"

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -1,4 +1,4 @@
-use super::Step;
+use super::Substep;
 use std::fmt::Debug;
 
 mod apply;
@@ -12,7 +12,7 @@ pub enum SortStep {
     BitPermutations,
 }
 
-impl Step for SortStep {}
+impl Substep for SortStep {}
 
 impl AsRef<str> for SortStep {
     fn as_ref(&self) -> &str {
@@ -29,7 +29,7 @@ pub enum ShuffleStep {
     Step3,
 }
 
-impl Step for ShuffleStep {}
+impl Substep for ShuffleStep {}
 
 impl AsRef<str> for ShuffleStep {
     fn as_ref(&self) -> &str {

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -9,7 +9,7 @@ use crate::{
     error::BoxError,
     field::Field,
     helpers::{fabric::Network, Direction, Identity},
-    protocol::{context::ProtocolContext, prss::IndexedSharedRandomness, RecordId, Step},
+    protocol::{context::ProtocolContext, prss::IndexedSharedRandomness, RecordId, Substep},
     secret_sharing::Replicated,
 };
 
@@ -30,7 +30,7 @@ enum ShuffleOrUnshuffle {
     Unshuffle,
 }
 
-impl Step for ShuffleOrUnshuffle {}
+impl Substep for ShuffleOrUnshuffle {}
 impl AsRef<str> for ShuffleOrUnshuffle {
     fn as_ref(&self) -> &str {
         match self {
@@ -216,7 +216,7 @@ mod tests {
         field::Fp31,
         protocol::{
             sort::shuffle::{generate_random_permutation, Shuffle, ShuffleOrUnshuffle},
-            QueryId, UniqueStepId,
+            QueryId, Step,
         },
         test_fixture::{
             generate_shares, make_contexts, make_participants, make_world, narrow_contexts,
@@ -230,7 +230,7 @@ mod tests {
     fn random_sequence_generated() {
         const BATCH_SIZE: usize = 10000;
         let (p1, p2, p3) = make_participants();
-        let step = UniqueStepId::default();
+        let step = Step::default();
         let perm1 = generate_random_permutation(BATCH_SIZE, p1.indexed(&step).as_ref());
         let perm2 = generate_random_permutation(BATCH_SIZE, p2.indexed(&step).as_ref());
         let perm3 = generate_random_permutation(BATCH_SIZE, p3.indexed(&step).as_ref());

--- a/src/test_fixture/fabric.rs
+++ b/src/test_fixture/fabric.rs
@@ -9,7 +9,7 @@ use crate::helpers;
 use crate::helpers::error::Error;
 use crate::helpers::fabric::{ChannelId, MessageChunks, MessageEnvelope, Network};
 use crate::helpers::{error, Identity};
-use crate::protocol::UniqueStepId;
+use crate::protocol::Step;
 use async_trait::async_trait;
 use futures::Sink;
 use futures::StreamExt;
@@ -42,7 +42,7 @@ pub struct InMemoryEndpoint {
     pub identity: Identity,
     /// Channels that this endpoint is listening to. There are two helper peers for 3 party setting.
     /// For each peer there are multiple channels open, one per query + step.
-    channels: Arc<Mutex<Vec<HashMap<UniqueStepId, InMemoryChannel>>>>,
+    channels: Arc<Mutex<Vec<HashMap<Step, InMemoryChannel>>>>,
     tx: Sender<ControlMessage>,
     rx: Arc<Mutex<Option<Receiver<MessageChunks>>>>,
     network: Weak<InMemoryNetwork>,

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -7,7 +7,7 @@ mod world;
 use self::fabric::InMemoryEndpoint;
 use crate::helpers::Identity;
 use crate::protocol::context::ProtocolContext;
-use crate::protocol::Step;
+use crate::protocol::Substep;
 use crate::secret_sharing::Replicated;
 use crate::{field::Fp31, protocol::prss::Endpoint as PrssEndpoint};
 use rand::rngs::mock::StepRng;
@@ -42,7 +42,7 @@ pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_, Arc<InMemor
 #[must_use]
 pub fn narrow_contexts<'a>(
     contexts: &[ProtocolContext<'a, Arc<InMemoryEndpoint>>; 3],
-    step: &impl Step,
+    step: &impl Substep,
 ) -> [ProtocolContext<'a, Arc<InMemoryEndpoint>>; 3] {
     // This really wants <[_; N]>::each_ref()
     contexts


### PR DESCRIPTION
This touches a bunch of code, but it is an automated rename so you can repeat it on your branch to rebase (then use `git merge -s ours rename-step` to create a commit that integrates this change).