### PR TITLE
Make GH clippy happy again

### DIFF
--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -568,6 +568,9 @@ pub mod test {
 
         let step = UniqueStepId::default().narrow("test");
         drop(p1.indexed(&step));
+        // TODO(alex): remove after clippy stops aggroing with no reason
+        // https://github.com/private-attribution/ipa/actions/runs/3340348412/jobs/5530341996
+        #[allow(clippy::let_underscore_drop)]
         let _ = p1.sequential(&step);
     }
 
@@ -577,6 +580,8 @@ pub mod test {
         let (p1, _p2, _p3) = make_participants();
 
         let step = UniqueStepId::default().narrow("test");
+        // TODO(alex): remove after clippy is fixed
+        #[allow(clippy::let_underscore_drop)]
         let _ = p1.sequential(&step);
         drop(p1.indexed(&step));
     }


### PR DESCRIPTION
Since yesterday, clippy seems unhappy with two `prss` tests with no obvious reason why.

```
error: non-binding `let` on a type that implements `Drop`
   --> src/protocol/prss.rs:571:9
    |
571 |         let _ = p1.sequential(&step);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::let-underscore-drop` implied by `-D clippy::pedantic`
    = help: consider using an underscore-prefixed named binding or dropping explicitly with `std::mem::drop`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_drop
```

It either sees what I don't see, but I wasn't able to find `Drop` implementation for that type. I also wasn't able to reproduce it locally neither on MacOS nor Linux, despite the fact that I am using the same cargo version as our GH action

```
~/workspace/raw-ipa% ~/.cargo/bin/cargo -V
cargo 1.64.0 (387270bc7 2022-09-16)
```

I wish I could learn clippy version as well, but reading the output did not reveal it.

There was a recent change in Clippy code that touched that lint: https://github.com/rust-lang/rust-clippy/pull/9697 but I can't see how it could trigger this behaviour. To unblock us, lets appease Clippy for now