### PR TITLE
Remove deny(warnings)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ jobs:
     name: Rust Checks
     env:
       CARGO_TERM_COLOR: always
+      RUSTFLAGS: -D warnings
+      RUSTDOCFLAGS: -D warnings
+
     runs-on: ubuntu-latest
 
     steps:

--- a/pre-commit
+++ b/pre-commit
@@ -46,10 +46,6 @@ error() {
 
 cargo build --benches --all-features || error "Benchmarks compilation errors"
 
-<<<<<<< Updated upstream
-cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
-=======
 cargo clippy --tests -- -D warnings || error "Clippy errors"
->>>>>>> Stashed changes
 
 cargo test || error "Test failures"

--- a/pre-commit
+++ b/pre-commit
@@ -46,6 +46,10 @@ error() {
 
 cargo build --benches --all-features || error "Benchmarks compilation errors"
 
-cargo clippy --tests || error "Clippy errors"
+<<<<<<< Updated upstream
+cargo clippy --tests -- -D warnings --D clippy::pedantic || error "Clippy errors"
+=======
+cargo clippy --tests -- -D warnings || error "Clippy errors"
+>>>>>>> Stashed changes
 
 cargo test || error "Test failures"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::pedantic, clippy::clone_on_ref_ptr)]
+#![deny(clippy::pedantic, clippy::clone_on_ref_ptr)]
 // The following warnings are too noisy for us and having them enabled leads to polluting the
 // code with allow annotations. Disabling them once per project here
 #![allow(clippy::similar_names)]


### PR DESCRIPTION
This setting prevents compiler from building the code with warnings. I think it is useful to be able to do that because often I prototype an implementation and want to see whether it compiles and it is ok if there are unadressed warnings such asunused imports. Also I want to be able to run tests and get feedback from them without addressing all the warnings.

I think we have good protection at PR level as GH action would prevent pushing code that violates this no warnings rule.

I also enabled validation for `cargo doc` if we ever need to use it  based on conversations in https://github.com/rust-lang/cargo/issues/8424

Verified it is working and failing build: https://github.com/akoshelev/raw-ipa/actions/runs/3486104797