### PR TITLE
Use PRSS sequential randomness to generate permutation instead of ChaCha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ metrics-tracing-context = { version = "0.12.0", optional = true }
 metrics-util = { version = "0.14.0", optional = true }
 pin-project = "1.0.12"
 rand = "0.8"
-rand_chacha = "0.3.1"
 rand_core = "0.6"
 
 # TODO consider using zerocopy or serde_bytes or in-house serialization

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -86,9 +86,9 @@ mod tests {
             let [ctx0, ctx1, ctx2] = make_contexts(&world);
 
             let sigma_and_randoms: [_; 3] = try_join_all([
-                shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), sigma.len(), sigma0),
-                shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), sigma.len(), sigma1),
-                shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), sigma.len(), sigma2),
+                shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), BATCHSIZE, sigma0),
+                shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), BATCHSIZE, sigma1),
+                shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), BATCHSIZE, sigma2),
             ])
             .await
             .unwrap()

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -83,6 +83,7 @@ impl AsRef<str> for ComposeStep {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ShuffleRevealStep {
+    GeneratePermutation,
     RevealPermutation,
     ShufflePermutation,
 }
@@ -92,6 +93,7 @@ impl Substep for ShuffleRevealStep {}
 impl AsRef<str> for ShuffleRevealStep {
     fn as_ref(&self) -> &str {
         match self {
+            Self::GeneratePermutation => "generate_permutation",
             Self::RevealPermutation => "reveal_permutation",
             Self::ShufflePermutation => "shuffle_permutation",
         }

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -91,9 +91,9 @@ mod tests {
             let [perm0, perm1, perm2] = generate_shares::<Fp31>(&permutation);
 
             let perm_and_randoms: [_; 3] = try_join_all([
-                shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), input.len(), perm0),
-                shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), input.len(), perm1),
-                shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), input.len(), perm2),
+                shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), BATCHSIZE, perm0),
+                shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), BATCHSIZE, perm1),
+                shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), BATCHSIZE, perm2),
             ])
             .await
             .unwrap()

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -3,16 +3,15 @@ use std::iter::{repeat, zip};
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
 use rand::seq::SliceRandom;
-use rand::SeedableRng;
-use rand_chacha::ChaCha8Rng;
 
 use crate::protocol::context::SemiHonestContext;
+use crate::protocol::prss::SequentialSharedRandomness;
 use crate::secret_sharing::SecretSharing;
 use crate::{
     error::Error,
     ff::Field,
     helpers::{Direction, Role},
-    protocol::{context::Context, prss::IndexedSharedRandomness, RecordId, Substep},
+    protocol::{context::Context, RecordId, Substep},
     secret_sharing::Replicated,
 };
 
