### PR TITLE
`make_contexts` returns a `ProtocolContext<'_, F>`

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -265,7 +265,7 @@ mod tests {
     #[tokio::test]
     pub async fn accumulate() {
         let world = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = StepRng::new(100, 1);
 
         let raw_input: [[u128; 4]; 9] = [

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -91,7 +91,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
         let mut counter = 0_u32;
 

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -225,7 +225,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         let a = Fp31::from(rng.gen::<u128>());
@@ -323,7 +323,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         let mut shared_inputs = [

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -131,7 +131,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let [c0, c1, c2] = context;
 
         let mask = (1_u64 << 41) - 1; // in binary, a sequence of 40 ones

--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -173,7 +173,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let world = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let ctx0 = &context[0];
         let ctx1 = &context[1];
         let ctx2 = &context[2];

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -204,7 +204,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         for i in 0..10_u32 {
@@ -249,7 +249,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         let mut inputs = Vec::with_capacity(10);
@@ -306,7 +306,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         for i in 0..10_u32 {
@@ -354,7 +354,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
         let mut inputs = Vec::with_capacity(10);

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -55,7 +55,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let world: TestWorld = make_world(QueryId);
-        let ctx = make_contexts(&world);
+        let ctx = make_contexts::<Fp31>(&world);
 
         for i in 0..10_u32 {
             let secret = rng.gen::<u128>();

--- a/src/protocol/reveal_additive_binary.rs
+++ b/src/protocol/reveal_additive_binary.rs
@@ -52,7 +52,7 @@ mod tests {
     use proptest::prelude::Rng;
 
     use crate::{
-        ff::Fp2,
+        ff::{Fp2, Fp31},
         protocol::{reveal_additive_binary::RevealAdditiveBinary, QueryId, RecordId},
         test_fixture::{make_contexts, make_world, TestWorld},
     };
@@ -63,7 +63,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let world: TestWorld = make_world(QueryId);
-        let ctx = make_contexts(&world);
+        let ctx = make_contexts::<Fp31>(&world);
         let [c0, c1, c2] = ctx;
 
         let mut bools: Vec<bool> = Vec::with_capacity(40);

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -81,7 +81,7 @@ pub mod tests {
         logging::setup();
 
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
         let mut rand = StepRng::new(1, 1);
 
         assert_eq!(30, multiply_sync(&context, "1", 6, 5, &mut rand).await?);
@@ -115,7 +115,7 @@ pub mod tests {
         logging::setup();
 
         let world = make_world(QueryId);
-        let contexts = make_contexts(&world);
+        let contexts = make_contexts::<Fp31>(&world);
         let mut rand = StepRng::new(1, 1);
 
         let mut multiplications = Vec::new();

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -95,7 +95,7 @@ mod tests {
     #[tokio::test]
     pub async fn bit_permutations() {
         let world = make_world(QueryId);
-        let [ctx0, ctx1, ctx2] = make_contexts(&world);
+        let [ctx0, ctx1, ctx2] = make_contexts::<Fp31>(&world);
         let mut rand = StepRng::new(100, 1);
 
         // With this input, for stable sort we expect all 0's to line up before 1's. The expected sort order is same as expected_sort_output

--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -104,7 +104,7 @@ mod tests {
             let record_id = RecordId::from(1_u32);
 
             let world: TestWorld = make_world(QueryId);
-            let context = make_contexts(&world);
+            let context = make_contexts::<Fp31>(&world);
 
             let reshare0 = Reshare::new(share[0]);
             let reshare1 = Reshare::new(share[1]);

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -253,7 +253,7 @@ mod tests {
     #[tokio::test]
     async fn shuffle() {
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
 
         let batchsize = 25;
         let input: Vec<u8> = (0..batchsize).collect();
@@ -315,7 +315,7 @@ mod tests {
     #[tokio::test]
     async fn shuffle_unshuffle() {
         let world: TestWorld = make_world(QueryId);
-        let context = make_contexts(&world);
+        let context = make_contexts::<Fp31>(&world);
 
         let batchsize = 5;
         let input: Vec<u128> = (0..batchsize).collect();

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -30,7 +30,7 @@ pub async fn arithmetic<F: Field>(width: u32, depth: u8) {
 }
 
 async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
-    let top_ctx = make_contexts(world);
+    let top_ctx = make_contexts::<Fp31>(world);
     let mut a = share(Fp31::ONE, &mut thread_rng());
 
     for bit in 0..depth {

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -21,7 +21,7 @@ pub use world::{make as make_world, TestWorld};
 /// # Panics
 /// Panics if world has more or less than 3 gateways/participants
 #[must_use]
-pub fn make_contexts(test_world: &TestWorld) -> [ProtocolContext<'_, Fp31>; 3] {
+pub fn make_contexts<F: Field>(test_world: &TestWorld) -> [ProtocolContext<'_, F>; 3] {
     test_world
         .gateways
         .iter()


### PR DESCRIPTION
Per discussion in #180, `ProtocolContext` is generic over an `F`. To support protocols that take `BinaryField` (i.e. `Fp2`) as inputs, change `make_contexts` to also become generic over `F` instead of returning a concrete implementation.