### PR TITLE
Creating a prime field with the largest 32-bit integer

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -27,6 +27,10 @@ impl Int for u8 {
     const BITS: u32 = u8::BITS;
 }
 
+impl Int for u32 {
+    const BITS: u32 = u32::BITS;
+}
+
 pub trait Field:
     Add<Output = Self>
     + AddAssign
@@ -48,6 +52,7 @@ pub trait Field:
     type Integer: Int;
 
     const PRIME: Self::Integer;
+    const PRIME_TO_INTMAX_DELTA: Self::Integer;
     /// Additive identity element
     const ZERO: Self;
     /// Multiplicative identity element

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -51,7 +51,6 @@ pub trait Field:
     type Integer: Int;
 
     const PRIME: Self::Integer;
-    const PRIME_TO_INTMAX_DELTA: Self::Integer;
     /// Additive identity element
     const ZERO: Self;
     /// Multiplicative identity element

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -15,7 +15,6 @@ pub trait Int:
     + Ord
     + Sub<Output = Self>
     + Into<u128>
-    + From<u8>
     + Shr<u32, Output = Self>
     + BitAnd<Self, Output = Self>
     + PartialEq
@@ -60,36 +59,6 @@ pub trait Field:
     /// Derived from the size of the backing field, this constant indicates how much
     /// space is required to store this field value
     const SIZE_IN_BYTES: u32 = Self::Integer::BITS / 8;
-
-    /// computes the multiplicative inverse of `self`. It is UB if `self` is 0.
-    #[must_use]
-    fn invert(&self) -> Self {
-        debug_assert!(
-            self != &Self::ZERO,
-            "Multiplicative inverse is not defined for 0"
-        );
-
-        self.pow(Self::PRIME - Self::ONE.into() - Self::ONE.into())
-    }
-
-    /// Computes modular exponentiation, self^exp (mod PRIME)
-    #[must_use]
-    fn pow(&self, exp: Self::Integer) -> Self {
-        let mut term = Self::ONE;
-        // compute: x^exp
-        // binary representation of exp: a_k*2^k + a_k-1*2^k-1 + ... + a_0*2^0
-        // x^exp = x^a_0 + (x^2)^a_1 + ... + (x^(2^k))^a_k
-        // * start at 0 and each time square the term.
-        // * term contributes to the result iff a_k bit is 1 (as (x^a)^0 == 1)
-        for i in (0..Self::Integer::BITS).rev() {
-            term *= term;
-            if (exp >> i) & Self::Integer::from(1) != Self::Integer::from(0) {
-                term *= *self;
-            }
-        }
-
-        term
-    }
 
     /// Blanket implementation to represent the instance of this trait as 16 byte integer.
     /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -7,13 +7,8 @@ macro_rules! field_impl {
             type Output = Self;
 
             fn add(self, rhs: Self) -> Self::Output {
-                let (result, did_overflow) = self.0.overflowing_add(rhs.0);
-                Self(
-                    (result
-                        + <Self as Field>::Integer::from(did_overflow)
-                            * Self::PRIME_TO_INTMAX_DELTA)
-                        % Self::PRIME,
-                )
+                let c = u64::from;
+                Self(((c(self.0) + c(rhs.0)) % c(Self::PRIME)) as <Self as Field>::Integer)
             }
         }
 
