### PR TITLE
Adding a new dot-product protocol

### DIFF
--- a/src/protocol/dot_product.rs
+++ b/src/protocol/dot_product.rs
@@ -1,0 +1,161 @@
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::{fabric::Network, Direction},
+    protocol::{context::ProtocolContext, RecordId},
+    secret_sharing::Replicated,
+};
+
+use serde::{Deserialize, Serialize};
+
+/// A message sent by each helper when they've computed one share of the result
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct UValue<F> {
+    u: F,
+}
+
+///
+/// This protocol is an extension of the CHIKP multiplication protocol described in the paper:
+/// "High-Throughput Secure AES Computation" (High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018)
+/// by Koji Chida, Koki Hamada, Dai Ikarashi, Ryo Kikuchi and Benny Pinkas
+/// <https://dl.acm.org/doi/10.1145/3267973.3267977>
+///
+/// The extension allows for the computation of the sum of multiple multiplications (in other words, a dot-product operation)
+/// at the communication cost of a single multiplication.
+///
+/// This extension is summarized in the paper:
+/// "Fast Large-Scale Honest-Majority MPC for Malicious Adversaries"
+/// by Koji Chida, Daniel Genkin, Koki Hamada, Dai Ikarashi, Ryo Kikuchi, Yehuda Lindell, and Ariel Nof
+/// <https://link.springer.com/content/pdf/10.1007/978-3-319-96878-0_2.pdf>
+///
+/// In that paper, this functionality is called `F_product` and
+/// an instantiation for Replciated Secret Sharing is provided in section 6.1 on page 25
+///
+/// To summarize the CHIKP protocol:
+/// each helper computes `u_i = (s_i + s_i+1) * (t_i + t_i+1) - s_i+1 * t_i+1`
+/// It then randomizes this share with correlated randomness, and sends it to the helper to its right
+/// Each helper then defines the pair `(u_i, u_i+1)` as its shares of the output.
+///
+/// (Note it is equivalent to compute `u_i = s_i * t_i + s_i+1 * t_i + s_i * t_i+1`,
+/// but this requires three multiplications instead of two. Assuming multiplying field elements is
+/// significantly more costly (in CPU terms) that addition, this is less efficient to compute)
+///
+/// The key observation, that makes this protocol work, is that each helper can compute many `u_i` values
+/// from many multiplications, sum them all together, randomize them with correlated randomness, and can
+/// send this single field value to the next helper. The result will be a replicated secret sharing of the
+/// dot-product of the two vectors.
+///
+/// ## Errors
+/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+/// back via the error response
+#[allow(dead_code)]
+pub async fn dot_product<F: Field, N: Network>(
+    ctx: ProtocolContext<'_, N>,
+    record_id: RecordId,
+    a: &[Replicated<F>],
+    b: &[Replicated<F>],
+) -> Result<Replicated<F>, BoxError> {
+    assert_eq!(a.len(), b.len(), "lengths of the lists must be the same");
+
+    let prss = &ctx.prss();
+    let (s_left, s_right): (F, F) = prss.generate_fields(record_id.into());
+
+    let mut u_right = s_right - s_left;
+    for i in 0..a.len() {
+        let (a_left, a_right) = a[i].as_tuple();
+        let (b_left, b_right) = b[i].as_tuple();
+        u_right += (a_left + a_right) * (b_left + b_right) - a_right * b_right;
+    }
+
+    // send our `u_i+1` value to the helper on the right
+    let channel = ctx.mesh();
+    channel
+        .send(
+            channel.identity().peer(Direction::Right),
+            record_id,
+            UValue { u: u_right },
+        )
+        .await?;
+
+    // receive `u_i` value from helper to the left
+    let UValue { u: u_left } = channel
+        .receive(channel.identity().peer(Direction::Left), record_id)
+        .await?;
+
+    Ok(Replicated::new(u_left, u_right))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::error::BoxError;
+    use crate::field::{Field, Fp31};
+    use crate::protocol::{dot_product::dot_product, QueryId, RecordId};
+    use crate::test_fixture::{
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
+    };
+    use proptest::prelude::Rng;
+
+    #[tokio::test]
+    async fn basic() -> Result<(), BoxError> {
+        logging::setup();
+
+        let world: TestWorld = make_world(QueryId);
+        let context = make_contexts(&world);
+        let mut rng = rand::thread_rng();
+        let mut a_shares = [
+            Vec::with_capacity(100),
+            Vec::with_capacity(100),
+            Vec::with_capacity(100),
+        ];
+        let mut b_shares = [
+            Vec::with_capacity(100),
+            Vec::with_capacity(100),
+            Vec::with_capacity(100),
+        ];
+        let mut correct_answer = Fp31::ZERO;
+
+        for _ in 0..100 {
+            let a_i = Fp31::from(rng.gen::<u128>());
+            let b_i = Fp31::from(rng.gen::<u128>());
+            let a_i_shares = share(a_i, &mut rng);
+            let b_i_shares = share(b_i, &mut rng);
+            a_shares[0].push(a_i_shares[0]);
+            a_shares[1].push(a_i_shares[1]);
+            a_shares[2].push(a_i_shares[2]);
+            b_shares[0].push(b_i_shares[0]);
+            b_shares[1].push(b_i_shares[1]);
+            b_shares[2].push(b_i_shares[2]);
+            correct_answer += a_i * b_i;
+        }
+
+        let record_id = RecordId::from(0);
+        let step = "some_step";
+
+        let result_shares = tokio::try_join!(
+            dot_product(
+                context[0].narrow(step),
+                record_id,
+                &a_shares[0],
+                &b_shares[0],
+            ),
+            dot_product(
+                context[1].narrow(step),
+                record_id,
+                &a_shares[1],
+                &b_shares[1],
+            ),
+            dot_product(
+                context[2].narrow(step),
+                record_id,
+                &a_shares[2],
+                &b_shares[2],
+            ),
+        )?;
+
+        let result = validate_and_reconstruct(result_shares);
+
+        assert_eq!(result, correct_answer);
+
+        Ok(())
+    }
+}

