### PR TITLE
Fix PrefixOr to work with F_p

### DIFF
--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -352,14 +352,11 @@ mod tests {
             .unzip();
 
         // Execute
-        let pre0 = PrefixOr::new(&s0);
-        let pre1 = PrefixOr::new(&s1);
-        let pre2 = PrefixOr::new(&s2);
         let step = "PrefixOr_Test";
         let result = try_join_all(vec![
-            pre0.execute(ctx[0].narrow(step), RecordId::from(0_u32)),
-            pre1.execute(ctx[1].narrow(step), RecordId::from(0_u32)),
-            pre2.execute(ctx[2].narrow(step), RecordId::from(0_u32)),
+            PrefixOr::new(&s0).execute(ctx[0].narrow(step), RecordId::from(0_u32)),
+            PrefixOr::new(&s1).execute(ctx[1].narrow(step), RecordId::from(0_u32)),
+            PrefixOr::new(&s2).execute(ctx[2].narrow(step), RecordId::from(0_u32)),
         ])
         .await
         .unwrap();


### PR DESCRIPTION
## Overview
Damgård's [paper](https://iacr.org/archive/tcc2006/38760286/38760286.pdf) describes the protocol in F_p, but my initial implementation used `BinaryField` to simplify boolean arithmetics. This, however, becomes a problem when we migrate to malicious because the chance of MACs not matching in Fp2 is 50%. This diff updates `PrefixOr` protocol to be generic over `F: Field`; a larger field than `BinaryField`.

## Description
This change affects one arithmetic logic where we calculate OR of two bits. (lines 49-55)

$OR([a], [b]) = ! ( ![a] * ![b] )$