### PR TITLE
Adding a new struct to help with upgrading to malicious security

### DIFF
--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -1,0 +1,186 @@
+use std::fmt::Formatter;
+use std::ops::AddAssign;
+use std::ops::SubAssign;
+use std::{
+    fmt::Debug,
+    ops::{Add, Mul, Neg, Sub},
+};
+
+use crate::field::Field;
+use crate::helpers::Identity;
+use crate::secret_sharing::Replicated;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct MaliciousReplicated<T>(Replicated<T>, Replicated<T>);
+
+impl<T: Debug> Debug for MaliciousReplicated<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "x: {:?}, rx: {:?}", self.0, self.1)
+    }
+}
+
+impl<T: Field> Default for MaliciousReplicated<T> {
+    fn default() -> Self {
+        MaliciousReplicated::new(Replicated::default(), Replicated::default())
+    }
+}
+
+impl<T: Field> MaliciousReplicated<T> {
+    #[must_use]
+    pub fn new(x: Replicated<T>, rx: Replicated<T>) -> Self {
+        Self(x, rx)
+    }
+
+    #[allow(dead_code)]
+    pub fn x(&self) -> Replicated<T> {
+        self.0
+    }
+
+    #[allow(dead_code)]
+    pub fn rx(&self) -> Replicated<T> {
+        self.1
+    }
+
+    /*
+    /// Unsure if we need this...
+    pub fn as_tuple(&self) -> (T, T) {
+        (self.0, self.1)
+    }
+    */
+
+    /// Returns a pair of replicated secret sharings. One of "one", one of "r"
+    #[allow(dead_code)]
+    pub fn one(helper_identity: Identity, r_share: Replicated<T>) -> Self {
+        Self::new(Replicated::one(helper_identity), r_share)
+    }
+}
+
+impl<T: Field> Add for MaliciousReplicated<T> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0, self.1 + rhs.1)
+    }
+}
+
+impl<T: Field> AddAssign for MaliciousReplicated<T> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = self.add(rhs);
+    }
+}
+
+impl<T: Field> SubAssign for MaliciousReplicated<T> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.sub(rhs);
+    }
+}
+
+impl<T: Field> Neg for MaliciousReplicated<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self {
+        Self(-self.0, -self.1)
+    }
+}
+
+impl<T: Field> Sub for MaliciousReplicated<T> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self(self.0 - rhs.0, self.1 - rhs.1)
+    }
+}
+
+impl<T: Field> Mul<T> for MaliciousReplicated<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self {
+        Self(self.0 * rhs, self.1 * rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MaliciousReplicated;
+    use crate::field::Field;
+    use crate::field::Fp31;
+    use crate::helpers::Identity;
+    use crate::test_fixture::{share, validate_and_reconstruct};
+    use proptest::prelude::Rng;
+
+    #[test]
+    #[allow(clippy::similar_names, clippy::many_single_char_names)]
+    fn test_local_operations() {
+        let mut rng = rand::thread_rng();
+
+        let a = Fp31::from(rng.gen::<u128>());
+        let b = Fp31::from(rng.gen::<u128>());
+        let c = Fp31::from(rng.gen::<u128>());
+        let d = Fp31::from(rng.gen::<u128>());
+        let e = Fp31::from(rng.gen::<u128>());
+        let f = Fp31::from(rng.gen::<u128>());
+        // Randomization constant
+        let r = Fp31::from(rng.gen::<u128>());
+
+        let a_shared = share(a, &mut rng);
+        let b_shared = share(b, &mut rng);
+        let c_shared = share(c, &mut rng);
+        let d_shared = share(d, &mut rng);
+        let e_shared = share(e, &mut rng);
+        let f_shared = share(f, &mut rng);
+        // Randomization constant
+        let r_shared = share(r, &mut rng);
+
+        let ra = a * r;
+        let rb = b * r;
+        let rc = c * r;
+        let rd = d * r;
+        let re = e * r;
+        let rf = f * r;
+
+        let ra_shared = share(ra, &mut rng);
+        let rb_shared = share(rb, &mut rng);
+        let rc_shared = share(rc, &mut rng);
+        let rd_shared = share(rd, &mut rng);
+        let re_shared = share(re, &mut rng);
+        let rf_shared = share(rf, &mut rng);
+
+        let identities = [Identity::H1, Identity::H2, Identity::H3];
+        let mut results = Vec::with_capacity(3);
+
+        for i in 0..3 {
+            let identity = identities[i];
+
+            let malicious_a = MaliciousReplicated::new(a_shared[i], ra_shared[i]);
+            let malicious_b = MaliciousReplicated::new(b_shared[i], rb_shared[i]);
+            let malicious_c = MaliciousReplicated::new(c_shared[i], rc_shared[i]);
+            let malicious_d = MaliciousReplicated::new(d_shared[i], rd_shared[i]);
+            let malicious_e = MaliciousReplicated::new(e_shared[i], re_shared[i]);
+            let malicious_f = MaliciousReplicated::new(f_shared[i], rf_shared[i]);
+
+            let malicious_a_plus_b = malicious_a + malicious_b;
+            let malicious_c_minus_d = malicious_c - malicious_d;
+            let malicious_1_minus_e = MaliciousReplicated::one(identity, r_shared[i]) - malicious_e;
+            let malicious_2f = malicious_f * Fp31::from(2_u128);
+
+            let mut temp = -malicious_a_plus_b;
+            temp -= malicious_c_minus_d;
+            temp -= malicious_1_minus_e;
+            temp = temp * Fp31::from(6_u128);
+            temp += malicious_2f;
+            results.push(temp);
+        }
+
+        let correct =
+            (-(a + b) - (c - d) - (Fp31::ONE - e)) * Fp31::from(6_u128) + Fp31::from(2_u128) * f;
+
+        assert_eq!(
+            validate_and_reconstruct((results[0].x(), results[1].x(), results[2].x())),
+            correct,
+        );
+        assert_eq!(
+            validate_and_reconstruct((results[0].rx(), results[1].rx(), results[2].rx())),
+            correct * r,
+        );
+    }
+}

--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -11,91 +11,99 @@ use crate::helpers::Identity;
 use crate::secret_sharing::Replicated;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct MaliciousReplicated<T>(Replicated<T>, Replicated<T>);
+pub struct MaliciousReplicated<F> {
+    x: Replicated<F>,
+    rx: Replicated<F>,
+}
 
-impl<T: Debug> Debug for MaliciousReplicated<T> {
+impl<F: Debug> Debug for MaliciousReplicated<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "x: {:?}, rx: {:?}", self.0, self.1)
+        write!(f, "x: {:?}, rx: {:?}", self.x, self.rx)
     }
 }
 
