### PR TITLE
Do not create the world for each test loop

### DIFF
--- a/src/protocol/boolean/bitwise_lt.rs
+++ b/src/protocol/boolean/bitwise_lt.rs
@@ -169,36 +169,29 @@ mod tests {
     use super::BitwiseLessThan;
     use crate::{
         error::Error,
-        ff::{Field, Fp31, Fp32BitPrime, Int},
-        protocol::{QueryId, RecordId},
+        ff::{Field, Fp31, Fp32BitPrime},
+        protocol::{context::ProtocolContext, QueryId, RecordId},
         secret_sharing::Replicated,
-        test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
+        test_fixture::{
+            make_contexts, make_world, shared_bits, transpose, validate_and_reconstruct, TestWorld,
+        },
     };
     use futures::future::try_join_all;
-    use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng, RngCore};
+    use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng, Rng};
 
-    /// From `Vec<[Replicated<F>; 3]>`, create `Vec<Replicated<F>>` taking `i`'th share per row
-    fn transpose<F: Field>(x: &[[Replicated<F>; 3]], i: usize) -> Vec<Replicated<F>> {
-        x.iter().map(|x| x[i].clone()).collect::<Vec<_>>()
-    }
+    // `fp_32bit_prime()` takes about 1sec with 30 tries
+    const TEST_TRIES: u32 = 30;
 
