### PR TITLE
Kill SecureMult structs

### DIFF
--- a/src/protocol/mul/mod.rs
+++ b/src/protocol/mul/mod.rs
@@ -23,7 +23,9 @@ pub trait SecureMul<F: Field> {
 }
 
 /// looks like clippy disagrees with itself on whether this attribute is useless or not.
-pub use {malicious::SecureMul as MaliciouslySecureMul, semi_honest::SecureMul as SemiHonestMul};
+pub use {
+    malicious::secure_mul as maliciously_secure_mul, semi_honest::secure_mul as semi_honest_mul,
+};
 
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
@@ -36,7 +38,7 @@ impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
         a: &Self::Share,
         b: &Self::Share,
     ) -> Result<Self::Share, Error> {
-        SemiHonestMul::new(self, record_id).execute(a, b).await
+        semi_honest_mul(self, record_id, a, b).await
     }
 }
 
@@ -51,8 +53,6 @@ impl<F: Field> SecureMul<F> for MaliciousContext<'_, F> {
         a: &Self::Share,
         b: &Self::Share,
     ) -> Result<Self::Share, Error> {
-        MaliciouslySecureMul::new(self, record_id)
-            .execute(a, b)
-            .await
+        maliciously_secure_mul(self, record_id, a, b).await
     }
 }

--- a/src/protocol/mul/semi_honest.rs
+++ b/src/protocol/mul/semi_honest.rs
@@ -4,61 +4,52 @@ use crate::helpers::Direction;
 use crate::protocol::context::SemiHonestContext;
 use crate::protocol::{context::Context, RecordId};
 use crate::secret_sharing::Replicated;
-use std::fmt::Debug;
 
 /// IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
 /// K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, and B. Pinkas. High-throughput secure AES computation. In WAHC@CCS 2018, pp. 13–24, 2018
-#[derive(Debug)]
-pub struct SecureMul<'a, F: Field> {
-    ctx: SemiHonestContext<'a, F>,
+
+/// Executes the secure multiplication on the MPC helper side. Each helper will proceed with
+/// their part, eventually producing 2/3 shares of the product and that is what this function
+/// returns.
+///
+/// ## Errors
+/// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
+/// back via the error response
+pub async fn secure_mul<F>(
+    ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-}
+    a: &Replicated<F>,
+    b: &Replicated<F>,
+) -> Result<Replicated<F>, Error>
+where
+    F: Field,
+{
+    let channel = ctx.mesh();
 
-impl<'a, F: Field> SecureMul<'a, F> {
-    #[must_use]
-    pub fn new(ctx: SemiHonestContext<'a, F>, record_id: RecordId) -> Self {
-        Self { ctx, record_id }
-    }
+    // generate shared randomness.
+    let prss = ctx.prss();
+    let (s0, s1) = prss.generate_fields(record_id);
+    let role = ctx.role();
 
-    /// Executes the secure multiplication on the MPC helper side. Each helper will proceed with
-    /// their part, eventually producing 2/3 shares of the product and that is what this function
-    /// returns.
-    ///
-    /// ## Errors
-    /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
-    /// back via the error response
-    pub async fn execute(
-        self,
-        a: &Replicated<F>,
-        b: &Replicated<F>,
-    ) -> Result<Replicated<F>, Error> {
-        let channel = self.ctx.mesh();
+    // compute the value (d_i) we want to send to the right helper (i+1)
+    let right_d = a.left() * b.right() + a.right() * b.left() - s0;
 
-        // generate shared randomness.
-        let prss = self.ctx.prss();
-        let (s0, s1) = prss.generate_fields(self.record_id);
-        let role = self.ctx.role();
+    // notify helper on the right that we've computed our value
+    channel
+        .send(role.peer(Direction::Right), record_id, right_d)
+        .await?;
 
-        // compute the value (d_i) we want to send to the right helper (i+1)
-        let right_d = a.left() * b.right() + a.right() * b.left() - s0;
+    // Sleep until helper on the left sends us their (d_i-1) value
+    let left_d = channel
+        .receive(role.peer(Direction::Left), record_id)
+        .await?;
 
-        // notify helper on the right that we've computed our value
-        channel
-            .send(role.peer(Direction::Right), self.record_id, right_d)
-            .await?;
+    // now we are ready to construct the result - 2/3 secret shares of a * b.
+    let lhs = a.left() * b.left() + left_d + s0;
+    let rhs = a.right() * b.right() + right_d + s1;
 
-        // Sleep until helper on the left sends us their (d_i-1) value
-        let left_d = channel
-            .receive(role.peer(Direction::Left), self.record_id)
-            .await?;
-
-        // now we are ready to construct the result - 2/3 secret shares of a * b.
-        let lhs = a.left() * b.left() + left_d + s0;
-        let rhs = a.right() * b.right() + right_d + s1;
-
-        Ok(Replicated::new(lhs, rhs))
-    }
+    Ok(Replicated::new(lhs, rhs))
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]


### PR DESCRIPTION
These structs aren't doing anything for us. Let's just use functions.