### PR TITLE
HTTP2/HTTP 1.1 metrics for IPA server

### DIFF
--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -24,14 +24,11 @@ pub mod metrics {
             const HTTP3: &str = "request.protocol.HTTP/3";
             const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
 
-            KeyName::from_const_str(if v.0 == Version::HTTP_11 {
-                HTTP11
-            } else if v.0 == Version::HTTP_2 {
-                HTTP2
-            } else if v.0 == Version::HTTP_3 {
-                HTTP3
-            } else {
-                UNKNOWN
+            KeyName::from_const_str(match v.0 {
+                Version::HTTP_11 => HTTP11,
+                Version::HTTP_2 => HTTP2,
+                Version::HTTP_3 => HTTP3,
+                _ => UNKNOWN,
             })
         }
     }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -20,8 +20,8 @@ pub mod metrics {
     impl From<RequestProtocolVersion> for KeyName {
         fn from(v: RequestProtocolVersion) -> Self {
             const HTTP11: &str = "request.protocol.HTTP/1.1";
-            const HTTP2: &str = "request.protocol.HTTP/2.0";
-            const HTTP3: &str = "request.protocol.HTTP/3.0";
+            const HTTP2: &str = "request.protocol.HTTP/2";
+            const HTTP3: &str = "request.protocol.HTTP/3";
             const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
 
             KeyName::from_const_str(if v.0 == Version::HTTP_11 {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,8 +1,40 @@
 pub mod metrics {
-    use metrics::describe_counter;
+    use axum::http::Version;
     use metrics::Unit;
+    use metrics::{describe_counter, KeyName};
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
+
+    /// Metric that records the version of HTTP protocol used for a particular request.
+    #[cfg(feature = "web-app")]
+    pub struct RequestProtocolVersion(Version);
+
+    #[cfg(feature = "web-app")]
+    impl From<Version> for RequestProtocolVersion {
+        fn from(v: Version) -> Self {
+            RequestProtocolVersion(v)
+        }
+    }
+
+    #[cfg(feature = "web-app")]
+    impl From<RequestProtocolVersion> for KeyName {
+        fn from(v: RequestProtocolVersion) -> Self {
+            const HTTP11: &str = "request.protocol.HTTP/1.1";
+            const HTTP2: &str = "request.protocol.HTTP/2.0";
+            const HTTP3: &str = "request.protocol.HTTP/3.0";
+            const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
+
+            KeyName::from_const_str(if v.0 == Version::HTTP_11 {
+                HTTP11
+            } else if v.0 == Version::HTTP_2 {
+                HTTP2
+            } else if v.0 == Version::HTTP_3 {
+                HTTP3
+            } else {
+                UNKNOWN
+            })
+        }
+    }
 
     /// Registers metrics used in the system with the metrics recorder.
     ///
@@ -19,23 +51,34 @@ pub mod metrics {
             Unit::Count,
             "Total number of requests received by the web server"
         );
+
+        describe_counter!(
+            RequestProtocolVersion::from(Version::HTTP_11),
+            Unit::Count,
+            "Total number of HTTP/1.1 requests received"
+        );
+
+        describe_counter!(
+            RequestProtocolVersion::from(Version::HTTP_2),
+            Unit::Count,
+            "Total number of HTTP/2 requests received"
+        );
     }
 
     #[cfg(test)]
     #[must_use]
-    pub fn get_counter_value(
+    pub fn get_counter_value<K: Into<KeyName>>(
         snapshot: metrics_util::debugging::Snapshot,
-        metric_name: &'static str,
+        metric_name: K,
     ) -> Option<u64> {
         use metrics_util::debugging::DebugValue;
         use metrics_util::MetricKind;
 
         let snapshot = snapshot.into_vec();
+        let metric_name = metric_name.into();
 
         for (key, _unit, _, val) in snapshot {
-            if key.kind() == MetricKind::Counter
-                && key.key().name().eq_ignore_ascii_case(metric_name)
-            {
+            if key.kind() == MetricKind::Counter && key.key().name() == metric_name.as_str() {
                 match val {
                     DebugValue::Counter(v) => return Some(v),
                     _ => unreachable!(),


### PR DESCRIPTION
This change makes IPA web server to emit a metric that shows which HTTP protocol was used for every request made to the helper. The goal is to be aware if helpers start using HTTP 1.1. Restricting server code to accept HTTP 2.0 only is not great because HTTP 1.1 is way easier to debug and therefore valuable to support.

Alternatively we could just use a config that instructs the server which protocol it should exclusively support. Right now it feels that having this visibility is enough, but we may reconsider this in the future.

Note that it may be a bit misleading if connection starts as HTTP/1.1 and then gets upgraded to HTTP/2.0 but in our setting helper clients should probably initiate HTTP/2 from the beginning.