@@ -40,39 +39,16 @@ impl AsRef<str> for ShuffleOrUnshuffle {
 /// This implements Fisher Yates shuffle described here <https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle>
 #[allow(clippy::cast_possible_truncation)]
 pub fn get_two_of_three_random_permutations(
-    batchsize: usize,
-    prss: &IndexedSharedRandomness,
+    batch_size: u32,
+    mut rng: (SequentialSharedRandomness, SequentialSharedRandomness),
 ) -> (Vec<u32>, Vec<u32>) {
-    // Chacha8Rng expects a [u8;32] seed whereas prss returns a u128 number.
-    // We are using two seeds from prss to generate a seed for shuffle and concatenating them
-    // Since reshare uses indexes 0..batchsize to generate random numbers from prss, we are using
-    // batchsize and batchsize+1 as index to get seeds for permutation
-    let randoms = (
-        prss.generate_values(batchsize as u128),
-        prss.generate_values(batchsize as u128 + 1),
-    );
+    let mut left_permutation = (0..batch_size).collect::<Vec<_>>();
+    let mut right_permutation = left_permutation.clone();
 
-    // generate seed for shuffle
-    let (mut seed_left, mut seed_right) = (Vec::with_capacity(32), Vec::with_capacity(32));
-    seed_left.extend_from_slice(&randoms.0 .0.to_le_bytes());
-    seed_left.extend_from_slice(&randoms.1 .0.to_le_bytes());
+    left_permutation.shuffle(&mut rng.0);
+    right_permutation.shuffle(&mut rng.1);
 
-    seed_right.extend_from_slice(&randoms.0 .1.to_le_bytes());
-    seed_right.extend_from_slice(&randoms.1 .1.to_le_bytes());
-
-    let max_index: u32 = batchsize.try_into().unwrap();
-
-    let mut permutations: (Vec<u32>, Vec<u32>) =
-        ((0..max_index).collect(), (0..max_index).collect());
-    // shuffle 0..N based on seed
-    permutations
-        .0
-        .shuffle(&mut ChaCha8Rng::from_seed(seed_left.try_into().unwrap()));
-    permutations
-        .1
-        .shuffle(&mut ChaCha8Rng::from_seed(seed_right.try_into().unwrap()));
-
-    permutations
+    (left_permutation, right_permutation)
 }
 
 /// This is SHUFFLE(Algorithm 1) described in <https://eprint.iacr.org/2019/695.pdf>.
@@ -231,15 +207,15 @@ mod tests {
 
     #[test]
     fn random_sequence_generated() {
-        const BATCH_SIZE: usize = 10000;
+        const BATCH_SIZE: u32 = 10000;
 
         logging::setup();
 
         let [p1, p2, p3] = make_participants();
         let step = Step::default();
-        let perm1 = get_two_of_three_random_permutations(BATCH_SIZE, p1.indexed(&step).as_ref());
-        let perm2 = get_two_of_three_random_permutations(BATCH_SIZE, p2.indexed(&step).as_ref());
-        let perm3 = get_two_of_three_random_permutations(BATCH_SIZE, p3.indexed(&step).as_ref());
+        let perm1 = get_two_of_three_random_permutations(BATCH_SIZE, p1.sequential(&step));
+        let perm2 = get_two_of_three_random_permutations(BATCH_SIZE, p2.sequential(&step));
+        let perm3 = get_two_of_three_random_permutations(BATCH_SIZE, p3.sequential(&step));
 
         assert_eq!(perm1.1, perm2.0);
         assert_eq!(perm2.1, perm3.0);
@@ -264,16 +240,16 @@ mod tests {
         let batchsize = 25;
         let input: Vec<u8> = (0..batchsize).collect();
         let hashed_input: HashSet<u8> = input.clone().into_iter().collect();
-        let input_len = input.len();
+        let input_len = u32::from(batchsize);
 
         let input_u128: Vec<u128> = input.iter().map(|x| u128::from(*x)).collect();
         let shares = generate_shares(&input_u128);
 
         let original = shares.clone();
 
-        let perm1 = get_two_of_three_random_permutations(input_len, context[0].prss().as_ref());
-        let perm2 = get_two_of_three_random_permutations(input_len, context[1].prss().as_ref());
-        let perm3 = get_two_of_three_random_permutations(input_len, context[2].prss().as_ref());
+        let perm1 = get_two_of_three_random_permutations(input_len, context[0].prss_rng());
+        let perm2 = get_two_of_three_random_permutations(input_len, context[1].prss_rng());
+        let perm3 = get_two_of_three_random_permutations(input_len, context[2].prss_rng());
 
         let [c0, c1, c2] = context;
 
@@ -307,7 +283,7 @@ mod tests {
 
     #[tokio::test]
     async fn shuffle_unshuffle() {
-        const BATCHSIZE: usize = 5;
+        const BATCHSIZE: u32 = 5;
 
         let world: TestWorld = make_world(QueryId);
         let context = make_contexts::<Fp31>(&world);
@@ -316,9 +292,9 @@ mod tests {
 
         let shares = generate_shares(&input);
 
-        let perm1 = get_two_of_three_random_permutations(BATCHSIZE, context[0].prss().as_ref());
-        let perm2 = get_two_of_three_random_permutations(BATCHSIZE, context[1].prss().as_ref());
-        let perm3 = get_two_of_three_random_permutations(BATCHSIZE, context[2].prss().as_ref());
+        let perm1 = get_two_of_three_random_permutations(BATCHSIZE, context[0].prss_rng());
+        let perm2 = get_two_of_three_random_permutations(BATCHSIZE, context[1].prss_rng());
+        let perm3 = get_two_of_three_random_permutations(BATCHSIZE, context[2].prss_rng());
 
         let shuffled: [_; 3] = {
             let [ctx0, ctx1, ctx2] = narrow_contexts(&context, &ShuffleOrUnshuffle::Shuffle);


### PR DESCRIPTION
I am on a crusade to eliminate different sources of randomness in IPA to keep PRSS and thread_rng() only. Having those prevents concurrency tests to provide "replay" functionality.

I believe we shouldn't be using any PRNG as our PRSS implementation already provides random generator that is suitable to shuffle vectors.

This change replaces ChaCha RNG with PRSS seq RNG