-impl<T: Field> Default for MaliciousReplicated<T> {
+impl<F: Field> Default for MaliciousReplicated<F> {
     fn default() -> Self {
         MaliciousReplicated::new(Replicated::default(), Replicated::default())
     }
 }
 
-impl<T: Field> MaliciousReplicated<T> {
+impl<F: Field> MaliciousReplicated<F> {
     #[must_use]
-    pub fn new(x: Replicated<T>, rx: Replicated<T>) -> Self {
-        Self(x, rx)
+    pub fn new(x: Replicated<F>, rx: Replicated<F>) -> Self {
+        Self { x, rx }
     }
 
     #[allow(dead_code)]
-    pub fn x(&self) -> Replicated<T> {
-        self.0
+    pub fn x(&self) -> Replicated<F> {
+        self.x
     }
 
     #[allow(dead_code)]
-    pub fn rx(&self) -> Replicated<T> {
-        self.1
+    pub fn rx(&self) -> Replicated<F> {
+        self.rx
     }
-
-    /*
-    /// Unsure if we need this...
-    pub fn as_tuple(&self) -> (T, T) {
-        (self.0, self.1)
-    }
-    */
 
     /// Returns a pair of replicated secret sharings. One of "one", one of "r"
     #[allow(dead_code)]
-    pub fn one(helper_identity: Identity, r_share: Replicated<T>) -> Self {
+    pub fn one(helper_identity: Identity, r_share: Replicated<F>) -> Self {
         Self::new(Replicated::one(helper_identity), r_share)
     }
 }
 
-impl<T: Field> Add for MaliciousReplicated<T> {
+impl<F: Field> Add for MaliciousReplicated<F> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        Self(self.0 + rhs.0, self.1 + rhs.1)
+        Self {
+            x: self.x + rhs.x,
+            rx: self.rx + rhs.rx,
+        }
     }
 }
 
-impl<T: Field> AddAssign for MaliciousReplicated<T> {
+impl<F: Field> AddAssign for MaliciousReplicated<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = self.add(rhs);
     }
 }
 
-impl<T: Field> SubAssign for MaliciousReplicated<T> {
+impl<F: Field> SubAssign for MaliciousReplicated<F> {
     fn sub_assign(&mut self, rhs: Self) {
         *self = self.sub(rhs);
     }
 }
 
-impl<T: Field> Neg for MaliciousReplicated<T> {
+impl<F: Field> Neg for MaliciousReplicated<F> {
     type Output = Self;
 
     fn neg(self) -> Self {
-        Self(-self.0, -self.1)
+        Self {
+            x: -self.x,
+            rx: -self.rx,
+        }
     }
 }
 
-impl<T: Field> Sub for MaliciousReplicated<T> {
+impl<F: Field> Sub for MaliciousReplicated<F> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        Self(self.0 - rhs.0, self.1 - rhs.1)
+        Self {
+            x: self.x - rhs.x,
+            rx: self.rx - rhs.rx,
+        }
     }
 }
 
-impl<T: Field> Mul<T> for MaliciousReplicated<T> {
+impl<F: Field> Mul<F> for MaliciousReplicated<F> {
     type Output = Self;
 
-    fn mul(self, rhs: T) -> Self {
-        Self(self.0 * rhs, self.1 * rhs)
+    fn mul(self, rhs: F) -> Self {
+        Self {
+            x: self.x * rhs,
+            rx: self.rx * rhs,
+        }
     }
 }
 

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -1,3 +1,4 @@
+mod malicious_replicated;
 mod replicated;
 mod shamir;
 

--- a/src/secret_sharing/replicated.rs
+++ b/src/secret_sharing/replicated.rs
@@ -1,5 +1,6 @@
 use std::fmt::Formatter;
 use std::ops::AddAssign;
+use std::ops::SubAssign;
 use std::{
     fmt::Debug,
     ops::{Add, Mul, Neg, Sub},
@@ -55,6 +56,12 @@ impl<T: Field> Add for Replicated<T> {
 impl<T: Field> AddAssign for Replicated<T> {
     fn add_assign(&mut self, rhs: Self) {
         *self = self.add(rhs);
+    }
+}
+
+impl<T: Field> SubAssign for Replicated<T> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = self.sub(rhs);
     }
 }
 

--- a/src/secret_sharing/replicated.rs
+++ b/src/secret_sharing/replicated.rs
@@ -10,27 +10,27 @@ use crate::field::Field;
 use crate::helpers::Identity;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Replicated<T>(T, T);
+pub struct Replicated<F>(F, F);
 
-impl<T: Debug> Debug for Replicated<T> {
+impl<F: Debug> Debug for Replicated<F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 
-impl<T: Field> Default for Replicated<T> {
+impl<F: Field> Default for Replicated<F> {
     fn default() -> Self {
-        Replicated::new(T::ZERO, T::ZERO)
+        Replicated::new(F::ZERO, F::ZERO)
     }
 }
 
-impl<T: Field> Replicated<T> {
+impl<F: Field> Replicated<F> {
     #[must_use]
-    pub fn new(a: T, b: T) -> Self {
+    pub fn new(a: F, b: F) -> Self {
         Self(a, b)
     }
 
-    pub fn as_tuple(&self) -> (T, T) {
+    pub fn as_tuple(&self) -> (F, F) {
         (self.0, self.1)
     }
 
@@ -38,14 +38,14 @@ impl<T: Field> Replicated<T> {
     #[must_use]
     pub fn one(helper_identity: Identity) -> Self {
         match helper_identity {
-            Identity::H1 => Self::new(T::ONE, T::ZERO),
-            Identity::H2 => Self::new(T::ZERO, T::ZERO),
-            Identity::H3 => Self::new(T::ZERO, T::ONE),
+            Identity::H1 => Self::new(F::ONE, F::ZERO),
+            Identity::H2 => Self::new(F::ZERO, F::ZERO),
+            Identity::H3 => Self::new(F::ZERO, F::ONE),
         }
     }
 }
 
-impl<T: Field> Add for Replicated<T> {
+impl<F: Field> Add for Replicated<F> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -53,19 +53,19 @@ impl<T: Field> Add for Replicated<T> {
     }
 }
 
-impl<T: Field> AddAssign for Replicated<T> {
+impl<F: Field> AddAssign for Replicated<F> {
     fn add_assign(&mut self, rhs: Self) {
         *self = self.add(rhs);
     }
 }
 
-impl<T: Field> SubAssign for Replicated<T> {
+impl<F: Field> SubAssign for Replicated<F> {
     fn sub_assign(&mut self, rhs: Self) {
         *self = self.sub(rhs);
     }
 }
 
-impl<T: Field> Neg for Replicated<T> {
+impl<F: Field> Neg for Replicated<F> {
     type Output = Self;
 
     fn neg(self) -> Self {
@@ -73,7 +73,7 @@ impl<T: Field> Neg for Replicated<T> {
     }
 }
 
-impl<T: Field> Sub for Replicated<T> {
+impl<F: Field> Sub for Replicated<F> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -81,10 +81,10 @@ impl<T: Field> Sub for Replicated<T> {
     }
 }
 
-impl<T: Field> Mul<T> for Replicated<T> {
+impl<F: Field> Mul<F> for Replicated<F> {
     type Output = Self;
 
-    fn mul(self, rhs: T) -> Self {
+    fn mul(self, rhs: F) -> Self {
         Self(rhs * self.0, rhs * self.1)
     }
 }


### PR DESCRIPTION
To upgrade to malicious security, we need to run every arithmetic circuit twice; one with the original numbers, and once with those numbers times a random, secret-shared value `r`. All of the local operations (like addition, subtraction, negation, and multiplication with a constant) can be done without communication between the helpers. We just need to do them both locally. This struct should help with that. It overrides the basic math operators to ensure all of the accounting is done twice.