### PR TITLE
Fix compilation errors for benchmarks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Release Build
         run: cargo build --release
 
+      - name: Build benchmarks
+        run: cargo build --benches --all-features
+
       - name: Check formatting
         if: ${{ success() || failure() }}
         run: cargo fmt --all -- --check

--- a/benches/ct/arithmetic_circuit.rs
+++ b/benches/ct/arithmetic_circuit.rs
@@ -1,9 +1,9 @@
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
-use raw_ipa::field::Fp31;
 use raw_ipa::test_fixture::circuit;
 use tokio::runtime::Builder;
+use raw_ipa::ff::Fp31;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let rt = Builder::new_multi_thread()

--- a/benches/ct/arithmetic_circuit.rs
+++ b/benches/ct/arithmetic_circuit.rs
@@ -1,9 +1,9 @@
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
+use raw_ipa::ff::Fp31;
 use raw_ipa::test_fixture::circuit;
 use tokio::runtime::Builder;
-use raw_ipa::ff::Fp31;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let rt = Builder::new_multi_thread()

--- a/benches/iai/arithmetic_circuit.rs
+++ b/benches/iai/arithmetic_circuit.rs
@@ -1,7 +1,7 @@
 use iai::black_box;
+use raw_ipa::ff::Fp31;
 use raw_ipa::test_fixture::circuit;
 use tokio::runtime::Builder;
-use raw_ipa::ff::Fp31;
 
 pub fn iai_benchmark() {
     let rt = Builder::new_multi_thread()

--- a/benches/iai/arithmetic_circuit.rs
+++ b/benches/iai/arithmetic_circuit.rs
@@ -1,7 +1,7 @@
 use iai::black_box;
-use raw_ipa::field::Fp31;
 use raw_ipa::test_fixture::circuit;
 use tokio::runtime::Builder;
+use raw_ipa::ff::Fp31;
 
 pub fn iai_benchmark() {
     let rt = Builder::new_multi_thread()

--- a/benches/oneshot/arithmetic_circuit.rs
+++ b/benches/oneshot/arithmetic_circuit.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
+use raw_ipa::ff::{Field, Fp31};
 use raw_ipa::test_fixture::circuit;
 use std::time::Instant;
-use raw_ipa::ff::{Field, Fp31};
 
 #[derive(Debug, Parser)]
 pub struct CircuitArgs {

--- a/benches/oneshot/arithmetic_circuit.rs
+++ b/benches/oneshot/arithmetic_circuit.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
-use raw_ipa::field::{Field, Fp31};
 use raw_ipa::test_fixture::circuit;
 use std::time::Instant;
+use raw_ipa::ff::{Field, Fp31};
 
 #[derive(Debug, Parser)]
 pub struct CircuitArgs {

--- a/pre-commit
+++ b/pre-commit
@@ -44,6 +44,8 @@ error() {
    exit 1
 }
 
+cargo build --benches --all-features || error "Benchmarks compilation errors"
+
 cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
 
 cargo test || error "Test failures"


### PR DESCRIPTION
I've also added compile benchmark target to stop the bleeding. Unfortunately that will take the PR approval run longer, open to alternatives here.