### PR TITLE
Be pedantic always

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Clippy
         if: ${{ success() || failure() }}
-        run: cargo clippy --tests -- -D warnings -D clippy::pedantic
+        run: cargo clippy --tests
 
       - name: Run Tests
         run: cargo test

--- a/pre-commit
+++ b/pre-commit
@@ -46,6 +46,6 @@ error() {
 
 cargo build --benches --all-features || error "Benchmarks compilation errors"
 
-cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
+cargo clippy --tests || error "Clippy errors"
 
 cargo test || error "Test failures"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::clone_on_ref_ptr)]
+#![deny(warnings, clippy::pedantic)]
 // The following warnings are too noisy for us and having them enabled leads to polluting the
 // code with allow annotations. Disabling them once per project here
 #![allow(clippy::similar_names)]


### PR DESCRIPTION
Though clippy::pedantic can backfire on occasion, this is easier to manage.  We can deal with exceptions here as well.