### PR TITLE
Implemeting a simple, straightforward bitwise les than protocol

### DIFF
--- a/src/protocol/boolean/bitwise_lt.rs
+++ b/src/protocol/boolean/bitwise_lt.rs
@@ -167,13 +167,16 @@ impl AsRef<str> for Step {
 
 #[cfg(test)]
 mod tests {
-    use super::BitwiseLessThan;
+    //use super::BitwiseLessThan;
+    use crate::protocol::boolean::dumb_bitwise_lt::BitwiseLessThan;
     use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         protocol::{QueryId, RecordId},
         test_fixture::{into_bits, Reconstruct, TestWorld},
     };
+    use proptest::prelude::Rng;
+    use rand::thread_rng;
     use rand::{distributions::Standard, prelude::Distribution};
 
     /// This protocol requires a number of inputs that are equal to a power of 2.
@@ -245,6 +248,21 @@ mod tests {
         );
 
         assert_eq!(zero, bitwise_lt(zero, c(Fp32BitPrime::PRIME)).await);
+    }
+
+    // this test is for manual execution only
+    #[ignore]
+    #[tokio::test]
+    pub async fn cmp_random_32_bit_prime_field_elements() {
+        let mut rand = thread_rng();
+        for _ in 0..1000 {
+            let a = rand.gen::<Fp32BitPrime>();
+            let b = rand.gen::<Fp32BitPrime>();
+            assert_eq!(
+                Fp32BitPrime::from(a.as_u128() < b.as_u128()),
+                bitwise_lt(a, b).await
+            );
+        }
     }
 
     // this test is for manual execution only