--- a/src/protocol/dot_product.rs
+++ b/src/protocol/dot_product.rs
@@ -1,19 +1,3 @@
-use crate::{
-    error::BoxError,
-    field::Field,
-    helpers::{fabric::Network, Direction},
-    protocol::{context::ProtocolContext, RecordId},
-    secret_sharing::Replicated,
-};
-
-use serde::{Deserialize, Serialize};
-
-/// A message sent by each helper when they've computed one share of the result
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct UValue<F> {
-    u: F,
-}
-
 ///
 /// This protocol is an extension of the CHIKP multiplication protocol described in the paper:
 /// "High-Throughput Secure AES Computation" (High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018)
@@ -33,7 +17,8 @@ pub struct UValue<F> {
 ///
 /// To summarize the CHIKP protocol:
 /// each helper computes `u_i+1 = (s_i + s_i+1) * (t_i + t_i+1) - s_i+1 * t_i+1`
-/// It then randomizes this share with correlated randomness, and sends it to the helper to its right,
+/// It then randomizes this share with randomness that it shares with the
+/// helper to its left, and sends it to the helper to its right,
 /// and receives `u_i` from the helper to its left.
 /// Each helper then defines the pair `(u_i, u_i+1)` as its shares of the output.
 ///
@@ -41,122 +26,148 @@ pub struct UValue<F> {
 /// but this requires three multiplications instead of two. Assuming multiplying field elements is
 /// significantly more costly (in CPU terms) than addition, this is less efficient to compute)
 ///
-/// The key observation, that makes this protocol work, is that each helper can compute many `u_i+1` values
+/// The key observation that makes this protocol work, is that each helper can compute many `u_i+1` values
 /// from many multiplications, sum them all together, randomize them with correlated randomness, and can
 /// send this single field value to the next helper. The result will be a replicated secret sharing of the
 /// dot-product of the two vectors.
 ///
-/// ## Errors
-/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
-/// back via the error response
-#[allow(dead_code)]
-pub async fn dot_product<F: Field, N: Network>(
-    ctx: ProtocolContext<'_, N>,
-    record_id: RecordId,
-    a: &[Replicated<F>],
-    b: &[Replicated<F>],
-) -> Result<Replicated<F>, BoxError> {
-    assert_eq!(a.len(), b.len(), "lengths of the lists must be the same");
+pub mod stream {
+    use crate::{
+        error::BoxError,
+        field::Field,
+        helpers::{fabric::Network, Direction},
+        protocol::{context::ProtocolContext, RecordId},
+        secret_sharing::Replicated,
+    };
+    use futures::stream::StreamExt; // for `next`
+    use futures::Stream;
+    use std::pin::Pin;
 
-    let prss = &ctx.prss();
-    let (s_left, s_right): (F, F) = prss.generate_fields(record_id.into());
+    use serde::{Deserialize, Serialize};
 
-    let mut u_right = s_right - s_left;
-    for i in 0..a.len() {
-        let (a_left, a_right) = a[i].as_tuple();
-        let (b_left, b_right) = b[i].as_tuple();
-        u_right += (a_left + a_right) * (b_left + b_right) - a_right * b_right;
+    /// A message sent by each helper when they've computed one share of the result
+    #[derive(Debug, Serialize, Deserialize, Default)]
+    pub struct UValue<F> {
+        u: F,
     }
 
-    // send our `u_i+1` value to the helper on the right
-    let channel = ctx.mesh();
-    channel
-        .send(
-            channel.identity().peer(Direction::Right),
-            record_id,
-            UValue { u: u_right },
-        )
-        .await?;
+    type PairOfShares<F> = (Replicated<F>, Replicated<F>);
 
-    // receive `u_i` value from helper to the left
-    let UValue { u: u_left } = channel
-        .receive(channel.identity().peer(Direction::Left), record_id)
-        .await?;
+    ///
+    /// Consumes the input stream of pairs of replicated secret shares and
+    /// for each pair, multiplies them, and accumulates the result in a running sum.
+    /// once all the values in the stream are consumed, it randomizes the sum with
+    /// randomness it shares with the helper to the left, and sends to the right.
+    /// It receives a randomized sum from the helper to its left, and is now in
+    /// possession of a replicated secret sharing of the dot-product of the two
+    /// streaming vectors of replicated secret shares.
+    ///
+    /// ## Errors
+    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+    /// back via the error response
+    #[allow(dead_code)]
+    pub async fn accumulate_dot_product<F: Field, N: Network>(
+        ctx: ProtocolContext<'_, N>,
+        record_id: RecordId,
+        mut input_stream: Pin<Box<dyn Stream<Item = PairOfShares<F>>>>,
+    ) -> Result<Replicated<F>, BoxError> {
+        let prss = &ctx.prss();
+        let (s_left, s_right): (F, F) = prss.generate_fields(record_id);
 
-    Ok(Replicated::new(u_left, u_right))
-}
+        let mut u_right = s_right - s_left;
 
-#[cfg(test)]
-pub mod tests {
-    use crate::error::BoxError;
-    use crate::field::{Field, Fp31};
-    use crate::protocol::{dot_product::dot_product, QueryId, RecordId};
-    use crate::test_fixture::{
-        logging, make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
-    };
-    use proptest::prelude::Rng;
+        while let Some(item) = input_stream.next().await {
+            let (a_share, b_share) = item;
 
-    #[tokio::test]
-    async fn basic() -> Result<(), BoxError> {
-        logging::setup();
-
-        let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
-        let mut rng = rand::thread_rng();
-        let mut a_shares = [
-            Vec::with_capacity(100),
-            Vec::with_capacity(100),
-            Vec::with_capacity(100),
-        ];
-        let mut b_shares = [
-            Vec::with_capacity(100),
-            Vec::with_capacity(100),
-            Vec::with_capacity(100),
-        ];
-        let mut correct_answer = Fp31::ZERO;
-
-        for _ in 0..100 {
-            let a_i = Fp31::from(rng.gen::<u128>());
-            let b_i = Fp31::from(rng.gen::<u128>());
-            let a_i_shares = share(a_i, &mut rng);
-            let b_i_shares = share(b_i, &mut rng);
-            a_shares[0].push(a_i_shares[0]);
-            a_shares[1].push(a_i_shares[1]);
-            a_shares[2].push(a_i_shares[2]);
-            b_shares[0].push(b_i_shares[0]);
-            b_shares[1].push(b_i_shares[1]);
-            b_shares[2].push(b_i_shares[2]);
-            correct_answer += a_i * b_i;
+            let (a_left, a_right) = a_share.as_tuple();
+            let (b_left, b_right) = b_share.as_tuple();
+            u_right += (a_left + a_right) * (b_left + b_right) - a_right * b_right;
         }
 
-        let record_id = RecordId::from(0);
-        let step = "some_step";
-
-        let result_shares = tokio::try_join!(
-            dot_product(
-                context[0].narrow(step),
+        // send our `u_i+1` value to the helper on the right
+        let channel = ctx.mesh();
+        channel
+            .send(
+                channel.identity().peer(Direction::Right),
                 record_id,
-                &a_shares[0],
-                &b_shares[0],
-            ),
-            dot_product(
-                context[1].narrow(step),
-                record_id,
-                &a_shares[1],
-                &b_shares[1],
-            ),
-            dot_product(
-                context[2].narrow(step),
-                record_id,
-                &a_shares[2],
-                &b_shares[2],
-            ),
-        )?;
+                UValue { u: u_right },
+            )
+            .await?;
 
-        let result = validate_and_reconstruct(result_shares);
+        // receive `u_i` value from helper to the left
+        let UValue { u: u_left } = channel
+            .receive(channel.identity().peer(Direction::Left), record_id)
+            .await?;
 
-        assert_eq!(result, correct_answer);
+        Ok(Replicated::new(u_left, u_right))
+    }
 
-        Ok(())
+    #[cfg(test)]
+    mod tests {
+        use crate::error::BoxError;
+        use crate::field::Field;
+        use crate::field::Fp31;
+        use crate::protocol::dot_product::stream::accumulate_dot_product;
+        use crate::protocol::{QueryId, RecordId};
+        use crate::test_fixture::{
+            logging, make_contexts, make_world, share, validate_and_reconstruct,
+        };
+        use futures_util::stream;
+        use proptest::prelude::Rng;
+
+        #[tokio::test]
+        async fn supports_stream_of_secret_shares() -> Result<(), BoxError> {
+            logging::setup();
+
+            let mut rng = rand::thread_rng();
+
+            let mut vec1 = Vec::with_capacity(100);
+            let mut vec2 = Vec::with_capacity(100);
+            let mut vec3 = Vec::with_capacity(100);
+
+            let mut correct_answer = Fp31::ZERO;
+
+            for _ in 0..100 {
+                let a_i = Fp31::from(rng.gen::<u128>());
+                let b_i = Fp31::from(rng.gen::<u128>());
+                let a_i_shares = share(a_i, &mut rng);
+                let b_i_shares = share(b_i, &mut rng);
+                vec1.push((a_i_shares[0], b_i_shares[0]));
+                vec2.push((a_i_shares[1], b_i_shares[1]));
+                vec3.push((a_i_shares[2], b_i_shares[2]));
+                correct_answer += a_i * b_i;
+            }
+
+            // setup helpers
+            let world = make_world(QueryId);
+            let context = make_contexts(&world);
+            let record_id = RecordId::from(0);
+            let step = "some_step".to_string();
+
+            let result_shares = tokio::try_join!(
+                accumulate_dot_product(
+                    context[0].narrow(&step),
+                    record_id,
+                    Box::pin(stream::iter(vec1)),
+                ),
+                accumulate_dot_product(
+                    context[1].narrow(&step),
+                    record_id,
+                    Box::pin(stream::iter(vec2)),
+                ),
+                accumulate_dot_product(
+                    context[2].narrow(&step),
+                    record_id,
+                    Box::pin(stream::iter(vec3)),
+                ),
+            )
+            .unwrap();
+
+            let result = validate_and_reconstruct(result_shares);
+
+            assert_eq!(result, correct_answer);
+
+            Ok(())
+        }
     }
 }

--- a/src/protocol/dot_product.rs
+++ b/src/protocol/dot_product.rs
@@ -31,143 +31,127 @@
 /// send this single field value to the next helper. The result will be a replicated secret sharing of the
 /// dot-product of the two vectors.
 ///
-pub mod stream {
-    use crate::{
-        error::BoxError,
-        field::Field,
-        helpers::{fabric::Network, Direction},
-        protocol::{context::ProtocolContext, RecordId},
-        secret_sharing::Replicated,
-    };
-    use futures::stream::StreamExt; // for `next`
-    use futures::Stream;
-    use std::pin::Pin;
+use crate::{
+    error::BoxError,
+    field::Field,
+    helpers::{fabric::Network, Direction},
+    protocol::{context::ProtocolContext, RecordId},
+    secret_sharing::Replicated,
+};
+use futures::{stream::StreamExt, Stream};
+use serde::{Deserialize, Serialize};
 
-    use serde::{Deserialize, Serialize};
+/// A message sent by each helper when they've computed one share of the result
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct UValue<F> {
+    u: F,
+}
 
-    /// A message sent by each helper when they've computed one share of the result
-    #[derive(Debug, Serialize, Deserialize, Default)]
-    pub struct UValue<F> {
-        u: F,
-    }
+///
+/// Consumes the input stream of pairs of replicated secret shares and
+/// for each pair, multiplies them, and accumulates the result in a running sum.
+/// once all the values in the stream are consumed, it randomizes the sum with
+/// randomness it shares with the helper to the left, and sends to the right.
+/// It receives a randomized sum from the helper to its left, and is now in
+/// possession of a replicated secret sharing of the dot-product of the two
+/// streaming vectors of replicated secret shares.
+///
+/// ## Errors
+/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+/// back via the error response
+#[allow(clippy::module_name_repetitions)]
+#[allow(dead_code)]
+pub async fn accumulate_dot_product<
+    F: Field,
+    N: Network,
+    S: Stream<Item = (Replicated<F>, Replicated<F>)>,
+>(
+    ctx: ProtocolContext<'_, N>,
+    record_id: RecordId,
+    input_stream: S,
+) -> Result<Replicated<F>, BoxError> {
+    let prss = &ctx.prss();
+    let (s_left, s_right): (F, F) = prss.generate_fields(record_id);
 
-    type PairOfShares<F> = (Replicated<F>, Replicated<F>);
-
-    ///
-    /// Consumes the input stream of pairs of replicated secret shares and
-    /// for each pair, multiplies them, and accumulates the result in a running sum.
-    /// once all the values in the stream are consumed, it randomizes the sum with
-    /// randomness it shares with the helper to the left, and sends to the right.
-    /// It receives a randomized sum from the helper to its left, and is now in
-    /// possession of a replicated secret sharing of the dot-product of the two
-    /// streaming vectors of replicated secret shares.
-    ///
-    /// ## Errors
-    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
-    /// back via the error response
-    #[allow(dead_code)]
-    pub async fn accumulate_dot_product<F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N>,
-        record_id: RecordId,
-        mut input_stream: Pin<Box<dyn Stream<Item = PairOfShares<F>>>>,
-    ) -> Result<Replicated<F>, BoxError> {
-        let prss = &ctx.prss();
-        let (s_left, s_right): (F, F) = prss.generate_fields(record_id);
-
-        let mut u_right = s_right - s_left;
-
-        while let Some(item) = input_stream.next().await {
-            let (a_share, b_share) = item;
-
+    let u_right = input_stream
+        .fold(s_right - s_left, |acc, (a_share, b_share)| async move {
             let (a_left, a_right) = a_share.as_tuple();
             let (b_left, b_right) = b_share.as_tuple();
-            u_right += (a_left + a_right) * (b_left + b_right) - a_right * b_right;
+            acc + (a_left + a_right) * (b_left + b_right) - a_right * b_right
+        })
+        .await;
+
+    // send our `u_i+1` value to the helper on the right
+    let channel = ctx.mesh();
+    channel
+        .send(
+            channel.identity().peer(Direction::Right),
+            record_id,
+            UValue { u: u_right },
+        )
+        .await?;
+
+    // receive `u_i` value from helper to the left
+    let UValue { u: u_left } = channel
+        .receive(channel.identity().peer(Direction::Left), record_id)
+        .await?;
+
+    Ok(Replicated::new(u_left, u_right))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::BoxError;
+    use crate::field::Field;
+    use crate::field::Fp31;
+    use crate::protocol::dot_product::accumulate_dot_product;
+    use crate::protocol::{QueryId, RecordId};
+    use crate::test_fixture::{
+        logging, make_contexts, make_world, share, validate_and_reconstruct,
+    };
+    use futures_util::stream;
+    use proptest::prelude::Rng;
+
+    #[tokio::test]
+    async fn supports_stream_of_secret_shares() -> Result<(), BoxError> {
+        logging::setup();
+
+        let mut rng = rand::thread_rng();
+
+        let mut vec1 = Vec::with_capacity(100);
+        let mut vec2 = Vec::with_capacity(100);
+        let mut vec3 = Vec::with_capacity(100);
+
+        let mut correct_answer = Fp31::ZERO;
+
+        for _ in 0..100 {
+            let a_i = Fp31::from(rng.gen::<u128>());
+            let b_i = Fp31::from(rng.gen::<u128>());
+            let a_i_shares = share(a_i, &mut rng);
+            let b_i_shares = share(b_i, &mut rng);
+            vec1.push((a_i_shares[0], b_i_shares[0]));
+            vec2.push((a_i_shares[1], b_i_shares[1]));
+            vec3.push((a_i_shares[2], b_i_shares[2]));
+            correct_answer += a_i * b_i;
         }
 
-        // send our `u_i+1` value to the helper on the right
-        let channel = ctx.mesh();
-        channel
-            .send(
-                channel.identity().peer(Direction::Right),
-                record_id,
-                UValue { u: u_right },
-            )
-            .await?;
+        // setup helpers
+        let world = make_world(QueryId);
+        let context = make_contexts(&world);
+        let record_id = RecordId::from(0);
+        let step = "some_step".to_string();
 
-        // receive `u_i` value from helper to the left
-        let UValue { u: u_left } = channel
-            .receive(channel.identity().peer(Direction::Left), record_id)
-            .await?;
+        let result_shares = tokio::try_join!(
+            accumulate_dot_product(context[0].narrow(&step), record_id, stream::iter(vec1),),
+            accumulate_dot_product(context[1].narrow(&step), record_id, stream::iter(vec2),),
+            accumulate_dot_product(context[2].narrow(&step), record_id, stream::iter(vec3),),
+        )
+        .unwrap();
 
-        Ok(Replicated::new(u_left, u_right))
-    }
+        let result = validate_and_reconstruct(result_shares);
 
-    #[cfg(test)]
-    mod tests {
-        use crate::error::BoxError;
-        use crate::field::Field;
-        use crate::field::Fp31;
-        use crate::protocol::dot_product::stream::accumulate_dot_product;
-        use crate::protocol::{QueryId, RecordId};
-        use crate::test_fixture::{
-            logging, make_contexts, make_world, share, validate_and_reconstruct,
-        };
-        use futures_util::stream;
-        use proptest::prelude::Rng;
+        assert_eq!(result, correct_answer);
 
-        #[tokio::test]
-        async fn supports_stream_of_secret_shares() -> Result<(), BoxError> {
-            logging::setup();
-
-            let mut rng = rand::thread_rng();
-
-            let mut vec1 = Vec::with_capacity(100);
-            let mut vec2 = Vec::with_capacity(100);
-            let mut vec3 = Vec::with_capacity(100);
-
-            let mut correct_answer = Fp31::ZERO;
-
-            for _ in 0..100 {
-                let a_i = Fp31::from(rng.gen::<u128>());
-                let b_i = Fp31::from(rng.gen::<u128>());
-                let a_i_shares = share(a_i, &mut rng);
-                let b_i_shares = share(b_i, &mut rng);
-                vec1.push((a_i_shares[0], b_i_shares[0]));
-                vec2.push((a_i_shares[1], b_i_shares[1]));
-                vec3.push((a_i_shares[2], b_i_shares[2]));
-                correct_answer += a_i * b_i;
-            }
-
-            // setup helpers
-            let world = make_world(QueryId);
-            let context = make_contexts(&world);
-            let record_id = RecordId::from(0);
-            let step = "some_step".to_string();
-
-            let result_shares = tokio::try_join!(
-                accumulate_dot_product(
-                    context[0].narrow(&step),
-                    record_id,
-                    Box::pin(stream::iter(vec1)),
-                ),
-                accumulate_dot_product(
-                    context[1].narrow(&step),
-                    record_id,
-                    Box::pin(stream::iter(vec2)),
-                ),
-                accumulate_dot_product(
-                    context[2].narrow(&step),
-                    record_id,
-                    Box::pin(stream::iter(vec3)),
-                ),
-            )
-            .unwrap();
-
-            let result = validate_and_reconstruct(result_shares);
-
-            assert_eq!(result, correct_answer);
-
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/src/protocol/dot_product.rs
+++ b/src/protocol/dot_product.rs
@@ -29,18 +29,19 @@ pub struct UValue<F> {
 /// <https://link.springer.com/content/pdf/10.1007/978-3-319-96878-0_2.pdf>
 ///
 /// In that paper, this functionality is called `F_product` and
-/// an instantiation for Replciated Secret Sharing is provided in section 6.1 on page 25
+/// an instantiation for Replciated Secret Sharing is provided in section 6.1 on page 27
 ///
 /// To summarize the CHIKP protocol:
-/// each helper computes `u_i = (s_i + s_i+1) * (t_i + t_i+1) - s_i+1 * t_i+1`
-/// It then randomizes this share with correlated randomness, and sends it to the helper to its right
+/// each helper computes `u_i+1 = (s_i + s_i+1) * (t_i + t_i+1) - s_i+1 * t_i+1`
+/// It then randomizes this share with correlated randomness, and sends it to the helper to its right,
+/// and receives `u_i` from the helper to its left.
 /// Each helper then defines the pair `(u_i, u_i+1)` as its shares of the output.
 ///
-/// (Note it is equivalent to compute `u_i = s_i * t_i + s_i+1 * t_i + s_i * t_i+1`,
+/// (Note it is equivalent to compute `u_i+1 = s_i * t_i + s_i+1 * t_i + s_i * t_i+1`,
 /// but this requires three multiplications instead of two. Assuming multiplying field elements is
-/// significantly more costly (in CPU terms) that addition, this is less efficient to compute)
+/// significantly more costly (in CPU terms) than addition, this is less efficient to compute)
 ///
-/// The key observation, that makes this protocol work, is that each helper can compute many `u_i` values
+/// The key observation, that makes this protocol work, is that each helper can compute many `u_i+1` values
 /// from many multiplications, sum them all together, randomize them with correlated randomness, and can
 /// send this single field value to the next helper. The result will be a replicated secret sharing of the
 /// dot-product of the two vectors.

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,6 +2,7 @@ mod attribution;
 mod batch;
 mod check_zero;
 pub mod context;
+mod dot_product;
 mod modulus_conversion;
 pub mod prss;
 mod reveal;


### PR DESCRIPTION
If you have two vectors of secret shared numbers, and you'd like to compute the dot-product of these two vectors (that is, the sum of the pairwise products), this can be accomplished with a communication cost that is equivalent to just one multiplication. That's right, it's irrelevant how long the vectors are. Pretty cool huh?