-    /// Take a field value `x` and turn them into replicated bitwise sharings of three
-    fn shared_bits<F: Field, R: RngCore>(x: F, rand: &mut R) -> Vec<[Replicated<F>; 3]>
+    async fn bitwise_lt<F: Field>(
+        ctx: [ProtocolContext<'_, Replicated<F>, F>; 3],
+        record_id: RecordId,
+        a: F,
+        b: F,
+    ) -> Result<F, Error>
     where
         Standard: Distribution<F>,
     {
-        let x = x.as_u128();
-        (0..F::Integer::BITS)
-            .map(|i| share(F::from(x >> i & 1), rand))
-            .collect::<Vec<_>>()
-    }
-
-    async fn bitwise_lt<F: Field>(a: F, b: F) -> Result<F, Error>
-    where
-        Standard: Distribution<F>,
-    {
-        let world: TestWorld = make_world(QueryId);
-        let ctx = make_contexts::<F>(&world);
+        let [c0, c1, c2] = ctx;
         let mut rand = StepRng::new(1, 1);
 
         // Generate secret shares
@@ -206,23 +199,22 @@ mod tests {
         let b_bits = shared_bits(b, &mut rand);
 
         // Execute
-        let step = "BitwiseLT_Test";
         let result = try_join_all([
             BitwiseLessThan::execute(
-                ctx[0].narrow(step),
-                RecordId::from(0),
+                c0.bind(record_id),
+                record_id,
                 &transpose(&a_bits, 0),
                 &transpose(&b_bits, 0),
             ),
             BitwiseLessThan::execute(
-                ctx[1].narrow(step),
-                RecordId::from(0),
+                c1.bind(record_id),
+                record_id,
                 &transpose(&a_bits, 1),
                 &transpose(&b_bits, 1),
             ),
             BitwiseLessThan::execute(
-                ctx[2].narrow(step),
-                RecordId::from(0),
+                c2.bind(record_id),
+                record_id,
                 &transpose(&a_bits, 2),
                 &transpose(&b_bits, 2),
             ),
@@ -235,63 +227,59 @@ mod tests {
 
     #[tokio::test]
     pub async fn fp31() -> Result<(), Error> {
-        let c = Fp31::from;
-        let zero = Fp31::ZERO;
-        let one = Fp31::ONE;
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp31>(&world);
+        let [c0, c1, c2] = ctx;
+        let mut rng = rand::thread_rng();
 
-        assert_eq!(one, bitwise_lt(zero, one).await?);
-        assert_eq!(zero, bitwise_lt(one, zero).await?);
-        assert_eq!(zero, bitwise_lt(zero, zero).await?);
-        assert_eq!(zero, bitwise_lt(one, one).await?);
+        for i in 0..TEST_TRIES {
+            let (a, b): (Fp31, Fp31) = (rng.gen::<Fp31>(), rng.gen::<Fp31>());
+            let expected = if a.as_u128() < b.as_u128() {
+                Fp31::ONE
+            } else {
+                Fp31::ZERO
+            };
 
-        assert_eq!(one, bitwise_lt(c(3_u8), c(7)).await?);
-        assert_eq!(zero, bitwise_lt(c(21), c(20)).await?);
-        assert_eq!(zero, bitwise_lt(c(9), c(9)).await?);
-
-        assert_eq!(zero, bitwise_lt(zero, c(Fp31::PRIME)).await?);
-
+            assert_eq!(
+                expected,
+                bitwise_lt(
+                    [c0.clone(), c1.clone(), c2.clone()],
+                    RecordId::from(i),
+                    a,
+                    b
+                )
+                .await?
+            );
+        }
         Ok(())
     }
 
     #[tokio::test]
     pub async fn fp_32bit_prime() -> Result<(), Error> {
-        let c = Fp32BitPrime::from;
-        let zero = Fp32BitPrime::ZERO;
-        let one = Fp32BitPrime::ONE;
-        let u16_max: u32 = u16::MAX.into();
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp32BitPrime>(&world);
+        let [c0, c1, c2] = ctx;
+        let mut rng = rand::thread_rng();
 
-        assert_eq!(one, bitwise_lt(zero, one).await?);
-        assert_eq!(zero, bitwise_lt(one, zero).await?);
-        assert_eq!(zero, bitwise_lt(zero, zero).await?);
-        assert_eq!(zero, bitwise_lt(one, one).await?);
+        for i in 0..TEST_TRIES {
+            let (a, b): (Fp32BitPrime, Fp32BitPrime) =
+                (rng.gen::<Fp32BitPrime>(), rng.gen::<Fp32BitPrime>());
+            let expected = if a.as_u128() < b.as_u128() {
+                Fp32BitPrime::ONE
+            } else {
+                Fp32BitPrime::ZERO
+            };
 
-        assert_eq!(one, bitwise_lt(c(3_u32), c(7)).await?);
-        assert_eq!(zero, bitwise_lt(c(21), c(20)).await?);
-        assert_eq!(zero, bitwise_lt(c(9), c(9)).await?);
-
-        assert_eq!(one, bitwise_lt(c(u16_max), c(u16_max + 1)).await?);
-        assert_eq!(zero, bitwise_lt(c(u16_max + 1), c(u16_max)).await?);
-        assert_eq!(
-            one,
-            bitwise_lt(c(u16_max), c(Fp32BitPrime::PRIME - 1)).await?
-        );
-
-        assert_eq!(zero, bitwise_lt(zero, c(Fp32BitPrime::PRIME)).await?);
-
-        Ok(())
-    }
-
-    // this test is for manual execution only
-    #[ignore]
-    #[tokio::test]
-    pub async fn cmp_all_fp31() -> Result<(), Error> {
-        for a in 0..Fp31::PRIME {
-            for b in 0..Fp31::PRIME {
-                assert_eq!(
-                    Fp31::from(a < b),
-                    bitwise_lt(Fp31::from(a), Fp31::from(b)).await?
-                );
-            }
+            assert_eq!(
+                expected,
+                bitwise_lt(
+                    [c0.clone(), c1.clone(), c2.clone()],
+                    RecordId::from(i),
+                    a,
+                    b
+                )
+                .await?
+            );
         }
         Ok(())
     }

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -22,15 +22,20 @@ mod tests {
     use crate::{
         error::Error,
         ff::{Field, Fp31},
-        protocol::{QueryId, RecordId},
+        protocol::{context::ProtocolContext, QueryId, RecordId},
+        secret_sharing::Replicated,
         test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
     };
     use futures::future::try_join_all;
     use rand::rngs::mock::StepRng;
 
-    async fn or_fp31(a: Fp31, b: Fp31) -> Result<Fp31, Error> {
-        let world: TestWorld = make_world(QueryId);
-        let ctx = make_contexts::<Fp31>(&world);
+    async fn or_fp31(
+        ctx: [ProtocolContext<'_, Replicated<Fp31>, Fp31>; 3],
+        record_id: RecordId,
+        a: Fp31,
+        b: Fp31,
+    ) -> Result<Fp31, Error> {
+        let [c0, c1, c2] = ctx;
         let mut rand = StepRng::new(1, 1);
 
         // Generate secret shares
@@ -39,26 +44,10 @@ mod tests {
         let b_shares = share(b, &mut rand);
 
         // Execute
-        let step = "Or_Test";
         let result = try_join_all(vec![
-            or(
-                ctx[0].narrow(step),
-                RecordId::from(0_u32),
-                &a_shares[0],
-                &b_shares[0],
-            ),
-            or(
-                ctx[1].narrow(step),
-                RecordId::from(0_u32),
-                &a_shares[1],
-                &b_shares[1],
-            ),
-            or(
-                ctx[2].narrow(step),
-                RecordId::from(0_u32),
-                &a_shares[2],
-                &b_shares[2],
-            ),
+            or(c0.bind(record_id), record_id, &a_shares[0], &b_shares[0]),
+            or(c1.bind(record_id), record_id, &a_shares[1], &b_shares[1]),
+            or(c2.bind(record_id), record_id, &a_shares[2], &b_shares[2]),
         ])
         .await
         .unwrap();
@@ -68,10 +57,50 @@ mod tests {
 
     #[tokio::test]
     pub async fn basic() -> Result<(), Error> {
-        assert_eq!(Fp31::ZERO, or_fp31(Fp31::ZERO, Fp31::ZERO).await?);
-        assert_eq!(Fp31::ONE, or_fp31(Fp31::ONE, Fp31::ZERO).await?);
-        assert_eq!(Fp31::ONE, or_fp31(Fp31::ZERO, Fp31::ONE).await?);
-        assert_eq!(Fp31::ONE, or_fp31(Fp31::ONE, Fp31::ONE).await?);
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp31>(&world);
+        let [c0, c1, c2] = ctx;
+
+        assert_eq!(
+            Fp31::ZERO,
+            or_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(0),
+                Fp31::ZERO,
+                Fp31::ZERO
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ONE,
+            or_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(1),
+                Fp31::ONE,
+                Fp31::ZERO
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ONE,
+            or_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(2),
+                Fp31::ZERO,
+                Fp31::ONE
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ONE,
+            or_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(3),
+                Fp31::ONE,
+                Fp31::ONE
+            )
+            .await?
+        );
 
         Ok(())
     }

--- a/src/protocol/boolean/prefix_or.rs
+++ b/src/protocol/boolean/prefix_or.rs
@@ -317,8 +317,8 @@ mod tests {
     use rand::{rngs::mock::StepRng, Rng};
     use std::iter::zip;
 
-    const BITS: [usize; 1] = [32];
-    const TEST_TRIES: usize = 16;
+    const BITS: [usize; 2] = [16, 32];
+    const TEST_TRIES: usize = 32;
 
     async fn prefix_or<F: Field>(
         ctx: [ProtocolContext<'_, Replicated<F>, F>; 3],
@@ -370,8 +370,11 @@ mod tests {
         // Test n-bit (n = BITS[i]) bitwise shares with randomly distributed
         // bits, for 16 times. The probability of i'th bit being 0 is 1/2^i,
         // so this test covers inputs that have all 0's in 5 first bits.
-        for (i, len) in BITS.into_iter().enumerate() {
-            for j in 0..TEST_TRIES {
+        for len in BITS {
+            let step = format!("test_{}bit", len);
+            let [c0, c1, c2] = [c0.narrow(&step), c1.narrow(&step), c2.narrow(&step)];
+
+            for i in 0..TEST_TRIES {
                 let input: Vec<Fp2> = (0..len).map(|_| Fp2::from(rng.gen::<bool>())).collect();
                 let mut expected: Vec<Fp2> = Vec::with_capacity(len);
 
@@ -384,7 +387,7 @@ mod tests {
                 // Execute the protocol
                 let result = prefix_or(
                     [c0.clone(), c1.clone(), c2.clone()],
-                    RecordId::from(i * TEST_TRIES + j),
+                    RecordId::from(i),
                     &input,
                 )
                 .await?;
@@ -411,8 +414,11 @@ mod tests {
         // Test n-bit (n = BITS[i]) bitwise shares with randomly distributed
         // bits, for 16 times. The probability of i'th bit being 0 is 1/2^i,
         // so this test covers inputs that have all 0's in 5 first bits.
-        for (i, len) in BITS.into_iter().enumerate() {
-            for j in 0..TEST_TRIES {
+        for len in BITS {
+            let step = format!("test_{}bit", len);
+            let [c0, c1, c2] = [c0.narrow(&step), c1.narrow(&step), c2.narrow(&step)];
+
+            for i in 0..TEST_TRIES {
                 // Generate a vector of Fp31::ZERO or Fp31::ONE from randomly picked bool values
                 let input: Vec<Fp31> = (0..len)
                     .map(|_| Fp31::from(u128::from(rng.gen::<bool>())))
@@ -429,7 +435,7 @@ mod tests {
                 // Execute the protocol
                 let result = prefix_or(
                     [c0.clone(), c1.clone(), c2.clone()],
-                    RecordId::from(i * TEST_TRIES + j),
+                    RecordId::from(i),
                     &input,
                 )
                 .await?;

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -21,15 +21,20 @@ mod tests {
     use crate::{
         error::Error,
         ff::{Field, Fp31},
-        protocol::{QueryId, RecordId},
+        protocol::{context::ProtocolContext, QueryId, RecordId},
+        secret_sharing::Replicated,
         test_fixture::{make_contexts, make_world, share, validate_and_reconstruct, TestWorld},
     };
     use futures::future::try_join_all;
     use rand::rngs::mock::StepRng;
 
-    async fn xor_fp31(a: Fp31, b: Fp31) -> Result<Fp31, Error> {
-        let world: TestWorld = make_world(QueryId);
-        let ctx = make_contexts::<Fp31>(&world);
+    async fn xor_fp31(
+        ctx: [ProtocolContext<'_, Replicated<Fp31>, Fp31>; 3],
+        record_id: RecordId,
+        a: Fp31,
+        b: Fp31,
+    ) -> Result<Fp31, Error> {
+        let [c0, c1, c2] = ctx;
         let mut rand = StepRng::new(1, 1);
 
         // Generate secret shares
@@ -38,26 +43,10 @@ mod tests {
         let b_shares = share(b, &mut rand);
 
         // Execute
-        let step = "Xor_Test";
         let result = try_join_all(vec![
-            xor(
-                ctx[0].narrow(step),
-                RecordId::from(0),
-                &a_shares[0],
-                &b_shares[0],
-            ),
-            xor(
-                ctx[1].narrow(step),
-                RecordId::from(0),
-                &a_shares[1],
-                &b_shares[1],
-            ),
-            xor(
-                ctx[2].narrow(step),
-                RecordId::from(0),
-                &a_shares[2],
-                &b_shares[2],
-            ),
+            xor(c0.bind(record_id), record_id, &a_shares[0], &b_shares[0]),
+            xor(c1.bind(record_id), record_id, &a_shares[1], &b_shares[1]),
+            xor(c2.bind(record_id), record_id, &a_shares[2], &b_shares[2]),
         ])
         .await
         .unwrap();
@@ -67,10 +56,50 @@ mod tests {
 
     #[tokio::test]
     pub async fn basic() -> Result<(), Error> {
-        assert_eq!(Fp31::ZERO, xor_fp31(Fp31::ZERO, Fp31::ZERO).await?);
-        assert_eq!(Fp31::ONE, xor_fp31(Fp31::ONE, Fp31::ZERO).await?);
-        assert_eq!(Fp31::ONE, xor_fp31(Fp31::ZERO, Fp31::ONE).await?);
-        assert_eq!(Fp31::ZERO, xor_fp31(Fp31::ONE, Fp31::ONE).await?);
+        let world: TestWorld = make_world(QueryId);
+        let ctx = make_contexts::<Fp31>(&world);
+        let [c0, c1, c2] = ctx;
+
+        assert_eq!(
+            Fp31::ZERO,
+            xor_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(0),
+                Fp31::ZERO,
+                Fp31::ZERO
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ONE,
+            xor_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(1),
+                Fp31::ONE,
+                Fp31::ZERO
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ONE,
+            xor_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(2),
+                Fp31::ZERO,
+                Fp31::ONE
+            )
+            .await?
+        );
+        assert_eq!(
+            Fp31::ZERO,
+            xor_fp31(
+                [c0.clone(), c1.clone(), c2.clone()],
+                RecordId::from(3),
+                Fp31::ONE,
+                Fp31::ONE
+            )
+            .await?
+        );
 
         Ok(())
     }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -18,8 +18,8 @@ use rand::rngs::mock::StepRng;
 use rand::thread_rng;
 
 pub use sharing::{
-    share, share_malicious, validate_and_reconstruct, validate_list_of_shares,
-    validate_list_of_shares_malicious,
+    share, share_malicious, shared_bits, transpose, validate_and_reconstruct,
+    validate_list_of_shares, validate_list_of_shares_malicious,
 };
 pub use world::{
     make as make_world, make_with_config as make_world_with_config, TestWorld, TestWorldConfig,


### PR DESCRIPTION
This diff improves the unit tests for many boolean protocols I implemented lately.

* Pull out `make_world()` and `make_contexts()` out of functions that are called every time a test case is executed.
* Move dup'ed test helper functions to `test_fixture`
* Replace hard-coded test cases to random test cases as much as appropriate

`Carries` (and `BitwiseSum` which calls `Carries`) is very slow (0.4 sec per invocation), so I limited the number of test tries to 5 to shorten the test case execution time. There are TODOs for some parts of the protocol that can be optimized, but still the protocol seems too expensive. I'll open an issue to track this.