### PR TITLE
Add shuttle crate and randomized test for sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,14 @@ rust-version = "1.64.0"
 edition = "2021"
 
 [features]
-default = ["debug", "cli"]
 cli = ["comfy-table", "clap", "enable-serde", "metrics-tracing-context", "metrics-util", "tracing-subscriber", "web-app"]
 debug = []
+default = ["debug", "cli"]
 enable-serde = ["serde", "serde_json"]
-web-app = ["tokio", "tokio-stream", "tokio-util", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
+shuttle = ["test-fixture"]
 test-fixture = []
+web-app = ["tokio", "tokio-stream", "tokio-util", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
 
 [dependencies]
 aes = "0.8"
@@ -58,6 +59,7 @@ x25519-dalek = "2.0.0-pre.1"
 criterion = { version = "0.4.0", default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
 iai = "0.1.1"
 proptest = "1.0.0"
+shuttle = "0.4.1"
 
 [lib]
 name = "raw_ipa"

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -1,73 +1,7 @@
-use futures_util::future::try_join_all;
-use rand::Rng;
 use raw_ipa::error::BoxError;
-use raw_ipa::ff::Field;
-use raw_ipa::ff::Fp32BitPrime;
-use raw_ipa::protocol::sort::generate_sort_permutation::generate_sort_permutation;
-use raw_ipa::protocol::QueryId;
-use raw_ipa::test_fixture::{
-    make_contexts, make_world_with_config, validate_and_reconstruct, TestWorldConfig,
-};
-use std::time::Instant;
+use raw_ipa::test_fixture::sort::execute_sort;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), BoxError> {
-    let mut config = TestWorldConfig::default();
-    config.gateway_config.send_buffer_config.items_in_batch = 1;
-    config.gateway_config.send_buffer_config.batch_count = 1000;
-    let world = make_world_with_config(QueryId, config);
-    let [ctx0, ctx1, ctx2] = make_contexts::<Fp32BitPrime>(&world);
-    let num_bits = 64;
-    let mut rng = rand::thread_rng();
-
-    let batchsize = 100;
-
-    let mut match_keys: Vec<u64> = Vec::new();
-    for _ in 0..batchsize {
-        match_keys.push(rng.gen::<u64>());
-    }
-
-    let input_len = match_keys.len();
-    let mut shares = [
-        Vec::with_capacity(input_len),
-        Vec::with_capacity(input_len),
-        Vec::with_capacity(input_len),
-    ];
-    for match_key in match_keys.clone() {
-        let share_0 = rng.gen::<u64>();
-        let share_1 = rng.gen::<u64>();
-        let share_2 = match_key ^ share_0 ^ share_1;
-
-        shares[0].push((share_0, share_1));
-        shares[1].push((share_1, share_2));
-        shares[2].push((share_2, share_0));
-    }
-
-    let start = Instant::now();
-    let result = try_join_all(vec![
-        generate_sort_permutation(ctx0, &shares[0], num_bits),
-        generate_sort_permutation(ctx1, &shares[1], num_bits),
-        generate_sort_permutation(ctx2, &shares[2], num_bits),
-    ])
-    .await?;
-    let duration = start.elapsed().as_secs_f32();
-    println!("benchmark complete after {duration}s");
-
-    assert_eq!(result[0].len(), input_len);
-    assert_eq!(result[1].len(), input_len);
-    assert_eq!(result[2].len(), input_len);
-
-    let mut mpc_sorted_list: Vec<u128> = (0..input_len).map(|i| i as u128).collect();
-    for (i, match_key) in match_keys.iter().enumerate() {
-        let index = validate_and_reconstruct(&result[0][i], &result[1][i], &result[2][i]);
-        mpc_sorted_list[index.as_u128() as usize] = u128::from(*match_key);
-    }
-
-    let mut sorted_match_keys = match_keys.clone();
-    sorted_match_keys.sort_unstable();
-    for i in 0..input_len {
-        assert_eq!(u128::from(sorted_match_keys[i]), mpc_sorted_list[i]);
-    }
-
-    Ok(())
+    execute_sort().await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,6 @@ pub mod telemetry;
 
 #[cfg(any(test, feature = "test-fixture"))]
 pub mod test_fixture;
+
+#[cfg(test)]
+mod tests;

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,6 +1,6 @@
-use std::marker::PhantomData;
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::sync::Arc;
+use std::marker::PhantomData;
 #[cfg(not(all(feature = "shuttle", test)))]
 use std::sync::Arc;
 

--- a/src/protocol/context.rs
+++ b/src/protocol/context.rs
@@ -1,4 +1,7 @@
 use std::marker::PhantomData;
+#[cfg(all(feature = "shuttle", test))]
+use shuttle::sync::Arc;
+#[cfg(not(all(feature = "shuttle", test)))]
 use std::sync::Arc;
 
 use super::{

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -10,6 +10,9 @@ use crate::{
     secret_sharing::{MaliciousReplicated, Replicated},
 };
 use futures::future::try_join;
+#[cfg(all(feature = "shuttle", test))]
+use shuttle::sync::{Arc, Mutex, Weak};
+#[cfg(not(all(feature = "shuttle", test)))]
 use std::sync::{Arc, Mutex, Weak};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/protocol/sort/generate_sort_permutation.rs
+++ b/src/protocol/sort/generate_sort_permutation.rs
@@ -74,77 +74,11 @@ pub async fn generate_sort_permutation<'a, F: Field>(
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
-
-    use futures::future::try_join_all;
-    use rand::Rng;
-
-    use crate::{
-        error::BoxError,
-        ff::{Field, Fp32BitPrime},
-        protocol::{sort::generate_sort_permutation::generate_sort_permutation, QueryId},
-        test_fixture::{logging, make_contexts, make_world, validate_and_reconstruct},
-    };
+    use crate::error::BoxError;
+    use crate::test_fixture::sort::execute_sort;
 
     #[tokio::test]
     pub async fn test_generate_sort_permutation() -> Result<(), BoxError> {
-        const ROUNDS: usize = 50;
-        const NUM_BITS: u8 = 24;
-        const MASK: u64 = u64::MAX >> (64 - NUM_BITS);
-
-        logging::setup();
-        let world = make_world(QueryId);
-        let [ctx0, ctx1, ctx2] = make_contexts::<Fp32BitPrime>(&world);
-        let mut rng = rand::thread_rng();
-
-        let mut match_keys: Vec<u64> = Vec::new();
-        for _ in 0..ROUNDS {
-            match_keys.push(rng.gen::<u64>() & MASK);
-        }
-
-        let mut shares = [
-            Vec::with_capacity(ROUNDS),
-            Vec::with_capacity(ROUNDS),
-            Vec::with_capacity(ROUNDS),
-        ];
-        for match_key in match_keys.clone() {
-            let share_0 = rng.gen::<u64>() & MASK;
-            let share_1 = rng.gen::<u64>() & MASK;
-            let share_2 = match_key ^ share_0 ^ share_1;
-
-            shares[0].push((share_0, share_1));
-            shares[1].push((share_1, share_2));
-            shares[2].push((share_2, share_0));
-        }
-
-        let [result0, result1, result2] = <[_; 3]>::try_from(
-            try_join_all([
-                generate_sort_permutation(ctx0, &shares[0], NUM_BITS),
-                generate_sort_permutation(ctx1, &shares[1], NUM_BITS),
-                generate_sort_permutation(ctx2, &shares[2], NUM_BITS),
-            ])
-            .await?,
-        )
-        .unwrap();
-
-        assert_eq!(result0.len(), ROUNDS);
-        assert_eq!(result1.len(), ROUNDS);
-        assert_eq!(result2.len(), ROUNDS);
-
-        let mut mpc_sorted_list: Vec<u128> = (0..ROUNDS).map(|i| i as u128).collect();
-        for (match_key, (r0, (r1, r2))) in
-            zip(match_keys.iter(), zip(result0, zip(result1, result2)))
-        {
-            let index = validate_and_reconstruct(&r0, &r1, &r2);
-            mpc_sorted_list[index.as_u128() as usize] = u128::from(*match_key);
-        }
-
-        let mut sorted_match_keys = match_keys.clone();
-        sorted_match_keys.sort_unstable();
-        for i in 0..ROUNDS {
-            assert_eq!(u128::from(sorted_match_keys[i]), mpc_sorted_list[i]);
-        }
-
-        Ok(())
+        execute_sort().await
     }
 }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -4,6 +4,7 @@ mod world;
 pub mod circuit;
 pub mod logging;
 pub mod network;
+pub mod sort;
 
 use crate::ff::{Field, Fp31};
 use crate::helpers::Role;

--- a/src/test_fixture/network.rs
+++ b/src/test_fixture/network.rs
@@ -6,13 +6,19 @@ use crate::{
     },
     protocol::Step,
 };
+use ::tokio::sync::mpsc::{self, Receiver, Sender};
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_util::stream::{FuturesUnordered, SelectAll};
+#[cfg(all(feature = "shuttle", test))]
+use shuttle::{
+    future as tokio,
+    sync::{Arc, Mutex, Weak},
+};
 use std::collections::{hash_map::Entry, HashMap};
 use std::fmt::{Debug, Formatter};
+#[cfg(not(all(feature = "shuttle", test)))]
 use std::sync::{Arc, Mutex, Weak};
-use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
 
@@ -90,7 +96,7 @@ impl InMemoryEndpoint {
                 let mut buf = HashMap::<ChannelId, Vec<u8>>::new();
 
                 loop {
-                    tokio::select! {
+                    ::tokio::select! {
                         // handle request to establish connection with a peer
                         Some(control_message) = open_channel_rx.recv() => {
                             match control_message {

--- a/src/test_fixture/sort.rs
+++ b/src/test_fixture/sort.rs
@@ -1,0 +1,74 @@
+use crate::error::BoxError;
+use crate::ff::Field;
+use crate::ff::Fp32BitPrime;
+use crate::protocol::sort::generate_sort_permutation::generate_sort_permutation;
+use crate::protocol::QueryId;
+use crate::test_fixture::{make_contexts, make_world, validate_and_reconstruct};
+use futures_util::future::try_join_all;
+use rand::Rng;
+use std::iter::zip;
+
+/// Executes the sort circuit.
+/// todo: make rounds, bits arguments to this function
+///
+/// ## Panics
+/// When sort panicked
+/// ## Errors
+/// When sort returned an error
+pub async fn execute_sort() -> Result<(), BoxError> {
+    const ROUNDS: usize = 50;
+    const NUM_BITS: u8 = 24;
+    const MASK: u64 = u64::MAX >> (64 - NUM_BITS);
+
+    let world = make_world(QueryId);
+    let [ctx0, ctx1, ctx2] = make_contexts::<Fp32BitPrime>(&world);
+    let mut rng = rand::thread_rng();
+
+    let mut match_keys: Vec<u64> = Vec::new();
+    for _ in 0..ROUNDS {
+        match_keys.push(rng.gen::<u64>() & MASK);
+    }
+
+    let mut shares = [
+        Vec::with_capacity(ROUNDS),
+        Vec::with_capacity(ROUNDS),
+        Vec::with_capacity(ROUNDS),
+    ];
+    for match_key in match_keys.clone() {
+        let share_0 = rng.gen::<u64>() & MASK;
+        let share_1 = rng.gen::<u64>() & MASK;
+        let share_2 = match_key ^ share_0 ^ share_1;
+
+        shares[0].push((share_0, share_1));
+        shares[1].push((share_1, share_2));
+        shares[2].push((share_2, share_0));
+    }
+
+    let [result0, result1, result2] = <[_; 3]>::try_from(
+        try_join_all([
+            generate_sort_permutation(ctx0, &shares[0], NUM_BITS),
+            generate_sort_permutation(ctx1, &shares[1], NUM_BITS),
+            generate_sort_permutation(ctx2, &shares[2], NUM_BITS),
+        ])
+        .await?,
+    )
+    .unwrap();
+
+    assert_eq!(result0.len(), ROUNDS);
+    assert_eq!(result1.len(), ROUNDS);
+    assert_eq!(result2.len(), ROUNDS);
+
+    let mut mpc_sorted_list: Vec<u128> = (0..ROUNDS).map(|i| i as u128).collect();
+    for (match_key, (r0, (r1, r2))) in zip(match_keys.iter(), zip(result0, zip(result1, result2))) {
+        let index = validate_and_reconstruct(&r0, &r1, &r2);
+        mpc_sorted_list[index.as_u128() as usize] = u128::from(*match_key);
+    }
+
+    let mut sorted_match_keys = match_keys.clone();
+    sorted_match_keys.sort_unstable();
+    for i in 0..ROUNDS {
+        assert_eq!(u128::from(sorted_match_keys[i]), mpc_sorted_list[i]);
+    }
+
+    Ok(())
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "shuttle")]
+mod randomized;

--- a/src/tests/randomized.rs
+++ b/src/tests/randomized.rs
@@ -1,0 +1,14 @@
+//! Randomized concurrency tests that use shuttle
+//!
+use crate::test_fixture::sort::execute_sort;
+
+#[test]
+fn sort() {
+    // TODO this test is failing, enable running it in GH actions once fixed
+    shuttle::check_random(
+        || {
+            shuttle::future::block_on(execute_sort()).unwrap();
+        },
+        5,
+    );
+}


### PR DESCRIPTION
Unfortunately I can't enable this test right now because we have a bug somewhere. Using this randomized scheduler revealed a bug in reveal (!?). Reveal reconstructs wrong secret for some of the permutation values. I am not sure where the bug is, likely in infra but it is certainly triggered by reordering task execution. Will be looking into that, submitting this PR if someone else wants to take a look  too.

Here is how to run this test

```bash
cargo test --features shuttle --lib tests::randomized::sort
```

I also refactored the sort circuit so we can run the same test in benchmarks, unit tests and randomized tests.

this is how test currently fails

```bash
thread 'main' panicked at 'index out of bounds: the len is 50 but the index is 2988901655', /Users/koshelev/workspace/raw-ipa/src/protocol/sort/apply.rs:39:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
stack backtrace:
```

I briefly checked it and it seems permutation slice contains garbage values along with actual indices. Would need to investigate further

## Why Shuttle?

* I had some good feedback about it from the folks I worked with before. They were using both Loom and Shuttle and Loom verification took much longer to execute for them. 