@@ -37,7 +32,7 @@ macro_rules! field_impl {
 
             fn sub(self, rhs: Self) -> Self::Output {
                 // TODO(mt) - constant time?
-                let c = u128::from;
+                let c = u64::from;
                 Self(
                     ((c(Self::PRIME) + c(self.0) - c(rhs.0)) % c(Self::PRIME))
                         as <Self as Field>::Integer,
@@ -57,7 +52,7 @@ macro_rules! field_impl {
 
             fn mul(self, rhs: Self) -> Self::Output {
                 // TODO(mt) - constant time?
-                let c = u128::from;
+                let c = u64::from;
                 #[allow(clippy::cast_possible_truncation)]
                 Self(((c(self.0) * c(rhs.0)) % c(Self::PRIME)) as <Self as Field>::Integer)
             }
@@ -99,7 +94,6 @@ field_impl! { Fp2 }
 impl Field for Fp2 {
     type Integer = u8;
     const PRIME: Self::Integer = 2;
-    const PRIME_TO_INTMAX_DELTA: Self::Integer = 254;
     const ZERO: Self = Fp2(0);
     const ONE: Self = Fp2(1);
 }
@@ -171,7 +165,6 @@ pub struct Fp31(<Self as Field>::Integer);
 impl Field for Fp31 {
     type Integer = u8;
     const PRIME: Self::Integer = 31;
-    const PRIME_TO_INTMAX_DELTA: Self::Integer = 225;
     const ZERO: Self = Fp31(0);
     const ONE: Self = Fp31(1);
 }
@@ -190,7 +183,6 @@ pub struct Fp32BitPrime(<Self as Field>::Integer);
 impl Field for Fp32BitPrime {
     type Integer = u32;
     const PRIME: Self::Integer = 4_294_967_291; // 2^32 - 5
-    const PRIME_TO_INTMAX_DELTA: Self::Integer = 5;
     const ZERO: Self = Fp32BitPrime(0);
     const ONE: Self = Fp32BitPrime(1);
 }

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -306,35 +306,18 @@ mod test {
 
     #[test]
     fn thirty_two_bit_additive_wrapping() {
-        // Two numbers that add up to EXACTLY u32::MAX will just barely not overflow
-        // the result is 4 larger than our prime, so the result should be 4
-        // this checks to ensure we have a `% PRIME` even in the case of no overflow
         let x = Fp32BitPrime::from(u32::MAX - 20);
         let y = Fp32BitPrime::from(20_u32);
         assert_eq!(x + y, Fp32BitPrime::from(4_u32));
 
-        // Two numbers that add up to one more than u32::MAX will overflow, wrapping around to 0_32
-        // the result is 5 larger than our prime, so the result should be 5
-        // this checks to ensure we do not panic when integer overflow happens,
-        // and that we add on the difference between the prime and the integer boundary to overflowing results.
         let x = Fp32BitPrime::from(u32::MAX - 20);
         let y = Fp32BitPrime::from(21_u32);
         assert_eq!(x + y, Fp32BitPrime::from(5_u32));
 
-        // Two numbers that add up to two more than u32::MAX will overflow, wrapping around to 1_32
-        // the result is 6 larger than our prime, so the result should be 6
-        // this checks to ensure we do not panic when integer overflow happens,
-        // and that we add on the difference between the prime and the integer boundary to overflowing results.
         let x = Fp32BitPrime::from(u32::MAX - 20);
         let y = Fp32BitPrime::from(22_u32);
         assert_eq!(x + y, Fp32BitPrime::from(6_u32));
 
-        // Add the two largest values in the field.
-        // This is overlow as much as we possibly can.
-        // The overflowing result will be 4_294_967_284_u32
-        // Once we add the difference between the prime and the integer boundary (5), it will be
-        // 4_294_967_289_u32, which is still two less than our prime.
-        // As such, we do NOT need a `% PRIME` operation in the overflowing case
         let x = Fp32BitPrime::from(4_294_967_290_u32); // PRIME - 1
         let y = Fp32BitPrime::from(4_294_967_290_u32); // PRIME - 1
         assert_eq!(x + y, Fp32BitPrime::from(4_294_967_289_u32));

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -1,5 +1,4 @@
 use super::{field::BinaryField, Field};
-use serde::{Deserialize, Serialize};
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 macro_rules! field_impl {
@@ -93,7 +92,6 @@ macro_rules! field_impl {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Fp2(<Self as Field>::Integer);
 
 field_impl! { Fp2 }
@@ -168,7 +166,6 @@ impl From<Fp2> for u8 {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Fp31(<Self as Field>::Integer);
 
 impl Field for Fp31 {
@@ -188,7 +185,6 @@ impl From<Fp31> for u8 {
 field_impl! { Fp31 }
 
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct Fp32BitPrime(<Self as Field>::Integer);
 
 impl Field for Fp32BitPrime {


### PR DESCRIPTION
In #186, @richajaindce wants to write a test for sorting N rows of data. Sadly, she cannot test sorting more than 30 rows of data, because 30 is the maximum value we can represent with our silly test field Fp31! 

So I created a much bigger field, using the prime number `2^32 - 5`, which is the largest prime number less than 2^32.