### PR TITLE
Implement Distribution<F> for Standard on prime fields

### DIFF
--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -87,6 +87,12 @@ macro_rules! field_impl {
             }
         }
 
+        impl rand::distributions::Distribution<$field> for rand::distributions::Standard {
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $field {
+                <$field>::from(rng.gen::<u128>())
+            }
+        }
+
         impl std::fmt::Debug for $field {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}_mod{}", self.0, Self::PRIME)

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -232,8 +232,8 @@ pub mod tests {
         let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
 
-        let a = Fp31::from(rng.gen::<u128>());
-        let b = Fp31::from(rng.gen::<u128>());
+        let a = rng.gen::<Fp31>();
+        let b = rng.gen::<Fp31>();
 
         let a_shares = share(a, &mut rng);
         let b_shares = share(b, &mut rng);
@@ -327,7 +327,7 @@ pub mod tests {
 
         let mut original_inputs = Vec::with_capacity(100);
         for _ in 0..100 {
-            let x = Fp31::from(rng.gen::<u128>());
+            let x = rng.gen::<Fp31>();
             original_inputs.push(x);
         }
         let shared_inputs: Vec<[Replicated<Fp31>; 3]> = original_inputs

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -206,8 +206,8 @@ pub mod tests {
         let mut rng = rand::thread_rng();
 
         for i in 0..10_u32 {
-            let a = Fp31::from(rng.gen::<u128>());
-            let b = Fp31::from(rng.gen::<u128>());
+            let a = rng.gen::<Fp31>();
+            let b = rng.gen::<Fp31>();
 
             let record_id = RecordId::from(0_u32);
 
@@ -252,8 +252,8 @@ pub mod tests {
         let mut futures = Vec::with_capacity(10);
 
         for i in 0..10_u32 {
-            let a = Fp31::from(rng.gen::<u128>());
-            let b = Fp31::from(rng.gen::<u128>());
+            let a = rng.gen::<Fp31>();
+            let b = rng.gen::<Fp31>();
 
             inputs.push((a, b));
 
@@ -304,8 +304,8 @@ pub mod tests {
         let mut rng = rand::thread_rng();
 
         for i in 0..10_u32 {
-            let a = Fp31::from(rng.gen::<u128>());
-            let b = Fp31::from(rng.gen::<u128>());
+            let a = rng.gen::<Fp31>();
+            let b = rng.gen::<Fp31>();
 
             let a_shares = share(a, &mut rng);
 
@@ -352,8 +352,8 @@ pub mod tests {
         let mut futures = Vec::with_capacity(10);
 
         for i in 0..10_u32 {
-            let a = Fp31::from(rng.gen::<u128>());
-            let b = Fp31::from(rng.gen::<u128>());
+            let a = rng.gen::<Fp31>();
+            let b = rng.gen::<Fp31>();
 
             inputs.push((a, b));
 

--- a/src/protocol/mul/semi_honest.rs
+++ b/src/protocol/mul/semi_honest.rs
@@ -71,6 +71,8 @@ pub mod tests {
         make_contexts, make_world, share, validate_and_reconstruct, TestWorld,
     };
     use futures_util::future::join_all;
+    use rand::distributions::Standard;
+    use rand::prelude::Distribution;
     use rand::rngs::mock::StepRng;
     use rand::RngCore;
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -142,7 +144,10 @@ pub mod tests {
         a: u8,
         b: u8,
         rng: &mut R,
-    ) -> Result<u128, BoxError> {
+    ) -> Result<u128, BoxError>
+    where
+        Standard: Distribution<F>,
+    {
         let a = F::from(u128::from(a));
         let b = F::from(u128::from(b));
 

--- a/src/protocol/reveal.rs
+++ b/src/protocol/reveal.rs
@@ -119,8 +119,7 @@ mod tests {
         let ctx = make_contexts::<Fp31>(&world);
 
         for i in 0..10_u32 {
-            let secret = rng.gen::<u128>();
-            let input = Fp31::from(secret);
+            let input = rng.gen::<Fp31>();
             let share = share(input, &mut rng);
             let record_id = RecordId::from(i);
             let results = try_join_all(vec![
@@ -144,8 +143,7 @@ mod tests {
         let ctx = make_contexts::<Fp31>(&world);
 
         for i in 0..10_u32 {
-            let secret = rng.gen::<u128>();
-            let input = Fp31::from(secret);
+            let input = rng.gen::<Fp31>();
             let share = share(input, &mut rng);
             let record_id = RecordId::from(i);
             let results = try_join_all(vec![
@@ -169,8 +167,7 @@ mod tests {
         let ctx = make_contexts::<Fp31>(&world);
 
         for i in 0..10_u32 {
-            let secret = rng.gen::<u128>();
-            let input = Fp31::from(secret);
+            let input = rng.gen::<Fp31>();
             let share = share(input, &mut rng);
             let record_id = RecordId::from(i);
             let result = try_join!(

--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -118,14 +118,14 @@ mod tests {
     fn test_local_operations() {
         let mut rng = rand::thread_rng();
 
-        let a = Fp31::from(rng.gen::<u128>());
-        let b = Fp31::from(rng.gen::<u128>());
-        let c = Fp31::from(rng.gen::<u128>());
-        let d = Fp31::from(rng.gen::<u128>());
-        let e = Fp31::from(rng.gen::<u128>());
-        let f = Fp31::from(rng.gen::<u128>());
+        let a = rng.gen::<Fp31>();
+        let b = rng.gen::<Fp31>();
+        let c = rng.gen::<Fp31>();
+        let d = rng.gen::<Fp31>();
+        let e = rng.gen::<Fp31>();
+        let f = rng.gen::<Fp31>();
         // Randomization constant
-        let r = Fp31::from(rng.gen::<u128>());
+        let r = rng.gen::<Fp31>();
 
         let a_shared = share(a, &mut rng);
         let b_shared = share(b, &mut rng);

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -10,6 +10,8 @@ use crate::protocol::context::ProtocolContext;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::secret_sharing::{Replicated, SecretSharing};
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
 use rand::rngs::mock::StepRng;
 use rand::thread_rng;
 
@@ -79,7 +81,10 @@ pub type ReplicatedShares<T> = (Vec<Replicated<T>>, Vec<Replicated<T>>, Vec<Repl
 
 // Generate vector shares from vector of inputs for three participant
 #[must_use]
-pub fn generate_shares<T: Field>(input: Vec<u128>) -> ReplicatedShares<T> {
+pub fn generate_shares<F: Field>(input: Vec<u128>) -> ReplicatedShares<F>
+where
+    Standard: Distribution<F>,
+{
     let mut rand = StepRng::new(100, 1);
 
     let len = input.len();
@@ -88,7 +93,7 @@ pub fn generate_shares<T: Field>(input: Vec<u128>) -> ReplicatedShares<T> {
     let mut shares2 = Vec::with_capacity(len);
 
     for iter in input {
-        let share = share(T::from(iter), &mut rand);
+        let share = share(F::from(iter), &mut rand);
         shares0.push(share[0]);
         shares1.push(share[1]);
         shares2.push(share[2]);

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,14 +1,19 @@
 use crate::ff::Field;
 use crate::secret_sharing::Replicated;
-use rand::Rng;
-use rand::RngCore;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng, RngCore,
+};
 
 use super::ReplicatedShares;
 
 /// Shares `input` into 3 replicated secret shares using the provided `rng` implementation
-pub fn share<F: Field, R: RngCore>(input: F, rng: &mut R) -> [Replicated<F>; 3] {
-    let x1 = F::from(rng.gen::<u128>());
-    let x2 = F::from(rng.gen::<u128>());
+pub fn share<F: Field, R: RngCore>(input: F, rng: &mut R) -> [Replicated<F>; 3]
+where
+    Standard: Distribution<F>,
+{
+    let x1 = rng.gen::<F>();
+    let x2 = rng.gen::<F>();
     let x3 = input - (x1 + x2);
 
     [


### PR DESCRIPTION
I tried to implement for any field, but I couldn't convince the compiler to let me do that.

This should make the testing pieces more ergonomic and maybe also some of the mainline code.