--- a/src/protocol/boolean/dumb_bitwise_lt.rs
+++ b/src/protocol/boolean/dumb_bitwise_lt.rs
@@ -1,0 +1,153 @@
+use super::xor::xor;
+use super::BitOpStep;
+use crate::error::Error;
+use crate::ff::Field;
+use crate::protocol::context::SemiHonestContext;
+use crate::protocol::{context::Context, mul::SecureMul, RecordId};
+use crate::secret_sharing::Replicated;
+use futures::future::{try_join, try_join_all};
+use std::iter::zip;
+
+/// This is an implementation of Bitwise Less-Than on bitwise-shared numbers.
+///
+/// `BitwiseLessThan` takes inputs `[a]_B = ([a_1]_p,...,[a_l]_p)` where
+/// `a1,...,a_l ∈ {0,1} ⊆ F_p` and `[b]_B = ([b_1]_p,...,[b_l]_p)` where
+/// `b1,...,b_l ∈ {0,1} ⊆ F_p`, then computes `h ∈ {0, 1} <- a <? b` where
+/// `h = 1` iff `a` is less than `b`.
+///
+/// Note that `[a]_B` can be converted to `[a]_p` by `Σ (2^i * a_i), i=0..l`. In
+/// other words, if comparing two integers, the protocol expects inputs to be in
+/// the little-endian; the least-significant byte at the smallest address (0'th
+/// element).
+///
+pub struct BitwiseLessThan {}
+
+impl BitwiseLessThan {
+    /// Step 1. `for i=0..l-1, [e_i] = XOR([a_i], [b_i])`
+    ///
+    /// # Example
+    /// ```ignore
+    ///   //  bit-0         bit-7
+    ///   //    v             v
+    ///   [a] = 1 0 1 0 1 0 0 0   // 21 in little-endian
+    ///   [b] = 0 1 1 1 1 0 0 0   // 30 in little-endian
+    ///   [e] = 1 1 0 1 0 0 0 0
+    /// ```
+    async fn xor_all_but_the_last_bit<F: Field>(
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<Replicated<F>>, Error> {
+        let xor = zip(a, b)
+            .enumerate()
+            .rev()
+            .take(a.len() - 1)
+            .map(|(i, (a_bit, b_bit))| {
+                let c = ctx.narrow(&BitOpStep::Step(i));
+                async move { xor(c, record_id, a_bit, b_bit).await }
+            });
+        try_join_all(xor).await
+    }
+
+    /// Step 2. `([f_(l-1)]..[f_0]) = PrefixOr([e_(l-1)]..[e_0])`
+    ///
+    /// We compute `PrefixOr` of [e] in the reverse order. Remember that the
+    /// inputs are in little-endian format. In this step, we try to find the
+    /// smallest `i` (or MSB since `e` is reversed) where `a_i != b_i`. The
+    /// output is in big-endian, note that the ordering of `[f]` in the notation
+    /// above is also reversed as in `([f_(l-1)]..[f_0])`, hence we reverse the
+    /// vector once again before returning.
+    ///
+    /// # Example
+    /// ```ignore
+    ///   //  bit-0         bit-7
+    ///   //    v             v
+    ///   [e] = 1 1 0 1 0 0 0 0
+    ///   [f] = 0 0 0 0 1 1 1 1
+    /// ```
+    async fn less_than_all_bits<F: Field>(
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<Replicated<F>>, Error> {
+        let less_than = zip(a, b).enumerate().rev().map(|(i, (a_bit, b_bit))| {
+            let c = ctx.narrow(&BitOpStep::Step(i));
+            let one = c.share_of_one();
+            async move { c.multiply(record_id, &(one - a_bit), b_bit).await }
+        });
+        try_join_all(less_than).await
+    }
+
+    #[allow(dead_code)]
+    #[allow(clippy::many_single_char_names)]
+    pub async fn execute<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        debug_assert_eq!(a.len(), b.len(), "Length of the input bits must be equal");
+        let (xored_bits, less_thaned_bits) = try_join(
+            Self::xor_all_but_the_last_bit(a, b, ctx.narrow(&Step::BitwiseAXorB), record_id),
+            Self::less_than_all_bits(a, b, ctx.narrow(&Step::BitwiseALessThanB), record_id),
+        )
+        .await?;
+
+        let one = ctx.share_of_one();
+        let mut any_condition_met = less_thaned_bits[0].clone();
+        let mut all_preceeding_bits_the_same = one.clone() - &(xored_bits[0]);
+        let check_each_bit_context = ctx.narrow(&Step::CheckEachBit);
+        let prefix_equal_context = ctx.narrow(&Step::PrefixEqual);
+        for i in 1..(less_thaned_bits.len() - 1) {
+            let (ith_bit_condition, prefix) = try_join(
+                check_each_bit_context.narrow(&BitOpStep::Step(i)).multiply(
+                    record_id,
+                    &less_thaned_bits[i],
+                    &all_preceeding_bits_the_same,
+                ),
+                prefix_equal_context.narrow(&BitOpStep::Step(i)).multiply(
+                    record_id,
+                    &(one.clone() - &xored_bits[i]),
+                    &all_preceeding_bits_the_same,
+                ),
+            )
+            .await?;
+            all_preceeding_bits_the_same = prefix;
+            any_condition_met += &ith_bit_condition;
+        }
+        let final_index = a.len() - 1;
+        let final_bit_condition = check_each_bit_context
+            .narrow(&BitOpStep::Step(final_index))
+            .multiply(
+                record_id,
+                &less_thaned_bits[final_index],
+                &all_preceeding_bits_the_same,
+            )
+            .await?;
+        any_condition_met += &final_bit_condition;
+        Ok(any_condition_met)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    BitwiseAXorB,
+    BitwiseALessThanB,
+    CheckEachBit,
+    PrefixEqual,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::BitwiseAXorB => "bitwise_a_xor_b",
+            Self::BitwiseALessThanB => "bitwise_a_lt_b",
+            Self::CheckEachBit => "check_each_bit",
+            Self::PrefixEqual => "prefix_equal",
+        }
+    }
+}

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -1,6 +1,7 @@
 mod bitwise_lt;
 mod bitwise_sum;
 mod carries;
+mod dumb_bitwise_lt;
 mod or;
 mod prefix_or;
 mod solved_bits;


### PR DESCRIPTION
Upon reviewing the BitwiseLessThan protocol (#206), I was struck by how incredibly complex the logic was. I found it very difficult to understand what the paper was saying, and why things needed to be that complicated.

So I thought I would implement a really dumb, straightforward way of doing things and compare performance.

# Comparing two 8-bit numbers
- Old: 44 multiplications
- New: 28 multiplications
36% reduction

# Comparing two 32-bit numbers
- Old: 176 multiplications
- New: 124 multiplications
30% reduction

In general, this "dumb" approach requires 4*(L - 1) multiplications.

In a debug build, when I just run `cargo test` this makes the "manual only" tests run much faster:

# Running the `cmp_all_fp31` test
- Old: 28.65 seconds
- New: 18.64 seconds
35% reduction

# Running the `cmp_random_32_bit_prime_field_elements` test
- Old: 116.54 seconds
- New: 70.74 seconds
39% reduction