### PR TITLE
Add sort bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,9 @@ name = "oneshot_arithmetic"
 path = "benches/oneshot/arithmetic_circuit.rs"
 harness = false
 required-features = ["test-fixture"]
+
+[[bench]]
+name = "oneshot_sort"
+path = "benches/oneshot/sort.rs"
+harness = false
+required-features = ["test-fixture"]

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -1,12 +1,14 @@
-use std::time::Instant;
 use futures_util::future::try_join_all;
 use rand::Rng;
 use raw_ipa::error::BoxError;
-use raw_ipa::ff::Fp32BitPrime;
-use raw_ipa::protocol::QueryId;
-use raw_ipa::test_fixture::{make_contexts, make_world_with_config, TestWorldConfig, validate_and_reconstruct};
-use raw_ipa::protocol::sort::generate_sort_permutation::GenerateSortPermutation;
 use raw_ipa::ff::Field;
+use raw_ipa::ff::Fp32BitPrime;
+use raw_ipa::protocol::sort::generate_sort_permutation::GenerateSortPermutation;
+use raw_ipa::protocol::QueryId;
+use raw_ipa::test_fixture::{
+    make_contexts, make_world_with_config, validate_and_reconstruct, TestWorldConfig,
+};
+use std::time::Instant;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), BoxError> {
@@ -46,7 +48,8 @@ async fn main() -> Result<(), BoxError> {
         GenerateSortPermutation::new(&shares[0], num_bits).execute(ctx0),
         GenerateSortPermutation::new(&shares[1], num_bits).execute(ctx1),
         GenerateSortPermutation::new(&shares[2], num_bits).execute(ctx2),
-    ]).await?;
+    ])
+    .await?;
     let duration = start.elapsed().as_secs_f32();
     println!("benchmark complete after {duration}s");
 

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -1,0 +1,70 @@
+use std::time::Instant;
+use futures_util::future::try_join_all;
+use rand::Rng;
+use raw_ipa::error::BoxError;
+use raw_ipa::ff::Fp32BitPrime;
+use raw_ipa::protocol::QueryId;
+use raw_ipa::test_fixture::{make_contexts, make_world_with_config, TestWorldConfig, validate_and_reconstruct};
+use raw_ipa::protocol::sort::generate_sort_permutation::GenerateSortPermutation;
+use raw_ipa::ff::Field;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 3)]
+async fn main() -> Result<(), BoxError> {
+    let mut config = TestWorldConfig::default();
+    config.gateway_config.send_buffer_config.items_in_batch = 1;
+    config.gateway_config.send_buffer_config.batch_count = 1000;
+    let world = make_world_with_config(QueryId, config);
+    let [ctx0, ctx1, ctx2] = make_contexts::<Fp32BitPrime>(&world);
+    let num_bits = 64;
+    let mut rng = rand::thread_rng();
+
+    let batchsize = 100;
+
+    let mut match_keys: Vec<u64> = Vec::new();
+    for _ in 0..batchsize {
+        match_keys.push(rng.gen::<u64>());
+    }
+
+    let input_len = match_keys.len();
+    let mut shares = [
+        Vec::with_capacity(input_len),
+        Vec::with_capacity(input_len),
+        Vec::with_capacity(input_len),
+    ];
+    for match_key in match_keys.clone() {
+        let share_0 = rng.gen::<u64>();
+        let share_1 = rng.gen::<u64>();
+        let share_2 = match_key ^ share_0 ^ share_1;
+
+        shares[0].push((share_0, share_1));
+        shares[1].push((share_1, share_2));
+        shares[2].push((share_2, share_0));
+    }
+
+    let start = Instant::now();
+    let result = try_join_all(vec![
+        GenerateSortPermutation::new(&shares[0], num_bits).execute(ctx0),
+        GenerateSortPermutation::new(&shares[1], num_bits).execute(ctx1),
+        GenerateSortPermutation::new(&shares[2], num_bits).execute(ctx2),
+    ]).await?;
+    let duration = start.elapsed().as_secs_f32();
+    println!("benchmark complete after {duration}s");
+
+    assert_eq!(result[0].len(), input_len);
+    assert_eq!(result[1].len(), input_len);
+    assert_eq!(result[2].len(), input_len);
+
+    let mut mpc_sorted_list: Vec<u128> = (0..input_len).map(|i| i as u128).collect();
+    for (i, match_key) in match_keys.iter().enumerate() {
+        let index = validate_and_reconstruct((result[0][i], result[1][i], result[2][i]));
+        mpc_sorted_list[index.as_u128() as usize] = u128::from(*match_key);
+    }
+
+    let mut sorted_match_keys = match_keys.clone();
+    sorted_match_keys.sort_unstable();
+    for i in 0..input_len {
+        assert_eq!(u128::from(sorted_match_keys[i]), mpc_sorted_list[i]);
+    }
+
+    Ok(())
+}

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -173,6 +173,7 @@ impl Gateway {
                         receive_buf.receive_messages(&channel_id, &messages);
                     }
                     Some((channel_id, msg)) = envelope_rx.recv() => {
+                        tracing::trace!("new SendRequest({channel_id:?}, {:?}", msg.record_id);
                         if let Some(buf_to_send) = send_buf.push(&channel_id, &msg).expect("Failed to append data to the send buffer") {
                             tracing::trace!("sending {} bytes to {:?}", buf_to_send.len(), &channel_id);
                             network_sink.send((channel_id, buf_to_send)).await

--- a/src/protocol/sort/generate_sort_permutation.rs
+++ b/src/protocol/sort/generate_sort_permutation.rs
@@ -25,7 +25,7 @@ pub struct GenerateSortPermutation<'a> {
 }
 
 impl<'a> GenerateSortPermutation<'a> {
-    #[allow(dead_code)]
+    #[must_use]
     pub fn new(input: &'a [(u64, u64)], num_bits: u8) -> GenerateSortPermutation {
         Self { input, num_bits }
     }

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 mod apply;
 pub mod bit_permutation;
 mod compose;
-mod generate_sort_permutation;
+pub mod generate_sort_permutation;
 pub mod reshare;
 mod secureapplyinv;
 mod shuffle;


### PR DESCRIPTION
Very rudimentary, just to reproduce #237

the way you would run it (if you want traces):

```rust
RUST_LOG=trace cargo bench --bench oneshot_sort --profile dev --features test-fixture
```