### PR TITLE
Dumb bitwise add

### DIFF
--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -1,5 +1,5 @@
-use super::bitwise_sum::BitwiseSum;
 use super::dumb_bitwise_lt::BitwiseLessThan;
+use super::dumb_bitwise_sum::BitwiseSum;
 use crate::error::Error;
 use crate::ff::{Field, Int};
 use crate::protocol::boolean::local_secret_shared_bits;

--- a/src/protocol/boolean/bitwise_sum.rs
+++ b/src/protocol/boolean/bitwise_sum.rs
@@ -83,7 +83,8 @@ impl AsRef<str> for Step {
 
 #[cfg(test)]
 mod tests {
-    use super::BitwiseSum;
+    //use super::BitwiseSum;
+    use crate::protocol::boolean::dumb_bitwise_sum::BitwiseSum;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         protocol::{QueryId, RecordId},
@@ -191,6 +192,20 @@ mod tests {
                 a.as_u128() + b.as_u128(),
                 bits_to_value(&bitwise_sum(a, b).await)
             );
+        }
+    }
+
+    // this test is for manual execution only
+    #[ignore]
+    #[tokio::test]
+    pub async fn cmp_all_fp31() {
+        for a in 0..Fp31::PRIME {
+            for b in 0..Fp31::PRIME {
+                assert_eq!(
+                    u128::from(a + b),
+                    bits_to_value(&bitwise_sum(Fp31::from(a), Fp31::from(b)).await)
+                );
+            }
         }
     }
 }

--- a/src/protocol/boolean/dumb_bitwise_sum.rs
+++ b/src/protocol/boolean/dumb_bitwise_sum.rs
@@ -1,0 +1,99 @@
+use super::BitOpStep;
+use crate::error::Error;
+use crate::ff::Field;
+use crate::protocol::boolean::or::or;
+use crate::protocol::context::SemiHonestContext;
+use crate::protocol::mul::SecureMul;
+use crate::protocol::{context::Context, RecordId};
+use crate::secret_sharing::Replicated;
+use futures::future::try_join_all;
+use std::iter::zip;
+
+/// This is an implementation of Bitwise Sum on bitwise-shared numbers.
+///
+/// `BitwiseSum` takes inputs `[a]_B = ([a_0]_p,...,[a_(l-1)]_p)` where
+/// `a_0,...,a_(l-1) ∈ {0,1} ⊆ F_p` and `[b]_B = ([b_0]_p,...,[b_(l-1)]_p)` where
+/// `b_0,...,b_(l-1) ∈ {0,1} ⊆ F_p`, then computes `[d]_B = ([d_0]_p,...,[d_l]_p)`
+/// of `a + b`.
+///
+/// Note that the index notation of the inputs is `0..l-1`, whereas the output
+/// index notation is `0..l`. This means that the output of this protocol will be
+/// "`l+1`"-bit long bitwise secret shares, where `l = |[a]_B|`.
+pub struct BitwiseSum {}
+
+impl BitwiseSum {
+    async fn multiply_all_the_bits<F: Field>(
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+    ) -> Result<Vec<Replicated<F>>, Error> {
+        let both_one = zip(a, b).enumerate().map(|(i, (a_bit, b_bit))| {
+            let c = ctx.narrow(&BitOpStep::Step(i));
+            async move { c.multiply(record_id, a_bit, b_bit).await }
+        });
+        try_join_all(both_one).await
+    }
+
+    #[allow(dead_code)]
+    #[allow(clippy::many_single_char_names)]
+    pub async fn execute<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        a: &[Replicated<F>],
+        b: &[Replicated<F>],
+    ) -> Result<Vec<Replicated<F>>, Error> {
+        debug_assert_eq!(a.len(), b.len(), "Length of the input bits must be equal");
+
+        let both_bits_one =
+            Self::multiply_all_the_bits(a, b, ctx.narrow(&Step::MultiplyAllTheBits), record_id)
+                .await?;
+        let mut xored_bits = Vec::with_capacity(a.len());
+        for i in 0..a.len() {
+            xored_bits.push(&a[i] + &b[i] - &(both_bits_one[i].clone() * F::from(2)));
+        }
+        let mut output = Vec::with_capacity(a.len() + 1);
+        output.push(xored_bits[0].clone());
+
+        let carry_and_xored_bit_ctx = ctx.narrow(&Step::CarryAndXORedBit);
+        let either_carry_condition_ctx = ctx.narrow(&Step::EitherCarryCondition);
+
+        let mut carry = both_bits_one[0].clone();
+        for i in 1..a.len() {
+            let carry_and_xored_bit = carry_and_xored_bit_ctx
+                .narrow(&BitOpStep::Step(i))
+                .multiply(record_id, &carry, &xored_bits[i])
+                .await?;
+            let next_carry = or(
+                either_carry_condition_ctx.narrow(&BitOpStep::Step(i)),
+                record_id,
+                &carry_and_xored_bit,
+                &both_bits_one[i],
+            )
+            .await?;
+            output.push(&a[i] + &b[i] + &carry - &(next_carry.clone() * F::from(2)));
+            carry = next_carry;
+        }
+        output.push(carry);
+        Ok(output)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    MultiplyAllTheBits,
+    CarryAndXORedBit,
+    EitherCarryCondition,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::MultiplyAllTheBits => "multiply_all_the_bits",
+            Self::CarryAndXORedBit => "carry_and_xored_bit",
+            Self::EitherCarryCondition => "either_carry_condition",
+        }
+    }
+}

