### PR TITLE
Implementing an optimized comparison with the prime

### DIFF
--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -1,4 +1,4 @@
-use super::dumb_bitwise_lt::BitwiseLessThan;
+use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use super::dumb_bitwise_sum::BitwiseSum;
 use crate::error::Error;
 use crate::ff::{Field, Int};
@@ -46,10 +46,12 @@ impl BitDecomposition {
         let d_b = BitwiseSum::execute(ctx.narrow(&Step::AddBtoC), record_id, &c_b, &r.b_b).await?;
 
         // Step 6. p <=? d. The paper says "p <? d", but should actually be "p <=? d"
-        let p_b = local_secret_shared_bits(F::PRIME.into(), ctx.role());
-        let q_p = Replicated::one(ctx.role())
-            - &(BitwiseLessThan::execute(ctx.narrow(&Step::IsPLessThanD), record_id, &d_b, &p_b)
-                .await?);
+        let q_p = BitwiseLessThanPrime::greater_than_or_equal_to_prime(
+            ctx.narrow(&Step::IsPLessThanD),
+            record_id,
+            &d_b,
+        )
+        .await?;
 
         // Step 7. a bitwise scalar value `f_B = bits(2^l - p)`
         let l = F::Integer::BITS;
@@ -144,7 +146,7 @@ mod tests {
 
     // This test takes more than 15 secs... I'm disabling it for now until
     // we optimize and/or find a way to make tests run faster.
-    #[ignore]
+    //#[ignore]
     #[tokio::test]
     pub async fn fp32_bit_prime() {
         let world = TestWorld::new(QueryId);

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -146,7 +146,7 @@ mod tests {
 
     // This test takes more than 15 secs... I'm disabling it for now until
     // we optimize and/or find a way to make tests run faster.
-    //#[ignore]
+    #[ignore]
     #[tokio::test]
     pub async fn fp32_bit_prime() {
         let world = TestWorld::new(QueryId);

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -131,6 +131,7 @@ impl BitwiseLessThanPrime {
     ) -> Result<Replicated<F>, Error> {
         let mut todo = x.to_vec();
         let mut mult_count = 0;
+
         while todo.len() > 1 {
             let half = todo.len() / 2;
             let mut multiplications = Vec::with_capacity(half);
@@ -143,8 +144,10 @@ impl BitwiseLessThanPrime {
                 mult_count += 1;
             }
             let mut results = try_join_all(multiplications).await?;
-            todo.drain(0..2 * half);
-            todo.append(&mut results);
+            if todo.len() % 2 == 1 {
+                results.push(todo.pop().unwrap());
+            }
+            todo = results;
         }
         Ok(todo[0].clone())
     }

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -1,0 +1,330 @@
+use super::or::or;
+use super::BitOpStep;
+use crate::error::Error;
+use crate::ff::Field;
+use crate::protocol::context::SemiHonestContext;
+use crate::protocol::{context::Context, mul::SecureMul, RecordId};
+use crate::secret_sharing::Replicated;
+use futures::future::{try_join, try_join_all};
+use std::cmp::Ordering;
+use std::iter::repeat;
+
+/// This is an implementation of Bitwise Less-Than on bitwise-shared numbers.
+///
+/// `BitwiseLessThan` takes inputs `[a]_B = ([a_1]_p,...,[a_l]_p)` where
+/// `a1,...,a_l ∈ {0,1} ⊆ F_p` and `[b]_B = ([b_1]_p,...,[b_l]_p)` where
+/// `b1,...,b_l ∈ {0,1} ⊆ F_p`, then computes `h ∈ {0, 1} <- a <? b` where
+/// `h = 1` iff `a` is less than `b`.
+///
+/// Note that `[a]_B` can be converted to `[a]_p` by `Σ (2^i * a_i), i=0..l`. In
+/// other words, if comparing two integers, the protocol expects inputs to be in
+/// the little-endian; the least-significant byte at the smallest address (0'th
+/// element).
+///
+pub struct BitwiseLessThanPrime {}
+
+impl BitwiseLessThanPrime {
+    pub async fn less_than_prime<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let one = ctx.share_of_one();
+        let gtoe = Self::greater_than_or_equal_to_prime(ctx, record_id, x).await?;
+        Ok(one - &gtoe)
+    }
+
+    pub async fn greater_than_or_equal_to_prime<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let prime = F::PRIME.into();
+        let l = u128::BITS - prime.leading_zeros();
+        let l_as_usize = l.try_into().unwrap();
+        match x.len().cmp(&l_as_usize) {
+            Ordering::Greater => {
+                let (zero_check, normal_check) = try_join(
+                    Self::any_ones(
+                        &ctx.narrow(&Step::CheckIfAnyOnes),
+                        record_id,
+                        &x[l_as_usize..],
+                    ),
+                    Self::greater_than_or_equal_to_prime_trimmed(
+                        ctx.narrow(&Step::CheckTrimmed),
+                        record_id,
+                        &x[0..l_as_usize],
+                    ),
+                )
+                .await?;
+                or(
+                    ctx.narrow(&Step::LeadingOnesOrRest),
+                    record_id,
+                    &zero_check,
+                    &normal_check,
+                )
+                .await
+            }
+            Ordering::Equal => {
+                Self::greater_than_or_equal_to_prime_trimmed(
+                    ctx.narrow(&Step::CheckTrimmed),
+                    record_id,
+                    x,
+                )
+                .await
+            }
+            Ordering::Less => {
+                panic!();
+            }
+        }
+    }
+
+    async fn greater_than_or_equal_to_prime_trimmed<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let prime = F::PRIME.into();
+        let l = u128::BITS - prime.leading_zeros();
+        let l_as_usize: usize = l.try_into().unwrap();
+        debug_assert!(x.len() == l_as_usize);
+
+        // Check if this is a Mersenne Prime
+        // In that special case, the only way for `x >= p` is if `x == p`,
+        // meaning all the bits of `x` are shares of one.
+        if prime == (2_u128.pow(l) - 1) {
+            return Self::check_if_all_ones(&ctx.narrow(&Step::CheckIfAllOnes), record_id, x).await;
+        }
+
+        // Assume this is an Fp32BitPrime
+        // Meaning the least significant three bits are exactly [1, 1, 0]
+        if prime == (2_u128.pow(l) - 5) {
+            let (check_if_all_ones, check_final_bits) = try_join(
+                Self::check_if_all_ones(&ctx.narrow(&Step::CheckIfAllOnes), record_id, &x[3..]),
+                Self::check_least_significant_bits(
+                    ctx.narrow(&Step::CheckLeastSignificantBits),
+                    record_id,
+                    &x[0..3],
+                ),
+            )
+            .await?;
+            return ctx
+                .narrow(&Step::AllOnesAndFinalBits)
+                .multiply(record_id, &check_if_all_ones, &check_final_bits)
+                .await;
+        }
+        // Not implemented for any other type of prime. Please add to this if you create a new type of Field which
+        // is neither a Mersenne Prime, nor which is equal to `2^n - 5` for some value of `n`
+        panic!();
+    }
+
+    /// To check if a list of shares are all shares of one, we just need to multiply them all together (in any order)
+    /// We can minimize circuit depth by doing this in a binary-tree like fashion, where pairs of shares are multiplied together
+    /// and those results are recursively multiplied.
+    pub async fn check_if_all_ones<F: Field>(
+        ctx: &SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let mut todo = x.to_vec();
+        let mut mult_count = 0;
+        while todo.len() > 1 {
+            let half = todo.len() / 2;
+            let mut multiplications = Vec::with_capacity(half);
+            for i in 0..half {
+                multiplications.push(ctx.narrow(&BitOpStep::Step(mult_count)).multiply(
+                    record_id,
+                    &todo[2 * i],
+                    &todo[2 * i + 1],
+                ));
+                mult_count += 1;
+            }
+            let mut results = try_join_all(multiplications).await?;
+            todo.drain(0..2 * half);
+            todo.append(&mut results);
+        }
+        Ok(todo[0].clone())
+    }
+
+    pub async fn any_ones<F: Field>(
+        ctx: &SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let one = ctx.share_of_one();
+        let inverted_elements = x
+            .iter()
+            .zip(repeat(one.clone()))
+            .map(|(a, one)| one - a)
+            .collect::<Vec<_>>();
+        let res = Self::check_if_all_ones(ctx, record_id, &inverted_elements).await?;
+        Ok(one - &res)
+    }
+
+    /// This is a *special case* implementation which assumes the prime is all ones except for the least significant bits which are: `[1 1 0]` (little-endian)
+    /// This is the case for `Fp32BitPrime`.
+    ///
+    /// Assuming that all the more significant bits of the value being checked are all shares of one, Just consider the least significant three bits:
+    /// Assume those bits are [1 1 0] (little-endian)
+    /// There are only 5 numbers that are greater than or equal to the prime
+    /// 1.) Four of them look like [X X 1] (values of X are irrelevant)
+    /// 2.) The final one is exactly [1 1 0]
+    /// We can check if either of these conditions is true with just 3 multiplications
+    pub async fn check_least_significant_bits<F: Field>(
+        ctx: SemiHonestContext<'_, F>,
+        record_id: RecordId,
+        x: &[Replicated<F>],
+    ) -> Result<Replicated<F>, Error> {
+        let prime = F::PRIME.into();
+        debug_assert!(prime & 0b111 == 0b011);
+        debug_assert!(x.len() == 3);
+        let least_significant_two_bits_both_one = ctx
+            .narrow(&BitOpStep::Step(0))
+            .multiply(record_id, &x[0], &x[1])
+            .await?;
+        let pivot_bit = &x[2];
+        let least_significant_three_bits_all_equal_to_prime = ctx
+            .narrow(&BitOpStep::Step(1))
+            .multiply(
+                record_id,
+                &least_significant_two_bits_both_one,
+                &(ctx.share_of_one() - pivot_bit),
+            )
+            .await?;
+        or(
+            ctx.narrow(&BitOpStep::Step(2)),
+            record_id,
+            pivot_bit,
+            &least_significant_three_bits_all_equal_to_prime,
+        )
+        .await
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    CheckTrimmed,
+    CheckIfAnyOnes,
+    LeadingOnesOrRest,
+    CheckIfAllOnes,
+    CheckLeastSignificantBits,
+    AllOnesAndFinalBits,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::CheckTrimmed => "check_trimmed",
+            Self::CheckIfAnyOnes => "check_if_any_ones",
+            Self::LeadingOnesOrRest => "leading_ones_or_rest",
+            Self::CheckIfAllOnes => "check_if_all_ones",
+            Self::CheckLeastSignificantBits => "check_least_significant_bits",
+            Self::AllOnesAndFinalBits => "final_step",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BitwiseLessThanPrime;
+    use crate::test_fixture::Runner;
+    use crate::{
+        ff::{Field, Fp31, Fp32BitPrime},
+        protocol::{QueryId, RecordId},
+        test_fixture::{get_bits, Reconstruct, TestWorld},
+    };
+    use rand::{distributions::Standard, prelude::Distribution};
+
+    #[tokio::test]
+    pub async fn fp31() {
+        let zero = Fp31::ZERO;
+        let one = Fp31::ONE;
+
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(30, 5).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(30, 6).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(31, 5).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(32, 6).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(64, 7).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(64, 8).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(128, 8).await);
+        assert_eq!(zero, bitwise_less_than_prime::<Fp31>(224, 8).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(29, 5).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(0, 5).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(1, 5).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(3, 5).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp31>(15, 5).await);
+    }
+
+    #[tokio::test]
+    pub async fn fp32_bit_prime() {
+        let zero = Fp32BitPrime::ZERO;
+        let one = Fp32BitPrime::ONE;
+
+        assert_eq!(
+            zero,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME, 32).await
+        );
+        assert_eq!(
+            zero,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME + 1, 32).await
+        );
+        assert_eq!(
+            zero,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME + 2, 32).await
+        );
+        assert_eq!(
+            zero,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME + 3, 32).await
+        );
+        assert_eq!(
+            zero,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME + 4, 32).await
+        );
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME - 1, 32).await
+        );
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME - 2, 32).await
+        );
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME - 3, 32).await
+        );
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(Fp32BitPrime::PRIME - 4, 32).await
+        );
+        assert_eq!(one, bitwise_less_than_prime::<Fp32BitPrime>(0, 32).await);
+        assert_eq!(one, bitwise_less_than_prime::<Fp32BitPrime>(1, 32).await);
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(65_536_u32, 32).await
+        );
+        assert_eq!(
+            one,
+            bitwise_less_than_prime::<Fp32BitPrime>(65_535_u32, 32).await
+        );
+    }
+
+    async fn bitwise_less_than_prime<F: Field>(a: u32, num_bits: usize) -> F
+    where
+        F: Sized,
+        Standard: Distribution<F>,
+    {
+        let world = TestWorld::new(QueryId);
+        let bits = get_bits::<F>(a, num_bits);
+        let result = world
+            .semi_honest(bits, |ctx, x_share| async move {
+                BitwiseLessThanPrime::less_than_prime(ctx, RecordId::from(0), &x_share)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+        result.reconstruct()
+    }
+}

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -4,6 +4,7 @@ use crate::secret_sharing::Replicated;
 use std::iter::repeat;
 
 mod bit_decomposition;
+mod bitwise_less_than_prime;
 mod bitwise_lt;
 mod bitwise_sum;
 mod carries;

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,5 +1,4 @@
-use super::dumb_bitwise_lt::BitwiseLessThan;
-use super::local_secret_shared_bits;
+use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use crate::error::Error;
 use crate::ff::{Field, Int};
 use crate::protocol::boolean::BitOpStep;
@@ -126,9 +125,9 @@ impl SolvedBits {
         record_id: RecordId,
         b_b: &[Replicated<F>],
     ) -> Result<bool, Error> {
-        let p_b = local_secret_shared_bits(F::PRIME.into(), ctx.role());
         let c_b =
-            BitwiseLessThan::execute(ctx.narrow(&Step::IsPLessThanB), record_id, b_b, &p_b).await?;
+            BitwiseLessThanPrime::less_than_prime(ctx.narrow(&Step::IsPLessThanB), record_id, b_b)
+                .await?;
         if ctx.narrow(&Step::RevealC).reveal(record_id, &c_b).await? == F::ZERO {
             return Ok(false);
         }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -16,7 +16,7 @@ use futures::TryFuture;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::rngs::mock::StepRng;
-pub use sharing::{into_bits, share, IntoShares, Reconstruct};
+pub use sharing::{get_bits, into_bits, share, IntoShares, Reconstruct};
 use std::fmt::Debug;
 pub use world::{Runner, TestWorld, TestWorldConfig};
 

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -84,6 +84,14 @@ pub fn into_bits<F: Field>(x: F) -> Vec<F> {
         .collect::<Vec<_>>()
 }
 
+/// Deconstructs a value into N values, one for each bit.
+#[must_use]
+pub fn get_bits<F: Field>(x: u32, num_bits: usize) -> Vec<F> {
+    (0..num_bits)
+        .map(|i| F::from(((x >> i) & 1).into()))
+        .collect::<Vec<_>>()
+}
+
 /// For upgrading various shapes of replicated share to malicious.
 #[async_trait]
 pub trait IntoMalicious<F: Field, M> {


### PR DESCRIPTION
When comparing two unknown numbers, we need to use the BitwiseLessThan protocol. It considers many possibilities. When comparing to a specific number we don't need to check as many things. The primes we use are even more specialized, they are almost entire ones. e.g. 31 = 0b11111, and our 32 bit prime is 0b11111111111111111111111111111011. Comparing to see if a number is *less than* these values is very easy, we can just check if the number is greater-than-or-equal-to the prime and negate the result. There are very few numbers that meet this condition. Basically, nearly all the bits need to be one. That's easy to check, just multiply all the bits that are supposed to be ones.
