### PR TITLE
Add From<i32> implementation for RecordId (tests only)

### DIFF
--- a/src/protocol/boolean/bitwise_lt.rs
+++ b/src/protocol/boolean/bitwise_lt.rs
@@ -210,19 +210,19 @@ mod tests {
         let result = try_join_all(vec![
             BitwiseLessThan::execute(
                 ctx[0].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 &transpose(&a_bits, 0),
                 &transpose(&b_bits, 0),
             ),
             BitwiseLessThan::execute(
                 ctx[1].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 &transpose(&a_bits, 1),
                 &transpose(&b_bits, 1),
             ),
             BitwiseLessThan::execute(
                 ctx[2].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 &transpose(&a_bits, 2),
                 &transpose(&b_bits, 2),
             ),

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -355,9 +355,9 @@ mod tests {
         // Execute
         let step = "PrefixOr_Test";
         let result = try_join_all(vec![
-            PrefixOr::execute(ctx[0].narrow(step), RecordId::from(0_u32), &s0),
-            PrefixOr::execute(ctx[1].narrow(step), RecordId::from(0_u32), &s1),
-            PrefixOr::execute(ctx[2].narrow(step), RecordId::from(0_u32), &s2),
+            PrefixOr::execute(ctx[0].narrow(step), RecordId::from(0), &s0),
+            PrefixOr::execute(ctx[1].narrow(step), RecordId::from(0), &s1),
+            PrefixOr::execute(ctx[2].narrow(step), RecordId::from(0), &s2),
         ])
         .await
         .unwrap();

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -42,19 +42,19 @@ mod tests {
         let result = try_join_all(vec![
             xor(
                 ctx[0].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 a_shares[0],
                 b_shares[0],
             ),
             xor(
                 ctx[1].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 a_shares[1],
                 b_shares[1],
             ),
             xor(
                 ctx[2].narrow(step),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 a_shares[2],
                 b_shares[2],
             ),

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -253,10 +253,10 @@ pub mod tests {
             let (ra, rb) = try_join(
                 a_ctx
                     .narrow("input")
-                    .multiply(RecordId::from(0_u32), a_shares[i], r_share),
+                    .multiply(RecordId::from(0), a_shares[i], r_share),
                 b_ctx
                     .narrow("input")
-                    .multiply(RecordId::from(0_u32), b_shares[i], r_share),
+                    .multiply(RecordId::from(0), b_shares[i], r_share),
             )
             .await?;
 
@@ -268,17 +268,17 @@ pub mod tests {
 
             acc.accumulate_macs(
                 &a_ctx.narrow(&Step::ValidateInput).prss(),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 a_malicious,
             );
             acc.accumulate_macs(
                 &b_ctx.narrow(&Step::ValidateInput).prss(),
-                RecordId::from(0_u32),
+                RecordId::from(0),
                 b_malicious,
             );
 
             let mult_result = a_ctx
-                .multiply(RecordId::from(0_u32), a_malicious, b_malicious)
+                .multiply(RecordId::from(0), a_malicious, b_malicious)
                 .await?;
 
             v.validate(ctx.narrow("SecurityValidatorValidate")).await?;
@@ -361,7 +361,7 @@ pub mod tests {
                         |(x, ctx)| async move {
                             let rx = ctx
                                 .narrow("mult")
-                                .multiply(RecordId::from(0_u32), *x, r_share)
+                                .multiply(RecordId::from(0), *x, r_share)
                                 .await?;
 
                             Ok::<_, BoxError>(MaliciousReplicated::new(*x, rx))
@@ -375,7 +375,7 @@ pub mod tests {
                     .map(|(maliciously_secure_input, ctx)| {
                         acc.accumulate_macs(
                             &ctx.narrow(&Step::ValidateInput).prss(),
-                            RecordId::from(0_u32),
+                            RecordId::from(0),
                             *maliciously_secure_input,
                         );
                     });
@@ -390,7 +390,7 @@ pub mod tests {
                             async move {
                                 ctx.narrow("Circuit_Step_2")
                                     .upgrade_to_malicious(acc)
-                                    .multiply(RecordId::from(0_u32), *a_malicious, *b_malicious)
+                                    .multiply(RecordId::from(0), *a_malicious, *b_malicious)
                                     .await
                             }
                         }),

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -252,6 +252,17 @@ impl From<usize> for RecordId {
     }
 }
 
+/// This implementation exists because I am tired of typing `RecordId::from(0_u32)` in tests.
+/// I simply want to be able to say `RecordId::from(0)` there.
+#[cfg(test)]
+impl From<i32> for RecordId {
+    fn from(v: i32) -> Self {
+        assert!(v >= 0, "Record identifier must be a non-negative number");
+
+        RecordId::from(u32::try_from(v).unwrap())
+    }
+}
+
 impl From<RecordId> for u128 {
     fn from(r: RecordId) -> Self {
         r.0.into()

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -209,7 +209,7 @@ pub mod tests {
             let a = rng.gen::<Fp31>();
             let b = rng.gen::<Fp31>();
 
-            let record_id = RecordId::from(0_u32);
+            let record_id = RecordId::from(0);
 
             let iteration = format!("{}", i);
 
@@ -257,7 +257,7 @@ pub mod tests {
 
             inputs.push((a, b));
 
-            let record_id = RecordId::from(0_u32);
+            let record_id = RecordId::from(0);
 
             let iteration = format!("{}", i);
 
@@ -309,7 +309,7 @@ pub mod tests {
 
             let a_shares = share(a, &mut rng);
 
-            let record_id = RecordId::from(0_u32);
+            let record_id = RecordId::from(0);
 
             let iteration = format!("{}", i);
 
@@ -359,7 +359,7 @@ pub mod tests {
 
             let a_shares = share(a, &mut rng);
 
-            let record_id = RecordId::from(0_u32);
+            let record_id = RecordId::from(0);
 
             let iteration = format!("{}", i);
 

--- a/src/protocol/mul/semi_honest.rs
+++ b/src/protocol/mul/semi_honest.rs
@@ -106,7 +106,7 @@ pub mod tests {
             v: (ProtocolContext<'_, Replicated<F>, F>, MulArgs<F>),
         ) -> Replicated<F> {
             let (ctx, (a, b)) = v;
-            ctx.multiply(RecordId::from(0_u32), a, b).await.unwrap()
+            ctx.multiply(RecordId::from(0), a, b).await.unwrap()
         }
 
         let world = make_world(QueryId);

--- a/src/protocol/sort/reshare.rs
+++ b/src/protocol/sort/reshare.rs
@@ -104,7 +104,7 @@ mod tests {
 
             let input = Fp31::from(secret);
             let share = share(input, &mut rand);
-            let record_id = RecordId::from(0_u32);
+            let record_id = RecordId::from(0);
 
             let reshare0 = Reshare::new(share[0]);
             let reshare1 = Reshare::new(share[1]);


### PR DESCRIPTION
I can't type `RecordId::from(0_u32)` anymore, sorry