### PR TITLE
bye bye BoxError

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -1,7 +1,7 @@
 use super::{AccumulateCreditInputRow, AccumulateCreditOutputRow, AttributionInputRow, IterStep};
 use crate::protocol::mul::SecureMul;
 use crate::{
-    error::BoxError,
+    error::Error,
     ff::Field,
     protocol::{
         batch::{Batch, RecordIndex},
@@ -55,7 +55,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
     pub async fn execute(
         &self,
         ctx: ProtocolContext<'_, Replicated<F>, F>,
-    ) -> Result<Batch<AccumulateCreditOutputRow<F>>, BoxError> {
+    ) -> Result<Batch<AccumulateCreditOutputRow<F>>, Error> {
         #[allow(clippy::cast_possible_truncation)]
         let num_rows = self.input.len() as RecordIndex;
 
@@ -165,7 +165,7 @@ impl<'a, F: Field> AccumulateCredit<'a, F> {
         current: AccumulateCreditInputRow<F>,
         successor: AccumulateCreditInputRow<F>,
         first_iteration: bool,
-    ) -> Result<(Replicated<F>, Replicated<F>), BoxError> {
+    ) -> Result<(Replicated<F>, Replicated<F>), Error> {
         // For each input row, we execute the accumulation logic in this method
         // `log2(input.len())` times. Each accumulation logic is executed with
         // the unique iteration/row pair sub-context. There are 2~4 multiplications

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
 use crate::secret_sharing::Replicated;
@@ -31,7 +31,7 @@ impl PrefixOr {
         b: &Replicated<F>,
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let one = Replicated::one(ctx.role());
         let result = ctx
             .multiply(record_id, &(one.clone() - a), &(one.clone() - b))
@@ -45,7 +45,7 @@ impl PrefixOr {
         k: usize,
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         #[allow(clippy::cast_possible_truncation)]
         let mut v = a[0].clone();
         for (i, bit) in a[1..].iter().enumerate() {
@@ -71,7 +71,7 @@ impl PrefixOr {
         lambda: usize,
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         let mut futures = Vec::with_capacity(lambda);
         (0..a.len()).step_by(lambda).for_each(|i| {
             futures.push(Self::block_or(&a[i..i + lambda], i, ctx.clone(), record_id));
@@ -92,7 +92,7 @@ impl PrefixOr {
         x: &[Replicated<F>],
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         let lambda = x.len();
         let mut y = Vec::with_capacity(lambda);
         y.push(x[0].clone());
@@ -135,7 +135,7 @@ impl PrefixOr {
         a: &[Replicated<F>],
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         let lambda = f.len();
         let mul = zip(repeat(ctx), a).enumerate().map(|(i, (ctx, a_bit))| {
             let f_bit = &f[i / lambda];
@@ -179,7 +179,7 @@ impl PrefixOr {
         c: &[Replicated<F>],
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         let lambda = c.len();
         let mut b = Vec::with_capacity(lambda);
         b.push(c[0].clone());
@@ -206,7 +206,7 @@ impl PrefixOr {
         b: &[Replicated<F>],
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         let lambda = f.len();
         let mut mul = Vec::new();
         for (i, f_bit) in f.iter().enumerate() {
@@ -248,7 +248,7 @@ impl PrefixOr {
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
         input: &[Replicated<F>],
-    ) -> Result<Vec<Replicated<F>>, BoxError> {
+    ) -> Result<Vec<Replicated<F>>, Error> {
         // The paper assumes `l = λ^2`, where `l` is the bit length of the input
         // share. Then the input is split into `λ` blocks each holding `λ` bits.
         // Or operations are executed in parallel by running the blocks in
@@ -322,7 +322,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::PrefixOr;
     use crate::{
-        error::BoxError,
+        error::Error,
         ff::{Field, Fp2, Fp31},
         protocol::{QueryId, RecordId},
         secret_sharing::Replicated,
@@ -336,7 +336,7 @@ mod tests {
     const BITS: [usize; 2] = [16, 32];
     const TEST_TRIES: usize = 16;
 
-    async fn prefix_or<F: Field>(input: &[F]) -> Result<Vec<F>, BoxError>
+    async fn prefix_or<F: Field>(input: &[F]) -> Result<Vec<F>, Error>
     where
         Standard: Distribution<F>,
     {
@@ -375,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     /// Test PrefixOr with the input ⊆ F_2
-    pub async fn fp2() -> Result<(), BoxError> {
+    pub async fn fp2() -> Result<(), Error> {
         let mut rng = rand::thread_rng();
 
         // Test n-bit (n = BITS[i]) bitwise shares with randomly distributed
@@ -405,7 +405,7 @@ mod tests {
 
     #[tokio::test]
     /// Test PrefixOr with the input ⊆ F_p (i.e. Fp31)
-    pub async fn fp31() -> Result<(), BoxError> {
+    pub async fn fp31() -> Result<(), Error> {
         let mut rng = rand::thread_rng();
 
         // Test n-bit (n = BITS[i]) bitwise shares with randomly distributed

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::ProtocolContext, mul::SecureMul, RecordId};
 use crate::secret_sharing::Replicated;
@@ -10,7 +10,7 @@ pub async fn xor<F: Field>(
     record_id: RecordId,
     a: &Replicated<F>,
     b: &Replicated<F>,
-) -> Result<Replicated<F>, BoxError> {
+) -> Result<Replicated<F>, Error> {
     let ab = ctx.multiply(record_id, a, b).await?;
     Ok(a + b - &(ab * F::from(2)))
 }
@@ -19,7 +19,7 @@ pub async fn xor<F: Field>(
 mod tests {
     use super::xor;
     use crate::{
-        error::BoxError,
+        error::Error,
         ff::{Field, Fp31},
         protocol::{QueryId, RecordId},
         test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
@@ -27,7 +27,7 @@ mod tests {
     use futures::future::try_join_all;
     use rand::rngs::mock::StepRng;
 
-    async fn xor_fp31(a: Fp31, b: Fp31) -> Result<Fp31, BoxError> {
+    async fn xor_fp31(a: Fp31, b: Fp31) -> Result<Fp31, Error> {
         let world: TestWorld = make_world(QueryId);
         let ctx = make_contexts::<Fp31>(&world);
         let mut rand = StepRng::new(1, 1);
@@ -66,7 +66,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn basic() -> Result<(), BoxError> {
+    pub async fn basic() -> Result<(), Error> {
         assert_eq!(Fp31::ZERO, xor_fp31(Fp31::ZERO, Fp31::ZERO).await?);
         assert_eq!(Fp31::ONE, xor_fp31(Fp31::ONE, Fp31::ZERO).await?);
         assert_eq!(Fp31::ONE, xor_fp31(Fp31::ZERO, Fp31::ONE).await?);

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -1,7 +1,7 @@
 use crate::protocol::mul::SecureMul;
 use crate::protocol::reveal::Reveal;
 use crate::{
-    error::BoxError,
+    error::Error,
     ff::Field,
     protocol::{context::ProtocolContext, RecordId},
     secret_sharing::Replicated,
@@ -65,7 +65,7 @@ pub async fn check_zero<F: Field>(
     ctx: ProtocolContext<'_, Replicated<F>, F>,
     record_id: RecordId,
     v: &Replicated<F>,
-) -> Result<bool, BoxError> {
+) -> Result<bool, Error> {
     let prss = &ctx.prss();
     let r_sharing = prss.generate_replicated(record_id);
 
@@ -83,13 +83,13 @@ pub async fn check_zero<F: Field>(
 
 #[cfg(test)]
 pub mod tests {
-    use crate::error::BoxError;
+    use crate::error::Error;
     use crate::ff::{Field, Fp31};
     use crate::protocol::{check_zero::check_zero, QueryId, RecordId};
     use crate::test_fixture::{make_contexts, make_world, share, TestWorld};
 
     #[tokio::test]
-    async fn basic() -> Result<(), BoxError> {
+    async fn basic() -> Result<(), Error> {
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -1,6 +1,6 @@
 use super::specialized_mul::{multiply_one_share_mostly_zeroes, multiply_two_shares_mostly_zeroes};
 use crate::{
-    error::BoxError,
+    error::Error,
     ff::{BinaryField, Field, Fp2},
     helpers::Role,
     protocol::{context::ProtocolContext, RecordId},
@@ -111,7 +111,7 @@ impl ConvertShares {
         record_id: RecordId,
         a: &Replicated<F>,
         b: &Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let result = multiply_two_shares_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - &(result * F::from(2)))
@@ -137,7 +137,7 @@ impl ConvertShares {
         record_id: RecordId,
         a: &Replicated<F>,
         b: &Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let result = multiply_one_share_mostly_zeroes(ctx, record_id, a, b).await?;
 
         Ok(a + b - &(result * F::from(2)))
@@ -148,7 +148,7 @@ impl ConvertShares {
         ctx: ProtocolContext<'_, Replicated<F>, F>,
         record_id: RecordId,
         bit_index: u8,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         assert!(bit_index < self.input.num_bits);
 
         let input = Replicated::new(
@@ -172,7 +172,7 @@ pub async fn convert_shares_for_a_bit<F: Field>(
     input: &[(u64, u64)],
     num_bits: u8,
     bit_index: u8,
-) -> Result<Vec<Replicated<F>>, BoxError> {
+) -> Result<Vec<Replicated<F>>, Error> {
     let converted_shares = try_join_all(zip(repeat(ctx), input).enumerate().map(
         |(record_id, (ctx, row))| async move {
             let record_id = RecordId::from(record_id);
@@ -193,7 +193,7 @@ pub async fn convert_shares_for_a_bit<F: Field>(
 mod tests {
 
     use crate::{
-        error::BoxError,
+        error::Error,
         ff::{Field, Fp31},
         protocol::{
             modulus_conversion::convert_shares::{ConvertShares, XorShares},
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn convert_one_bit_of_many_match_keys() -> Result<(), BoxError> {
+    pub async fn convert_one_bit_of_many_match_keys() -> Result<(), Error> {
         let mut rng = rand::thread_rng();
 
         let world: TestWorld = make_world(QueryId);

--- a/src/protocol/modulus_conversion/specialized_mul.rs
+++ b/src/protocol/modulus_conversion/specialized_mul.rs
@@ -186,7 +186,7 @@ pub async fn multiply_one_share_mostly_zeroes<F: Field>(
 pub mod tests {
     use std::iter::zip;
 
-    use crate::error::BoxError;
+    use crate::error::Error;
     use crate::ff::{Field, Fp31};
     use crate::protocol::{
         modulus_conversion::specialized_mul::{
@@ -202,7 +202,7 @@ pub mod tests {
     use proptest::prelude::Rng;
 
     #[tokio::test]
-    async fn specialized_1_sequence() -> Result<(), BoxError> {
+    async fn specialized_1_sequence() -> Result<(), Error> {
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
@@ -246,7 +246,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn specialized_1_parallel() -> Result<(), BoxError> {
+    async fn specialized_1_parallel() -> Result<(), Error> {
         const ROUNDS: usize = 10;
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);
@@ -311,7 +311,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn specialized_2_sequence() -> Result<(), BoxError> {
+    async fn specialized_2_sequence() -> Result<(), Error> {
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);
         let mut rng = rand::thread_rng();
@@ -356,7 +356,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn specialized_2_parallel() -> Result<(), BoxError> {
+    async fn specialized_2_parallel() -> Result<(), Error> {
         const ROUNDS: usize = 10;
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);

--- a/src/protocol/mul/malicious.rs
+++ b/src/protocol/mul/malicious.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::mul::SemiHonestMul;
 use crate::protocol::{
@@ -79,7 +79,7 @@ impl<'a, F: Field> SecureMul<'a, F> {
         self,
         a: &MaliciousReplicated<F>,
         b: &MaliciousReplicated<F>,
-    ) -> Result<MaliciousReplicated<F>, BoxError> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         // being clever and assuming a clean context...
         let duplicate_multiply_ctx = self.ctx.narrow(&Step::DuplicateMultiply);
         let random_constant_prss = self.ctx.narrow(&Step::RandomnessForValidation).prss();

--- a/src/protocol/mul/mod.rs
+++ b/src/protocol/mul/mod.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::ProtocolContext;
 use crate::protocol::RecordId;
@@ -19,7 +19,7 @@ pub trait SecureMul<F: Field> {
         record_id: RecordId,
         a: &Self::Share,
         b: &Self::Share,
-    ) -> Result<Self::Share, BoxError>;
+    ) -> Result<Self::Share, Error>;
 }
 
 /// looks like clippy disagrees with itself on whether this attribute is useless or not.
@@ -35,7 +35,7 @@ impl<F: Field> SecureMul<F> for ProtocolContext<'_, Replicated<F>, F> {
         record_id: RecordId,
         a: &Self::Share,
         b: &Self::Share,
-    ) -> Result<Self::Share, BoxError> {
+    ) -> Result<Self::Share, Error> {
         SemiHonestMul::new(self, record_id).execute(a, b).await
     }
 }
@@ -50,7 +50,7 @@ impl<F: Field> SecureMul<F> for ProtocolContext<'_, MaliciousReplicated<F>, F> {
         record_id: RecordId,
         a: &Self::Share,
         b: &Self::Share,
-    ) -> Result<Self::Share, BoxError> {
+    ) -> Result<Self::Share, Error> {
         let acc = self.accumulator();
         MaliciouslySecureMul::new(self, record_id, acc)
             .execute(a, b)

--- a/src/protocol/mul/semi_honest.rs
+++ b/src/protocol/mul/semi_honest.rs
@@ -1,4 +1,4 @@
-use crate::error::BoxError;
+use crate::error::Error;
 use crate::ff::Field;
 use crate::helpers::Direction;
 use crate::protocol::{context::ProtocolContext, RecordId};
@@ -31,7 +31,7 @@ impl<'a, F: Field> SecureMul<'a, F> {
         self,
         a: &Replicated<F>,
         b: &Replicated<F>,
-    ) -> Result<Replicated<F>, BoxError> {
+    ) -> Result<Replicated<F>, Error> {
         let channel = self.ctx.mesh();
 
         // generate shared randomness.
@@ -62,7 +62,7 @@ impl<'a, F: Field> SecureMul<'a, F> {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::error::BoxError;
+    use crate::error::Error;
     use crate::ff::{Field, Fp31};
     use crate::protocol::mul::SecureMul;
     use crate::protocol::{context::ProtocolContext, QueryId, RecordId};
@@ -80,7 +80,7 @@ pub mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     #[tokio::test]
-    async fn basic() -> Result<(), BoxError> {
+    async fn basic() -> Result<(), Error> {
         let world: TestWorld = make_world(QueryId);
         let mut rand = StepRng::new(1, 1);
         let contexts = make_contexts::<Fp31>(&world);
@@ -146,7 +146,7 @@ pub mod tests {
         a: u8,
         b: u8,
         rng: &mut R,
-    ) -> Result<u128, BoxError>
+    ) -> Result<u128, Error>
     where
         Standard: Distribution<F>,
     {


### PR DESCRIPTION
Now that SecureMul doesn't throw BoxErrors, all the protocols that call it can just use normal errors. This should make it easier to match on them and stuff.