### PR TITLE
Add `InfraError` member to error type.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     #[error("failed to parse json: {0}")]
     #[cfg(feature = "enable-serde")]
     Serde(#[from] serde_json::Error),
+    #[error("Infrastructure error: {0}")]
+    InfraError(#[from] crate::helpers::Error),
 }
 
 impl Error {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,13 +1,13 @@
 use std::ops::{Index, IndexMut};
 
 mod buffers;
-pub mod error;
+mod error;
 pub mod fabric;
 pub mod messaging;
 
-use crate::error::Error;
 use crate::helpers::Direction::{Left, Right};
 use crate::helpers::Identity::{H1, H2, H3};
+pub use error::Error;
 pub use error::Result;
 
 /// Represents a unique identity of each helper running MPC computation.
@@ -53,14 +53,14 @@ impl Identity {
 }
 
 impl TryFrom<&str> for Identity {
-    type Error = Error;
+    type Error = crate::error::Error;
 
     fn try_from(id: &str) -> std::result::Result<Self, Self::Error> {
         match id {
             Identity::H1_STR => Ok(H1),
             Identity::H2_STR => Ok(H2),
             Identity::H3_STR => Ok(H3),
-            other => Err(Error::path_parse_error(other)),
+            other => Err(crate::error::Error::path_parse_error(other)),
         }
     }
 }

--- a/src/test_fixture/fabric.rs
+++ b/src/test_fixture/fabric.rs
@@ -6,9 +6,8 @@ use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 
 use crate::helpers;
-use crate::helpers::error::Error;
 use crate::helpers::fabric::{ChannelId, MessageChunks, MessageEnvelope, Network};
-use crate::helpers::{error, Identity};
+use crate::helpers::{Error, Identity};
 use crate::protocol::UniqueStepId;
 use async_trait::async_trait;
 use futures::Sink;
@@ -237,7 +236,7 @@ impl InMemorySink {
 }
 
 impl Sink<MessageChunks> for InMemorySink {
-    type Error = error::Error;
+    type Error = Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.project();


### PR DESCRIPTION
I noticed that we use boxed errors inside protocols in cases where we don't have to because infrastructure errors cannot be converted to `Error` object and therefore `?` operator cannot be used.

This change was inspired by #199 where reveal protocol could've just returned `Result<(), Error>` and test for correct error type inside unit tests.