### PR TITLE
Optimizing the multiplication protocol used in share conversion

### DIFF
--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -4,7 +4,7 @@ use crate::{
     helpers::fabric::Network,
     protocol::{
         context::ProtocolContext,
-        modulus_conversion::gen_random::{GenRandom, ReplicatedBinary},
+        modulus_conversion::double_random::{DoubleRandom, ReplicatedBinary},
         reveal_additive_binary::RevealAdditiveBinary,
         RecordId,
     },
@@ -79,9 +79,8 @@ impl ConvertShares {
             .map(|(ctx, b0, b1, input_xor_r)| async move {
                 let r_binary = ReplicatedBinary::new(b0, b1);
 
-                let gen_random = GenRandom::new(r_binary);
                 let gen_random_future =
-                    gen_random.execute(ctx.narrow(&Step::DoubleRandom), record_id);
+                    DoubleRandom::execute(ctx.narrow(&Step::DoubleRandom), record_id, r_binary);
 
                 let reveal_future = RevealAdditiveBinary::execute(
                     ctx.narrow(&Step::BinaryReveal),

--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -3,7 +3,11 @@ use crate::{
     field::Field,
     helpers::{fabric::Network, Identity},
     protocol::{
-        context::ProtocolContext, modulus_conversion::specialized_mul::SpecializedMul, RecordId,
+        context::ProtocolContext,
+        modulus_conversion::specialized_mul::{
+            multiply_one_share_mostly_zeroes, multiply_two_shares_mostly_zeroes,
+        },
+        RecordId,
     },
     secret_sharing::Replicated,
 };
@@ -115,7 +119,7 @@ impl DoubleRandom {
         a: Replicated<F>,
         b: Replicated<F>,
     ) -> Result<Replicated<F>, BoxError> {
-        let result = SpecializedMul::execute_specialized_1(ctx, record_id, a, b).await?;
+        let result = multiply_two_shares_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - (result * F::from(2)))
     }
@@ -141,7 +145,7 @@ impl DoubleRandom {
         a: Replicated<F>,
         b: Replicated<F>,
     ) -> Result<Replicated<F>, BoxError> {
-        let result = SpecializedMul::execute_specialized_2(ctx, record_id, a, b).await?;
+        let result = multiply_one_share_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - (result * F::from(2)))
     }

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -1,2 +1,3 @@
 mod convert_shares;
-mod gen_random;
+mod double_random;
+mod specialized_mul;

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -1,0 +1,424 @@
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::{fabric::Network, Direction, Identity},
+    protocol::{context::ProtocolContext, RecordId},
+    secret_sharing::Replicated,
+};
+
+use serde::{Deserialize, Serialize};
+
+/// A message sent by each helper when they've multiplied their own shares
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct DValue<F> {
+    d: F,
+}
+
+/// A variant of the IKHC multiplication protocol
+/// for use in special cases where many of the shares are known to be zero.
+/// Original IKHC multiplication protocol from:
+/// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
+/// Optimizations from: "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
+/// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda, Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
+#[derive(Debug)]
+pub struct SpecializedMul {}
+
+impl SpecializedMul {
+    /// A highly specialized variant of the secure multiplication protocol which is only valid
+    /// in the case where 4 of the 6 shares are zero.
+    ///
+    /// This is taken from Appendix F: "Conversion Protocols" from the paper:
+    /// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
+    /// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
+    /// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
+    ///
+    /// This protocol can only be used in the case where:
+    /// Helper 1 has shares (a, 0) and (0, b)
+    /// Helper 2 has shares (0, 0) and (b, 0)
+    /// Helper 3 has shares (0, a) and (0, 0)
+    ///
+    /// In the IKHC multiplication protocol, each helper computes `d_i` and
+    /// sends it to the next helper. But in this case, `d_2` and `d_3` are publicly known to all
+    /// the helper parties and can be replaced with constants, e.g. 0. Therefore, these do not
+    /// need to be sent.
+    ///
+    /// ## Errors
+    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+    /// back via the error response
+    #[allow(dead_code)]
+    pub async fn execute_specialized_1<F: Field, N: Network>(
+        ctx: ProtocolContext<'_, N>,
+        record_id: RecordId,
+        a: Replicated<F>,
+        b: Replicated<F>,
+    ) -> Result<Replicated<F>, BoxError> {
+        match ctx.role() {
+            Identity::H1 => {
+                let prss = &ctx.prss();
+                let (s_3_1, _) = prss.generate_fields(record_id.into());
+
+                // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
+                // d_1 = a_1 * b_2 + 0 * 0 - s_3,1
+                let (a_1, _) = a.as_tuple();
+                let (_, b_2) = b.as_tuple();
+                let d_1 = a_1 * b_2 - s_3_1;
+
+                // notify helper on the right that we've computed our value
+                let channel = ctx.mesh();
+                channel
+                    .send(
+                        channel.identity().peer(Direction::Right),
+                        record_id,
+                        DValue { d: d_1 },
+                    )
+                    .await?;
+
+                Ok(Replicated::new(s_3_1, d_1))
+            }
+            Identity::H2 => {
+                // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
+                // d_2 = 0 * 0 + 0 * b - s_1,2
+                // d_2 = s_1,2
+                // d_2 is a constant, known in advance. So we can replace it with zero
+                // And there is no need to send it.
+
+                // Sleep until helper on the left sends us their (d_i-1) value
+                let channel = ctx.mesh();
+                let DValue { d: d_1 } = channel
+                    .receive(channel.identity().peer(Direction::Left), record_id)
+                    .await?;
+
+                Ok(Replicated::new(d_1, F::ZERO))
+            }
+            Identity::H3 => {
+                // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
+                // d_3 = 0 * 0 + a * 0 - s_2,3
+                // d_3 = s_2,3
+                // d_3 is a constant, known in advance. So we can replace it with zero
+                // And there is no need to send it.
+
+                let prss = &ctx.prss();
+                let (_, s_3_1) = prss.generate_fields(record_id.into());
+
+                Ok(Replicated::new(F::ZERO, s_3_1))
+            }
+        }
+    }
+
+    /// A highly specialized variant of the secure multiplication protocol which is only valid
+    /// in the case where 3 of the 6 shares are zero.
+    ///
+    /// This is taken from Appendix F: "Conversion Protocols" from the paper:
+    /// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
+    /// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
+    /// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
+    ///
+    /// This protocol can only be used in the case where:
+    /// Helper 1 has shares `(a_1, a_2)` and `(0, 0)`
+    /// Helper 2 has shares `(a_2, a_3)` and `(0, b)`
+    /// Helper 3 has shares `(a_3, a_1)` and `(b, 0)`
+    ///
+    /// In the IKHC multiplication protocol, each helper computes `d_i` and
+    /// sends it to the next helper. But in this case, `d_1` is publicly known to all
+    /// the helper parties and can be replaced with a constant, e.g. 0. Therefore, it does not
+    /// need to be sent.
+    ///
+    /// ## Errors
+    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+    /// back via the error response
+    #[allow(dead_code)]
+    pub async fn execute_specialized_2<F: Field, N: Network>(
+        ctx: ProtocolContext<'_, N>,
+        record_id: RecordId,
+        a: Replicated<F>,
+        b: Replicated<F>,
+    ) -> Result<Replicated<F>, BoxError> {
+        let prss = &ctx.prss();
+        let (s_left, s_right) = prss.generate_fields(record_id.into());
+
+        match ctx.role() {
+            Identity::H1 => {
+                // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
+                // d_1 = a_1 * 0 + a_2 * 0 - s_3,1
+                // d_1 = - s_3,1
+                // d_2 is a constant, known in advance. So we can replace it with zero
+                // And there is no need to send it.
+
+                // Sleep until helper on the left sends us their (d_i-1) value
+                let channel = ctx.mesh();
+                let DValue { d: d_3 } = channel
+                    .receive(channel.identity().peer(Direction::Left), record_id)
+                    .await?;
+
+                Ok(Replicated::new(d_3, s_right))
+            }
+            Identity::H2 => {
+                // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
+                // d_2 = a_2 * b_3 + a_3 * 0 - s_1,2
+                // d_2 = a_2 * b_3 - s_1,2
+                let (a_2, a_3) = a.as_tuple();
+                let (_, b_3) = b.as_tuple();
+                let d_2 = a_2 * b_3 - s_left;
+
+                // notify helper on the right that we've computed our value
+                let channel = ctx.mesh();
+                channel
+                    .send(
+                        channel.identity().peer(Direction::Right),
+                        record_id,
+                        DValue { d: d_2 },
+                    )
+                    .await?;
+
+                Ok(Replicated::new(s_left, a_3 * b_3 + d_2 + s_right))
+            }
+            Identity::H3 => {
+                // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
+                // d_3 = a_3 * 0 + a_1 * b_3 - s_2,3
+                // d_3 = a_1 * b_3 - s_2,3
+                let (a_3, a_1) = a.as_tuple();
+                let (b_3, _) = b.as_tuple();
+                let d_3 = a_1 * b_3 - s_left;
+
+                // notify helper on the right that we've computed our value
+                let channel = ctx.mesh();
+                channel
+                    .send(
+                        channel.identity().peer(Direction::Right),
+                        record_id,
+                        DValue { d: d_3 },
+                    )
+                    .await?;
+
+                // Sleep until helper on the left sends us their (d_i-1) value
+                let DValue { d: d_2 } = channel
+                    .receive(channel.identity().peer(Direction::Left), record_id)
+                    .await?;
+
+                Ok(Replicated::new(a_3 * b_3 + d_2 + s_left, d_3))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::error::BoxError;
+    use crate::field::{Field, Fp31};
+    use crate::protocol::{modulus_conversion::specialized_mul::SpecializedMul, QueryId, RecordId};
+    use crate::secret_sharing::Replicated;
+    use crate::test_fixture::{
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
+    };
+    use futures::future::try_join_all;
+    use proptest::prelude::Rng;
+
+    #[tokio::test]
+    async fn specialized_1_sequence() -> Result<(), BoxError> {
+        logging::setup();
+
+        let world: TestWorld = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rng = rand::thread_rng();
+
+        for i in 0..10 {
+            let a = Fp31::from(rng.gen::<u128>());
+            let b = Fp31::from(rng.gen::<u128>());
+
+            let record_id = RecordId::from(i);
+
+            let iteration = format!("{}", i);
+
+            let result_shares = tokio::try_join!(
+                SpecializedMul::execute_specialized_1(
+                    context[0].narrow(&iteration),
+                    record_id,
+                    Replicated::new(a, Fp31::ZERO),
+                    Replicated::new(Fp31::ZERO, b)
+                ),
+                SpecializedMul::execute_specialized_1(
+                    context[1].narrow(&iteration),
+                    record_id,
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO),
+                    Replicated::new(b, Fp31::ZERO)
+                ),
+                SpecializedMul::execute_specialized_1(
+                    context[2].narrow(&iteration),
+                    record_id,
+                    Replicated::new(Fp31::ZERO, a),
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO)
+                ),
+            )?;
+
+            let result = validate_and_reconstruct(result_shares);
+
+            assert_eq!(result, a * b);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn specialized_1_parallel() -> Result<(), BoxError> {
+        logging::setup();
+
+        let world: TestWorld = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rng = rand::thread_rng();
+
+        let mut inputs = Vec::with_capacity(10);
+        let mut futures = Vec::with_capacity(10);
+
+        for i in 0..10 {
+            let a = Fp31::from(rng.gen::<u128>());
+            let b = Fp31::from(rng.gen::<u128>());
+
+            inputs.push((a, b));
+
+            let record_id = RecordId::from(i);
+
+            let iteration = format!("{}", i);
+
+            futures.push(try_join_all(vec![
+                SpecializedMul::execute_specialized_1(
+                    context[0].narrow(&iteration),
+                    record_id,
+                    Replicated::new(a, Fp31::ZERO),
+                    Replicated::new(Fp31::ZERO, b),
+                ),
+                SpecializedMul::execute_specialized_1(
+                    context[1].narrow(&iteration),
+                    record_id,
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO),
+                    Replicated::new(b, Fp31::ZERO),
+                ),
+                SpecializedMul::execute_specialized_1(
+                    context[2].narrow(&iteration),
+                    record_id,
+                    Replicated::new(Fp31::ZERO, a),
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO),
+                ),
+            ]));
+        }
+
+        let results = try_join_all(futures).await?;
+
+        for i in 0..10 {
+            let input = inputs[i];
+            let result_shares = &results[i];
+            let multiplication_output =
+                validate_and_reconstruct((result_shares[0], result_shares[1], result_shares[2]));
+
+            assert_eq!(multiplication_output, input.0 * input.1);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn specialized_2_sequence() -> Result<(), BoxError> {
+        logging::setup();
+
+        let world: TestWorld = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rng = rand::thread_rng();
+
+        for i in 0..10 {
+            let a = Fp31::from(rng.gen::<u128>());
+            let b = Fp31::from(rng.gen::<u128>());
+
+            let a_shares = share(a, &mut rng);
+
+            let record_id = RecordId::from(i);
+
+            let iteration = format!("{}", i);
+
+            let result_shares = tokio::try_join!(
+                SpecializedMul::execute_specialized_2(
+                    context[0].narrow(&iteration),
+                    record_id,
+                    a_shares[0],
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO)
+                ),
+                SpecializedMul::execute_specialized_2(
+                    context[1].narrow(&iteration),
+                    record_id,
+                    a_shares[1],
+                    Replicated::new(Fp31::ZERO, b)
+                ),
+                SpecializedMul::execute_specialized_2(
+                    context[2].narrow(&iteration),
+                    record_id,
+                    a_shares[2],
+                    Replicated::new(b, Fp31::ZERO)
+                ),
+            )?;
+
+            println!("A: {:#?}, B: {:#?}, A*B: {:#?}", a_shares, b, result_shares);
+            let result = validate_and_reconstruct(result_shares);
+
+            assert_eq!(result, a * b);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn specialized_2_parallel() -> Result<(), BoxError> {
+        logging::setup();
+
+        let world: TestWorld = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rng = rand::thread_rng();
+
+        let mut inputs = Vec::with_capacity(10);
+        let mut futures = Vec::with_capacity(10);
+
+        for i in 0..10 {
+            let a = Fp31::from(rng.gen::<u128>());
+            let b = Fp31::from(rng.gen::<u128>());
+
+            inputs.push((a, b));
+
+            let a_shares = share(a, &mut rng);
+
+            let record_id = RecordId::from(i);
+
+            let iteration = format!("{}", i);
+
+            futures.push(try_join_all(vec![
+                SpecializedMul::execute_specialized_2(
+                    context[0].narrow(&iteration),
+                    record_id,
+                    a_shares[0],
+                    Replicated::new(Fp31::ZERO, Fp31::ZERO),
+                ),
+                SpecializedMul::execute_specialized_2(
+                    context[1].narrow(&iteration),
+                    record_id,
+                    a_shares[1],
+                    Replicated::new(Fp31::ZERO, b),
+                ),
+                SpecializedMul::execute_specialized_2(
+                    context[2].narrow(&iteration),
+                    record_id,
+                    a_shares[2],
+                    Replicated::new(b, Fp31::ZERO),
+                ),
+            ]));
+        }
+
+        let results = try_join_all(futures).await?;
+
+        for i in 0..10 {
+            let input = inputs[i];
+            let result_shares = &results[i];
+            let multiplication_output =
+                validate_and_reconstruct((result_shares[0], result_shares[1], result_shares[2]));
+
+            assert_eq!(multiplication_output, input.0 * input.1);
+        }
+
+        Ok(())
+    }
+}

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -14,189 +14,190 @@ pub struct DValue<F> {
     d: F,
 }
 
-/// A variant of the IKHC multiplication protocol
-/// for use in special cases where many of the shares are known to be zero.
+/// A highly specialized variant of the IKHC multiplication protocol which is only valid
+/// in the case where 4 of the 6 shares are zero.
+///
 /// Original IKHC multiplication protocol from:
 /// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
-/// Optimizations from: "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
-/// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda, Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
-#[derive(Debug)]
-pub struct SpecializedMul {}
+///
+/// Optimizations taken from Appendix F: "Conversion Protocols" from the paper:
+/// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
+/// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
+/// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
+///
+/// This protocol can only be used in the case where:
+/// Helper 1 has shares (a, 0) and (0, b)
+/// Helper 2 has shares (0, 0) and (b, 0)
+/// Helper 3 has shares (0, a) and (0, 0)
+///
+/// But in this case, `d_2` and `d_3` are publicly known to all the helper parties
+/// and can be replaced with constants, e.g. 0. Therefore, these do not need to be sent.
+///
+/// ## Errors
+/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+/// back via the error response
+#[allow(dead_code)]
+pub async fn multiply_two_shares_mostly_zeroes<F: Field, N: Network>(
+    ctx: ProtocolContext<'_, N>,
+    record_id: RecordId,
+    a: Replicated<F>,
+    b: Replicated<F>,
+) -> Result<Replicated<F>, BoxError> {
+    match ctx.role() {
+        Identity::H1 => {
+            let prss = &ctx.prss();
+            let (s_3_1, _) = prss.generate_fields(record_id.into());
 
-impl SpecializedMul {
-    /// A highly specialized variant of the secure multiplication protocol which is only valid
-    /// in the case where 4 of the 6 shares are zero.
-    ///
-    /// This is taken from Appendix F: "Conversion Protocols" from the paper:
-    /// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
-    /// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
-    /// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
-    ///
-    /// This protocol can only be used in the case where:
-    /// Helper 1 has shares (a, 0) and (0, b)
-    /// Helper 2 has shares (0, 0) and (b, 0)
-    /// Helper 3 has shares (0, a) and (0, 0)
-    ///
-    /// In the IKHC multiplication protocol, each helper computes `d_i` and
-    /// sends it to the next helper. But in this case, `d_2` and `d_3` are publicly known to all
-    /// the helper parties and can be replaced with constants, e.g. 0. Therefore, these do not
-    /// need to be sent.
-    ///
-    /// ## Errors
-    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
-    /// back via the error response
-    #[allow(dead_code)]
-    pub async fn execute_specialized_1<F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N>,
-        record_id: RecordId,
-        a: Replicated<F>,
-        b: Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
-        match ctx.role() {
-            Identity::H1 => {
-                let prss = &ctx.prss();
-                let (s_3_1, _) = prss.generate_fields(record_id.into());
+            // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
+            // d_1 = a_1 * b_2 + 0 * 0 - s_3,1
+            let (a_1, a_2) = a.as_tuple();
+            let (b_1, b_2) = b.as_tuple();
+            debug_assert!(a_2 == F::ZERO);
+            debug_assert!(b_1 == F::ZERO);
 
-                // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
-                // d_1 = a_1 * b_2 + 0 * 0 - s_3,1
-                let (a_1, _) = a.as_tuple();
-                let (_, b_2) = b.as_tuple();
-                let d_1 = a_1 * b_2 - s_3_1;
+            let d_1 = a_1 * b_2 - s_3_1;
 
-                // notify helper on the right that we've computed our value
-                let channel = ctx.mesh();
-                channel
-                    .send(
-                        channel.identity().peer(Direction::Right),
-                        record_id,
-                        DValue { d: d_1 },
-                    )
-                    .await?;
+            // notify helper on the right that we've computed our value
+            let channel = ctx.mesh();
+            channel
+                .send(
+                    channel.identity().peer(Direction::Right),
+                    record_id,
+                    DValue { d: d_1 },
+                )
+                .await?;
 
-                Ok(Replicated::new(s_3_1, d_1))
-            }
-            Identity::H2 => {
-                // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
-                // d_2 = 0 * 0 + 0 * b - s_1,2
-                // d_2 = s_1,2
-                // d_2 is a constant, known in advance. So we can replace it with zero
-                // And there is no need to send it.
+            Ok(Replicated::new(s_3_1, d_1))
+        }
+        Identity::H2 => {
+            // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
+            // d_2 = 0 * 0 + 0 * b - s_1,2
+            // d_2 = s_1,2
+            // d_2 is a constant, known in advance. So we can replace it with zero
+            // And there is no need to send it.
 
-                // Sleep until helper on the left sends us their (d_i-1) value
-                let channel = ctx.mesh();
-                let DValue { d: d_1 } = channel
-                    .receive(channel.identity().peer(Direction::Left), record_id)
-                    .await?;
+            // Sleep until helper on the left sends us their (d_i-1) value
+            let channel = ctx.mesh();
+            let DValue { d: d_1 } = channel
+                .receive(channel.identity().peer(Direction::Left), record_id)
+                .await?;
 
-                Ok(Replicated::new(d_1, F::ZERO))
-            }
-            Identity::H3 => {
-                // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
-                // d_3 = 0 * 0 + a * 0 - s_2,3
-                // d_3 = s_2,3
-                // d_3 is a constant, known in advance. So we can replace it with zero
-                // And there is no need to send it.
+            Ok(Replicated::new(d_1, F::ZERO))
+        }
+        Identity::H3 => {
+            // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
+            // d_3 = 0 * 0 + a * 0 - s_2,3
+            // d_3 = s_2,3
+            // d_3 is a constant, known in advance. So we can replace it with zero
+            // And there is no need to send it.
 
-                let prss = &ctx.prss();
-                let (_, s_3_1) = prss.generate_fields(record_id.into());
+            let prss = &ctx.prss();
+            let (_, s_3_1) = prss.generate_fields(record_id.into());
 
-                Ok(Replicated::new(F::ZERO, s_3_1))
-            }
+            Ok(Replicated::new(F::ZERO, s_3_1))
         }
     }
+}
 
-    /// A highly specialized variant of the secure multiplication protocol which is only valid
-    /// in the case where 3 of the 6 shares are zero.
-    ///
-    /// This is taken from Appendix F: "Conversion Protocols" from the paper:
-    /// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
-    /// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
-    /// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
-    ///
-    /// This protocol can only be used in the case where:
-    /// Helper 1 has shares `(a_1, a_2)` and `(0, 0)`
-    /// Helper 2 has shares `(a_2, a_3)` and `(0, b)`
-    /// Helper 3 has shares `(a_3, a_1)` and `(b, 0)`
-    ///
-    /// In the IKHC multiplication protocol, each helper computes `d_i` and
-    /// sends it to the next helper. But in this case, `d_1` is publicly known to all
-    /// the helper parties and can be replaced with a constant, e.g. 0. Therefore, it does not
-    /// need to be sent.
-    ///
-    /// ## Errors
-    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
-    /// back via the error response
-    #[allow(dead_code)]
-    pub async fn execute_specialized_2<F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N>,
-        record_id: RecordId,
-        a: Replicated<F>,
-        b: Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
-        let prss = &ctx.prss();
-        let (s_left, s_right) = prss.generate_fields(record_id.into());
+/// Another highly specialized variant of the IKHC multiplication protocol which is only valid
+/// in the case where one of the two secret sharings has 2 of the 3 shares set to zero.
+///
+/// Original IKHC multiplication protocol from:
+/// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
+///
+/// Optimizations taken from Appendix F: "Conversion Protocols" from the paper:
+/// "Adam in Private: Secure and Fast Training of Deep Neural Networks with Adaptive Moment Estimation"
+/// by Nuttapong Attrapadung, Koki Hamada, Dai Ikarashi, Ryo Kikuchi*, Takahiro Matsuda,
+/// Ibuki Mishina, Hiraku Morita, and Jacob C. N. Schuldt
+///
+/// This protocol can only be used in the case where:
+/// Helper 1 has shares `(a_1, a_2)` and `(0, 0)`
+/// Helper 2 has shares `(a_2, a_3)` and `(0, b)`
+/// Helper 3 has shares `(a_3, a_1)` and `(b, 0)`
+///
+/// In the IKHC multiplication protocol, each helper computes `d_i` as
+/// `d_i = a_i * b_i+1 + a_i+1 * b_i - s_i+2,i`
+/// and sends it to the next helper.
+/// But in this case, `d_1` is publicly known to all the helper parties
+/// and can be replaced with a constant, e.g. 0. Therefore, it does not need to be sent.
+///
+/// ## Errors
+/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+/// back via the error response
+#[allow(dead_code)]
+pub async fn multiply_one_share_mostly_zeroes<F: Field, N: Network>(
+    ctx: ProtocolContext<'_, N>,
+    record_id: RecordId,
+    a: Replicated<F>,
+    b: Replicated<F>,
+) -> Result<Replicated<F>, BoxError> {
+    let prss = &ctx.prss();
+    let (s_left, s_right) = prss.generate_fields(record_id.into());
 
-        match ctx.role() {
-            Identity::H1 => {
-                // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
-                // d_1 = a_1 * 0 + a_2 * 0 - s_3,1
-                // d_1 = - s_3,1
-                // d_2 is a constant, known in advance. So we can replace it with zero
-                // And there is no need to send it.
+    match ctx.role() {
+        Identity::H1 => {
+            // d_1 = a_1 * b_2 + a_2 * b_1 - s_3,1
+            // d_1 = a_1 * 0 + a_2 * 0 - s_3,1
+            // d_1 = - s_3,1
+            // d_2 is a constant, known in advance. So we can replace it with zero
+            // And there is no need to send it.
 
-                // Sleep until helper on the left sends us their (d_i-1) value
-                let channel = ctx.mesh();
-                let DValue { d: d_3 } = channel
-                    .receive(channel.identity().peer(Direction::Left), record_id)
-                    .await?;
+            // Sleep until helper on the left sends us their (d_i-1) value
+            let channel = ctx.mesh();
+            let DValue { d: d_3 } = channel
+                .receive(channel.identity().peer(Direction::Left), record_id)
+                .await?;
 
-                Ok(Replicated::new(d_3, s_right))
-            }
-            Identity::H2 => {
-                // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
-                // d_2 = a_2 * b_3 + a_3 * 0 - s_1,2
-                // d_2 = a_2 * b_3 - s_1,2
-                let (a_2, a_3) = a.as_tuple();
-                let (_, b_3) = b.as_tuple();
-                let d_2 = a_2 * b_3 - s_left;
+            Ok(Replicated::new(d_3, s_right))
+        }
+        Identity::H2 => {
+            // d_2 = a_2 * b_3 + a_3 * b_2 - s_1,2
+            // d_2 = a_2 * b_3 + a_3 * 0 - s_1,2
+            // d_2 = a_2 * b_3 - s_1,2
+            let (a_2, a_3) = a.as_tuple();
+            let (b_2, b_3) = b.as_tuple();
+            debug_assert!(b_2 == F::ZERO);
 
-                // notify helper on the right that we've computed our value
-                let channel = ctx.mesh();
-                channel
-                    .send(
-                        channel.identity().peer(Direction::Right),
-                        record_id,
-                        DValue { d: d_2 },
-                    )
-                    .await?;
+            let d_2 = a_2 * b_3 - s_left;
 
-                Ok(Replicated::new(s_left, a_3 * b_3 + d_2 + s_right))
-            }
-            Identity::H3 => {
-                // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
-                // d_3 = a_3 * 0 + a_1 * b_3 - s_2,3
-                // d_3 = a_1 * b_3 - s_2,3
-                let (a_3, a_1) = a.as_tuple();
-                let (b_3, _) = b.as_tuple();
-                let d_3 = a_1 * b_3 - s_left;
+            // notify helper on the right that we've computed our value
+            let channel = ctx.mesh();
+            channel
+                .send(
+                    channel.identity().peer(Direction::Right),
+                    record_id,
+                    DValue { d: d_2 },
+                )
+                .await?;
 
-                // notify helper on the right that we've computed our value
-                let channel = ctx.mesh();
-                channel
-                    .send(
-                        channel.identity().peer(Direction::Right),
-                        record_id,
-                        DValue { d: d_3 },
-                    )
-                    .await?;
+            Ok(Replicated::new(s_left, a_3 * b_3 + d_2 + s_right))
+        }
+        Identity::H3 => {
+            // d_3 = a_3 * b_1 + a_1 * b_3 - s_2,3
+            // d_3 = a_3 * 0 + a_1 * b_3 - s_2,3
+            // d_3 = a_1 * b_3 - s_2,3
+            let (a_3, a_1) = a.as_tuple();
+            let (b_3, b_1) = b.as_tuple();
+            debug_assert!(b_1 == F::ZERO);
 
-                // Sleep until helper on the left sends us their (d_i-1) value
-                let DValue { d: d_2 } = channel
-                    .receive(channel.identity().peer(Direction::Left), record_id)
-                    .await?;
+            let d_3 = a_1 * b_3 - s_left;
 
-                Ok(Replicated::new(a_3 * b_3 + d_2 + s_left, d_3))
-            }
+            // notify helper on the right that we've computed our value
+            let channel = ctx.mesh();
+            channel
+                .send(
+                    channel.identity().peer(Direction::Right),
+                    record_id,
+                    DValue { d: d_3 },
+                )
+                .await?;
+
+            // Sleep until helper on the left sends us their (d_i-1) value
+            let DValue { d: d_2 } = channel
+                .receive(channel.identity().peer(Direction::Left), record_id)
+                .await?;
+
+            Ok(Replicated::new(a_3 * b_3 + d_2 + s_left, d_3))
         }
     }
 }
@@ -205,7 +206,12 @@ impl SpecializedMul {
 pub mod tests {
     use crate::error::BoxError;
     use crate::field::{Field, Fp31};
-    use crate::protocol::{modulus_conversion::specialized_mul::SpecializedMul, QueryId, RecordId};
+    use crate::protocol::{
+        modulus_conversion::specialized_mul::{
+            multiply_one_share_mostly_zeroes, multiply_two_shares_mostly_zeroes,
+        },
+        QueryId, RecordId,
+    };
     use crate::secret_sharing::Replicated;
     use crate::test_fixture::{
         logging, make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
@@ -230,19 +236,19 @@ pub mod tests {
             let iteration = format!("{}", i);
 
             let result_shares = tokio::try_join!(
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[0].narrow(&iteration),
                     record_id,
                     Replicated::new(a, Fp31::ZERO),
                     Replicated::new(Fp31::ZERO, b)
                 ),
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[1].narrow(&iteration),
                     record_id,
                     Replicated::new(Fp31::ZERO, Fp31::ZERO),
                     Replicated::new(b, Fp31::ZERO)
                 ),
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[2].narrow(&iteration),
                     record_id,
                     Replicated::new(Fp31::ZERO, a),
@@ -280,19 +286,19 @@ pub mod tests {
             let iteration = format!("{}", i);
 
             futures.push(try_join_all(vec![
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[0].narrow(&iteration),
                     record_id,
                     Replicated::new(a, Fp31::ZERO),
                     Replicated::new(Fp31::ZERO, b),
                 ),
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[1].narrow(&iteration),
                     record_id,
                     Replicated::new(Fp31::ZERO, Fp31::ZERO),
                     Replicated::new(b, Fp31::ZERO),
                 ),
-                SpecializedMul::execute_specialized_1(
+                multiply_two_shares_mostly_zeroes(
                     context[2].narrow(&iteration),
                     record_id,
                     Replicated::new(Fp31::ZERO, a),
@@ -334,19 +340,19 @@ pub mod tests {
             let iteration = format!("{}", i);
 
             let result_shares = tokio::try_join!(
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[0].narrow(&iteration),
                     record_id,
                     a_shares[0],
                     Replicated::new(Fp31::ZERO, Fp31::ZERO)
                 ),
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[1].narrow(&iteration),
                     record_id,
                     a_shares[1],
                     Replicated::new(Fp31::ZERO, b)
                 ),
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[2].narrow(&iteration),
                     record_id,
                     a_shares[2],
@@ -387,19 +393,19 @@ pub mod tests {
             let iteration = format!("{}", i);
 
             futures.push(try_join_all(vec![
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[0].narrow(&iteration),
                     record_id,
                     a_shares[0],
                     Replicated::new(Fp31::ZERO, Fp31::ZERO),
                 ),
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[1].narrow(&iteration),
                     record_id,
                     a_shares[1],
                     Replicated::new(Fp31::ZERO, b),
                 ),
-                SpecializedMul::execute_specialized_2(
+                multiply_one_share_mostly_zeroes(
                     context[2].narrow(&iteration),
                     record_id,
                     a_shares[2],


### PR DESCRIPTION
We can use a specialized multiplication protocol to save half the communication bandwidth, because we know that a large number of shares are zero.