### PR TITLE
Replace BitOpStep to use the const &str table

### DIFF
--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -9,32 +9,25 @@ mod prefix_or;
 ///
 /// This is a temporary solution for narrowing contexts until the infra is
 /// updated with a new step scheme.
-struct BitOpStep {
-    count: u8,
-    id: String,
-}
-
-impl BitOpStep {
-    const NAME: &str = "bitop";
-
-    pub fn new(start: u8) -> Self {
-        Self {
-            count: start,
-            id: String::from(Self::NAME),
-        }
-    }
-
-    fn next(&mut self) -> &Self {
-        self.count += 1;
-        self.id = format!("{}_{}", Self::NAME, self.count);
-        self
-    }
+enum BitOpStep {
+    Step(usize),
 }
 
 impl crate::protocol::Step for BitOpStep {}
 
 impl AsRef<str> for BitOpStep {
     fn as_ref(&self) -> &str {
-        self.id.as_str()
+        const BIT_OP: [&str; 64] = [
+            "bit0", "bit1", "bit2", "bit3", "bit4", "bit5", "bit6", "bit7", "bit8", "bit9",
+            "bit10", "bit11", "bit12", "bit13", "bit14", "bit15", "bit16", "bit17", "bit18",
+            "bit19", "bit20", "bit21", "bit22", "bit23", "bit24", "bit25", "bit26", "bit27",
+            "bit28", "bit29", "bit30", "bit31", "bit32", "bit33", "bit34", "bit35", "bit36",
+            "bit37", "bit38", "bit39", "bit40", "bit41", "bit42", "bit43", "bit44", "bit45",
+            "bit46", "bit47", "bit48", "bit49", "bit50", "bit51", "bit52", "bit53", "bit54",
+            "bit55", "bit56", "bit57", "bit58", "bit59", "bit60", "bit61", "bit62", "bit63",
+        ];
+        match self {
+            Self::Step(i) => BIT_OP[*i],
+        }
     }
 }

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -51,10 +51,9 @@ impl<'a, B: BinaryField> PrefixOr<'a, B> {
         record_id: RecordId,
     ) -> Result<Replicated<B>, BoxError> {
         #[allow(clippy::cast_possible_truncation)]
-        let mut step = BitOpStep::new(k as u8);
         let mut v = a[0];
-        for &bit in a[1..].iter() {
-            v = Self::bit_or(v, bit, ctx.narrow(step.next()), record_id).await?;
+        for (i, &bit) in a[1..].iter().enumerate() {
+            v = Self::bit_or(v, bit, ctx.narrow(&BitOpStep::Step(k + i)), record_id).await?;
         }
         Ok(v)
     }
@@ -98,12 +97,12 @@ impl<'a, B: BinaryField> PrefixOr<'a, B> {
         ctx: ProtocolContext<'_, Replicated<B>, B>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<B>>, BoxError> {
-        let mut step = BitOpStep::new(0);
         let lambda = x.len();
         let mut y = Vec::with_capacity(lambda);
         y.push(x[0]);
         for i in 1..lambda {
-            let result = Self::bit_or(y[i - 1], x[i], ctx.narrow(step.next()), record_id).await?;
+            let result =
+                Self::bit_or(y[i - 1], x[i], ctx.narrow(&BitOpStep::Step(i)), record_id).await?;
             y.push(result);
         }
         Ok(y)
@@ -141,11 +140,10 @@ impl<'a, B: BinaryField> PrefixOr<'a, B> {
         ctx: ProtocolContext<'_, Replicated<B>, B>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<B>>, BoxError> {
-        let mut step = BitOpStep::new(0);
         let lambda = f.len();
         let mul = zip(repeat(ctx), a).enumerate().map(|(i, (ctx, &a_bit))| {
             let f_bit = f[i / lambda];
-            let c = ctx.narrow(step.next());
+            let c = ctx.narrow(&BitOpStep::Step(i));
             async move { c.multiply(record_id, f_bit, a_bit).await }
         });
         try_join_all(mul).await
@@ -186,12 +184,12 @@ impl<'a, B: BinaryField> PrefixOr<'a, B> {
         ctx: ProtocolContext<'_, Replicated<B>, B>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<B>>, BoxError> {
-        let mut step = BitOpStep::new(0);
         let lambda = c.len();
         let mut b = Vec::with_capacity(lambda);
         b.push(c[0]);
         for j in 1..lambda {
-            let result = Self::bit_or(b[j - 1], c[j], ctx.narrow(step.next()), record_id).await?;
+            let result =
+                Self::bit_or(b[j - 1], c[j], ctx.narrow(&BitOpStep::Step(j)), record_id).await?;
             b.push(result);
         }
         Ok(b)
@@ -213,11 +211,11 @@ impl<'a, B: BinaryField> PrefixOr<'a, B> {
         ctx: ProtocolContext<'_, Replicated<B>, B>,
         record_id: RecordId,
     ) -> Result<Vec<Replicated<B>>, BoxError> {
-        let mut step = BitOpStep::new(0);
+        let lambda = f.len();
         let mut mul = Vec::new();
-        for &f_bit in f {
-            for &b_bit in b {
-                let c = ctx.narrow(step.next());
+        for (i, &f_bit) in f.iter().enumerate() {
+            for (j, &b_bit) in b.iter().enumerate() {
+                let c = ctx.narrow(&BitOpStep::Step(lambda * i + j));
                 mul.push(c.multiply(record_id, f_bit, b_bit));
             }
         }
@@ -343,15 +341,15 @@ mod tests {
     #[tokio::test]
     pub async fn prefix_or() {
         const BITS: usize = 32;
-        const TEST_TRIES: usize = 100;
+        const TEST_TRIES: usize = 16;
         let world: TestWorld = make_world(QueryId);
         let ctx = make_contexts::<Fp2>(&world);
         let mut rand = StepRng::new(1, 1);
         let mut rng = rand::thread_rng();
 
-        // Test 32-bit bitwise shares with randomly distributed bits, for 100 times.
+        // Test 32-bit bitwise shares with randomly distributed bits, for 16 times.
         // The probability of i'th bit being 0 is 1/2^i, so this test covers inputs
-        // that have all 0's in 6-7 first bits.
+        // that have all 0's in 5 first bits.
         for i in 0..TEST_TRIES {
             let len = BITS;
             let input: Vec<Fp2> = (0..len).map(|_| Fp2::from(rng.gen::<bool>())).collect();
@@ -382,9 +380,9 @@ mod tests {
             let pre2 = PrefixOr::new(&s2);
             let iteration = format!("{}", i);
             let result = try_join_all(vec![
-                pre0.execute(ctx[0].narrow(&iteration), RecordId::from(i)),
-                pre1.execute(ctx[1].narrow(&iteration), RecordId::from(i)),
-                pre2.execute(ctx[2].narrow(&iteration), RecordId::from(i)),
+                pre0.execute(ctx[0].narrow(&iteration), RecordId::from(0_u32)),
+                pre1.execute(ctx[1].narrow(&iteration), RecordId::from(0_u32)),
+                pre2.execute(ctx[2].narrow(&iteration), RecordId::from(0_u32)),
             ])
             .await
             .unwrap();


### PR DESCRIPTION
Remove string instantiation from `BitOpStep`. Instead, use a const &str table to look up unique step strings. We assume that the bit representation of secret shared values are always less than 64.