### PR TITLE
Run lint/Clippy first before build in GH actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,15 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        if: ${{ success() || failure() }}
+        run: cargo clippy --tests
+
       - name: Build
+        if: ${{ success() || failure() }}
         run: cargo build --tests
 
       - name: Release Build
@@ -35,14 +43,6 @@ jobs:
 
       - name: Build benchmarks
         run: cargo build --benches --all-features
-
-      - name: Check formatting
-        if: ${{ success() || failure() }}
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        if: ${{ success() || failure() }}
-        run: cargo clippy --tests
 
       - name: Run Tests
         run: cargo test


### PR DESCRIPTION
Most of the time, PR is broken because of formatting and/or Clippy issues. Therefore, it is desirable to run these checks first and get the feedback earlier before running builds and tests. My observation (likely biased towards my own behavior) is that we rarely submit code that does not compile or tests that are broken.