### PR TITLE
Replacing permutations crate with home-rolled code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ hyper-tls = { version = "0.5.0", optional = true }
 metrics = "0.20.1"
 metrics-tracing-context = { version = "0.12.0", optional = true }
 metrics-util = { version = "0.14.0", optional = true }
-permutation = "0.4.1"
 pin-project = "1.0.12"
 rand = "0.8"
 rand_chacha = "0.3.1"

--- a/pre-commit
+++ b/pre-commit
@@ -46,6 +46,6 @@ error() {
 
 cargo build --benches --all-features || error "Benchmarks compilation errors"
 
-cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
+# cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
 
-cargo test || error "Test failures"
+# cargo test || error "Test failures"

--- a/pre-commit
+++ b/pre-commit
@@ -46,6 +46,6 @@ error() {
 
 cargo build --benches --all-features || error "Benchmarks compilation errors"
 
-# cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
+cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
 
-# cargo test || error "Test failures"
+cargo test || error "Test failures"

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use embed_doc_image::embed_doc_image;
 use futures::future::{try_join, try_join_all};
-use permutation::Permutation;
 
 /// This implements a reveal algorithm
 /// For simplicity, we consider a simple revealing in which each `P_i` sends `\[a\]_i` to `P_i+1` after which
@@ -78,7 +77,7 @@ pub async fn reveal_malicious<F: Field, G: Field>(
 pub async fn reveal_permutation<F: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     permutation: &[Replicated<F>],
-) -> Result<Permutation, BoxError> {
+) -> Result<Vec<usize>, BoxError> {
     let revealed_permutation = try_join_all(zip(repeat(ctx), permutation).enumerate().map(
         |(index, (ctx, input))| async move {
             let reveal_value = reveal(ctx, RecordId::from(index), *input).await;
@@ -90,7 +89,7 @@ pub async fn reveal_permutation<F: Field>(
     ))
     .await?;
 
-    Ok(Permutation::oneline(revealed_permutation))
+    Ok(revealed_permutation)
 }
 
 #[cfg(test)]

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -77,7 +77,7 @@ pub async fn reveal_malicious<F: Field, G: Field>(
 pub async fn reveal_permutation<F: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     permutation: &[Replicated<F>],
-) -> Result<Vec<usize>, BoxError> {
+) -> Result<Vec<u32>, BoxError> {
     let revealed_permutation = try_join_all(zip(repeat(ctx), permutation).enumerate().map(
         |(index, (ctx, input))| async move {
             let reveal_value = reveal(ctx, RecordId::from(index), *input).await;

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -21,7 +21,6 @@ pub fn apply<T>(permutation: &[u32], values: &mut [T]) {
                 pos_i = pos_j;
                 pos_j = permutation[pos_i] as usize;
             }
-            permuted.set(i, true);
         }
     }
 }
@@ -41,7 +40,6 @@ pub fn apply_inv<T>(permutation: &[u32], values: &mut [T]) {
                 permuted.set(destination, true);
                 destination = permutation[destination] as usize;
             }
-            permuted.set(i, true);
         }
     }
 }

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -14,7 +14,7 @@ pub fn apply<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
     let mut tmp: T = T::default();
 
     for i in 0..permutation.len() {
-        if permuted[i] == false {
+        if !permuted[i] {
             mem::swap(&mut tmp, &mut values[i]);
             let mut pos_i = i;
             let mut pos_j: usize = permutation[pos_i] as usize;
@@ -39,7 +39,7 @@ pub fn apply_inv<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
     let mut tmp: T;
 
     for i in 0..permutation.len() {
-        if permuted[i] == false {
+        if !permuted[i] {
             let mut destination: usize = permutation[i] as usize;
             tmp = values[i];
             while destination != i {

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -104,11 +104,11 @@ mod tests {
     }
 
     #[test]
-    fn permutations_a_million_long() {
-        const SUPER_LONG: usize = 16 * 16 * 16 * 16 * 16; // 1,048,576, a bit over a million
+    fn permutations_super_long() {
+        const SUPER_LONG: usize = 16 * 16 * 16 * 16; // 65,536
         let mut original_values = Vec::with_capacity(SUPER_LONG);
         for i in 0..SUPER_LONG {
-            original_values.push(format!("{:#07x}", i));
+            original_values.push(format!("{:#06x}", i));
         }
         let mut permutation: Vec<u32> = (0..SUPER_LONG)
             .map(|i| usize::try_into(i).unwrap())

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -1,6 +1,5 @@
 use bitvec::bitvec;
 use embed_doc_image::embed_doc_image;
-use std::mem;
 
 #[embed_doc_image("apply", "images/sort/apply.png")]
 #[embed_doc_image("apply_inv", "images/sort/apply_inv.png")]
@@ -8,23 +7,20 @@ use std::mem;
 /// Permutation reorders (1, 2, . . . , m) into (σ(1), σ(2), . . . , σ(m)).
 /// For example, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is reordered into (C, D, B, A) by σ.
 /// ![Apply steps][apply]
-pub fn apply<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
+pub fn apply<T>(permutation: &[u32], values: &mut [T]) {
     debug_assert!(permutation.len() == values.len());
     let mut permuted = bitvec![0; permutation.len()];
-    let mut tmp: T = T::default();
 
     for i in 0..permutation.len() {
         if !permuted[i] {
-            mem::swap(&mut tmp, &mut values[i]);
             let mut pos_i = i;
-            let mut pos_j: usize = permutation[pos_i] as usize;
+            let mut pos_j = permutation[pos_i] as usize;
             while pos_j != i {
-                values[pos_i] = values[pos_j];
+                values.swap(pos_i, pos_j);
+                permuted.set(pos_j, true);
                 pos_i = pos_j;
                 pos_j = permutation[pos_i] as usize;
-                permuted.set(pos_i, true);
             }
-            mem::swap(&mut values[pos_i], &mut tmp);
             permuted.set(i, true);
         }
     }
@@ -34,20 +30,17 @@ pub fn apply<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
 /// is moved by `apply_inv` to be the σ(i)-th item. Therefore, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is
 /// reordered into (D, C, A, B).
 /// ![Apply inv steps][apply_inv]
-pub fn apply_inv<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
+pub fn apply_inv<T>(permutation: &[u32], values: &mut [T]) {
     let mut permuted = bitvec![0; permutation.len()];
-    let mut tmp: T;
 
     for i in 0..permutation.len() {
         if !permuted[i] {
-            let mut destination: usize = permutation[i] as usize;
-            tmp = values[i];
+            let mut destination = permutation[i] as usize;
             while destination != i {
-                mem::swap(&mut tmp, &mut values[destination]);
+                values.swap(i, destination);
                 permuted.set(destination, true);
                 destination = permutation[destination] as usize;
             }
-            mem::swap(&mut values[i], &mut tmp);
             permuted.set(i, true);
         }
     }
@@ -56,6 +49,7 @@ pub fn apply_inv<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
 #[cfg(test)]
 mod tests {
     use super::{apply, apply_inv};
+    use rand::seq::SliceRandom;
 
     #[test]
     fn apply_just_one_cycle() {
@@ -109,6 +103,32 @@ mod tests {
         let expected_output_apply = ["B", "A", "C", "J", "K", "D", "E", "F", "G", "H", "I"];
         apply_inv(&permutation, &mut values);
         assert_eq!(values, expected_output_apply);
+    }
+
+    #[test]
+    fn permutations_a_million_long() {
+        const SUPER_LONG: usize = 16 * 16 * 16 * 16 * 16; // 1,048,576, a bit over a million
+        let mut original_values = Vec::with_capacity(SUPER_LONG);
+        for i in 0..SUPER_LONG {
+            original_values.push(format!("{:#07x}", i));
+        }
+        let mut permutation: Vec<u32> = (0..SUPER_LONG)
+            .map(|i| usize::try_into(i).unwrap())
+            .collect();
+        let mut rng = rand::thread_rng();
+        permutation.shuffle(&mut rng);
+
+        let mut after_apply = original_values.clone();
+        apply(&permutation, &mut after_apply);
+        for i in 0..SUPER_LONG {
+            assert_eq!(after_apply[i], original_values[permutation[i] as usize]);
+        }
+
+        let mut after_apply_inv = original_values.clone();
+        apply_inv(&permutation, &mut after_apply_inv);
+        for i in 0..SUPER_LONG {
+            assert_eq!(original_values[i], after_apply_inv[permutation[i] as usize]);
+        }
     }
 
     #[test]

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -1,5 +1,6 @@
+use bitvec::bitvec;
 use embed_doc_image::embed_doc_image;
-use permutation::Permutation;
+use std::mem;
 
 // TODO #OptimizeLater
 // For now, we are using Permutation crate to implement `apply_inv` and `apply` functions.
@@ -11,46 +12,112 @@ use permutation::Permutation;
 
 #[embed_doc_image("apply", "images/sort/apply.png")]
 #[embed_doc_image("apply_inv", "images/sort/apply_inv.png")]
+#[embed_doc_image("apply", "images/sort/apply.png")]
+#[embed_doc_image("apply_inv", "images/sort/apply_inv.png")]
+
 /// Permutation reorders (1, 2, . . . , m) into (σ(1), σ(2), . . . , σ(m)).
 /// For example, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is reordered into (C, D, B, A) by σ.
 /// ![Apply steps][apply]
-pub fn apply<T: Copy + Default, S>(mut permutation: Permutation, values: &mut S)
-where
-    S: AsMut<[T]>,
-{
-    permutation.apply_slice_in_place(values);
+pub fn apply<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
+    let mut permuted = bitvec![0; permutation.len()];
+    let mut tmp: T = T::default();
+
+    for i in 0..permutation.len() {
+        if permuted[i] == false {
+            mem::swap(&mut tmp, &mut values[i]);
+            let mut pos_i = i;
+            let mut pos_j = permutation[pos_i];
+            while pos_j != i {
+                values[pos_i] = values[pos_j];
+                pos_i = pos_j;
+                pos_j = permutation[pos_i];
+                permuted.set(pos_i, true);
+            }
+            mem::swap(&mut values[pos_i], &mut tmp);
+            permuted.set(i, true);
+        }
+    }
 }
 
 /// To compute `apply_inv` on values, permutation(i) can be regarded as the destination of i, i.e., the i-th item
 /// is moved by `apply_inv` to be the σ(i)-th item. Therefore, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is
 /// reordered into (D, C, A, B).
 /// ![Apply inv steps][apply_inv]
-pub fn apply_inv<T: Copy + Default, S>(mut permutation: Permutation, values: &mut S)
-where
-    S: AsMut<[T]>,
-{
-    permutation.apply_inv_slice_in_place(values);
+pub fn apply_inv<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
+    let mut permuted = bitvec![0; permutation.len()];
+    let mut tmp: T;
+
+    for i in 0..permutation.len() {
+        if permuted[i] == false {
+            let mut destination = permutation[i];
+            tmp = values[i];
+            while destination != i {
+                mem::swap(&mut tmp, &mut values[destination]);
+                permuted.set(destination, true);
+                destination = permutation[destination];
+            }
+            mem::swap(&mut values[i], &mut tmp);
+            permuted.set(i, true);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{apply, apply_inv};
-    use permutation::Permutation;
-    use rand::seq::SliceRandom;
 
     #[test]
-    fn apply_shares() {
+    fn apply_just_one_cycle() {
         let mut values = ["A", "B", "C", "D"];
-        let indices = Permutation::oneline([2, 3, 1, 0]).inverse();
+        let permutation = [2, 3, 1, 0];
         let expected_output_apply = ["C", "D", "B", "A"];
-        apply(indices, &mut values);
+        apply(&permutation, &mut values);
         assert_eq!(values, expected_output_apply);
+    }
 
+    #[test]
+    fn apply_just_two_cycles() {
+        let mut values = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"];
+        let permutation = [3, 4, 6, 7, 0, 9, 10, 1, 2, 8, 5];
+        let expected_output_apply = ["D", "E", "G", "H", "A", "J", "K", "B", "C", "I", "F"];
+        apply(&permutation, &mut values);
+        assert_eq!(values, expected_output_apply);
+    }
+
+    #[test]
+    fn apply_complex() {
+        let mut values = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"];
+        let permutation = [1, 0, 2, 5, 6, 7, 8, 9, 10, 3, 4];
+        let expected_output_apply = ["B", "A", "C", "F", "G", "H", "I", "J", "K", "D", "E"];
+        apply(&permutation, &mut values);
+        assert_eq!(values, expected_output_apply);
+    }
+
+    #[test]
+    fn apply_inv_just_one_cycle() {
         let mut values = ["A", "B", "C", "D"];
-        let indices = Permutation::oneline([2, 3, 1, 0]).inverse();
-        let expected_output_apply_inv = ["D", "C", "A", "B"];
-        apply_inv(indices, &mut values);
-        assert_eq!(values, expected_output_apply_inv);
+        let permutation = [2, 3, 1, 0];
+        let expected_output_apply = ["D", "C", "A", "B"];
+        apply_inv(&permutation, &mut values);
+        assert_eq!(values, expected_output_apply);
+    }
+
+    #[test]
+    fn apply_inv_just_two_cycles() {
+        let mut values = ["A", "B", "C", "D", "E"];
+        let permutation = [3, 4, 1, 0, 2];
+        let expected_output_apply = ["D", "C", "E", "A", "B"];
+        apply_inv(&permutation, &mut values);
+        assert_eq!(values, expected_output_apply);
+    }
+
+    #[test]
+    fn apply_inv_complex() {
+        let mut values = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"];
+        let permutation = [1, 0, 2, 5, 6, 7, 8, 9, 10, 3, 4];
+        let expected_output_apply = ["B", "A", "C", "J", "K", "D", "E", "F", "G", "H", "I"];
+        apply_inv(&permutation, &mut values);
+        assert_eq!(values, expected_output_apply);
     }
 
     #[test]
@@ -59,29 +126,7 @@ mod tests {
         let mut rho = vec![3, 4, 0, 5, 1, 2];
 
         // Applying sigma on rho
-        apply_inv(Permutation::oneline(sigma), &mut rho);
+        apply(&sigma, &mut rho);
         assert_eq!(rho, vec![1, 0, 3, 2, 4, 5]);
-    }
-
-    #[test]
-    pub fn apply_apply_inv_relation() {
-        // This test shows that apply(permutation, values) is same as apply_inv(permutation.inverse(), values)
-        let batchsize: usize = 100;
-        let mut rng = rand::thread_rng();
-
-        let mut permutation: Vec<usize> = (0..batchsize).collect();
-        permutation.shuffle(&mut rng);
-
-        let mut values: Vec<_> = (0..batchsize).collect();
-        let mut values_copy = values.clone();
-
-        apply(Permutation::oneline(permutation.clone()), &mut values);
-
-        apply_inv(
-            Permutation::oneline(permutation).inverse(),
-            &mut values_copy,
-        );
-
-        assert_eq!(values, values_copy);
     }
 }

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -2,23 +2,14 @@ use bitvec::bitvec;
 use embed_doc_image::embed_doc_image;
 use std::mem;
 
-// TODO #OptimizeLater
-// For now, we are using Permutation crate to implement `apply_inv` and `apply` functions.
-// However this uses usize which is either 32-bit or 64-bit depending on the architecture we are using.
-// In our case, if we are sorting less than 2^32 elements (over 4 billion) 32-bits is sufficient.
-// We probably never need a 64-bit number and is not optimal.
-// It would even be cool to use a u16 if you're sorting less than 65,000 items
-// In future, we should plan to change this code to use u32 or u16 based on number of items
-
-#[embed_doc_image("apply", "images/sort/apply.png")]
-#[embed_doc_image("apply_inv", "images/sort/apply_inv.png")]
 #[embed_doc_image("apply", "images/sort/apply.png")]
 #[embed_doc_image("apply_inv", "images/sort/apply_inv.png")]
 
 /// Permutation reorders (1, 2, . . . , m) into (σ(1), σ(2), . . . , σ(m)).
 /// For example, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is reordered into (C, D, B, A) by σ.
 /// ![Apply steps][apply]
-pub fn apply<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
+pub fn apply<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
+    debug_assert!(permutation.len() == values.len());
     let mut permuted = bitvec![0; permutation.len()];
     let mut tmp: T = T::default();
 
@@ -26,11 +17,11 @@ pub fn apply<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
         if permuted[i] == false {
             mem::swap(&mut tmp, &mut values[i]);
             let mut pos_i = i;
-            let mut pos_j = permutation[pos_i];
+            let mut pos_j: usize = permutation[pos_i] as usize;
             while pos_j != i {
                 values[pos_i] = values[pos_j];
                 pos_i = pos_j;
-                pos_j = permutation[pos_i];
+                pos_j = permutation[pos_i] as usize;
                 permuted.set(pos_i, true);
             }
             mem::swap(&mut values[pos_i], &mut tmp);
@@ -43,18 +34,18 @@ pub fn apply<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
 /// is moved by `apply_inv` to be the σ(i)-th item. Therefore, if σ(1) = 2, σ(2) = 3, σ(3) = 1, and σ(4) = 0, an input (A, B, C, D) is
 /// reordered into (D, C, A, B).
 /// ![Apply inv steps][apply_inv]
-pub fn apply_inv<T: Copy + Default>(permutation: &[usize], values: &mut [T]) {
+pub fn apply_inv<T: Copy + Default>(permutation: &[u32], values: &mut [T]) {
     let mut permuted = bitvec![0; permutation.len()];
     let mut tmp: T;
 
     for i in 0..permutation.len() {
         if permuted[i] == false {
-            let mut destination = permutation[i];
+            let mut destination: usize = permutation[i] as usize;
             tmp = values[i];
             while destination != i {
                 mem::swap(&mut tmp, &mut values[destination]);
                 permuted.set(destination, true);
-                destination = permutation[destination];
+                destination = permutation[destination] as usize;
             }
             mem::swap(&mut values[i], &mut tmp);
             permuted.set(i, true);

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -93,11 +93,11 @@ mod tests {
             let mut sigma: Vec<u32> = (0..BATCHSIZE).collect();
             sigma.shuffle(&mut rng_sigma);
 
-            let sigma_u128: Vec<u128> = sigma.iter().map(|x| *x as u128).collect();
+            let sigma_u128: Vec<u128> = sigma.iter().map(|x| u128::from(*x)).collect();
 
             let mut rho: Vec<u32> = (0..BATCHSIZE).collect();
             rho.shuffle(&mut rng_rho);
-            let rho_u128: Vec<u128> = rho.iter().map(|x| *x as u128).collect();
+            let rho_u128: Vec<u128> = rho.iter().map(|x| u128::from(*x)).collect();
 
             let mut rho_composed = rho_u128.clone();
             apply(&sigma, &mut rho_composed);

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -39,13 +39,12 @@ impl Compose {
         sigma: Vec<Replicated<F>>,
         mut rho: Vec<Replicated<F>>,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
-        let (left_random_permutation, right_random_permutation) =
-            get_two_of_three_random_permutations(rho.len(), &ctx.prss());
+        let prss = &ctx.prss();
+        let random_permutations = get_two_of_three_random_permutations(rho.len(), prss);
 
         let shuffled_sigma = shuffle_shares(
             sigma,
-            &left_random_permutation,
-            &right_random_permutation,
+            (&random_permutations.0, &random_permutations.1),
             ctx.narrow(&ShuffleSigma),
         )
         .await?;
@@ -56,8 +55,7 @@ impl Compose {
 
         let unshuffled_rho = unshuffle_shares(
             rho,
-            &left_random_permutation,
-            &right_random_permutation,
+            (&random_permutations.0, &random_permutations.1),
             ctx.narrow(&UnshuffleRho),
         )
         .await?;

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -85,17 +85,17 @@ mod tests {
 
     #[tokio::test]
     pub async fn compose() -> Result<(), BoxError> {
-        const BATCHSIZE: usize = 25;
+        const BATCHSIZE: u32 = 25;
         for _ in 0..10 {
             let mut rng_sigma = rand::thread_rng();
             let mut rng_rho = rand::thread_rng();
 
-            let mut sigma: Vec<usize> = (0..BATCHSIZE).collect();
+            let mut sigma: Vec<u32> = (0..BATCHSIZE).collect();
             sigma.shuffle(&mut rng_sigma);
 
             let sigma_u128: Vec<u128> = sigma.iter().map(|x| *x as u128).collect();
 
-            let mut rho: Vec<usize> = (0..BATCHSIZE).collect();
+            let mut rho: Vec<u32> = (0..BATCHSIZE).collect();
             rho.shuffle(&mut rng_rho);
             let rho_u128: Vec<u128> = rho.iter().map(|x| *x as u128).collect();
 
@@ -113,9 +113,9 @@ mod tests {
 
             rho_shares = try_join!(h0_future, h1_future, h2_future)?;
 
-            assert_eq!(rho_shares.0.len(), BATCHSIZE);
-            assert_eq!(rho_shares.1.len(), BATCHSIZE);
-            assert_eq!(rho_shares.2.len(), BATCHSIZE);
+            assert_eq!(rho_shares.0.len(), BATCHSIZE as usize);
+            assert_eq!(rho_shares.1.len(), BATCHSIZE as usize);
+            assert_eq!(rho_shares.2.len(), BATCHSIZE as usize);
 
             // We should get the same result of applying inverse of sigma on rho as in clear
             validate_list_of_shares(&rho_composed, &rho_shares);

--- a/src/protocol/sort/generate_sort_permutation.rs
+++ b/src/protocol/sort/generate_sort_permutation.rs
@@ -148,15 +148,15 @@ mod tests {
         assert_eq!(result[2].len(), input_len);
 
         let mut mpc_sorted_list: Vec<u128> = (0..input_len).map(|i| i as u128).collect();
-        for i in 0..input_len {
+        for (i, match_key) in match_keys.iter().enumerate() {
             let index = validate_and_reconstruct((result[0][i], result[1][i], result[2][i]));
-            mpc_sorted_list[index.as_u128() as usize] = match_keys[i] as u128;
+            mpc_sorted_list[index.as_u128() as usize] = u128::from(*match_key);
         }
 
         let mut sorted_match_keys = match_keys.clone();
-        sorted_match_keys.sort();
+        sorted_match_keys.sort_unstable();
         for i in 0..input_len {
-            assert_eq!(sorted_match_keys[i] as u128, mpc_sorted_list[i]);
+            assert_eq!(u128::from(sorted_match_keys[i]), mpc_sorted_list[i]);
         }
 
         Ok(())

--- a/src/protocol/sort/generate_sort_permutation.rs
+++ b/src/protocol/sort/generate_sort_permutation.rs
@@ -63,7 +63,7 @@ impl<'a> GenerateSortPermutation<'a> {
         let mut composed_less_significant_bits_permutation = bit_0_permutation;
         for bit_num in 1..self.num_bits {
             let ctx_bit = ctx.narrow(&Sort(bit_num));
-            let bit_i = convert_shares_for_a_bit(
+            let mut bit_i = convert_shares_for_a_bit(
                 ctx_bit.narrow(&ModulusConversion),
                 self.input,
                 self.num_bits,
@@ -72,19 +72,19 @@ impl<'a> GenerateSortPermutation<'a> {
             .await?;
             let bit_i_sorted_by_less_significant_bits = SecureApplyInv::execute(
                 ctx_bit.narrow(&ApplyInv),
-                bit_i,
-                composed_less_significant_bits_permutation.clone(),
+                &mut bit_i,
+                &mut composed_less_significant_bits_permutation.clone(),
             )
             .await?;
 
-            let bit_i_permutation = BitPermutation::new(&bit_i_sorted_by_less_significant_bits)
+            let mut bit_i_permutation = BitPermutation::new(&bit_i_sorted_by_less_significant_bits)
                 .execute(ctx_bit.narrow(&BitPermutationStep))
                 .await?;
 
             let composed_i_permutation = Compose::execute(
                 ctx_bit.narrow(&ComposeStep),
-                composed_less_significant_bits_permutation,
-                bit_i_permutation,
+                &mut composed_less_significant_bits_permutation,
+                &mut bit_i_permutation,
             )
             .await?;
             composed_less_significant_bits_permutation = composed_i_permutation;
@@ -100,9 +100,9 @@ mod tests {
 
     use crate::{
         error::BoxError,
-        ff::Fp32BitPrime,
+        ff::{Field, Fp32BitPrime},
         protocol::{sort::generate_sort_permutation::GenerateSortPermutation, QueryId},
-        test_fixture::{logging, make_contexts, make_world, validate_list_of_shares},
+        test_fixture::{logging, make_contexts, make_world, validate_and_reconstruct},
     };
 
     #[tokio::test]
@@ -120,18 +120,13 @@ mod tests {
             match_keys.push(rng.gen::<u64>());
         }
 
-        let mut expected_sort_output: Vec<u128> = (0..batchsize).collect();
-
-        let mut permutation = permutation::sort(match_keys.clone());
-        permutation.apply_inv_slice_in_place(&mut expected_sort_output);
-
         let input_len = match_keys.len();
         let mut shares = [
             Vec::with_capacity(input_len),
             Vec::with_capacity(input_len),
             Vec::with_capacity(input_len),
         ];
-        for match_key in match_keys {
+        for match_key in match_keys.clone() {
             let share_0 = rng.gen::<u64>();
             let share_1 = rng.gen::<u64>();
             let share_2 = match_key ^ share_0 ^ share_1;
@@ -141,7 +136,7 @@ mod tests {
             shares[2].push((share_2, share_0));
         }
 
-        let mut result = try_join_all(vec![
+        let result = try_join_all(vec![
             GenerateSortPermutation::new(&shares[0], num_bits).execute(ctx0),
             GenerateSortPermutation::new(&shares[1], num_bits).execute(ctx1),
             GenerateSortPermutation::new(&shares[2], num_bits).execute(ctx2),
@@ -152,10 +147,18 @@ mod tests {
         assert_eq!(result[1].len(), input_len);
         assert_eq!(result[2].len(), input_len);
 
-        validate_list_of_shares(
-            &expected_sort_output,
-            &(result.remove(0), result.remove(0), result.remove(0)),
-        );
+        let mut mpc_sorted_list: Vec<u128> = (0..input_len).map(|i| i as u128).collect();
+        for i in 0..input_len {
+            let index = validate_and_reconstruct((result[0][i], result[1][i], result[2][i]));
+            mpc_sorted_list[index.as_u128() as usize] = match_keys[i] as u128;
+        }
+
+        let mut sorted_match_keys = match_keys.clone();
+        sorted_match_keys.sort();
+        for i in 0..input_len {
+            assert_eq!(sorted_match_keys[i] as u128, mpc_sorted_list[i]);
+        }
+
         Ok(())
     }
 }

--- a/src/protocol/sort/generate_sort_permutation.rs
+++ b/src/protocol/sort/generate_sort_permutation.rs
@@ -63,7 +63,7 @@ impl<'a> GenerateSortPermutation<'a> {
         let mut composed_less_significant_bits_permutation = bit_0_permutation;
         for bit_num in 1..self.num_bits {
             let ctx_bit = ctx.narrow(&Sort(bit_num));
-            let mut bit_i = convert_shares_for_a_bit(
+            let bit_i = convert_shares_for_a_bit(
                 ctx_bit.narrow(&ModulusConversion),
                 self.input,
                 self.num_bits,
@@ -72,19 +72,19 @@ impl<'a> GenerateSortPermutation<'a> {
             .await?;
             let bit_i_sorted_by_less_significant_bits = SecureApplyInv::execute(
                 ctx_bit.narrow(&ApplyInv),
-                &mut bit_i,
-                &mut composed_less_significant_bits_permutation.clone(),
+                bit_i,
+                composed_less_significant_bits_permutation.clone(),
             )
             .await?;
 
-            let mut bit_i_permutation = BitPermutation::new(&bit_i_sorted_by_less_significant_bits)
+            let bit_i_permutation = BitPermutation::new(&bit_i_sorted_by_less_significant_bits)
                 .execute(ctx_bit.narrow(&BitPermutationStep))
                 .await?;
 
             let composed_i_permutation = Compose::execute(
                 ctx_bit.narrow(&ComposeStep),
-                &mut composed_less_significant_bits_permutation,
-                &mut bit_i_permutation,
+                composed_less_significant_bits_permutation,
+                bit_i_permutation,
             )
             .await?;
             composed_less_significant_bits_permutation = composed_i_permutation;

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -103,7 +103,7 @@ mod tests {
             // Applying permutation on the input in clear to get the expected result
             apply_inv(&permutation, &mut expected_result);
 
-            let permutation: Vec<u128> = permutation.iter().map(|x| *x as u128).collect();
+            let permutation: Vec<u128> = permutation.iter().map(|x| u128::from(*x)).collect();
 
             let mut perm_shares = generate_shares::<Fp31>(permutation);
             let mut input_shares = generate_shares::<Fp31>(input);

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -45,20 +45,18 @@ impl SecureApplyInv {
         input: Vec<Replicated<F>>,
         sort_permutation: Vec<Replicated<F>>,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
-        let (left_random_permutation, right_random_permutation) =
-            get_two_of_three_random_permutations(input.len(), &ctx.prss());
+        let prss = &ctx.prss();
+        let random_permutations = get_two_of_three_random_permutations(input.len(), prss);
 
         let (mut shuffled_input, shuffled_sort_permutation) = try_join(
             shuffle_shares(
                 input,
-                &left_random_permutation,
-                &right_random_permutation,
+                (&random_permutations.0, &random_permutations.1),
                 ctx.narrow(&ShuffleInputs),
             ),
             shuffle_shares(
                 sort_permutation,
-                &left_random_permutation,
-                &right_random_permutation,
+                (&random_permutations.0, &random_permutations.1),
                 ctx.narrow(&ShufflePermutation),
             ),
         )

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -42,8 +42,8 @@ impl SecureApplyInv {
     /// 5. All helpers call `apply` to apply the permutation locally.
     pub async fn execute<F: Field>(
         ctx: ProtocolContext<'_, Replicated<F>, F>,
-        input: &mut [Replicated<F>],
-        sort_permutation: &mut [Replicated<F>],
+        input: Vec<Replicated<F>>,
+        sort_permutation: Vec<Replicated<F>>,
     ) -> Result<Vec<Replicated<F>>, BoxError> {
         let (left_random_permutation, right_random_permutation) =
             get_two_of_three_random_permutations(input.len(), &ctx.prss());
@@ -105,15 +105,15 @@ mod tests {
 
             let permutation: Vec<u128> = permutation.iter().map(|x| u128::from(*x)).collect();
 
-            let mut perm_shares = generate_shares::<Fp31>(permutation);
+            let perm_shares = generate_shares::<Fp31>(permutation);
             let mut input_shares = generate_shares::<Fp31>(input);
 
             let world = make_world(QueryId);
             let [ctx0, ctx1, ctx2] = make_contexts(&world);
 
-            let h0_future = SecureApplyInv::execute(ctx0, &mut input_shares.0, &mut perm_shares.0);
-            let h1_future = SecureApplyInv::execute(ctx1, &mut input_shares.1, &mut perm_shares.1);
-            let h2_future = SecureApplyInv::execute(ctx2, &mut input_shares.2, &mut perm_shares.2);
+            let h0_future = SecureApplyInv::execute(ctx0, input_shares.0, perm_shares.0);
+            let h1_future = SecureApplyInv::execute(ctx1, input_shares.1, perm_shares.1);
+            let h2_future = SecureApplyInv::execute(ctx2, input_shares.2, perm_shares.2);
 
             input_shares = try_join!(h0_future, h1_future, h2_future).unwrap();
 

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -65,8 +65,7 @@ impl SecureApplyInv {
         .await?;
         let revealed_permutation =
             reveal_permutation(ctx.narrow(&RevealPermutation), &shuffled_sort_permutation).await?;
-        // The paper expects us to apply an inverse on the inverted Permutation (i.e. apply_inv(permutation.inverse(), input))
-        // Since this is same as apply(permutation, input), we are doing that instead to save on compute.
+
         apply_inv(&revealed_permutation, &mut shuffled_input);
         Ok(shuffled_input)
     }
@@ -88,20 +87,18 @@ mod tests {
 
     #[tokio::test]
     pub async fn secureapplyinv() {
-        const BATCHSIZE: usize = 25;
+        const BATCHSIZE: u32 = 25;
         for _ in 0..10 {
             let mut rng = rand::thread_rng();
-            let mut input: Vec<u128> = Vec::with_capacity(BATCHSIZE);
+            let mut input: Vec<u128> = Vec::with_capacity(BATCHSIZE as usize);
             for _ in 0..BATCHSIZE {
                 input.push(rng.gen::<u128>() % 31_u128);
             }
 
-            let mut permutation: Vec<usize> = (0..BATCHSIZE).collect();
+            let mut permutation: Vec<u32> = (0..BATCHSIZE).collect();
             permutation.shuffle(&mut rng);
 
             let mut expected_result = input.clone();
-            // The actual paper expects us to apply an inverse on the inverted Permutation (i.e. apply_inv(perm.inverse(), input))
-            // Since this is same as apply(perm, input), we are doing that instead both in the code and in the test.
 
             // Applying permutation on the input in clear to get the expected result
             apply_inv(&permutation, &mut expected_result);
@@ -120,9 +117,9 @@ mod tests {
 
             input_shares = try_join!(h0_future, h1_future, h2_future).unwrap();
 
-            assert_eq!(input_shares.0.len(), BATCHSIZE);
-            assert_eq!(input_shares.1.len(), BATCHSIZE);
-            assert_eq!(input_shares.2.len(), BATCHSIZE);
+            assert_eq!(input_shares.0.len(), BATCHSIZE as usize);
+            assert_eq!(input_shares.1.len(), BATCHSIZE as usize);
+            assert_eq!(input_shares.2.len(), BATCHSIZE as usize);
 
             // We should get the same result of applying inverse as what we get when applying in clear
             validate_list_of_shares(&expected_result, &input_shares);

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -1,6 +1,5 @@
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
-use permutation::Permutation;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -18,12 +17,6 @@ use super::{
     reshare::Reshare,
     ShuffleStep::{self, Step1, Step2, Step3},
 };
-
-pub struct Shuffle<F> {
-    input: Vec<Replicated<F>>,
-    permutation_left: Permutation,
-    permutation_right: Permutation,
-}
 
 #[derive(Debug)]
 enum ShuffleOrUnshuffle {
@@ -46,7 +39,7 @@ impl AsRef<str> for ShuffleOrUnshuffle {
 pub fn get_two_of_three_random_permutations(
     batchsize: usize,
     prss: &IndexedSharedRandomness,
-) -> (Permutation, Permutation) {
+) -> (Vec<usize>, Vec<usize>) {
     // Chacha8Rng expects a [u8;32] seed whereas prss returns a u128 number.
     // We are using two seeds from prss to generate a seed for shuffle and concatenating them
     // Since reshare uses indexes 0..batchsize to generate random numbers from prss, we are using
@@ -74,127 +67,147 @@ pub fn get_two_of_three_random_permutations(
         .1
         .shuffle(&mut ChaCha8Rng::from_seed(seed_right.try_into().unwrap()));
 
-    (
-        Permutation::oneline(permutations.0),
-        Permutation::oneline(permutations.1),
-    )
+    permutations
 }
 
 /// This is SHUFFLE(Algorithm 1) described in <https://eprint.iacr.org/2019/695.pdf>.
 /// This protocol shuffles the given inputs across 3 helpers making them indistinguishable to the helpers
-impl<F: Field> Shuffle<F> {
-    pub fn new(input: Vec<Replicated<F>>, permutations: (Permutation, Permutation)) -> Self {
-        Self {
-            input,
-            permutation_left: permutations.0,
-            permutation_right: permutations.1,
-        }
+
+// We call shuffle with helpers involved as (H2, H3), (H3, H1) and (H1, H2). In other words, the shuffle is being called for
+// H1, H2 and H3 respectively (since they do not participate in the step) and hence are the recipients of the shuffle.
+fn shuffle_for_helper(which_step: ShuffleStep) -> Role {
+    match which_step {
+        Step1 => Role::H1,
+        Step2 => Role::H2,
+        Step3 => Role::H3,
     }
+}
 
-    // We call shuffle with helpers involved as (H2, H3), (H3, H1) and (H1, H2). In other words, the shuffle is being called for
-    // H1, H2 and H3 respectively (since they do not participate in the step) and hence are the recipients of the shuffle.
-    fn shuffle_for_helper(which_step: ShuffleStep) -> Role {
-        match which_step {
-            Step1 => Role::H1,
-            Step2 => Role::H2,
-            Step3 => Role::H3,
-        }
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    async fn reshare_all_shares(
-        &self,
-        ctx: &ProtocolContext<'_, Replicated<F>, F>,
-        to_helper: Role,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
-        let reshares = self
-            .input
-            .iter()
-            .enumerate()
-            .map(|(index, input)| async move {
-                Reshare::new(*input)
-                    .execute(ctx, RecordId::from(index), to_helper)
-                    .await
-            });
-        try_join_all(reshares).await
-    }
-
-    /// `shuffle_or_unshuffle_once` is called for the helpers
-    /// i)   2 helpers receive permutation pair and choose the permutation to be applied
-    /// ii)  2 helpers apply the permutation to their shares
-    /// iii) reshare to `to_helper`
-    #[allow(clippy::cast_possible_truncation)]
-    async fn shuffle_or_unshuffle_once(
-        &mut self,
-        shuffle_or_unshuffle: ShuffleOrUnshuffle,
-        ctx: &ProtocolContext<'_, Replicated<F>, F>,
-        which_step: ShuffleStep,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
-        let to_helper = Self::shuffle_for_helper(which_step);
-        let ctx = ctx.narrow(&which_step);
-        let mut permutation_to_apply = Permutation::oneline(vec![]);
-        if to_helper != ctx.role() {
-            if to_helper.peer(Direction::Left) == ctx.role() {
-                std::mem::swap(&mut permutation_to_apply, &mut self.permutation_left);
-            } else {
-                std::mem::swap(&mut permutation_to_apply, &mut self.permutation_right);
-            };
-            // at this point, permutation_to_apply should have a legit permutation
-            assert_ne!(permutation_to_apply.len(), 0);
-
-            match shuffle_or_unshuffle {
-                ShuffleOrUnshuffle::Shuffle => apply_inv(permutation_to_apply, &mut self.input),
-                ShuffleOrUnshuffle::Unshuffle => apply(permutation_to_apply, &mut self.input),
-            }
-        }
-        self.reshare_all_shares(&ctx, to_helper).await
-    }
-
-    #[embed_doc_image("shuffle", "images/sort/shuffle.png")]
-    /// Shuffle calls `shuffle_or_unshuffle_once` three times with 2 helpers shuffling the shares each time.
-    /// Order of calling `shuffle_or_unshuffle_once` is shuffle with (H2, H3), (H3, H1) and (H1, H2).
-    /// Each shuffle requires communication between helpers to perform reshare.
-    /// Infrastructure has a pre-requisite to distinguish each communication step uniquely.
-    /// For this, we have three shuffle steps one per `shuffle_or_unshuffle_once` i.e. Step1, Step2 and Step3.
-    /// The Shuffle object receives a step function and appends a `ShuffleStep` to form a concrete step
-    /// ![Shuffle steps][shuffle]
-    pub async fn execute(
-        &mut self,
-        ctx: ProtocolContext<'_, Replicated<F>, F>,
-    ) -> Result<Vec<Replicated<F>>, BoxError>
-    where
-        F: Field,
-    {
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step1)
-            .await?;
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step2)
-            .await?;
-        self.shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Shuffle, &ctx, Step3)
+#[allow(clippy::cast_possible_truncation)]
+async fn reshare_all_shares<F: Field>(
+    input: &mut [Replicated<F>],
+    ctx: &ProtocolContext<'_, Replicated<F>, F>,
+    to_helper: Role,
+) -> Result<Vec<Replicated<F>>, BoxError> {
+    let reshares = input.iter().enumerate().map(|(index, input)| async move {
+        Reshare::new(*input)
+            .execute(ctx, RecordId::from(index), to_helper)
             .await
-    }
+    });
+    try_join_all(reshares).await
+}
 
-    #[embed_doc_image("unshuffle", "images/sort/unshuffle.png")]
-    /// Unshuffle calls `shuffle_or_unshuffle_once` three times with 2 helpers shuffling the shares each time in the opposite order to shuffle.
-    /// Order of calling `shuffle_or_unshuffle_once` is shuffle with (H1, H2), (H3, H1) and (H2, H3)
-    /// ![Unshuffle steps][unshuffle]
-    pub async fn execute_unshuffle(
-        &mut self,
-        ctx: ProtocolContext<'_, Replicated<F>, F>,
-    ) -> Result<Vec<Replicated<F>>, BoxError>
-    where
-        F: Field,
-    {
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step3)
-            .await?;
-        self.input = self
-            .shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step2)
-            .await?;
-        self.shuffle_or_unshuffle_once(ShuffleOrUnshuffle::Unshuffle, &ctx, Step1)
-            .await
+/// `shuffle_or_unshuffle_once` is called for the helpers
+/// i)   2 helpers receive permutation pair and choose the permutation to be applied
+/// ii)  2 helpers apply the permutation to their shares
+/// iii) reshare to `to_helper`
+#[allow(clippy::cast_possible_truncation)]
+async fn shuffle_or_unshuffle_once<F: Field>(
+    input: &mut [Replicated<F>],
+    permutation_left: &[usize],
+    permutation_right: &[usize],
+    shuffle_or_unshuffle: ShuffleOrUnshuffle,
+    ctx: &ProtocolContext<'_, Replicated<F>, F>,
+    which_step: ShuffleStep,
+) -> Result<Vec<Replicated<F>>, BoxError> {
+    let to_helper = shuffle_for_helper(which_step);
+    let ctx = ctx.narrow(&which_step);
+
+    if to_helper != ctx.role() {
+        let permutation_to_apply = if to_helper.peer(Direction::Left) == ctx.role() {
+            permutation_left
+        } else {
+            permutation_right
+        };
+
+        match shuffle_or_unshuffle {
+            ShuffleOrUnshuffle::Shuffle => apply_inv(permutation_to_apply, input),
+            ShuffleOrUnshuffle::Unshuffle => apply(permutation_to_apply, input),
+        }
     }
+    reshare_all_shares(input, &ctx, to_helper).await
+}
+
+#[embed_doc_image("shuffle", "images/sort/shuffle.png")]
+/// Shuffle calls `shuffle_or_unshuffle_once` three times with 2 helpers shuffling the shares each time.
+/// Order of calling `shuffle_or_unshuffle_once` is shuffle with (H2, H3), (H3, H1) and (H1, H2).
+/// Each shuffle requires communication between helpers to perform reshare.
+/// Infrastructure has a pre-requisite to distinguish each communication step uniquely.
+/// For this, we have three shuffle steps one per `shuffle_or_unshuffle_once` i.e. Step1, Step2 and Step3.
+/// The Shuffle object receives a step function and appends a `ShuffleStep` to form a concrete step
+/// ![Shuffle steps][shuffle]
+pub async fn shuffle_shares<F: Field>(
+    input: &mut [Replicated<F>],
+    permutation_left: &[usize],
+    permutation_right: &[usize],
+    ctx: ProtocolContext<'_, Replicated<F>, F>,
+) -> Result<Vec<Replicated<F>>, BoxError> {
+    let mut once_shuffled = shuffle_or_unshuffle_once(
+        input,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Shuffle,
+        &ctx,
+        Step1,
+    )
+    .await?;
+    let mut twice_shuffled = shuffle_or_unshuffle_once(
+        &mut once_shuffled,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Shuffle,
+        &ctx,
+        Step2,
+    )
+    .await?;
+    shuffle_or_unshuffle_once(
+        &mut twice_shuffled,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Shuffle,
+        &ctx,
+        Step3,
+    )
+    .await
+}
+
+#[embed_doc_image("unshuffle", "images/sort/unshuffle.png")]
+/// Unshuffle calls `shuffle_or_unshuffle_once` three times with 2 helpers shuffling the shares each time in the opposite order to shuffle.
+/// Order of calling `shuffle_or_unshuffle_once` is shuffle with (H1, H2), (H3, H1) and (H2, H3)
+/// ![Unshuffle steps][unshuffle]
+pub async fn unshuffle_shares<F: Field>(
+    input: &mut [Replicated<F>],
+    permutation_left: &[usize],
+    permutation_right: &[usize],
+    ctx: ProtocolContext<'_, Replicated<F>, F>,
+) -> Result<Vec<Replicated<F>>, BoxError> {
+    let mut once_shuffled = shuffle_or_unshuffle_once(
+        input,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Unshuffle,
+        &ctx,
+        Step3,
+    )
+    .await?;
+    let mut twice_shuffled = shuffle_or_unshuffle_once(
+        &mut once_shuffled,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Unshuffle,
+        &ctx,
+        Step2,
+    )
+    .await?;
+    shuffle_or_unshuffle_once(
+        &mut twice_shuffled,
+        permutation_left,
+        permutation_right,
+        ShuffleOrUnshuffle::Unshuffle,
+        &ctx,
+        Step1,
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -205,15 +218,17 @@ mod tests {
     use crate::{
         ff::Fp31,
         protocol::{
-            sort::shuffle::{get_two_of_three_random_permutations, Shuffle, ShuffleOrUnshuffle},
+            sort::shuffle::{
+                get_two_of_three_random_permutations, shuffle_shares, unshuffle_shares,
+                ShuffleOrUnshuffle,
+            },
             QueryId, UniqueStepId,
         },
         test_fixture::{
             generate_shares, make_contexts, make_participants, make_world, narrow_contexts,
-            validate_and_reconstruct, TestWorld,
+            permutation_valid, validate_and_reconstruct, TestWorld,
         },
     };
-    use permutation::Permutation;
     use tokio::try_join;
 
     #[test]
@@ -238,9 +253,9 @@ mod tests {
         assert_ne!(perm2.0, perm2.1);
         assert_ne!(perm3.0, perm3.1);
 
-        assert!(Permutation::valid(&perm1.0));
-        assert!(Permutation::valid(&perm2.0));
-        assert!(Permutation::valid(&perm3.0));
+        assert!(permutation_valid(&perm1.0));
+        assert!(permutation_valid(&perm2.0));
+        assert!(permutation_valid(&perm3.0));
     }
 
     #[tokio::test]
@@ -265,13 +280,10 @@ mod tests {
         let perm3 = get_two_of_three_random_permutations(input_len, context[2].prss().as_ref());
 
         let [c0, c1, c2] = context;
-        let mut shuffle0 = Shuffle::new(shares.0, perm1);
-        let mut shuffle1 = Shuffle::new(shares.1, perm2);
-        let mut shuffle2 = Shuffle::new(shares.2, perm3);
 
-        let h0_future = shuffle0.execute(c0);
-        let h1_future = shuffle1.execute(c1);
-        let h2_future = shuffle2.execute(c2);
+        let h0_future = shuffle_shares(&mut shares.0, &perm1.0, &perm1.1, c0);
+        let h1_future = shuffle_shares(&mut shares.1, &perm2.0, &perm2.1, c1);
+        let h2_future = shuffle_shares(&mut shares.2, &perm3.0, &perm3.1, c2);
 
         shares = try_join!(h0_future, h1_future, h2_future).unwrap();
 
@@ -319,26 +331,19 @@ mod tests {
 
         {
             let [ctx0, ctx1, ctx2] = narrow_contexts(&context, &ShuffleOrUnshuffle::Shuffle);
-            let mut shuffle0 = Shuffle::new(shares.0, perm1.clone());
-            let mut shuffle1 = Shuffle::new(shares.1, perm2.clone());
-            let mut shuffle2 = Shuffle::new(shares.2, perm3.clone());
-            let h0_future = shuffle0.execute(ctx0);
-            let h1_future = shuffle1.execute(ctx1);
-            let h2_future = shuffle2.execute(ctx2);
+            let h0_future = shuffle_shares(&mut shares.0, &perm1.0, &perm1.1, ctx0);
+            let h1_future = shuffle_shares(&mut shares.1, &perm2.0, &perm2.1, ctx1);
+            let h2_future = shuffle_shares(&mut shares.2, &perm3.0, &perm3.1, ctx2);
 
             shares = try_join!(h0_future, h1_future, h2_future).unwrap();
         }
         {
             let [ctx0, ctx1, ctx2] = narrow_contexts(&context, &ShuffleOrUnshuffle::Unshuffle);
-            let mut unshuffle0 = Shuffle::new(shares.0, perm1);
-            let mut unshuffle1 = Shuffle::new(shares.1, perm2);
-            let mut unshuffle2 = Shuffle::new(shares.2, perm3);
+            let h0_future = unshuffle_shares(&mut shares.0, &perm1.0, &perm1.1, ctx0);
+            let h1_future = unshuffle_shares(&mut shares.1, &perm2.0, &perm2.1, ctx1);
+            let h2_future = unshuffle_shares(&mut shares.2, &perm3.0, &perm3.1, ctx2);
 
             // When unshuffle and shuffle are called with same step, they undo each other's effect
-            let h0_future = unshuffle0.execute_unshuffle(ctx0);
-            let h1_future = unshuffle1.execute_unshuffle(ctx1);
-            let h2_future = unshuffle2.execute_unshuffle(ctx2);
-
             shares = try_join!(h0_future, h1_future, h2_future).unwrap();
         }
 

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -226,18 +226,15 @@ mod tests {
 
     #[test]
     fn random_sequence_generated() {
-        const BATCH_SIZE: u32 = 10000;
+        const BATCH_SIZE: usize = 10000;
 
         logging::setup();
 
         let (p1, p2, p3) = make_participants();
         let step = UniqueStepId::default();
-        let perm1 =
-            get_two_of_three_random_permutations(BATCH_SIZE as usize, p1.indexed(&step).as_ref());
-        let perm2 =
-            get_two_of_three_random_permutations(BATCH_SIZE as usize, p2.indexed(&step).as_ref());
-        let perm3 =
-            get_two_of_three_random_permutations(BATCH_SIZE as usize, p3.indexed(&step).as_ref());
+        let perm1 = get_two_of_three_random_permutations(BATCH_SIZE, p1.indexed(&step).as_ref());
+        let perm2 = get_two_of_three_random_permutations(BATCH_SIZE, p2.indexed(&step).as_ref());
+        let perm3 = get_two_of_three_random_permutations(BATCH_SIZE, p3.indexed(&step).as_ref());
 
         assert_eq!(perm1.1, perm2.0);
         assert_eq!(perm2.1, perm3.0);

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -96,11 +96,11 @@ pub fn generate_shares<T: Field>(input: Vec<u128>) -> ReplicatedShares<T> {
     (shares0, shares1, shares2)
 }
 
-pub fn permutation_valid(permutation: &[usize]) -> bool {
+pub fn permutation_valid(permutation: &[u32]) -> bool {
     let mut c = permutation.to_vec();
     c.sort();
     for i in 0..c.len() {
-        assert_eq!(c[i], i);
+        assert_eq!(c[i] as usize, i);
     }
     true
 }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -96,11 +96,15 @@ pub fn generate_shares<T: Field>(input: Vec<u128>) -> ReplicatedShares<T> {
     (shares0, shares1, shares2)
 }
 
+/// # Panics
+/// Panics if the permutation is not a valid one.
+/// Here "valid" means it contains all the numbers in the range 0..length, and each only appears once.
+#[must_use]
 pub fn permutation_valid(permutation: &[u32]) -> bool {
     let mut c = permutation.to_vec();
-    c.sort();
-    for i in 0..c.len() {
-        assert_eq!(c[i] as usize, i);
+    c.sort_unstable();
+    for (i, position) in c.iter().enumerate() {
+        assert_eq!(*position as usize, i);
     }
     true
 }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -95,3 +95,12 @@ pub fn generate_shares<T: Field>(input: Vec<u128>) -> ReplicatedShares<T> {
     }
     (shares0, shares1, shares2)
 }
+
+pub fn permutation_valid(permutation: &[usize]) -> bool {
+    let mut c = permutation.to_vec();
+    c.sort();
+    for i in 0..c.len() {
+        assert_eq!(c[i], i);
+    }
+    true
+}

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -46,9 +46,6 @@ pub fn validate_list_of_shares<F: Field>(expected_result: &[u128], result: &Repl
         .map(|i| validate_and_reconstruct((result.0[i], result.1[i], result.2[i])))
         .collect();
 
-    println!("expected results: {:#?}", expected_result);
-    println!("revealed values: {:#?}", revealed_values);
-
     for i in 0..revealed_values.len() {
         assert_eq!(revealed_values[i], F::from(expected_result[i]));
     }

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -42,10 +42,14 @@ pub fn validate_and_reconstruct<F: Field>(
 /// # Panics
 /// Panics if the expected result is not same as obtained result. Also panics if `validate_and_reconstruct` fails
 pub fn validate_list_of_shares<F: Field>(expected_result: &[u128], result: &ReplicatedShares<F>) {
-    (0..result.0.len()).for_each(|i| {
-        assert_eq!(
-            validate_and_reconstruct((result.0[i], result.1[i], result.2[i])),
-            F::from(expected_result[i])
-        );
-    });
+    let revealed_values: Vec<F> = (0..result.0.len())
+        .map(|i| validate_and_reconstruct((result.0[i], result.1[i], result.2[i])))
+        .collect();
+
+    println!("expected results: {:#?}", expected_result);
+    println!("revealed values: {:#?}", revealed_values);
+
+    for i in 0..revealed_values.len() {
+        assert_eq!(revealed_values[i], F::from(expected_result[i]));
+    }
 }


### PR DESCRIPTION
The permutations crate has a few issues:
1.) Naming convention is reverse of the paper
2.) It *mutates* the permutation being applied, which means we have to clone permutations pretty often (wasteful)
3.) Strange Permutation.online() stuff all over the place.