### PR TITLE
Add new action to check deps against advisory DB

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,0 +1,24 @@
+name: Check dependencies against Advisory DB
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  audit:
+    name: Security audit
+    env:
+      CARGO_TERM_COLOR: always
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-daily.yml
+++ b/.github/workflows/audit-daily.yml
@@ -1,0 +1,15 @@
+name: Daily security audit against advisory DB
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two new actions have been added. One runs the security audit (cargo-audit) if any of the cargo config files has changed. Another one runs periodically and scans Cargo.lock against advisory db. If a new CVE is posted there, new issue will be created in IPA repo (at least I hope it will, I haven't tested that part)


## Testing

Tested it locally to confirm that action runs if `Cargo.*` files changed: https://github.com/akoshelev/raw-ipa/actions/runs/3375031039