--- a/src/protocol/boolean/dumb_bitwise_sum.rs
+++ b/src/protocol/boolean/dumb_bitwise_sum.rs
@@ -1,4 +1,4 @@
-use super::BitOpStep;
+use super::{align_bit_lengths, BitOpStep};
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::boolean::or::or;
@@ -55,10 +55,10 @@ impl BitwiseSum {
         a: &[Replicated<F>],
         b: &[Replicated<F>],
     ) -> Result<Vec<Replicated<F>>, Error> {
-        debug_assert_eq!(a.len(), b.len(), "Length of the input bits must be equal");
+        let (a, b) = align_bit_lengths(a, b);
 
         let both_bits_one =
-            Self::multiply_all_the_bits(a, b, ctx.narrow(&Step::MultiplyAllTheBits), record_id)
+            Self::multiply_all_the_bits(&a, &b, ctx.narrow(&Step::MultiplyAllTheBits), record_id)
                 .await?;
         let mut xored_bits = Vec::with_capacity(a.len());
         for i in 0..a.len() {

--- a/src/protocol/boolean/dumb_bitwise_sum.rs
+++ b/src/protocol/boolean/dumb_bitwise_sum.rs
@@ -35,6 +35,18 @@ impl BitwiseSum {
         try_join_all(both_one).await
     }
 
+    ///
+    /// Really simple logic. Just follows the way you do addition in grade school
+    /// Starting from the least significant digit add up the digits, carrying when required.
+    ///
+    /// For the very first digit, the output is `a_0 XOR b_0` and it carries `a_0 * b_0`
+    /// For all the following digits, we need to carry if EITHER:
+    /// `a_i` and `b_i` are both one, OR
+    /// one of `a_i` and `b_i` are one AND the carry digit is also one
+    /// we can compute the first condition as `a_i * b_i`
+    /// the second condition is `XOR(a_i, b_i) * carry_i`
+    /// Finally, each digit of the output can be found by just summing up `a_i`, `b_i` and `carry_i`,
+    /// then subtracting 2 if `carry_{i+1} == 1`.
     #[allow(dead_code)]
     #[allow(clippy::many_single_char_names)]
     pub async fn execute<F: Field>(

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -8,6 +8,7 @@ mod bitwise_lt;
 mod bitwise_sum;
 mod carries;
 mod dumb_bitwise_lt;
+mod dumb_bitwise_sum;
 mod or;
 mod prefix_or;
 pub mod random_bits_generator;

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -1,20 +1,19 @@
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::SemiHonestContext;
-use crate::protocol::{context::Context, mul::SecureMul, RecordId};
+use crate::protocol::{mul::SecureMul, RecordId};
 use crate::secret_sharing::Replicated;
 
-/// Secure XOR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
-/// It computes `[a] + [b] - 2[ab]`
+/// Secure OR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
+/// It computes `[a] + [b] - [ab]`
 pub async fn or<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
     a: &Replicated<F>,
     b: &Replicated<F>,
 ) -> Result<Replicated<F>, Error> {
-    let one = Replicated::one(ctx.role());
-    let result = ctx.multiply(record_id, &(&one - a), &(&one - b)).await?;
-    Ok(one - &result)
+    let ab = ctx.multiply(record_id, a, b).await?;
+    Ok(a + b - &ab)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Our current BitwiseAdd protocol is VERY SLOW. I didn't understand why the current protocol was so complicated so I created a much simpler one and benchmarked it:

# add two Fp31
- Old: 35 multiplications
- New: 13 multiplications
63% reduction

# add two Fp32BitPrime
- Old: 1520 multiplications
- New: 94 multiplications
94% reduction (!!!)

This makes the tests run a LOT faster.

# Add every element of Fp31 to every other element of Fp31
- Old: 23.47 seconds
- New: 10.66 seconds
63% reduction

# Add two, randomly selected elements of Fp32BitPrime, looped 100x
- Old: 82.82 seconds
- New: 5 seconds 
94% reduction (!!!)