### PR TITLE
Bitwise Carries protocol

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -127,6 +127,6 @@ pub trait BinaryField:
     + BitOrAssign
     + BitXor<Output = Self>
     + BitXorAssign
-    + Not
+    + Not<Output = Self>
 {
 }

--- a/src/protocol/boolean/carries.rs
+++ b/src/protocol/boolean/carries.rs
@@ -1,0 +1,361 @@
+use super::or::or;
+use super::xor::xor;
+use super::BitOpStep;
+use crate::error::BoxError;
+use crate::ff::Field;
+use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
+use crate::secret_sharing::Replicated;
+use futures::future::try_join_all;
+use std::iter::{repeat, zip};
+
+#[derive(Copy, Clone, Debug)]
+/// This struct represents set/propagate/kill bits used to compute the carries.
+struct CarryPropagationShares<F: Field> {
+    s: Replicated<F>,
+    p: Replicated<F>,
+    k: Replicated<F>,
+}
+
+/// This is an implementation of Carries on bitwise-shared numbers.
+///
+/// `Carries` takes inputs `[a]_B = ([a_1]_p,...,[a_l]_p)` where
+/// `a_1,...,a_l ∈ {0,1} ⊆ F_p`, and `[b]_B = ([b_1]_p,...,[b_l]_p)` where
+/// `b_1,...,b_l ∈ {0,1} ⊆ F_p`, then computes `[c]_B = ([c_1]_p,...,[c_l]_p)`
+/// where `c_1,...,c_l ∈ {0,1} ⊆ F_p`, and `c_i = 1` iff `i`'th carry bit is
+/// set.
+///
+/// In order to compute the carries, we use set (s) / propagate (p) / kill (k)
+/// algorithm. `s_i = 1` iff a carry is set at position `i` (i.e., `a_i + b_i = 2`);
+/// `p_i = 1` iff a carry would be propagated at position `i`
+/// (i.e., `a_i + b_i = 1`); and `k_i = 1` iff a carry would be killed at
+/// position `i` (i.e., `a_i + b_i = 0`).
+///
+/// 6.3 Computing the carry bits
+/// 6.4 Unbounded fan-in carry propagation
+/// "Unconditionally Secure Constant-Rounds Multi-party Computation for Equality, Comparison, Bits, and Exponentiation"
+/// I. Damgård et al.
+pub struct Carries {}
+
+impl Carries {
+    #[allow(dead_code)]
+    #[allow(clippy::many_single_char_names)]
+    pub async fn execute<F: Field>(
+        ctx: ProtocolContext<'_, Replicated<F>, F>,
+        record_id: RecordId,
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+    ) -> Result<Vec<Replicated<F>>, BoxError> {
+        debug_assert_eq!(a.len(), b.len(), "Length of the input bits must be equal");
+        let s = Self::step1(a, b, ctx.narrow(&Step::AMultB), record_id).await?;
+        let e = Self::step2(a, b, &s, ctx.clone(), record_id).await?;
+        let f = Self::step3(&e, ctx.narrow(&Step::CarryPropagation), record_id).await?;
+        let s = f.iter().map(|&x| x.s).collect::<Vec<_>>();
+        Ok(s)
+    }
+
+    /// Step 1. for `i=0..l=1`, `[s_i] = MULT([a_i], [b_i])`
+    ///
+    /// The interpretation is, `s_i` = 1 iff i'th bit of a and b are 1.
+    ///
+    /// # Example
+    /// ```ignore
+    ///   // Input
+    ///   [a] = 1 1 0 1 0 1 1 0   // 214 in LE
+    ///   [b] = 0 0 0 1 1 1 0 0   // 28 in LE
+    ///   // Output
+    ///   [s] = 0 0 0 1 0 1 0 0
+    /// ```
+    async fn step1<F: Field>(
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+        ctx: ProtocolContext<'_, Replicated<F>, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<Replicated<F>>, BoxError> {
+        let mul = zip(repeat(ctx), zip(a, b))
+            .enumerate()
+            .map(|(i, (ctx, (&a_bit, &b_bit)))| {
+                let c = ctx.narrow(&BitOpStep::Step(i));
+                async move { c.multiply(record_id, a_bit, b_bit).await }
+            });
+        try_join_all(mul).await
+    }
+
+    /// Step 2. for `i=0..l=1`, generate a vector of tuples `([s], [p], [k])` where
+    /// `[p_i] = [a_i] + [b_i] - 2*[s_i]`, and `[k_i] = 1 - [s_i] - [p_i]`
+    ///
+    /// The interpretations is:
+    ///   * `s_i = 1` iff carry is set at position `i` (i.e. `a_i + b_i = 2`)
+    ///   * `p_i = 1` iff carry would be propagated at position `i` (i.e. `a_i + b_i = 1`)
+    ///   * `k_i = 1` iff a carry would be killed at position `i` (i.e. `a_i + b_i = 0`)
+    ///
+    /// Therefore, we compute `p_i = XOR(a_i, b_i)`, and `k_i = !OR(a_i, b_i)`
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Input
+    ///   [a] = 1 1 0 1 0 1 1 0   // 214 in LE
+    ///   [b] = 0 0 0 1 1 1 0 0   // 28 in LE
+    ///   [s] = 0 0 0 1 0 1 0 0
+    /// // Output
+    ///   [s] = 0 0 0 1 0 1 0 0   // `a_i & b_i`
+    ///   [p] = 1 1 0 0 1 0 1 0   // `a_i ^ b_i`
+    ///   [k] = 0 0 1 0 0 0 0 1   // `!(a_i | b_i)`
+    /// ```
+    #[allow(clippy::many_single_char_names)]
+    async fn step2<F: Field>(
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+        s: &[Replicated<F>],
+        ctx: ProtocolContext<'_, Replicated<F>, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<CarryPropagationShares<F>>, BoxError> {
+        let xor_ctx = ctx.narrow(&Step::AXorB);
+        let or_ctx = ctx.narrow(&Step::AOrB);
+        let (p_futures, k_futures): (Vec<_>, Vec<_>) = zip(a, b)
+            .enumerate()
+            .map(|(i, (&a_bit, &b_bit))| {
+                let c1 = xor_ctx.narrow(&BitOpStep::Step(i));
+                let c2 = or_ctx.narrow(&BitOpStep::Step(i));
+                (
+                    async move { xor(c1, record_id, a_bit, b_bit).await },
+                    async move { or(c2, record_id, a_bit, b_bit).await },
+                )
+            })
+            .unzip();
+
+        //TODO(taikiy): These two futures are independent. How can we run them at once?
+        let p = try_join_all(p_futures).await?;
+        let k = try_join_all(k_futures).await?;
+
+        Ok(zip(p, k)
+            .zip(s)
+            .map(|((p_bit, k_bit), &s_bit)| CarryPropagationShares {
+                s: s_bit,
+                p: p_bit,
+                k: Replicated::one(ctx.role()) - k_bit,
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Step 3. Prefix Carry-Propagation
+    ///
+    /// Let `e_i = (s_i, p_i, k_i)`, and `○` be the carry-propagation operator, it
+    /// computes `([f_0],...,[f_l]) ← PRE○([e_0],...,[e_l])`.
+    async fn step3<F: Field>(
+        e: &[CarryPropagationShares<F>],
+        ctx: ProtocolContext<'_, Replicated<F>, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<CarryPropagationShares<F>>, BoxError> {
+        let l = e.len();
+        let futures = (0..l).map(|i| {
+            let c = ctx.narrow(&BitOpStep::Step(i));
+            async move { Self::fan_in_carry_propagation(&e[0..=i], c, record_id).await }
+        });
+        try_join_all(futures).await
+    }
+
+    /// 6.4 Unbounded Fan-In Carry Propagation
+    ///
+    /// Step 1. `for i=1..l, [b] ← ∧ [p_i] i=1..l`
+    /// Step 2. `for i=l..1, [q] = PRE∧ [p_j]`
+    /// Step 3. `for i=1..l-1, [c_i] = [k_i] ^ [q_(i+1)]`, and `[c_l] = [k_l]`
+    /// Step 4. `for i=1..l, [c] = Σ [c_i]`
+    /// Step 5. `[a] = 1 - [b] - [c]`
+    ///
+    /// Output: ([a], [b], [c])
+    /// `[a]` => carry set flag
+    /// `[b]` => propagate flag
+    /// `[c]` => kill flag
+    #[allow(clippy::many_single_char_names)]
+    async fn fan_in_carry_propagation<F: Field>(
+        e: &[CarryPropagationShares<F>],
+        ctx: ProtocolContext<'_, Replicated<F>, F>,
+        record_id: RecordId,
+    ) -> Result<CarryPropagationShares<F>, BoxError> {
+        let l = e.len();
+
+        // TODO(taikiy): Optimization: Could run the following 2 blocks in parallel
+
+        // Step 1. fan-in AND. for `i=1..l, ∧ [p_i]`
+        let c = ctx.narrow(&Step::FanInAndP);
+        let mut b = e[0].p;
+        for (i, &x) in e.iter().enumerate().skip(1) {
+            let c = c.narrow(&BitOpStep::Step(i));
+            b = c.multiply(record_id, b, x.p).await?;
+        }
+
+        // Step 2. prefix AND. for `i=l..1, ∧ [p_j]` where `j=l..i`
+        // Note the `i=l..1`. The output bits are in the reverse order.
+        let c = ctx.narrow(&Step::PrefixAndP);
+        let mut q = Vec::with_capacity(l);
+        q.push(e[l - 1].p);
+        for (i, &x) in e.iter().rev().enumerate().skip(1) {
+            let c = c.narrow(&BitOpStep::Step(i));
+            // TODO(taikiy): Optimization. Use the symmetric function `PrefixAnd`?
+            let result = c.multiply(record_id, q[i - 1], x.p).await?;
+            q.push(result);
+        }
+        // Change the order back to LE (LSB first). The next step traverses [q] in i=1..l
+        q.reverse();
+
+        // Step 3. for `i=1..l-1, [c_i] = [k_i] ^ [q_(i+1)]`, and `[c_l] = [k_l]`
+        let c = ctx.narrow(&Step::KAndQ);
+        let futures = e
+            .iter()
+            .enumerate()
+            .take_while(|(i, _)| *i < l - 1)
+            .map(|(i, &x)| {
+                let c = c.narrow(&BitOpStep::Step(i));
+                c.multiply(record_id, x.k, q[i + 1])
+            })
+            .collect::<Vec<_>>();
+        let mut c = try_join_all(futures).await?;
+        c.push(e[l - 1].k);
+
+        // Step 4. `[c] = Σ [c_i]`
+        // There's at most one c_i = 1. [c] will be a secret sharing of 0 or 1.
+        let c = c.iter().fold(Replicated::ZERO, |acc, &x| acc + x);
+
+        // Step 5. `[a] = 1 - [b] - [c]`
+        let a = Replicated::one(ctx.role()) - b - c;
+
+        Ok(CarryPropagationShares { s: a, p: b, k: c })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    AXorB,
+    AOrB,
+    AMultB,
+    CarryPropagation,
+    FanInAndP,
+    PrefixAndP,
+    KAndQ,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::AXorB => "a_xor_b",
+            Self::AOrB => "a_or_b",
+            Self::AMultB => "a_mult_b",
+            Self::CarryPropagation => "carry_propagation",
+            Self::FanInAndP => "fan_in_and_p",
+            Self::PrefixAndP => "prefix_and_p",
+            Self::KAndQ => "k_and_q",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Carries;
+    use crate::error::BoxError;
+    use crate::ff::{Field, Fp31};
+    use crate::protocol::{QueryId, RecordId};
+    use crate::secret_sharing::Replicated;
+    use crate::test_fixture::{
+        make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
+    };
+    use futures::future::try_join_all;
+    use rand::rngs::mock::StepRng;
+    use std::iter::zip;
+
+    type BitwiseShares = (
+        Vec<Replicated<Fp31>>,
+        (Vec<Replicated<Fp31>>, Vec<Replicated<Fp31>>),
+    );
+
+    fn fp31_to_bits(x: Fp31) -> Vec<Fp31> {
+        let x = u8::from(x);
+        (0..u8::BITS).map(|i| Fp31::from(x >> i & 1)).collect()
+    }
+
+    async fn carries(a: Fp31, b: Fp31) -> Result<Vec<Fp31>, BoxError> {
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp31>(&world);
+        let mut rand = StepRng::new(1, 1);
+
+        let a_bits = fp31_to_bits(a);
+        let b_bits = fp31_to_bits(b);
+
+        // Generate secret shares
+        #[allow(clippy::type_complexity)]
+        let ((a0, (a1, a2)), (b0, (b1, b2))): (BitwiseShares, BitwiseShares) = zip(a_bits, b_bits)
+            .map(|(a_i, b_i)| {
+                let x = share(a_i, &mut rand);
+                let y = share(b_i, &mut rand);
+                ((x[0], (x[1], x[2])), (y[0], (y[1], y[2])))
+            })
+            .unzip();
+
+        // Execute
+        let step = "Carries_Test";
+        let result = try_join_all(vec![
+            Carries::execute(ctx[0].narrow(step), RecordId::from(0_u32), &a0, &b0),
+            Carries::execute(ctx[1].narrow(step), RecordId::from(0_u32), &a1, &b1),
+            Carries::execute(ctx[2].narrow(step), RecordId::from(0_u32), &a2, &b2),
+        ])
+        .await
+        .unwrap();
+
+        let carries = (0..result[0].len())
+            .map(|i| validate_and_reconstruct((result[0][i], result[1][i], result[2][i])))
+            .collect::<Vec<_>>();
+
+        Ok(carries)
+    }
+
+    #[tokio::test]
+    pub async fn basic() -> Result<(), BoxError> {
+        let fp31 = Fp31::from;
+        let zero = Fp31::ZERO;
+        let one = Fp31::ONE;
+
+        // 0 + 0 -> no carry
+        assert_eq!(
+            vec![zero, zero, zero, zero, zero, zero, zero, zero],
+            carries(fp31(0_u32), fp31(0)).await?
+        );
+        // 0 + 0 -> no carry
+        assert_eq!(
+            vec![zero, zero, zero, zero, zero, zero, zero, zero],
+            carries(fp31(1), fp31(0)).await?
+        );
+        // 01 + 01 -> carry at i=0
+        assert_eq!(
+            vec![one, zero, zero, zero, zero, zero, zero, zero],
+            carries(fp31(1), fp31(1)).await?
+        );
+        // 10 + 01 -> no carry
+        assert_eq!(
+            vec![zero, zero, zero, zero, zero, zero, zero, zero],
+            carries(fp31(2), fp31(1)).await?
+        );
+        // 11 + 01 -> carries at i=0,1
+        assert_eq!(
+            vec![one, one, zero, zero, zero, zero, zero, zero],
+            carries(fp31(3), fp31(1)).await?
+        );
+        // 0101 + 0101 -> carries at i=0,2
+        assert_eq!(
+            vec![one, zero, one, zero, zero, zero, zero, zero],
+            carries(fp31(5), fp31(5)).await?
+        );
+        // 1111 + 0001 -> carries at i=0,1,2,3,
+        assert_eq!(
+            vec![one, one, one, one, zero, zero, zero, zero],
+            carries(fp31(15), fp31(1)).await?
+        );
+        // 0001 1110 + 0000 0011 -> carries at i=2,3,4,5
+        assert_eq!(
+            vec![zero, one, one, one, one, zero, zero, zero],
+            carries(fp31(30), fp31(3)).await?
+        );
+
+        Ok(())
+    }
+}

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -1,4 +1,6 @@
 mod bitwise_lt;
+mod carries;
+mod or;
 mod prefix_or;
 mod xor;
 

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -1,0 +1,78 @@
+use crate::error::BoxError;
+use crate::ff::Field;
+use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
+use crate::secret_sharing::Replicated;
+
+/// Secure XOR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
+/// It computes `[a] + [b] - 2[ab]`
+pub async fn or<F: Field>(
+    ctx: ProtocolContext<'_, Replicated<F>, F>,
+    record_id: RecordId,
+    a: Replicated<F>,
+    b: Replicated<F>,
+) -> Result<Replicated<F>, BoxError> {
+    let one = Replicated::one(ctx.role());
+    let result = ctx.multiply(record_id, one - a, one - b).await?;
+    Ok(one - result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::or;
+    use crate::{
+        error::BoxError,
+        ff::{Field, Fp31},
+        protocol::{QueryId, RecordId},
+        test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
+    };
+    use futures::future::try_join_all;
+    use rand::rngs::mock::StepRng;
+
+    async fn or_fp31(a: Fp31, b: Fp31) -> Result<Fp31, BoxError> {
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp31>(&world);
+        let mut rand = StepRng::new(1, 1);
+
+        // Generate secret shares
+        #[allow(clippy::type_complexity)]
+        let a_shares = share(a, &mut rand);
+        let b_shares = share(b, &mut rand);
+
+        // Execute
+        let step = "Or_Test";
+        let result = try_join_all(vec![
+            or(
+                ctx[0].narrow(step),
+                RecordId::from(0_u32),
+                a_shares[0],
+                b_shares[0],
+            ),
+            or(
+                ctx[1].narrow(step),
+                RecordId::from(0_u32),
+                a_shares[1],
+                b_shares[1],
+            ),
+            or(
+                ctx[2].narrow(step),
+                RecordId::from(0_u32),
+                a_shares[2],
+                b_shares[2],
+            ),
+        ])
+        .await
+        .unwrap();
+
+        Ok(validate_and_reconstruct((result[0], result[1], result[2])))
+    }
+
+    #[tokio::test]
+    pub async fn basic() -> Result<(), BoxError> {
+        assert_eq!(Fp31::ZERO, or_fp31(Fp31::ZERO, Fp31::ZERO).await?);
+        assert_eq!(Fp31::ONE, or_fp31(Fp31::ONE, Fp31::ZERO).await?);
+        assert_eq!(Fp31::ONE, or_fp31(Fp31::ZERO, Fp31::ONE).await?);
+        assert_eq!(Fp31::ONE, or_fp31(Fp31::ONE, Fp31::ONE).await?);
+
+        Ok(())
+    }
+}

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
 use crate::secret_sharing::Replicated;
@@ -8,19 +8,19 @@ use crate::secret_sharing::Replicated;
 pub async fn or<F: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     record_id: RecordId,
-    a: Replicated<F>,
-    b: Replicated<F>,
-) -> Result<Replicated<F>, BoxError> {
+    a: &Replicated<F>,
+    b: &Replicated<F>,
+) -> Result<Replicated<F>, Error> {
     let one = Replicated::one(ctx.role());
-    let result = ctx.multiply(record_id, one - a, one - b).await?;
-    Ok(one - result)
+    let result = ctx.multiply(record_id, &(&one - a), &(&one - b)).await?;
+    Ok(one - &result)
 }
 
 #[cfg(test)]
 mod tests {
     use super::or;
     use crate::{
-        error::BoxError,
+        error::Error,
         ff::{Field, Fp31},
         protocol::{QueryId, RecordId},
         test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
@@ -28,7 +28,7 @@ mod tests {
     use futures::future::try_join_all;
     use rand::rngs::mock::StepRng;
 
-    async fn or_fp31(a: Fp31, b: Fp31) -> Result<Fp31, BoxError> {
+    async fn or_fp31(a: Fp31, b: Fp31) -> Result<Fp31, Error> {
         let world: TestWorld = make_world(QueryId);
         let ctx = make_contexts::<Fp31>(&world);
         let mut rand = StepRng::new(1, 1);
@@ -44,30 +44,30 @@ mod tests {
             or(
                 ctx[0].narrow(step),
                 RecordId::from(0_u32),
-                a_shares[0],
-                b_shares[0],
+                &a_shares[0],
+                &b_shares[0],
             ),
             or(
                 ctx[1].narrow(step),
                 RecordId::from(0_u32),
-                a_shares[1],
-                b_shares[1],
+                &a_shares[1],
+                &b_shares[1],
             ),
             or(
                 ctx[2].narrow(step),
                 RecordId::from(0_u32),
-                a_shares[2],
-                b_shares[2],
+                &a_shares[2],
+                &b_shares[2],
             ),
         ])
         .await
         .unwrap();
 
-        Ok(validate_and_reconstruct((result[0], result[1], result[2])))
+        Ok(validate_and_reconstruct(&result[0], &result[1], &result[2]))
     }
 
     #[tokio::test]
-    pub async fn basic() -> Result<(), BoxError> {
+    pub async fn basic() -> Result<(), Error> {
         assert_eq!(Fp31::ZERO, or_fp31(Fp31::ZERO, Fp31::ZERO).await?);
         assert_eq!(Fp31::ONE, or_fp31(Fp31::ONE, Fp31::ZERO).await?);
         assert_eq!(Fp31::ONE, or_fp31(Fp31::ZERO, Fp31::ONE).await?);

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -1,11 +1,10 @@
+use super::{or::or, BitOpStep};
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
 use crate::secret_sharing::Replicated;
 use futures::future::try_join_all;
 use std::iter::{repeat, zip};
-
-use super::BitOpStep;
 
 /// This is an implementation of Prefix-Or on bitwise-shared numbers.
 ///
@@ -24,21 +23,6 @@ use super::BitOpStep;
 pub struct PrefixOr {}
 
 impl PrefixOr {
-    /// Securely computes `[a] | [b] where a, b ∈ {0, 1} ⊆ F_p`
-    /// OR can be computed as: `!MULT(![a], ![b])`
-    async fn bit_or<F: Field>(
-        a: &Replicated<F>,
-        b: &Replicated<F>,
-        ctx: ProtocolContext<'_, Replicated<F>, F>,
-        record_id: RecordId,
-    ) -> Result<Replicated<F>, Error> {
-        let one = Replicated::one(ctx.role());
-        let result = ctx
-            .multiply(record_id, &(one.clone() - a), &(one.clone() - b))
-            .await?;
-        Ok(one - &result)
-    }
-
     /// Securely computes `∨ [a_1],...[a_n]`
     async fn block_or<F: Field>(
         a: &[Replicated<F>],
@@ -47,9 +31,9 @@ impl PrefixOr {
         record_id: RecordId,
     ) -> Result<Replicated<F>, Error> {
         #[allow(clippy::cast_possible_truncation)]
-        let mut v = a[0].clone();
-        for (i, bit) in a[1..].iter().enumerate() {
-            v = Self::bit_or(&v, bit, ctx.narrow(&BitOpStep::Step(k + i)), record_id).await?;
+        let mut v = a[0];
+        for (i, &bit) in a[1..].iter().enumerate() {
+            v = or(ctx.narrow(&BitOpStep::Step(k + i)), record_id, v, bit).await?;
         }
         Ok(v)
     }
@@ -97,8 +81,7 @@ impl PrefixOr {
         let mut y = Vec::with_capacity(lambda);
         y.push(x[0].clone());
         for i in 1..lambda {
-            let result =
-                Self::bit_or(&y[i - 1], &x[i], ctx.narrow(&BitOpStep::Step(i)), record_id).await?;
+            let result = or(ctx.narrow(&BitOpStep::Step(i)), record_id, y[i - 1], x[i]).await?;
             y.push(result);
         }
         Ok(y)
@@ -184,8 +167,7 @@ impl PrefixOr {
         let mut b = Vec::with_capacity(lambda);
         b.push(c[0].clone());
         for j in 1..lambda {
-            let result =
-                Self::bit_or(&b[j - 1], &c[j], ctx.narrow(&BitOpStep::Step(j)), record_id).await?;
+            let result = or(ctx.narrow(&BitOpStep::Step(j)), record_id, b[j - 1], c[j]).await?;
             b.push(result);
         }
         Ok(b)

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -31,9 +31,9 @@ impl PrefixOr {
         record_id: RecordId,
     ) -> Result<Replicated<F>, Error> {
         #[allow(clippy::cast_possible_truncation)]
-        let mut v = a[0];
-        for (i, &bit) in a[1..].iter().enumerate() {
-            v = or(ctx.narrow(&BitOpStep::Step(k + i)), record_id, v, bit).await?;
+        let mut v = a[0].clone();
+        for (i, bit) in a[1..].iter().enumerate() {
+            v = or(ctx.narrow(&BitOpStep::Step(k + i)), record_id, &v, bit).await?;
         }
         Ok(v)
     }
@@ -81,7 +81,7 @@ impl PrefixOr {
         let mut y = Vec::with_capacity(lambda);
         y.push(x[0].clone());
         for i in 1..lambda {
-            let result = or(ctx.narrow(&BitOpStep::Step(i)), record_id, y[i - 1], x[i]).await?;
+            let result = or(ctx.narrow(&BitOpStep::Step(i)), record_id, &y[i - 1], &x[i]).await?;
             y.push(result);
         }
         Ok(y)
@@ -167,7 +167,7 @@ impl PrefixOr {
         let mut b = Vec::with_capacity(lambda);
         b.push(c[0].clone());
         for j in 1..lambda {
-            let result = or(ctx.narrow(&BitOpStep::Step(j)), record_id, b[j - 1], c[j]).await?;
+            let result = or(ctx.narrow(&BitOpStep::Step(j)), record_id, &b[j - 1], &c[j]).await?;
             b.push(result);
         }
         Ok(b)

--- a/src/secret_sharing/replicated.rs
+++ b/src/secret_sharing/replicated.rs
@@ -45,6 +45,9 @@ impl<F: Field> Replicated<F> {
             Role::H3 => Self::new(F::ZERO, F::ONE),
         }
     }
+
+    /// Replicated secret share where both left and right values are `F::ZERO`
+    pub const ZERO: Replicated<F> = Self(F::ZERO, F::ZERO);
 }
 
 impl<F: Field> Add<Self> for &Replicated<F> {


### PR DESCRIPTION
This diff implements `Carries` protocol. "6.3 Computing the carry bits" from the [paper](https://iacr.org/archive/tcc2006/38760286/38760286.pdf), "Unconditionally Secure Constant-Rounds Multi-party Computation for Equality, Comparison, Bits, and Exponentiation".

`Carries` computes... well, the carries. It takes two bitwise shared secrets, and outputs a bitwise share indicating the indice where bit-carries occur.

This by itself is not useful, but this is a part of the bitwise sum protocol, which I will send out the PR next.