### PR TITLE
Suppress similar_names and module_name_repetitions lints

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,6 @@ pub enum Error {
 
 impl Error {
     #[must_use]
-    #[allow(clippy::module_name_repetitions)] // follows convention of `Error::ParseError`
     pub fn path_parse_error(source: &str) -> Error {
         Error::ParseError(format!("unexpected value \"{source}\" in path").into())
     }
@@ -51,7 +50,6 @@ impl From<std::num::ParseIntError> for Error {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 pub type Res<T> = Result<T, Error>;

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -118,7 +118,6 @@ pub trait Field:
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 pub trait BinaryField:
     Field
     + BitAnd<Output = Self>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #![deny(clippy::clone_on_ref_ptr)]
+// The following warnings are too noisy for us and having them enabled leads to polluting the
+// code with allow annotations. Disabling them once per project here
+#![allow(clippy::similar_names)]
+#![allow(clippy::module_name_repetitions)]
 
 pub mod chunkscan;
 pub mod cli;

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -97,7 +97,6 @@ pub enum BindTarget {
 /// Contains all of the state needed to start the MPC server.
 /// For now, stub out gateway with simple send/receive
 /// TODO (ts): replace stub with real thing when [`Network`] is implemented
-#[allow(clippy::module_name_repetitions)] // standard naming convention
 pub struct MpcServer {
     tx: mpsc::Sender<MessageChunks>,
 }

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -2,7 +2,6 @@ use crate::secret_sharing::Replicated;
 
 mod accumulate_credit;
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Copy, Clone)]
 pub struct AttributionInputRow<F> {
     is_trigger_bit: Replicated<F>,

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -18,7 +18,6 @@ use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing};
 
 /// Context used by each helper to perform computation. Currently they need access to shared
 /// randomness generator (see `Participant`) and communication trait to send messages to each other.
-#[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug)]
 pub struct ProtocolContext<'a, S: SecretSharing<F>, F> {
     role: Identity,

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -273,7 +273,6 @@ pub mod tests {
                 b_malicious,
             );
 
-            #[allow(clippy::similar_names)]
             let mult_result = a_ctx
                 .multiply(RecordId::from(0_u32), a_malicious, b_malicious)
                 .await?;

--- a/src/protocol/mul/malicious.rs
+++ b/src/protocol/mul/malicious.rs
@@ -75,7 +75,6 @@ impl<'a, F: Field> SecureMul<'a, F> {
     /// back via the error response
     /// ## Panics
     /// Panics if the mutex is found to be poisoned
-    #[allow(clippy::similar_names)]
     pub async fn execute(
         self,
         a: MaliciousReplicated<F>,

--- a/src/protocol/mul/mod.rs
+++ b/src/protocol/mul/mod.rs
@@ -10,7 +10,6 @@ mod semi_honest;
 
 /// Trait to multiply secret shares. That requires communication and `multiply` function is async.
 #[async_trait]
-#[allow(clippy::module_name_repetitions)]
 pub trait SecureMul<F: Field> {
     type Share: SecretSharing<F>;
 
@@ -24,7 +23,6 @@ pub trait SecureMul<F: Field> {
 }
 
 /// looks like clippy disagrees with itself on whether this attribute is useless or not.
-#[allow(clippy::module_name_repetitions, clippy::useless_attribute)]
 pub use {malicious::SecureMul as MaliciouslySecureMul, semi_honest::SecureMul as SemiHonestMul};
 
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -107,7 +107,6 @@ impl IndexedSharedRandomness {
 /// An implementation of `RngCore` that uses the same underlying `Generator`.
 /// For use in place of `PrssSpace` where indexing cannot be used, such as
 /// in APIs that expect `Rng`.
-#[allow(clippy::module_name_repetitions)]
 pub struct SequentialSharedRandomness {
     generator: Generator,
     counter: u128,

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -45,7 +45,6 @@ pub async fn reveal<F: Field, G: Field>(
 }
 
 #[allow(dead_code)]
-#[allow(clippy::module_name_repetitions)]
 pub async fn reveal_malicious<F: Field, G: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     record_id: RecordId,
@@ -76,7 +75,6 @@ pub async fn reveal_malicious<F: Field, G: Field>(
 /// Given a vector containing secret shares of a permutation, this returns a revealed permutation.
 /// This executes `reveal` protocol on each row of the vector and then constructs a `Permutation` object
 /// from the revealed rows.
-#[allow(clippy::module_name_repetitions)]
 pub async fn reveal_permutation<F: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     permutation: &[Replicated<F>],

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -25,7 +25,6 @@ where
 /// is moved by `apply_inv` to be the σ(i)-th item. Therefore, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is
 /// reordered into (D, C, A, B).
 /// ![Apply inv steps][apply_inv]
-#[allow(clippy::module_name_repetitions)]
 pub fn apply_inv<T: Copy + Default, S>(permutation: &mut Permutation, values: &mut S)
 where
     S: AsMut<[T]>,

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -8,7 +8,6 @@ mod shuffle;
 
 use super::Step;
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum SortStep {
     BitPermutations,

--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -114,7 +114,7 @@ mod tests {
     use proptest::prelude::Rng;
 
     #[test]
-    #[allow(clippy::similar_names, clippy::many_single_char_names)]
+    #[allow(clippy::many_single_char_names)]
     fn test_local_operations() {
         let mut rng = rand::thread_rng();
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -10,7 +10,6 @@ use std::{fmt::Debug, sync::Arc};
 /// there is no need to associate each of them with `QueryId`, but this API makes it possible
 /// to do if we need it.
 #[derive(Debug)]
-#[allow(clippy::module_name_repetitions)]
 pub struct TestWorld {
     pub query_id: QueryId,
     pub gateways: [Gateway; 3],


### PR DESCRIPTION
Discussed this on Wire. We mostly ignore them anyway