### PR TITLE
Restructuring code in shuffle/applyinv/compose to consume inputs

### DIFF
--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -96,7 +96,7 @@ pub enum BindTarget {
 
 /// Contains all of the state needed to start the MPC server.
 /// For now, stub out gateway with simple send/receive
-/// TODO (ts): replace stub with real thing when [`Network`] is implemented
+/// TODO (ts): replace stub with real thing when Network is implemented
 pub struct MpcServer {
     tx: mpsc::Sender<MessageChunks>,
 }

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -14,10 +14,11 @@ use permutation::Permutation;
 /// Permutation reorders (1, 2, . . . , m) into (σ(1), σ(2), . . . , σ(m)).
 /// For example, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is reordered into (C, D, B, A) by σ.
 /// ![Apply steps][apply]
-pub fn apply<T: Copy + Default, S>(permutation: &mut Permutation, values: &mut S)
+pub fn apply<T: Copy + Default, S>(permutation: Permutation, values: &mut S)
 where
     S: AsMut<[T]>,
 {
+    let mut permutation = permutation;
     permutation.apply_slice_in_place(values);
 }
 
@@ -25,10 +26,11 @@ where
 /// is moved by `apply_inv` to be the σ(i)-th item. Therefore, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is
 /// reordered into (D, C, A, B).
 /// ![Apply inv steps][apply_inv]
-pub fn apply_inv<T: Copy + Default, S>(permutation: &mut Permutation, values: &mut S)
+pub fn apply_inv<T: Copy + Default, S>(permutation: Permutation, values: &mut S)
 where
     S: AsMut<[T]>,
 {
+    let mut permutation = permutation;
     permutation.apply_inv_slice_in_place(values);
 }
 
@@ -41,15 +43,15 @@ mod tests {
     #[test]
     fn apply_shares() {
         let mut values = ["A", "B", "C", "D"];
-        let mut indices = Permutation::oneline([2, 3, 1, 0]).inverse();
+        let indices = Permutation::oneline([2, 3, 1, 0]).inverse();
         let expected_output_apply = ["C", "D", "B", "A"];
-        apply(&mut indices, &mut values);
+        apply(indices, &mut values);
         assert_eq!(values, expected_output_apply);
 
         let mut values = ["A", "B", "C", "D"];
-        let mut indices = Permutation::oneline([2, 3, 1, 0]).inverse();
+        let indices = Permutation::oneline([2, 3, 1, 0]).inverse();
         let expected_output_apply_inv = ["D", "C", "A", "B"];
-        apply_inv(&mut indices, &mut values);
+        apply_inv(indices, &mut values);
         assert_eq!(values, expected_output_apply_inv);
     }
 
@@ -58,7 +60,7 @@ mod tests {
         let sigma = vec![4, 2, 0, 5, 1, 3];
         let mut rho = vec![3, 4, 0, 5, 1, 2];
         // Applying sigma on rho
-        apply_inv(&mut Permutation::oneline(sigma), &mut rho);
+        apply_inv(Permutation::oneline(sigma), &mut rho);
         assert_eq!(rho, vec![1, 0, 3, 2, 4, 5]);
     }
 
@@ -74,10 +76,10 @@ mod tests {
         let mut values: Vec<_> = (0..batchsize).collect();
         let mut values_copy = values.clone();
 
-        apply(&mut Permutation::oneline(permutation.clone()), &mut values);
+        apply(Permutation::oneline(permutation.clone()), &mut values);
 
         apply_inv(
-            &mut Permutation::oneline(permutation).inverse(),
+            Permutation::oneline(permutation).inverse(),
             &mut values_copy,
         );
 

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -49,18 +49,18 @@ impl SecureApplyInv {
         let mut random_permutations =
             get_two_of_three_random_permutations(input.len(), &ctx.prss());
 
-        let (mut shuffled_input, sort_permutation) = try_join(
+        let (mut shuffled_input, shuffled_sort_permutation) = try_join(
             Shuffle::new(input)
                 .execute(ctx.narrow(&ShuffleInputs), &mut random_permutations.clone()),
             Shuffle::new(sort_permutation)
                 .execute(ctx.narrow(&ShufflePermutation), &mut random_permutations),
         )
         .await?;
-        let mut permutation =
-            reveal_permutation(ctx.narrow(&RevealPermutation), &sort_permutation).await?;
+        let mut revealed_permutation =
+            reveal_permutation(ctx.narrow(&RevealPermutation), &shuffled_sort_permutation).await?;
         // The paper expects us to apply an inverse on the inverted Permutation (i.e. apply_inv(permutation.inverse(), input))
         // Since this is same as apply(permutation, input), we are doing that instead to save on compute.
-        apply(&mut permutation, &mut shuffled_input);
+        apply(&mut revealed_permutation, &mut shuffled_input);
         Ok(shuffled_input)
     }
 }

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -1,5 +1,3 @@
-use std::mem::take;
-
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
 use permutation::Permutation;
@@ -168,11 +166,8 @@ impl<F: Field> Shuffle<F> {
         self.input = self
             .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step2, permutations)
             .await?;
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step3, permutations)
-            .await?;
-
-        Ok(take(&mut self.input))
+        self.shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step3, permutations)
+            .await
     }
 
     #[embed_doc_image("unshuffle", "images/sort/unshuffle.png")]
@@ -193,11 +188,8 @@ impl<F: Field> Shuffle<F> {
         self.input = self
             .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step2, permutations)
             .await?;
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step1, permutations)
-            .await?;
-
-        Ok(take(&mut self.input))
+        self.shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step1, permutations)
+            .await
     }
 }
 


### PR DESCRIPTION
Restructuring code in shuffle/applyinv/compose to consume data which is input to them and return the transformed output rather than doing an in-place change. This will help in better code readability.
It is a part of comment on #186 : https://github.com/private-attribution/ipa/pull/186#discussion_r1016252919 "What I really don't like about these 23 lines of code, is that it's not obvious which arguments are updated / modified by these Protocols. "