### PR TITLE
Make multiply and malicious_multiply non-async functions on `ProtocolContext`

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -169,7 +169,6 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         let mut b = ctx
             .narrow(&Step::HelperBitTimesIsTriggerBit)
             .multiply(record_id)
-            .await
             .execute(successor.report.helper_bit, successor.report.is_trigger_bit)
             .await?;
 
@@ -178,7 +177,6 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
             b = ctx
                 .narrow(&Step::BTimesStopBit)
                 .multiply(RecordId::from(1_u32))
-                .await
                 .execute(b, current.stop_bit)
                 .await?;
         }
@@ -186,16 +184,13 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         let credit_future = ctx
             .narrow(&Step::BTimesSuccessorCredit)
             .multiply(record_id)
-            .await
             .execute(b, successor.credit);
 
         // for the same reason as calculating [b], we skip the multiplication in the first iteration
         let stop_bit_future = if first_iteration {
             futures::future::Either::Left(futures::future::ok(b))
         } else {
-            futures::future::Either::Right(
-                ctx.multiply(record_id).await.execute(b, successor.stop_bit),
-            )
+            futures::future::Either::Right(ctx.multiply(record_id).execute(b, successor.stop_bit))
         };
 
         try_join(credit_future, stop_bit_future).await

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -71,7 +71,6 @@ pub async fn check_zero<F: Field>(
     let rv_share = ctx
         .narrow(&Step::MultiplyWithR)
         .multiply(record_id)
-        .await
         .execute(r_sharing, v)
         .await?;
     let rv = reveal(ctx.narrow(&Step::RevealR), record_id, rv_share).await?;

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -102,19 +102,16 @@ impl<'a, F: Field> ProtocolContext<'a, F> {
         self.gateway.mesh(&self.step)
     }
 
-    /// Request multiplication for a given record. This function is intentionally made async
-    /// to allow backpressure if infrastructure layer cannot keep up with protocols demand.
-    /// In this case, function returns only when multiplication for this record can actually
-    /// be processed.
-    #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
-    pub async fn multiply(self, record_id: RecordId) -> SecureMul<'a, F> {
+    /// Request a multiplication for a given record.
+    #[must_use]
+    pub fn multiply(self, record_id: RecordId) -> SecureMul<'a, F> {
         SecureMul::new(self, record_id)
     }
 
     /// ## Panics
     /// If you failed to upgrade to malicious protocol context
-    #[allow(clippy::unused_async)] // eventually there will be await b/c of backpressure implementation
-    pub async fn malicious_multiply(self, record_id: RecordId) -> MaliciouslySecureMul<'a, F> {
+    #[must_use]
+    pub fn malicious_multiply(self, record_id: RecordId) -> MaliciouslySecureMul<'a, F> {
         let accumulator = self.accumulator.as_ref().unwrap().clone();
         MaliciouslySecureMul::new(self, record_id, accumulator)
     }

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -248,12 +248,10 @@ pub mod tests {
                 a_ctx
                     .narrow("input")
                     .multiply(RecordId::from(0_u32))
-                    .await
                     .execute(a_shares[i], r_share),
                 b_ctx
                     .narrow("input")
                     .multiply(RecordId::from(1_u32))
-                    .await
                     .execute(b_shares[i], r_share),
             )
             .await?;
@@ -275,7 +273,6 @@ pub mod tests {
             #[allow(clippy::similar_names)]
             let mult_result = a_ctx
                 .malicious_multiply(RecordId::from(0_u32))
-                .await
                 .execute(a_malicious, b_malicious)
                 .await?;
 
@@ -368,7 +365,6 @@ pub mod tests {
                             let rx = ctx
                                 .narrow("mult")
                                 .multiply(RecordId::from(i))
-                                .await
                                 .execute(*x, r_share)
                                 .await?;
 
@@ -398,7 +394,6 @@ pub mod tests {
                         .map(|(i, ((a_malicious, b_malicious), ctx))| async move {
                             ctx.narrow("Circuit_Step_2")
                                 .malicious_multiply(RecordId::from(i))
-                                .await
                                 .execute(*a_malicious, *b_malicious)
                                 .await
                         }),

--- a/src/protocol/securemul.rs
+++ b/src/protocol/securemul.rs
@@ -106,7 +106,6 @@ pub mod tests {
         async fn mul<F: Field>(v: (ProtocolContext<'_, F>, MulArgs<F>)) -> Replicated<F> {
             let (ctx, (a, b)) = v;
             ctx.multiply(RecordId::from(1_u32))
-                .await
                 .execute(a, b)
                 .await
                 .unwrap()
@@ -167,17 +166,14 @@ pub mod tests {
             context[0]
                 .narrow(narrowed_context_str)
                 .multiply(record_id)
-                .await
                 .execute(a[0], b[0]),
             context[1]
                 .narrow(narrowed_context_str)
                 .multiply(record_id)
-                .await
                 .execute(a[1], b[1]),
             context[2]
                 .narrow(narrowed_context_str)
                 .multiply(record_id)
-                .await
                 .execute(a[2], b[2]),
         )?;
 

--- a/src/protocol/sort/bit_permutations.rs
+++ b/src/protocol/sort/bit_permutations.rs
@@ -64,7 +64,7 @@ impl<'a, F: Field> BitPermutations<'a, F> {
             zip(repeat(ctx), mult_input)
                 .enumerate()
                 .map(|(i, (ctx, (x, sum)))| async move {
-                    ctx.multiply(RecordId::from(i)).await.execute(x, sum).await
+                    ctx.multiply(RecordId::from(i)).execute(x, sum).await
                 });
         let mut mult_output = try_join_all(async_multiply).await?;
 

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -39,7 +39,7 @@ async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicat
         a = async move {
             let mut coll = Vec::new();
             for (i, ctx) in bit_ctx.iter().enumerate() {
-                let mul = ctx.narrow(&"mult".to_string()).multiply(record_id).await;
+                let mul = ctx.narrow(&"mult".to_string()).multiply(record_id);
                 coll.push(mul.execute(a[i], b[i]));
             }
 


### PR DESCRIPTION
The original idea of using `async` was to provide backpressure to slow down protocols that are moving too fast. However, after doing some benchmarking, creating the multiplication struct is almost zero cost and protocol will be blocked after computing `right_d` anyway.

There is no reason to provide backpressure at the creation time - it carries no benefit compared to providing backpressure on `execute` call.