### PR TITLE
Create a folder for buffers module

### DIFF
--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -1,0 +1,5 @@
+mod receive;
+mod send;
+
+pub(in crate::helpers) use receive::ReceiveBuffer;
+pub(in crate::helpers) use send::SendBuffer;

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -1,0 +1,61 @@
+use crate::helpers::fabric::{ChannelId, MessageEnvelope};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::mem;
+
+/// Buffer that keeps messages that must be sent to other helpers
+#[derive(Debug)]
+pub(in crate::helpers) struct SendBuffer {
+    max_capacity: usize,
+    inner: HashMap<ChannelId, Vec<MessageEnvelope>>,
+}
+
+impl SendBuffer {
+    pub fn new(max_channel_capacity: u32) -> Self {
+        Self {
+            max_capacity: max_channel_capacity as usize,
+            inner: HashMap::default(),
+        }
+    }
+
+    pub fn push(
+        &mut self,
+        channel_id: ChannelId,
+        msg: MessageEnvelope,
+    ) -> Option<Vec<MessageEnvelope>> {
+        let vec = match self.inner.entry(channel_id) {
+            Entry::Occupied(entry) => {
+                let vec = entry.into_mut();
+                vec.push(msg);
+
+                vec
+            }
+            Entry::Vacant(entry) => {
+                let vec = entry.insert(Vec::with_capacity(self.max_capacity));
+                vec.push(msg);
+
+                vec
+            }
+        };
+
+        if vec.len() >= self.max_capacity {
+            let data = mem::replace(vec, Vec::with_capacity(self.max_capacity));
+            Some(data)
+        } else {
+            None
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn remove_random(&mut self) -> (ChannelId, Vec<MessageEnvelope>) {
+        assert!(self.len() > 0);
+
+        let channel_id = self.inner.keys().next().unwrap().clone();
+        let data = self.inner.remove(&channel_id).unwrap();
+
+        (channel_id, data)
+    }
+}


### PR DESCRIPTION
`SendBuffer` is about to receive a major overhaul, so it requires its own space. It is better to make this change in advance so subsequent reviews are easier to follow.

There are no functional changes in this PR, only refactoring