### PR TITLE
Small optimizations for reveal_permutation fn

### DIFF
--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::BoxError,
     ff::Field,
-    protocol::{context::ProtocolContext, reveal::reveal_a_permutation},
+    protocol::{context::ProtocolContext, reveal::reveal_permutation},
     secret_sharing::Replicated,
 };
 use embed_doc_image::embed_doc_image;
@@ -50,7 +50,7 @@ impl<'a, F: Field> Compose<'a, F> {
             .execute(ctx.narrow(&ShuffleSigma), &mut random_permutations)
             .await?;
 
-        let mut perms = reveal_a_permutation(ctx.narrow(&RevealPermutation), self.sigma).await?;
+        let mut perms = reveal_permutation(ctx.narrow(&RevealPermutation), self.sigma).await?;
 
         apply_inv(&mut perms, &mut self.rho);
 

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -3,7 +3,7 @@ use crate::{
     ff::Field,
     protocol::{
         context::ProtocolContext,
-        reveal::reveal_a_permutation,
+        reveal::reveal_permutation,
         sort::ApplyInvStep::{RevealPermutation, ShuffleInputs, ShufflePermutation},
     },
     secret_sharing::Replicated,
@@ -56,7 +56,7 @@ impl SecureApplyInv {
         )
         .await?;
         let mut permutation =
-            reveal_a_permutation(ctx.narrow(&RevealPermutation), sort_permutation).await?;
+            reveal_permutation(ctx.narrow(&RevealPermutation), sort_permutation).await?;
         // The paper expects us to apply an inverse on the inverted Permutation (i.e. apply_inv(permutation.inverse(), input))
         // Since this is same as apply(permutation, input), we are doing that instead to save on compute.
         apply(&mut permutation, input);


### PR DESCRIPTION
Stumbled across this code while looking for patterns how to use `narrow`, decided to send a quick fix

* we don't need to allocate a vector to hold the results of reveal. `try_join_all` returns a `Vec` so we can re-use it if it stores `usize` elements
* no need to take an exclusive reference to permutation for reveal operation
* naming suggestion