### PR TITLE
Remove `F` from ProtocolContext

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -52,7 +52,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
     #[allow(dead_code)]
     pub async fn execute(
         &self,
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
     ) -> Result<Batch<AccumulateCreditOutputRow<F>>, BoxError> {
         #[allow(clippy::cast_possible_truncation)]
         let num_rows = self.input.len() as RecordIndex;
@@ -154,7 +154,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
     }
 
     async fn get_accumulated_credit(
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
         current: AccumulateCreditInputRow<F>,
         successor: AccumulateCreditInputRow<F>,

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -61,7 +61,7 @@ impl AsRef<str> for Step {
 /// back via the error response
 #[allow(dead_code)]
 pub async fn check_zero<F: Field>(
-    ctx: ProtocolContext<'_, F>,
+    ctx: ProtocolContext<'_>,
     record_id: RecordId,
     v: Replicated<F>,
 ) -> Result<bool, BoxError> {

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -121,7 +121,7 @@ pub struct SecurityValidator<F> {
 impl<F: Field> SecurityValidator<F> {
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(ctx: ProtocolContext<'_, F>) -> SecurityValidator<F> {
+    pub fn new(ctx: ProtocolContext<'_>) -> SecurityValidator<F> {
         let prss = ctx.prss();
 
         let r_share = prss.generate_replicated(RECORD_0);
@@ -156,7 +156,7 @@ impl<F: Field> SecurityValidator<F> {
     /// ## Panics
     /// Will panic if the mutex is poisoned
     #[allow(clippy::await_holding_lock)]
-    pub async fn validate(self, ctx: ProtocolContext<'_, F>) -> Result<(), BoxError> {
+    pub async fn validate(self, ctx: ProtocolContext<'_>) -> Result<(), BoxError> {
         // send our `u_i+1` value to the helper on the right
         let channel = ctx.mesh();
         let helper_right = ctx.role().peer(Direction::Right);

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -67,7 +67,7 @@ impl ConvertShares {
     #[allow(dead_code)]
     pub async fn execute<F: Field>(
         &self,
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let prss = &ctx.prss();

--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -102,7 +102,7 @@ impl DoubleRandom {
     /// And helper 3 has shares:
     /// a: (0, x1) and b: (0, 0)
     async fn xor_specialized_1<F: Field>(
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
@@ -128,7 +128,7 @@ impl DoubleRandom {
     /// And helper 3 has shares:
     /// (x3, 0)
     async fn xor_specialized_2<F: Field>(
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
@@ -144,7 +144,7 @@ impl DoubleRandom {
     /// where the caller can select the output Field.
     #[allow(dead_code)]
     pub async fn execute<B: BinaryField, F: Field>(
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
         random_sharing: Replicated<B>,
     ) -> Result<Replicated<F>, BoxError> {

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -30,7 +30,7 @@ use crate::{
 /// back via the error response
 #[allow(dead_code)]
 pub async fn multiply_two_shares_mostly_zeroes<F: Field>(
-    ctx: ProtocolContext<'_, F>,
+    ctx: ProtocolContext<'_>,
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,
@@ -114,7 +114,7 @@ pub async fn multiply_two_shares_mostly_zeroes<F: Field>(
 /// back via the error response
 #[allow(dead_code)]
 pub async fn multiply_one_share_mostly_zeroes<F: Field>(
-    ctx: ProtocolContext<'_, F>,
+    ctx: ProtocolContext<'_>,
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -18,7 +18,7 @@ use embed_doc_image::embed_doc_image;
 #[embed_doc_image("reveal", "images/reveal.png")]
 #[allow(dead_code)]
 pub async fn reveal<F: Field>(
-    ctx: ProtocolContext<'_, F>,
+    ctx: ProtocolContext<'_>,
     record_id: RecordId,
     input: Replicated<F>,
 ) -> Result<F, BoxError> {

--- a/src/protocol/reveal_additive_binary.rs
+++ b/src/protocol/reveal_additive_binary.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::BoxError,
-    ff::{Field, Fp2},
+    ff::Fp2,
     helpers::Direction,
     protocol::{context::ProtocolContext, RecordId},
 };
@@ -19,8 +19,8 @@ pub struct RevealAdditiveBinary {}
 
 impl RevealAdditiveBinary {
     #[allow(dead_code)]
-    pub async fn execute<F: Field>(
-        ctx: ProtocolContext<'_, F>,
+    pub async fn execute(
+        ctx: ProtocolContext<'_>,
         record_id: RecordId,
         input: Fp2,
     ) -> Result<Fp2, BoxError> {

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -44,10 +44,7 @@ impl<'a, F: Field> BitPermutations<'a, F> {
     /// ## Errors
     /// It will propagate errors from multiplication protocol.
     #[allow(dead_code)]
-    pub async fn execute(
-        &self,
-        ctx: ProtocolContext<'_, F>,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    pub async fn execute(&self, ctx: ProtocolContext<'_>) -> Result<Vec<Replicated<F>>, BoxError> {
         let share_of_one = Replicated::one(ctx.role());
 
         let mult_input = self

--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -36,7 +36,7 @@ impl<F: Field> Reshare<F> {
     ///    `to_helper.right` = (`rand_right`, part1 + part2) = (r0, part1 + part2)
     pub async fn execute(
         self,
-        ctx: &ProtocolContext<'_, F>,
+        ctx: &ProtocolContext<'_>,
         record_id: RecordId,
         to_helper: Identity,
     ) -> Result<Replicated<F>, BoxError> {

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -100,7 +100,7 @@ impl<'a, F: Field> Shuffle<'a, F> {
     #[allow(clippy::cast_possible_truncation)]
     async fn reshare_all_shares(
         &self,
-        ctx: &ProtocolContext<'_, F>,
+        ctx: &ProtocolContext<'_>,
         to_helper: Identity,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let reshares = self
@@ -123,7 +123,7 @@ impl<'a, F: Field> Shuffle<'a, F> {
     async fn shuffle_or_unshuffle_once(
         &mut self,
         shuffle_or_unshuffle: ShuffleOrUnshuffle,
-        ctx: &ProtocolContext<'_, F>,
+        ctx: &ProtocolContext<'_>,
         which_step: ShuffleStep,
         permutations: &(Permutation, Permutation),
     ) -> Result<Vec<Replicated<F>>, BoxError> {
@@ -156,7 +156,7 @@ impl<'a, F: Field> Shuffle<'a, F> {
     #[allow(dead_code)]
     pub async fn execute(
         &mut self,
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         permutations: &(Permutation, Permutation),
     ) -> Result<(), BoxError>
     where
@@ -185,7 +185,7 @@ impl<'a, F: Field> Shuffle<'a, F> {
     #[allow(dead_code)]
     pub async fn execute_unshuffle(
         &mut self,
-        ctx: ProtocolContext<'_, F>,
+        ctx: ProtocolContext<'_>,
         permutations: &(Permutation, Permutation),
     ) -> Result<(), BoxError>
     where

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -4,7 +4,7 @@ pub mod logging;
 mod sharing;
 mod world;
 
-use crate::ff::{Field, Fp31};
+use crate::ff::Fp31;
 use crate::helpers::Identity;
 use crate::protocol::context::ProtocolContext;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
@@ -21,7 +21,7 @@ pub use world::{make as make_world, TestWorld};
 /// # Panics
 /// Panics if world has more or less than 3 gateways/participants
 #[must_use]
-pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_, Fp31>; 3] {
+pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_>; 3] {
     test_world
         .gateways
         .iter()
@@ -39,10 +39,10 @@ pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_, Fp31>; 3] {
 /// # Panics
 /// Never, but then Rust doesn't know that; this is only needed because we don't have `each_ref()`.
 #[must_use]
-pub fn narrow_contexts<'a, F: Field>(
-    contexts: &[ProtocolContext<'a, F>; 3],
+pub fn narrow_contexts<'a>(
+    contexts: &[ProtocolContext<'a>; 3],
     step: &impl Step,
-) -> [ProtocolContext<'a, F>; 3] {
+) -> [ProtocolContext<'a>; 3] {
     // This really wants <[_; N]>::each_ref()
     contexts
         .iter()


### PR DESCRIPTION
I created this PR as a recommendation regarding my comment on #169:

> I should have commented on #164, but should `ProtocolContext` be generic over `F`? We have one protocol, `ConvertShares`, which takes `XorShares` as its input. It isn't causing any issue now because the context in ConvertShares is only used to identify the helper, but using a context that takes an `F` to execute on shares that are not fields feels odd. It also forces `make_contexts` to return contexts with `Fp31`, but the code that generates the contexts is agnostic about this.
> 
> Would it be possible to pass `SecurityValidatorAccumulator` and specify an `F` when calling `MaliciouslySecureMul::execute()`?

In this PR, I moved `SecurityValidatorAccumulator` as a `malicous_multiply()` parameter. But once we have `MaliciouslySecureMul`, I think it makes more sense for `execute` to be generic over `F` and inside it creates an instance of `SecurityValidatorAccumulator`.