### PR TITLE
Three changes

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -2,7 +2,6 @@ use super::{AccumulateCreditInputRow, AccumulateCreditOutputRow, AttributionInpu
 use crate::{
     error::BoxError,
     ff::Field,
-    helpers::fabric::Network,
     protocol::{
         batch::{Batch, RecordIndex},
         context::ProtocolContext,
@@ -51,9 +50,9 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
     /// each iteration by a factor of two, we ensure that each node only accumulates the value of each successor only once.
     /// <https://github.com/patcg-individual-drafts/ipa/blob/main/IPA-End-to-End.md#oblivious-last-touch-attribution>
     #[allow(dead_code)]
-    pub async fn execute<N: Network>(
+    pub async fn execute(
         &self,
-        ctx: ProtocolContext<'_, N, F>,
+        ctx: ProtocolContext<'_, F>,
     ) -> Result<Batch<AccumulateCreditOutputRow<F>>, BoxError> {
         #[allow(clippy::cast_possible_truncation)]
         let num_rows = self.input.len() as RecordIndex;
@@ -154,8 +153,8 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         Ok(output)
     }
 
-    async fn get_accumulated_credit<N: Network>(
-        ctx: ProtocolContext<'_, N, F>,
+    async fn get_accumulated_credit(
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
         current: AccumulateCreditInputRow<F>,
         successor: AccumulateCreditInputRow<F>,
@@ -178,7 +177,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         if !first_iteration {
             b = ctx
                 .narrow(&Step::BTimesStopBit)
-                .multiply(RecordId::from(1))
+                .multiply(RecordId::from(1_u32))
                 .await
                 .execute(b, current.stop_bit)
                 .await?;

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -1,7 +1,6 @@
 use crate::{
     error::BoxError,
     ff::Field,
-    helpers::fabric::Network,
     protocol::{context::ProtocolContext, reveal::reveal, RecordId},
     secret_sharing::Replicated,
 };
@@ -61,8 +60,8 @@ impl AsRef<str> for Step {
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
 #[allow(dead_code)]
-pub async fn check_zero<F: Field, N: Network>(
-    ctx: ProtocolContext<'_, N, F>,
+pub async fn check_zero<F: Field>(
+    ctx: ProtocolContext<'_, F>,
     record_id: RecordId,
     v: Replicated<F>,
 ) -> Result<bool, BoxError> {
@@ -94,7 +93,7 @@ pub mod tests {
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts(&world);
         let mut rng = rand::thread_rng();
-        let mut counter = 0;
+        let mut counter = 0_u32;
 
         for v in 0..u32::from(Fp31::PRIME) {
             let v = Fp31::from(v);

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -8,7 +8,6 @@ use super::{
 use crate::{
     ff::Field,
     helpers::{
-        fabric::Network,
         messaging::{Gateway, Mesh},
         Identity,
     },
@@ -19,16 +18,16 @@ use crate::{
 /// randomness generator (see `Participant`) and communication trait to send messages to each other.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
-pub struct ProtocolContext<'a, N, F> {
+pub struct ProtocolContext<'a, F> {
     role: Identity,
     step: UniqueStepId,
     prss: &'a PrssEndpoint,
-    gateway: &'a Gateway<N>,
+    gateway: &'a Gateway,
     accumulator: Option<SecurityValidatorAccumulator<F>>,
 }
 
-impl<'a, N, F> ProtocolContext<'a, N, F> {
-    pub fn new(role: Identity, participant: &'a PrssEndpoint, gateway: &'a Gateway<N>) -> Self {
+impl<'a, F> ProtocolContext<'a, F> {
+    pub fn new(role: Identity, participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self {
             role,
             step: UniqueStepId::default(),
@@ -99,10 +98,10 @@ impl<'a, N, F> ProtocolContext<'a, N, F> {
     }
 }
 
-impl<'a, N: Network, F: Field> ProtocolContext<'a, N, F> {
+impl<'a, F: Field> ProtocolContext<'a, F> {
     /// Get a set of communications channels to different peers.
     #[must_use]
-    pub fn mesh(&self) -> Mesh<'_, '_, N> {
+    pub fn mesh(&self) -> Mesh<'_, '_> {
         self.gateway.mesh(&self.step)
     }
 
@@ -111,7 +110,7 @@ impl<'a, N: Network, F: Field> ProtocolContext<'a, N, F> {
     /// In this case, function returns only when multiplication for this record can actually
     /// be processed.
     #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
-    pub async fn multiply(self, record_id: RecordId) -> SecureMul<'a, N, F> {
+    pub async fn multiply(self, record_id: RecordId) -> SecureMul<'a, F> {
         SecureMul::new(self, record_id)
     }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -175,6 +175,12 @@ impl From<u32> for RecordId {
     }
 }
 
+impl From<usize> for RecordId {
+    fn from(v: usize) -> Self {
+        RecordId::from(u32::try_from(v).unwrap())
+    }
+}
+
 impl From<RecordId> for u128 {
     fn from(r: RecordId) -> Self {
         r.0.into()

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -1,7 +1,6 @@
 use crate::{
     error::BoxError,
     ff::{Field, Fp2},
-    helpers::fabric::Network,
     protocol::{
         context::ProtocolContext, modulus_conversion::double_random::DoubleRandom,
         reveal_additive_binary::RevealAdditiveBinary, RecordId,
@@ -66,9 +65,9 @@ impl ConvertShares {
     }
 
     #[allow(dead_code)]
-    pub async fn execute<F: Field, N: Network>(
+    pub async fn execute<F: Field>(
         &self,
-        ctx: ProtocolContext<'_, N, F>,
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let prss = &ctx.prss();

--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::BoxError,
     ff::{BinaryField, Field},
-    helpers::{fabric::Network, Identity},
+    helpers::Identity,
     protocol::{
         context::ProtocolContext,
         modulus_conversion::specialized_mul::{
@@ -101,8 +101,8 @@ impl DoubleRandom {
     ///
     /// And helper 3 has shares:
     /// a: (0, x1) and b: (0, 0)
-    async fn xor_specialized_1<F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N, F>,
+    async fn xor_specialized_1<F: Field>(
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
@@ -127,8 +127,8 @@ impl DoubleRandom {
     ///
     /// And helper 3 has shares:
     /// (x3, 0)
-    async fn xor_specialized_2<F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N, F>,
+    async fn xor_specialized_2<F: Field>(
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
@@ -143,8 +143,8 @@ impl DoubleRandom {
     /// of unknown number 'r') into a random secret sharing of the same value in `Z_p`
     /// where the caller can select the output Field.
     #[allow(dead_code)]
-    pub async fn execute<B: BinaryField, F: Field, N: Network>(
-        ctx: ProtocolContext<'_, N, F>,
+    pub async fn execute<B: BinaryField, F: Field>(
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
         random_sharing: Replicated<B>,
     ) -> Result<Replicated<F>, BoxError> {
@@ -181,7 +181,7 @@ mod tests {
         let mut bools: Vec<u128> = Vec::with_capacity(40);
         let mut futures = Vec::with_capacity(40);
 
-        for i in 0..40 {
+        for i in 0..40_u32 {
             let b0 = rng.gen::<bool>();
             let b1 = rng.gen::<bool>();
             let b2 = rng.gen::<bool>();

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::BoxError,
     ff::Field,
-    helpers::{fabric::Network, Direction, Identity},
+    helpers::{Direction, Identity},
     protocol::{context::ProtocolContext, RecordId},
     secret_sharing::Replicated,
 };
@@ -29,8 +29,8 @@ use crate::{
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
 #[allow(dead_code)]
-pub async fn multiply_two_shares_mostly_zeroes<F: Field, N: Network>(
-    ctx: ProtocolContext<'_, N, F>,
+pub async fn multiply_two_shares_mostly_zeroes<F: Field>(
+    ctx: ProtocolContext<'_, F>,
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,
@@ -113,8 +113,8 @@ pub async fn multiply_two_shares_mostly_zeroes<F: Field, N: Network>(
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
 #[allow(dead_code)]
-pub async fn multiply_one_share_mostly_zeroes<F: Field, N: Network>(
-    ctx: ProtocolContext<'_, N, F>,
+pub async fn multiply_one_share_mostly_zeroes<F: Field>(
+    ctx: ProtocolContext<'_, F>,
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,
@@ -207,7 +207,7 @@ pub mod tests {
         let context = make_contexts(&world);
         let mut rng = rand::thread_rng();
 
-        for i in 0..10 {
+        for i in 0..10_u32 {
             let a = Fp31::from(rng.gen::<u128>());
             let b = Fp31::from(rng.gen::<u128>());
 
@@ -255,7 +255,7 @@ pub mod tests {
         let mut inputs = Vec::with_capacity(10);
         let mut futures = Vec::with_capacity(10);
 
-        for i in 0..10 {
+        for i in 0..10_u32 {
             let a = Fp31::from(rng.gen::<u128>());
             let b = Fp31::from(rng.gen::<u128>());
 
@@ -309,7 +309,7 @@ pub mod tests {
         let context = make_contexts(&world);
         let mut rng = rand::thread_rng();
 
-        for i in 0..10 {
+        for i in 0..10_u32 {
             let a = Fp31::from(rng.gen::<u128>());
             let b = Fp31::from(rng.gen::<u128>());
 
@@ -360,7 +360,7 @@ pub mod tests {
         let mut inputs = Vec::with_capacity(10);
         let mut futures = Vec::with_capacity(10);
 
-        for i in 0..10 {
+        for i in 0..10_u32 {
             let a = Fp31::from(rng.gen::<u128>());
             let b = Fp31::from(rng.gen::<u128>());
 

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -1,5 +1,4 @@
 use crate::ff::Field;
-use crate::helpers::fabric::Network;
 use crate::protocol::context::ProtocolContext;
 use crate::secret_sharing::Replicated;
 use crate::{error::BoxError, helpers::Direction, protocol::RecordId};
@@ -18,8 +17,8 @@ use embed_doc_image::embed_doc_image;
 /// i.e. their own shares and received share.
 #[embed_doc_image("reveal", "images/reveal.png")]
 #[allow(dead_code)]
-pub async fn reveal<F: Field, N: Network>(
-    ctx: ProtocolContext<'_, N, F>,
+pub async fn reveal<F: Field>(
+    ctx: ProtocolContext<'_, F>,
     record_id: RecordId,
     input: Replicated<F>,
 ) -> Result<F, BoxError> {
@@ -58,7 +57,7 @@ mod tests {
         let world: TestWorld = make_world(QueryId);
         let ctx = make_contexts(&world);
 
-        for i in 0..10 {
+        for i in 0..10_u32 {
             let secret = rng.gen::<u128>();
 
             let input = Fp31::from(secret);

--- a/src/protocol/reveal_additive_binary.rs
+++ b/src/protocol/reveal_additive_binary.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::BoxError,
     ff::{Field, Fp2},
-    helpers::{fabric::Network, Direction},
+    helpers::Direction,
     protocol::{context::ProtocolContext, RecordId},
 };
 
@@ -19,8 +19,8 @@ pub struct RevealAdditiveBinary {}
 
 impl RevealAdditiveBinary {
     #[allow(dead_code)]
-    pub async fn execute<N: Network, F: Field>(
-        ctx: ProtocolContext<'_, N, F>,
+    pub async fn execute<F: Field>(
+        ctx: ProtocolContext<'_, F>,
         record_id: RecordId,
         input: Fp2,
     ) -> Result<Fp2, BoxError> {
@@ -68,7 +68,7 @@ mod tests {
 
         let mut bools: Vec<bool> = Vec::with_capacity(40);
 
-        let inputs = (0..10).into_iter().map(|i| {
+        let inputs = (0..10_u32).into_iter().map(|i| {
             let b0 = rng.gen::<bool>();
             let b1 = rng.gen::<bool>();
             let b2 = rng.gen::<bool>();

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -1,3 +1,5 @@
+use std::iter::{repeat, zip};
+
 use crate::{
     error::BoxError,
     ff::Field,
@@ -5,7 +7,6 @@ use crate::{
     secret_sharing::Replicated,
 };
 
-use crate::helpers::fabric::Network;
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
 
@@ -43,9 +44,9 @@ impl<'a, F: Field> BitPermutations<'a, F> {
     /// ## Errors
     /// It will propagate errors from multiplication protocol.
     #[allow(dead_code)]
-    pub async fn execute<N: Network>(
+    pub async fn execute(
         &self,
-        ctx: &ProtocolContext<'_, N, F>,
+        ctx: ProtocolContext<'_, F>,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let share_of_one = Replicated::one(ctx.role());
 
@@ -54,21 +55,17 @@ impl<'a, F: Field> BitPermutations<'a, F> {
             .iter()
             .map(move |x: &Replicated<F>| share_of_one - *x)
             .chain(self.input.iter().copied())
-            .enumerate()
-            .scan(Replicated::<F>::new(F::ZERO, F::ZERO), |sum, (index, x)| {
+            .scan(Replicated::<F>::new(F::ZERO, F::ZERO), |sum, x| {
                 *sum += x;
-                Some((
-                    ctx.narrow(&format!("record_{}", index)),
-                    RecordId::from(u32::try_from(index).unwrap()),
-                    x,
-                    *sum,
-                ))
+                Some((x, *sum))
             });
 
-        let async_multiply = mult_input.map(|(ctx, record_id, x, sum)| async move {
-            //ctx.narrow(&Step::MultiplyAcross)
-            ctx.multiply(record_id).await.execute(x, sum).await
-        });
+        let async_multiply =
+            zip(repeat(ctx), mult_input)
+                .enumerate()
+                .map(|(i, (ctx, (x, sum)))| async move {
+                    ctx.multiply(RecordId::from(i)).await.execute(x, sum).await
+                });
         let mut mult_output = try_join_all(async_multiply).await?;
 
         assert_eq!(mult_output.len(), self.input.len() * 2);
@@ -98,7 +95,7 @@ mod tests {
     #[tokio::test]
     pub async fn bit_permutations() {
         let world = make_world(QueryId);
-        let context = make_contexts(&world);
+        let [ctx0, ctx1, ctx2] = make_contexts(&world);
         let mut rand = StepRng::new(100, 1);
 
         // With this input, for stable sort we expect all 0's to line up before 1's. The expected sort order is same as expected_sort_output
@@ -121,9 +118,9 @@ mod tests {
         let bitperms0 = BitPermutations::new(&shares[0]);
         let bitperms1 = BitPermutations::new(&shares[1]);
         let bitperms2 = BitPermutations::new(&shares[2]);
-        let h0_future = bitperms0.execute(&context[0]);
-        let h1_future = bitperms1.execute(&context[1]);
-        let h2_future = bitperms2.execute(&context[2]);
+        let h0_future = bitperms0.execute(ctx0);
+        let h1_future = bitperms1.execute(ctx1);
+        let h2_future = bitperms2.execute(ctx2);
 
         let result = try_join!(h0_future, h1_future, h2_future).unwrap();
 

--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -1,5 +1,4 @@
 use crate::ff::Field;
-use crate::helpers::fabric::Network;
 use crate::{
     error::BoxError,
     helpers::{Direction, Identity},
@@ -35,9 +34,9 @@ impl<F: Field> Reshare<F> {
     ///    `to_helper.left`  = (part1 + part2, `rand_left`)  = (part1 + part2, r1)
     ///    `to_helper`       = (`rand_left`, `rand_right`)     = (r0, r1)
     ///    `to_helper.right` = (`rand_right`, part1 + part2) = (r0, part1 + part2)
-    pub async fn execute<N: Network>(
+    pub async fn execute(
         self,
-        ctx: &ProtocolContext<'_, N, F>,
+        ctx: &ProtocolContext<'_, F>,
         record_id: RecordId,
         to_helper: Identity,
     ) -> Result<Replicated<F>, BoxError> {
@@ -102,7 +101,7 @@ mod tests {
 
             let input = Fp31::from(secret);
             let share = share(input, &mut rand);
-            let record_id = RecordId::from(1);
+            let record_id = RecordId::from(1_u32);
 
             let world: TestWorld = make_world(QueryId);
             let context = make_contexts(&world);

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -8,7 +8,7 @@ use rand_chacha::ChaCha8Rng;
 use crate::{
     error::BoxError,
     ff::Field,
-    helpers::{fabric::Network, Direction, Identity},
+    helpers::{Direction, Identity},
     protocol::{context::ProtocolContext, prss::IndexedSharedRandomness, RecordId, Step},
     secret_sharing::Replicated,
 };
@@ -98,9 +98,9 @@ impl<'a, F: Field> Shuffle<'a, F> {
     }
 
     #[allow(clippy::cast_possible_truncation)]
-    async fn reshare_all_shares<N: Network>(
+    async fn reshare_all_shares(
         &self,
-        ctx: &ProtocolContext<'_, N, F>,
+        ctx: &ProtocolContext<'_, F>,
         to_helper: Identity,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let reshares = self
@@ -120,10 +120,10 @@ impl<'a, F: Field> Shuffle<'a, F> {
     /// ii)  2 helpers apply the permutation to their shares
     /// iii) reshare to `to_helper`
     #[allow(clippy::cast_possible_truncation)]
-    async fn shuffle_or_unshuffle_once<N: Network>(
+    async fn shuffle_or_unshuffle_once(
         &mut self,
         shuffle_or_unshuffle: ShuffleOrUnshuffle,
-        ctx: &ProtocolContext<'_, N, F>,
+        ctx: &ProtocolContext<'_, F>,
         which_step: ShuffleStep,
         permutations: &(Permutation, Permutation),
     ) -> Result<Vec<Replicated<F>>, BoxError> {
@@ -154,9 +154,9 @@ impl<'a, F: Field> Shuffle<'a, F> {
     /// The Shuffle object receives a step function and appends a `ShuffleStep` to form a concrete step
     /// ![Shuffle steps][shuffle]
     #[allow(dead_code)]
-    pub async fn execute<N: Network>(
+    pub async fn execute(
         &mut self,
-        ctx: ProtocolContext<'_, N, F>,
+        ctx: ProtocolContext<'_, F>,
         permutations: &(Permutation, Permutation),
     ) -> Result<(), BoxError>
     where
@@ -183,9 +183,9 @@ impl<'a, F: Field> Shuffle<'a, F> {
     /// Order of calling `shuffle_or_unshuffle_once` is shuffle with (H1, H2), (H3, H1) and (H2, H3)
     /// ![Unshuffle steps][unshuffle]
     #[allow(dead_code)]
-    pub async fn execute_unshuffle<N: Network>(
+    pub async fn execute_unshuffle(
         &mut self,
-        ctx: ProtocolContext<'_, N, F>,
+        ctx: ProtocolContext<'_, F>,
         permutations: &(Permutation, Permutation),
     ) -> Result<(), BoxError>
     where

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -4,9 +4,7 @@ pub mod logging;
 mod sharing;
 mod world;
 
-use self::fabric::InMemoryEndpoint;
 use crate::ff::{Field, Fp31};
-use crate::helpers::fabric::Network;
 use crate::helpers::Identity;
 use crate::protocol::context::ProtocolContext;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
@@ -14,7 +12,6 @@ use crate::protocol::Step;
 use crate::secret_sharing::Replicated;
 use rand::rngs::mock::StepRng;
 use rand::thread_rng;
-use std::sync::Arc;
 
 pub use sharing::{share, validate_and_reconstruct};
 pub use world::{make as make_world, TestWorld};
@@ -24,9 +21,7 @@ pub use world::{make as make_world, TestWorld};
 /// # Panics
 /// Panics if world has more or less than 3 gateways/participants
 #[must_use]
-pub fn make_contexts(
-    test_world: &TestWorld,
-) -> [ProtocolContext<'_, Arc<InMemoryEndpoint>, Fp31>; 3] {
+pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_, Fp31>; 3] {
     test_world
         .gateways
         .iter()
@@ -44,10 +39,10 @@ pub fn make_contexts(
 /// # Panics
 /// Never, but then Rust doesn't know that; this is only needed because we don't have `each_ref()`.
 #[must_use]
-pub fn narrow_contexts<'a, N: Network + std::fmt::Debug, F: Field>(
-    contexts: &[ProtocolContext<'a, N, F>; 3],
+pub fn narrow_contexts<'a, F: Field>(
+    contexts: &[ProtocolContext<'a, F>; 3],
     step: &impl Step,
-) -> [ProtocolContext<'a, N, F>; 3] {
+) -> [ProtocolContext<'a, F>; 3] {
     // This really wants <[_; N]>::each_ref()
     contexts
         .iter()

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 use std::{fmt::Debug, sync::Arc};
 
-use super::fabric::InMemoryEndpoint;
-
 /// Test environment for protocols to run tests that require communication between helpers.
 /// For now the messages sent through it never leave the test infra memory perimeter, so
 /// there is no need to associate each of them with `QueryId`, but this API makes it possible
@@ -16,7 +14,7 @@ use super::fabric::InMemoryEndpoint;
 #[allow(clippy::module_name_repetitions)]
 pub struct TestWorld {
     pub query_id: QueryId,
-    pub gateways: [Gateway<Arc<InMemoryEndpoint>>; 3],
+    pub gateways: [Gateway; 3],
     pub participants: [PrssEndpoint; 3],
     _network: Arc<InMemoryNetwork>,
 }
@@ -49,13 +47,7 @@ pub fn make(query_id: QueryId) -> TestWorld {
     let gateways = network
         .endpoints
         .iter()
-        .map(|endpoint| {
-            Gateway::new(
-                endpoint.identity,
-                Arc::clone(endpoint),
-                config.gateway_config,
-            )
-        })
+        .map(|endpoint| Gateway::new(endpoint.identity, endpoint, config.gateway_config))
         .collect::<Vec<_>>()
         .try_into()
         .unwrap();


### PR DESCRIPTION
1. remove network from gateway, which reduces the complexity of the context declaration
2. add RecordId::from(usize), which complicates usage in some places, but simplifies others
3. fix the bit permutation code

I'll split this up later if necessary, but I need to attend to other things for now.