### PR TITLE
Validate indices used in PRSS

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -215,9 +215,9 @@ impl TryFrom<&str> for QueryId {
 pub struct RecordId(u32);
 
 pub const RECORD_0: RecordId = RecordId(0);
-pub const RECORD_1: RecordId = RecordId(0);
-pub const RECORD_2: RecordId = RecordId(0);
-pub const RECORD_3: RecordId = RecordId(0);
+pub const RECORD_1: RecordId = RecordId(1);
+pub const RECORD_2: RecordId = RecordId(2);
+pub const RECORD_3: RecordId = RecordId(3);
 
 impl From<u32> for RecordId {
     fn from(v: u32) -> Self {

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -334,7 +334,6 @@ pub mod tests {
                 ),
             )?;
 
-            println!("A: {:#?}, B: {:#?}, A*B: {:#?}", a_shares, b, result_shares);
             let result = validate_and_reconstruct(result_shares);
 
             assert_eq!(result, a * b);

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -9,10 +9,12 @@ use hkdf::Hkdf;
 use rand::{CryptoRng, RngCore};
 use sha2::Sha256;
 use std::{
-    collections::{HashMap, HashSet},
-    fmt::{Debug, Formatter},
+    collections::HashMap,
+    fmt::Debug,
     sync::{Arc, Mutex},
 };
+#[cfg(debug_assertions)]
+use std::{collections::HashSet, fmt::Formatter};
 use x25519_dalek::{EphemeralSecret, PublicKey};
 
 use super::UniqueStepId;
@@ -27,6 +29,7 @@ struct UsedSet {
     used: Arc<Mutex<HashSet<usize>>>,
 }
 
+#[cfg(debug_assertions)]
 impl UsedSet {
     fn new(key: String) -> Self {
         Self {
@@ -55,6 +58,7 @@ impl UsedSet {
     }
 }
 
+#[cfg(debug_assertions)]
 impl Debug for UsedSet {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "IndicesSet(key={})", self.key)
@@ -81,9 +85,11 @@ impl IndexedSharedRandomness {
     #[must_use]
     pub fn generate_values<I: Into<u128>>(&self, index: I) -> (u128, u128) {
         let index = index.into();
-        if cfg!(debug_assertions) {
+        #[cfg(debug_assertions)]
+        {
             self.used.insert(index);
         }
+
         (self.left.generate(index), self.right.generate(index))
     }
 

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -655,6 +655,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic]
     fn indexed_rejects_the_same_index() {
         let (p1, _p2, _p3) = make_participants();

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -9,19 +9,65 @@ use hkdf::Hkdf;
 use rand::{CryptoRng, RngCore};
 use sha2::Sha256;
 use std::{
-    collections::HashMap,
-    fmt::Debug,
+    collections::{HashMap, HashSet},
+    fmt::{Debug, Formatter},
     sync::{Arc, Mutex},
 };
 use x25519_dalek::{EphemeralSecret, PublicKey};
 
 use super::UniqueStepId;
 
+/// Keeps track of all indices used to generate shared randomness inside `IndexedSharedRandomness`.
+/// Any two indices provided to `IndexesSharedRandomness::generate_values` must be unique.
+/// As PRSS instance is unique per step, this only constrains randomness generated within
+/// a given step.
+#[cfg(debug_assertions)]
+struct UsedSet {
+    key: String,
+    used: Arc<Mutex<HashSet<usize>>>,
+}
+
+impl UsedSet {
+    fn new(key: String) -> Self {
+        Self {
+            key,
+            used: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Adds a given index to the list of used indices.
+    ///
+    /// ## Panics
+    /// Panic if this index has been used before.
+    fn insert(&self, index: u128) {
+        if index > usize::MAX as u128 {
+            tracing::warn!(
+                "PRSS verification can validate values not exceeding {}, index {index} is greater.",
+                usize::MAX
+            );
+        } else {
+            assert!(
+                self.used.lock().unwrap().insert(index as usize),
+                "Generated randomness for index '{index}' twice using the same key '{}'",
+                self.key
+            );
+        }
+    }
+}
+
+impl Debug for UsedSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IndicesSet(key={})", self.key)
+    }
+}
+
 /// A participant in a 2-of-N replicated secret sharing.
 #[derive(Debug)] // TODO(mt) custom debug implementation
 pub struct IndexedSharedRandomness {
     left: Generator,
     right: Generator,
+    #[cfg(debug_assertions)]
+    used: UsedSet,
 }
 
 /// Pseudorandom Secret-Sharing has many applications to the 3-party, replicated secret sharing scheme
@@ -35,6 +81,9 @@ impl IndexedSharedRandomness {
     #[must_use]
     pub fn generate_values<I: Into<u128>>(&self, index: I) -> (u128, u128) {
         let index = index.into();
+        if cfg!(debug_assertions) {
+            self.used.insert(index);
+        }
         (self.left.generate(index), self.right.generate(index))
     }
 
@@ -215,6 +264,8 @@ impl EndpointInner {
                 EndpointItem::Indexed(Arc::new(IndexedSharedRandomness {
                     left: self.left.generator(k.as_bytes()),
                     right: self.right.generator(k.as_bytes()),
+                    #[cfg(debug_assertions)]
+                    used: UsedSet::new(key.to_owned()),
                 }))
             })
         };
@@ -340,6 +391,7 @@ impl Generator {
 pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{ff::Fp31, protocol::UniqueStepId, test_fixture::make_participants};
+    use rand::prelude::SliceRandom;
     use rand::{thread_rng, Rng};
     use std::mem::drop;
 
@@ -581,5 +633,28 @@ pub mod test {
         #[allow(clippy::let_underscore_drop)]
         let _ = p1.sequential(&step);
         drop(p1.indexed(&step));
+    }
+
+    #[test]
+    fn indexed_accepts_unique_index() {
+        let (_, p2, _p3) = make_participants();
+        let step = UniqueStepId::default().narrow("test");
+        let mut indices = (1..100_u128).collect::<Vec<_>>();
+        indices.shuffle(&mut thread_rng());
+        let indexed_prss = p2.indexed(&step);
+
+        for index in indices {
+            let _ = indexed_prss.random_u128(index);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn indexed_rejects_the_same_index() {
+        let (p1, _p2, _p3) = make_participants();
+        let step = UniqueStepId::default().narrow("test");
+
+        let _ = p1.indexed(&step).random_u128(100_u128);
+        let _ = p1.indexed(&step).random_u128(100_u128);
     }
 }


### PR DESCRIPTION
Similarly to validating steps while narrowing contexts, this change makes PRSS validate the indices passed on to it when generating randomness.

It should be a mistake to use the same index twice within the same PRSS instance. This change enables PRSS to panic and abort in such cases.

Interestingly it already helped to catch one bug inside the malicious implementation.

This should help with some issues presented in #135 as well. The cost we pay is another HashSet in memory. It can grow up to $O(N)$ where $N$ is the  size of the input. It may be acceptable for debug builds. There is also an optimization we could use to reduce the footprint https://docs.rs/tinyset/latest/tinyset/setu64/struct.SetU64.html 

