### PR TITLE
Make context.multiply() consume the context

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -12,6 +12,25 @@ use crate::{
 };
 use futures::future::{try_join, try_join_all};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    HelperBitTimesIsTriggerBit,
+    BTimesStopBit,
+    BTimesSuccessorCredit,
+}
+
+impl crate::protocol::Step for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::HelperBitTimesIsTriggerBit => "helper_bit_times_is_trigger_bit",
+            Self::BTimesStopBit => "b_times_stop_bit",
+            Self::BTimesSuccessorCredit => "b_times_successor_credit",
+        }
+    }
+}
+
 /// Accumulation step for Oblivious Attribution protocol.
 #[allow(dead_code)]
 pub struct AccumulateCredit<'a, F> {
@@ -94,6 +113,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
 
                 accumulation_futures.push(Self::get_accumulated_credit(
                     ctx.narrow(multiply_step.next()),
+                    RecordId::from(i),
                     current,
                     successor,
                     iteration_step.is_first_iteration(),
@@ -136,6 +156,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
 
     async fn get_accumulated_credit<N: Network>(
         ctx: ProtocolContext<'_, N>,
+        record_id: RecordId,
         current: AccumulateCreditInputRow<F>,
         successor: AccumulateCreditInputRow<F>,
         first_iteration: bool,
@@ -147,7 +168,8 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
 
         // first, calculate [successor.helper_bit * successor.trigger_bit]
         let mut b = ctx
-            .multiply(RecordId::from(0))
+            .narrow(&Step::HelperBitTimesIsTriggerBit)
+            .multiply(record_id)
             .await
             .execute(successor.report.helper_bit, successor.report.is_trigger_bit)
             .await?;
@@ -155,6 +177,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         // since `stop_bits` is initialized with `[1]`s, we only multiply `stop_bit` in the second and later iterations
         if !first_iteration {
             b = ctx
+                .narrow(&Step::BTimesStopBit)
                 .multiply(RecordId::from(1))
                 .await
                 .execute(b, current.stop_bit)
@@ -162,7 +185,8 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         }
 
         let credit_future = ctx
-            .multiply(RecordId::from(2))
+            .narrow(&Step::BTimesSuccessorCredit)
+            .multiply(record_id)
             .await
             .execute(b, successor.credit);
 
@@ -171,9 +195,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
             futures::future::Either::Left(futures::future::ok(b))
         } else {
             futures::future::Either::Right(
-                ctx.multiply(RecordId::from(3))
-                    .await
-                    .execute(b, successor.stop_bit),
+                ctx.multiply(record_id).await.execute(b, successor.stop_bit),
             )
         };
 

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -82,7 +82,7 @@ impl<'a, N> ProtocolContext<'a, N> {
     }
 }
 
-impl<N: Network> ProtocolContext<'_, N> {
+impl<'a, N: Network> ProtocolContext<'a, N> {
     /// Get a set of communications channels to different peers.
     #[must_use]
     pub fn mesh(&self) -> Mesh<'_, '_, N> {
@@ -94,7 +94,7 @@ impl<N: Network> ProtocolContext<'_, N> {
     /// In this case, function returns only when multiplication for this record can actually
     /// be processed.
     #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
-    pub async fn multiply<'a>(&'a self, record_id: RecordId) -> SecureMul<'a, N> {
+    pub async fn multiply(self, record_id: RecordId) -> SecureMul<'a, N> {
         SecureMul::new(self, record_id)
     }
 }

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -5,7 +5,6 @@ use crate::protocol::{context::ProtocolContext, RecordId};
 use crate::secret_sharing::Replicated;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use thiserror::Error;
 
 /// A message sent by each helper when they've multiplied their own shares
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -18,12 +17,12 @@ pub struct DValue<F> {
 /// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
 #[derive(Debug)]
 pub struct SecureMul<'a, N> {
-    ctx: &'a ProtocolContext<'a, N>,
+    ctx: ProtocolContext<'a, N>,
     record_id: RecordId,
 }
 
 impl<'a, N: Network> SecureMul<'a, N> {
-    pub fn new(ctx: &'a ProtocolContext<'a, N>, record_id: RecordId) -> Self {
+    pub fn new(ctx: ProtocolContext<'a, N>, record_id: RecordId) -> Self {
         Self { ctx, record_id }
     }
 
@@ -72,137 +71,6 @@ impl<'a, N: Network> SecureMul<'a, N> {
     }
 }
 
-#[derive(Error, Debug)]
-pub enum Error {}
-
-/// Module to support streaming interface for secure multiplication
-pub mod stream {
-    use crate::field::Field;
-    use crate::protocol::context::ProtocolContext;
-    use crate::secret_sharing::Replicated;
-    use futures::Stream;
-
-    use crate::chunkscan::ChunkScan;
-    use crate::helpers::fabric::Network;
-    use crate::protocol::{RecordId, Step};
-
-    #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-    pub struct StreamingStep;
-
-    impl Step for StreamingStep {}
-    impl AsRef<str> for StreamingStep {
-        fn as_ref(&self) -> &str {
-            "streaming"
-        }
-    }
-
-    /// Consumes the input stream of replicated secret shares and produces a new stream with elements
-    /// being the product of items in the input stream. For example, if (a, b, c) are elements of the
-    /// input stream, output will contain two elements: (a*b, a*b*c)
-    ///
-    /// ## Panics
-    /// Panics if one of the internal invariants does not hold.
-    #[allow(dead_code)]
-    pub fn secure_multiply<'a, F, N, S>(
-        input_stream: S,
-        ctx: &'a ProtocolContext<'a, N>,
-        _index: u128,
-    ) -> impl Stream<Item = Replicated<F>> + 'a
-    where
-        S: Stream<Item = Replicated<F>> + 'a,
-        F: Field,
-        N: Network,
-    {
-        let mut stream_element_idx = 0;
-
-        // TODO (alex): is there a way to deal with async without pinning stream to the heap?
-        Box::pin(ChunkScan::new(
-            input_stream,
-            2, // buffer two elements
-            move |mut items: Vec<Replicated<F>>| async move {
-                debug_assert!(items.len() == 2);
-
-                let b_share = items.pop().unwrap();
-                let a_share = items.pop().unwrap();
-                stream_element_idx += 1; // TODO(mt): revisit (use enumerate()?)
-
-                ctx.multiply(RecordId::from(stream_element_idx))
-                    .await
-                    .execute(a_share, b_share)
-                    .await
-            },
-        ))
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::field::Fp31;
-        use crate::helpers::Identity;
-        use crate::protocol::context::ProtocolContext;
-        use crate::protocol::securemul::stream::secure_multiply;
-        use crate::protocol::QueryId;
-        use crate::secret_sharing::Replicated;
-        use crate::test_fixture::{logging, make_world, share, validate_and_reconstruct};
-        use futures::StreamExt;
-        use futures_util::future::join_all;
-        use futures_util::stream;
-        use rand::rngs::mock::StepRng;
-
-        /// Secure multiplication may be used with Stream API where shares are provided as elements
-        /// of a `Stream`.
-        #[tokio::test]
-        async fn supports_stream_of_secret_shares() {
-            // beforeEach is not a thing in Rust yet: https://github.com/rust-lang/rfcs/issues/1664
-            logging::setup();
-
-            // we compute a*b*c in this test. 4*3*2 = 24
-            let mut rand = StepRng::new(1, 1);
-            let a = share(Fp31::from(4_u128), &mut rand);
-            let b = share(Fp31::from(3_u128), &mut rand);
-            let c = share(Fp31::from(2_u128), &mut rand);
-            let start_index = 1024_u128;
-
-            // setup helpers
-            let world = make_world(QueryId);
-
-            // dedicated streams for each helper
-            let input = [
-                stream::iter(vec![a[0], b[0], c[0]]),
-                stream::iter(vec![a[1], b[1], c[1]]),
-                stream::iter(vec![a[2], b[2], c[2]]),
-            ];
-
-            // create 3 tasks (1 per helper) that will execute secure multiplication
-            let handles = input
-                .into_iter()
-                .zip(world.participants)
-                .zip(world.gateways)
-                .zip([Identity::H1, Identity::H2, Identity::H3])
-                .map(|(((input, prss), gateway), role)| {
-                    tokio::spawn(async move {
-                        let ctx = ProtocolContext::new(role, &prss, &gateway);
-                        let mut stream = secure_multiply(input, &ctx, start_index);
-
-                        // compute a*b
-                        let _ = stream.next().await.expect("Failed to compute a*b");
-
-                        // compute (a*b)*c and return it
-                        stream.next().await.expect("Failed to compute a*b*c")
-                    })
-                });
-
-            let result_shares: [Replicated<Fp31>; 3] =
-                join_all(handles.map(|handle| async { handle.await.unwrap() }))
-                    .await
-                    .try_into()
-                    .unwrap();
-            let result_shares = (result_shares[0], result_shares[1], result_shares[2]);
-
-            assert_eq!(Fp31::from(24_u128), validate_and_reconstruct(result_shares));
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use crate::error::BoxError;
@@ -230,13 +98,13 @@ pub mod tests {
         let context = make_contexts(&world);
         let mut rand = StepRng::new(1, 1);
 
-        assert_eq!(30, multiply_sync(&context, 6, 5, &mut rand).await?);
-        assert_eq!(25, multiply_sync(&context, 5, 5, &mut rand).await?);
-        assert_eq!(7, multiply_sync(&context, 7, 1, &mut rand).await?);
-        assert_eq!(0, multiply_sync(&context, 0, 14, &mut rand).await?);
-        assert_eq!(8, multiply_sync(&context, 7, 10, &mut rand).await?);
-        assert_eq!(4, multiply_sync(&context, 5, 7, &mut rand).await?);
-        assert_eq!(1, multiply_sync(&context, 16, 2, &mut rand).await?);
+        assert_eq!(30, multiply_sync(&context, "1", 6, 5, &mut rand).await?);
+        assert_eq!(25, multiply_sync(&context, "2", 5, 5, &mut rand).await?);
+        assert_eq!(7, multiply_sync(&context, "3", 7, 1, &mut rand).await?);
+        assert_eq!(0, multiply_sync(&context, "4", 0, 14, &mut rand).await?);
+        assert_eq!(8, multiply_sync(&context, "5", 7, 10, &mut rand).await?);
+        assert_eq!(4, multiply_sync(&context, "6", 5, 7, &mut rand).await?);
+        assert_eq!(1, multiply_sync(&context, "7", 16, 2, &mut rand).await?);
 
         Ok(())
     }
@@ -294,6 +162,7 @@ pub mod tests {
 
     async fn multiply_sync<R: RngCore, N: Network>(
         context: &[ProtocolContext<'_, N>; 3],
+        narrowed_context_str: &str,
         a: u8,
         b: u8,
         rng: &mut R,
@@ -314,9 +183,21 @@ pub mod tests {
         let b = share(b, rng);
 
         let result_shares = tokio::try_join!(
-            context[0].multiply(record_id).await.execute(a[0], b[0]),
-            context[1].multiply(record_id).await.execute(a[1], b[1]),
-            context[2].multiply(record_id).await.execute(a[2], b[2]),
+            context[0]
+                .narrow(narrowed_context_str)
+                .multiply(record_id)
+                .await
+                .execute(a[0], b[0]),
+            context[1]
+                .narrow(narrowed_context_str)
+                .multiply(record_id)
+                .await
+                .execute(a[1], b[1]),
+            context[2]
+                .narrow(narrowed_context_str)
+                .multiply(record_id)
+                .await
+                .execute(a[2], b[2]),
         )?;
 
         Ok(validate_and_reconstruct(result_shares).into())

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -43,7 +43,7 @@ async fn circuit<F: Field>(
         a = async move {
             let mut coll = Vec::new();
             for (i, ctx) in bit_ctx.iter().enumerate() {
-                let mul = ctx.multiply(record_id).await;
+                let mul = ctx.narrow(&"mult".to_string()).multiply(record_id).await;
                 coll.push(mul.execute(a[i], b[i]));
             }
 


### PR DESCRIPTION
This was @martinthomson's recommendation. I think it helps us utilize the "step" stuff better.