### PR TITLE
Adding a Maliciously Secure multiplication protocol

### DIFF
--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -95,9 +95,7 @@ impl<'a, F: Field> ProtocolContext<'a, F> {
     pub fn prss_rng(&self) -> (SequentialSharedRandomness, SequentialSharedRandomness) {
         self.prss.sequential(&self.step)
     }
-}
 
-impl<'a, F: Field> ProtocolContext<'a, F> {
     /// Get a set of communications channels to different peers.
     #[must_use]
     pub fn mesh(&self) -> Mesh<'_, '_> {

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use super::{
+    maliciously_secure_mul::MaliciouslySecureMul,
     prss::{IndexedSharedRandomness, SequentialSharedRandomness},
     securemul::SecureMul,
     RecordId, Step, UniqueStepId,
@@ -26,7 +27,7 @@ pub struct ProtocolContext<'a, F> {
     accumulator: Option<SecurityValidatorAccumulator<F>>,
 }
 
-impl<'a, F> ProtocolContext<'a, F> {
+impl<'a, F: Field> ProtocolContext<'a, F> {
     pub fn new(role: Identity, participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self {
             role,
@@ -69,9 +70,7 @@ impl<'a, F> ProtocolContext<'a, F> {
             step: self.step.narrow(step),
             prss: self.prss,
             gateway: self.gateway,
-            // TODO: make this work
-            // accumulator: self.accumulator, //TODO: make this work
-            accumulator: None, // God help me, I just can't make this work
+            accumulator: self.accumulator.clone(),
         }
     }
 
@@ -117,10 +116,8 @@ impl<'a, F: Field> ProtocolContext<'a, F> {
     /// ## Panics
     /// If you failed to upgrade to malicious protocol context
     #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
-    pub async fn malicious_multiply(self, _record_id: RecordId) {
-        // -> MaliciouslySecureMul<'a, N, F> {
-        let _accumulator = self.accumulator.as_ref().unwrap().clone();
-        // TODO: next diff!
-        // MaliciouslySecureMul::new(self, record_id, accumulator)
+    pub async fn malicious_multiply(self, record_id: RecordId) -> MaliciouslySecureMul<'a, F> {
+        let accumulator = self.accumulator.as_ref().unwrap().clone();
+        MaliciouslySecureMul::new(self, record_id, accumulator)
     }
 }

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -202,7 +202,9 @@ pub mod tests {
         QueryId, RecordId,
     };
     use crate::secret_sharing::{MaliciousReplicated, Replicated};
-    use crate::test_fixture::{logging, make_contexts, make_world, share, TestWorld};
+    use crate::test_fixture::{
+        logging, make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
+    };
     use futures::future::{try_join, try_join_all};
     use proptest::prelude::Rng;
 
@@ -239,8 +241,8 @@ pub mod tests {
             let acc = v.accumulator();
             let r_share = v.r_share();
 
-            let a_ctx = ctx.narrow("1");
-            let b_ctx = ctx.narrow("2");
+            let a_ctx = ctx.narrow("1").upgrade_to_malicious(acc.clone());
+            let b_ctx = ctx.narrow("2").upgrade_to_malicious(acc.clone());
 
             let (ra, rb) = try_join(
                 a_ctx
@@ -270,30 +272,31 @@ pub mod tests {
                 b_malicious,
             );
 
-            let (ab, rab) = try_join(
-                a_ctx
-                    .narrow("SingleMult")
-                    .multiply(RecordId::from(0_u32))
-                    .await
-                    .execute(a_shares[i], b_shares[i]),
-                a_ctx
-                    .narrow("DoubleMult")
-                    .multiply(RecordId::from(1_u32))
-                    .await
-                    .execute(ra, b_shares[i]),
-            )
-            .await?;
+            #[allow(clippy::similar_names)]
+            let mult_result = a_ctx
+                .malicious_multiply(RecordId::from(0_u32))
+                .await
+                .execute(a_malicious, b_malicious)
+                .await?;
 
-            acc.accumulate_macs(
-                &a_ctx.narrow(&Step::ValidateMultiplySubstep).prss(),
-                RecordId::from(0_u32),
-                MaliciousReplicated::new(ab, rab),
-            );
+            v.validate(ctx.narrow("SecurityValidatorValidate")).await?;
 
-            v.validate(ctx.narrow("SecurityValidatorValidate")).await
+            Ok::<(MaliciousReplicated<Fp31>, Replicated<Fp31>), BoxError>((mult_result, r_share))
         });
 
-        try_join_all(futures).await?;
+        let ab_pieces = try_join_all(futures).await?;
+
+        let r = validate_and_reconstruct((ab_pieces[0].1, ab_pieces[1].1, ab_pieces[2].1));
+        let ab =
+            validate_and_reconstruct((ab_pieces[0].0.x(), ab_pieces[1].0.x(), ab_pieces[2].0.x()));
+        let rab = validate_and_reconstruct((
+            ab_pieces[0].0.rx(),
+            ab_pieces[1].0.rx(),
+            ab_pieces[2].0.rx(),
+        ));
+
+        assert_eq!(ab, a * b);
+        assert_eq!(rab, r * a * b);
 
         Ok(())
     }
@@ -319,7 +322,8 @@ pub mod tests {
     /// MACs are compared. If any helper deviated from the protocol, chances are that the MACs will not match up.
     /// There is a small chance of failure which is `2 / |F|`, where `|F|` is the cardinality of the prime field.
     #[tokio::test]
-    async fn test_complex_circuit() -> Result<(), BoxError> {
+    #[allow(clippy::too_many_lines)]
+    async fn complex_circuit() -> Result<(), BoxError> {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
@@ -342,91 +346,112 @@ pub mod tests {
         let futures =
             context
                 .into_iter()
-                .zip(shared_inputs)
+                .zip(shared_inputs.clone())
                 .map(|(ctx, input_shares)| async move {
                     let v = SecurityValidator::new(ctx.narrow("SecurityValidatorInit"));
                     let acc = v.accumulator();
 
                     let mut row_narrowed_contexts = Vec::with_capacity(100);
                     for i in 0..100 {
-                        row_narrowed_contexts.push(ctx.narrow(&format!("row {}", i)));
+                        row_narrowed_contexts.push(
+                            ctx.narrow(&format!("row {}", i))
+                                .upgrade_to_malicious(acc.clone()),
+                        );
                     }
 
                     let r_share = v.r_share();
 
-                    let rx_values: Vec<Replicated<Fp31>> = try_join_all(
+                    let maliciously_secure_inputs = try_join_all(
                         input_shares
                             .iter()
                             .zip(row_narrowed_contexts.iter())
                             .enumerate()
                             .map(|(i, (x, ctx))| async move {
-                                ctx.narrow("mult")
-                                    .multiply(RecordId::from(u32::try_from(i).unwrap()))
+                                let record_id = RecordId::from(u32::try_from(i).unwrap());
+
+                                let rx = ctx
+                                    .narrow("mult")
+                                    .multiply(record_id)
                                     .await
                                     .execute(*x, r_share)
+                                    .await?;
+
+                                Ok::<MaliciousReplicated<Fp31>, BoxError>(MaliciousReplicated::new(
+                                    *x, rx,
+                                ))
+                            }),
+                    )
+                    .await?;
+
+                    let _ = maliciously_secure_inputs
+                        .iter()
+                        .zip(row_narrowed_contexts.iter())
+                        .enumerate()
+                        .map(|(i, (maliciously_secure_input, ctx))| {
+                            acc.accumulate_macs(
+                                &ctx.narrow(&Step::ValidateInput).prss(),
+                                RecordId::from(u32::try_from(i).unwrap()),
+                                *maliciously_secure_input,
+                            );
+                        });
+
+                    let mult_results = try_join_all(
+                        maliciously_secure_inputs
+                            .iter()
+                            .zip(maliciously_secure_inputs.iter().skip(1))
+                            .zip(row_narrowed_contexts.iter())
+                            .enumerate()
+                            .map(|(i, ((a_malicious, b_malicious), ctx))| async move {
+                                ctx.narrow("Circuit_Step_2")
+                                    .malicious_multiply(RecordId::from(u32::try_from(i).unwrap()))
+                                    .await
+                                    .execute(*a_malicious, *b_malicious)
                                     .await
                             }),
                     )
                     .await?;
 
-                    let _ = input_shares.iter().zip(rx_values.iter()).enumerate().map(
-                        |(i, (x, rx))| {
-                            acc.accumulate_macs(
-                                &ctx.narrow(&Step::ValidateInput).prss(),
-                                RecordId::from(u32::try_from(i).unwrap()),
-                                MaliciousReplicated::new(*x, *rx),
-                            );
-                        },
-                    );
+                    v.validate(ctx.narrow("SecurityValidatorValidate")).await?;
 
-                    let (ab_outputs, double_check_outputs) = try_join(
-                        try_join_all(
-                            input_shares
-                                .iter()
-                                .zip(input_shares.iter().skip(1))
-                                .zip(row_narrowed_contexts.iter())
-                                .enumerate()
-                                .map(|(i, ((a, b), ctx))| async move {
-                                    ctx.narrow("SingleMult")
-                                        .multiply(RecordId::from(u32::try_from(i).unwrap()))
-                                        .await
-                                        .execute(*a, *b)
-                                        .await
-                                }),
-                        ),
-                        try_join_all(
-                            input_shares
-                                .iter()
-                                .zip(rx_values.iter().skip(1))
-                                .zip(row_narrowed_contexts.iter())
-                                .enumerate()
-                                .map(|(i, ((a, rb), ctx))| async move {
-                                    ctx.narrow("DoubleMult")
-                                        .multiply(RecordId::from(u32::try_from(i).unwrap()))
-                                        .await
-                                        .execute(*a, *rb)
-                                        .await
-                                }),
-                        ),
-                    )
-                    .await?;
-
-                    let _ = ab_outputs
-                        .iter()
-                        .zip(double_check_outputs.iter())
-                        .enumerate()
-                        .map(|(i, (ab, rab))| {
-                            acc.accumulate_macs(
-                                &ctx.narrow(&Step::ValidateMultiplySubstep).prss(),
-                                RecordId::from(u32::try_from(i).unwrap()),
-                                MaliciousReplicated::new(*ab, *rab),
-                            );
-                        });
-
-                    v.validate(ctx.narrow("SecurityValidatorValidate")).await
+                    Ok::<(Vec<MaliciousReplicated<Fp31>>, Replicated<Fp31>), BoxError>((
+                        mult_results,
+                        r_share,
+                    ))
                 });
 
-        try_join_all(futures).await?;
+        let processed_outputs = try_join_all(futures).await?;
+
+        let r = validate_and_reconstruct((
+            processed_outputs[0].1,
+            processed_outputs[1].1,
+            processed_outputs[2].1,
+        ));
+
+        for i in 0..99 {
+            let x1 = validate_and_reconstruct((
+                shared_inputs[0][i],
+                shared_inputs[1][i],
+                shared_inputs[2][i],
+            ));
+            let x2 = validate_and_reconstruct((
+                shared_inputs[0][i + 1],
+                shared_inputs[1][i + 1],
+                shared_inputs[2][i + 1],
+            ));
+            let x1_times_x2 = validate_and_reconstruct((
+                processed_outputs[0].0[i].x(),
+                processed_outputs[1].0[i].x(),
+                processed_outputs[2].0[i].x(),
+            ));
+            let r_times_x1_times_x2 = validate_and_reconstruct((
+                processed_outputs[0].0[i].rx(),
+                processed_outputs[1].0[i].rx(),
+                processed_outputs[2].0[i].rx(),
+            ));
+
+            assert_eq!(x1 * x2, x1_times_x2);
+            assert_eq!(r * x1 * x2, r_times_x1_times_x2);
+        }
 
         Ok(())
     }

--- a/src/protocol/maliciously_secure_mul.rs
+++ b/src/protocol/maliciously_secure_mul.rs
@@ -1,0 +1,99 @@
+use crate::error::BoxError;
+use crate::ff::Field;
+use crate::protocol::{
+    context::ProtocolContext, malicious::SecurityValidatorAccumulator, securemul::SecureMul,
+    RecordId,
+};
+use crate::secret_sharing::MaliciousReplicated;
+use futures::future::try_join;
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    DuplicateMultiply,
+    RandomnessForValidation,
+}
+
+impl crate::protocol::Step for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::DuplicateMultiply => "duplicate_multiply",
+            Self::RandomnessForValidation => "randomness_for_validation",
+        }
+    }
+}
+
+///
+/// Implementation drawn from:
+/// "Fast Large-Scale Honest-Majority MPC for Malicious Adversaries"
+/// by by K. Chida, D. Genkin, K. Hamada, D. Ikarashi, R. Kikuchi, Y. Lindell, and A. Nof
+/// <https://link.springer.com/content/pdf/10.1007/978-3-319-96878-0_2.pdf>
+///
+/// Protocol 5.3 "Computing Arithmetic Circuits Over Any Finite F"
+/// Step 5: "Circuit Emulation"
+/// (In our case, simplified slightly because δ=1)
+/// When `G_k` is a multiplication gate:
+/// Given tuples:  `([x], [r · x])` and `([y], [r · y])`
+/// (a) The parties call `F_mult` on `[x]` and `[y]` to receive `[x · y]`
+/// (b) The parties call `F_mult` on `[r · x]` and `[y]` to receive `[r · x · y]`.
+///
+/// As each multiplication gate affects Step 6: "Verification Stage", the Security Validator
+/// must be provided. The two outputs of the multiplication, `[x · y]` and  `[r · x · y]`
+/// will be provided to this Security Validator, and will update two information-theoretic MACs.
+///
+/// It's cricital that the functionality `F_mult` is secure up to an additive attack.
+/// `SecureMult` is an implementation of the IKHC multiplication protocol, which has this property.
+///
+pub struct MaliciouslySecureMul<'a, F> {
+    ctx: ProtocolContext<'a, F>,
+    record_id: RecordId,
+    accumulator: SecurityValidatorAccumulator<F>,
+}
+
+impl<'a, F: Field> MaliciouslySecureMul<'a, F> {
+    #[must_use]
+    pub fn new(
+        ctx: ProtocolContext<'a, F>,
+        record_id: RecordId,
+        accumulator: SecurityValidatorAccumulator<F>,
+    ) -> Self {
+        Self {
+            ctx,
+            record_id,
+            accumulator,
+        }
+    }
+
+    /// Executes two parallel multiplications;
+    /// `A * B`, and `rA * B`, yielding both `AB` and `rAB`
+    /// both `AB` and `rAB` are provided to the security validator
+    ///
+    /// ## Errors
+    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+    /// back via the error response
+    /// ## Panics
+    /// Panics if the mutex is found to be poisoned
+    pub async fn execute(
+        self,
+        a: MaliciousReplicated<F>,
+        b: MaliciousReplicated<F>,
+    ) -> Result<MaliciousReplicated<F>, BoxError> {
+        // being clever and assuming a clean context...
+        let duplicate_multiply_ctx = self.ctx.narrow(&Step::DuplicateMultiply);
+        let random_constant_prss = self.ctx.narrow(&Step::RandomnessForValidation).prss();
+        let (ab, rab) = try_join(
+            SecureMul::new(self.ctx, self.record_id).execute(a.x(), b.x()),
+            SecureMul::new(duplicate_multiply_ctx, self.record_id).execute(a.rx(), b.x()),
+        )
+        .await?;
+
+        let malicious_ab = MaliciousReplicated::new(ab, rab);
+
+        self.accumulator
+            .accumulate_macs(&random_constant_prss, self.record_id, malicious_ab);
+
+        Ok(malicious_ab)
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -3,6 +3,7 @@ mod batch;
 mod check_zero;
 pub mod context;
 pub mod malicious;
+mod maliciously_secure_mul;
 mod modulus_conversion;
 pub mod prss;
 mod reveal;


### PR DESCRIPTION
The 3rd step in a stack of 3 diffs to upgrade our arithmetic circuits to malicious security.

This introduces a new "Maliciously Secure Multiplication" protocol, which performs a multiplication twice, once to compute `a * b`, and once to produce `r * a * b`. This protocol automatically updates the information theoretic MACs that will eventually be checked at the conclusion of the protocol.