### PR TITLE
Move from `BoxError` to `Error` in reveal

### DIFF
--- a/src/protocol/modulus_conversion/double_random.rs
+++ b/src/protocol/modulus_conversion/double_random.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::BoxError,
+    error::Error,
     ff::{BinaryField, Field},
     helpers::Identity,
     protocol::{
@@ -106,7 +106,7 @@ impl DoubleRandom {
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let result = multiply_two_shares_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - (result * F::from(2)))
@@ -132,7 +132,7 @@ impl DoubleRandom {
         record_id: RecordId,
         a: Replicated<F>,
         b: Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let result = multiply_one_share_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - (result * F::from(2)))
@@ -147,7 +147,7 @@ impl DoubleRandom {
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
         random_sharing: Replicated<B>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let (sh0, sh1, sh2) = Self::local_secret_share(random_sharing, ctx.role());
 
         let sh0_xor_sh1 =

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::BoxError,
+    error::Error,
     ff::Field,
     helpers::{Direction, Identity},
     protocol::{context::ProtocolContext, RecordId},
@@ -34,7 +34,7 @@ pub async fn multiply_two_shares_mostly_zeroes<F: Field>(
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,
-) -> Result<Replicated<F>, BoxError> {
+) -> Result<Replicated<F>, Error> {
     match ctx.role() {
         Identity::H1 => {
             let prss = &ctx.prss();
@@ -118,7 +118,7 @@ pub async fn multiply_one_share_mostly_zeroes<F: Field>(
     record_id: RecordId,
     a: Replicated<F>,
     b: Replicated<F>,
-) -> Result<Replicated<F>, BoxError> {
+) -> Result<Replicated<F>, Error> {
     let prss = &ctx.prss();
     let (s_left, s_right) = prss.generate_fields(record_id);
 


### PR DESCRIPTION
Some related protocols have changed their error type as well. It is possible because of #202. Using `Error` is more ergonomic when actual error type need to be tested (in unit tests)