### PR TITLE
Move RandomBitsGenerator out of context

### DIFF
--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -13,8 +13,8 @@ async fn main() -> Result<(), Error> {
     let mut config = TestWorldConfig::default();
     config.gateway_config.send_buffer_config.items_in_batch = 1;
     config.gateway_config.send_buffer_config.batch_count = 1000;
-    let world = TestWorld::<Fp32BitPrime>::new_with(QueryId, config);
-    let [ctx0, ctx1, ctx2] = world.contexts();
+    let world = TestWorld::new_with(QueryId, config);
+    let [ctx0, ctx1, ctx2] = world.contexts::<Fp32BitPrime>();
     let num_bits = 64;
     let mut rng = thread_rng();
 

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -265,8 +265,8 @@ mod tests {
         config.gateway_config.send_buffer_config.items_in_batch = 1; // Send every record
         config.gateway_config.send_buffer_config.batch_count = 3; // keep 3 at a time
 
-        let world = Box::leak(Box::new(TestWorld::<Fp31>::new_with(QueryId, config)));
-        let contexts = world.contexts();
+        let world = Box::leak(Box::new(TestWorld::new_with(QueryId, config)));
+        let contexts = world.contexts::<Fp31>();
         let sender_ctx = contexts[0].narrow("reordering-test");
         let recv_ctx = contexts[1].narrow("reordering-test");
 

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -373,7 +373,7 @@ mod tests {
         ];
         let expected = TEST_CASE.iter().map(|t| t[4]).collect::<Vec<_>>();
 
-        let world = TestWorld::<Fp31>::new(QueryId);
+        let world = TestWorld::new(QueryId);
         let context = world.contexts();
         let mut rng = StepRng::new(100, 1);
 
@@ -408,7 +408,7 @@ mod tests {
         let mut rng = thread_rng();
         let secret: [Fp31; 4] = [(); 4].map(|_| rng.gen::<Fp31>());
 
-        let world = TestWorld::<Fp31>::new(QueryId);
+        let world = TestWorld::new(QueryId);
 
         for &role in Role::all() {
             let new_shares = world

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -1,5 +1,6 @@
 use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use super::dumb_bitwise_sum::BitwiseSum;
+use super::random_bits_generator::RandomBitsGenerator;
 use crate::error::Error;
 use crate::ff::{Field, Int};
 use crate::protocol::boolean::local_secret_shared_bits;
@@ -21,6 +22,7 @@ pub struct BitDecomposition {}
 impl BitDecomposition {
     #[allow(dead_code)]
     pub async fn execute<F: Field>(
+        rbg: RandomBitsGenerator<F>,
         ctx: SemiHonestContext<'_, F>,
         record_id: RecordId,
         a_p: &Replicated<F>,
@@ -28,10 +30,7 @@ impl BitDecomposition {
         // step 1 in the paper is just describing the input, `[a]_p` where `a ∈ F_p`
 
         // Step 2. Generate random bitwise shares
-        let r = ctx
-            .random_bits_generator()
-            .take_one(ctx.narrow(&Step::GenerateRandomBits))
-            .await?;
+        let r = rbg.take_one(ctx.narrow(&Step::GenerateRandomBits)).await?;
 
         // Step 3, 4. Reveal c = [a - b]_p
         let c = ctx
@@ -105,19 +104,21 @@ mod tests {
     use super::BitDecomposition;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Int},
-        protocol::{QueryId, RecordId},
+        protocol::{boolean::random_bits_generator::RandomBitsGenerator, QueryId, RecordId},
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};
 
-    async fn bit_decomposition<F: Field>(world: &TestWorld<F>, a: F) -> Vec<F>
+    async fn bit_decomposition<F: Field>(world: &TestWorld, a: F) -> Vec<F>
     where
         F: Sized,
         Standard: Distribution<F>,
     {
         let result = world
             .semi_honest(a, |ctx, a_p| async move {
-                BitDecomposition::execute(ctx, RecordId::from(0), &a_p)
+                let rbg = RandomBitsGenerator::new();
+
+                BitDecomposition::execute(rbg, ctx, RecordId::from(0), &a_p)
                     .await
                     .unwrap()
             })

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -22,9 +22,9 @@ pub struct BitDecomposition {}
 impl BitDecomposition {
     #[allow(dead_code)]
     pub async fn execute<F: Field>(
-        rbg: RandomBitsGenerator<F>,
         ctx: SemiHonestContext<'_, F>,
         record_id: RecordId,
+        rbg: RandomBitsGenerator<F>,
         a_p: &Replicated<F>,
     ) -> Result<Vec<Replicated<F>>, Error> {
         // step 1 in the paper is just describing the input, `[a]_p` where `a ∈ F_p`
@@ -118,7 +118,7 @@ mod tests {
             .semi_honest(a, |ctx, a_p| async move {
                 let rbg = RandomBitsGenerator::new();
 
-                BitDecomposition::execute(rbg, ctx, RecordId::from(0), &a_p)
+                BitDecomposition::execute(ctx, RecordId::from(0), rbg, &a_p)
                     .await
                     .unwrap()
             })

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -177,9 +177,10 @@ impl<F: Field> Clone for RandomBitsGenerator<F> {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
+    use super::RandomBitsGenerator;
     use crate::{
         ff::Fp31,
-        protocol::{context::Context, QueryId},
+        protocol::QueryId,
         test_fixture::{join3, TestWorld},
     };
 
@@ -188,12 +189,12 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::cast_possible_truncation)]
     pub async fn basic() {
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let [c0, c1, c2] = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let [c0, c1, c2] = world.contexts::<Fp31>();
 
-        let rbg0 = c0.random_bits_generator();
-        let rbg1 = c1.random_bits_generator();
-        let rbg2 = c2.random_bits_generator();
+        let rbg0 = RandomBitsGenerator::new();
+        let rbg1 = RandomBitsGenerator::new();
+        let rbg2 = RandomBitsGenerator::new();
 
         let _result = join3(
             rbg0.take_one(c0.clone()),

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -212,8 +212,8 @@ mod tests {
 
     #[tokio::test]
     pub async fn fp31() -> Result<(), Error> {
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let ctx = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let ctx = world.contexts::<Fp31>();
         let [c0, c1, c2] = ctx;
 
         let mut success = 0;
@@ -236,8 +236,8 @@ mod tests {
 
     #[tokio::test]
     pub async fn fp_32bit_prime() -> Result<(), Error> {
-        let world = TestWorld::<Fp32BitPrime>::new(QueryId);
-        let ctx = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let ctx = world.contexts::<Fp32BitPrime>();
         let [c0, c1, c2] = ctx;
 
         let mut success = 0;

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -25,7 +25,7 @@ mod tests {
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
 
-    async fn xor_fp31(world: &TestWorld<Fp31>, a: Fp31, b: Fp31) -> Fp31 {
+    async fn xor_fp31(world: &TestWorld, a: Fp31, b: Fp31) -> Fp31 {
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
                 xor(ctx, RecordId::from(0), &a_share, &b_share)

--- a/src/protocol/check_zero.rs
+++ b/src/protocol/check_zero.rs
@@ -93,8 +93,8 @@ mod tests {
 
     #[tokio::test]
     async fn basic() -> Result<(), Error> {
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let context = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let context = world.contexts::<Fp31>();
         let mut rng = thread_rng();
         let mut counter = 0_u32;
 

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -2,7 +2,6 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::helpers::messaging::{Gateway, Mesh};
 use crate::helpers::Role;
-use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
 use crate::protocol::context::{Context, SemiHonestContext};
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::mul::SecureMul;
@@ -88,12 +87,6 @@ impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
         MaliciousReplicated::one(self.role(), self.inner.r_share.clone())
     }
-
-    fn random_bits_generator(&self) -> RandomBitsGenerator<F> {
-        // RandomBitsGenerator has only one direct member which is wrapped in
-        // `Arc`. This `clone()` will only increment the ref count.
-        self.inner.random_bits_generator.clone()
-    }
 }
 
 /// Sometimes it is required to reinterpret malicious context as semi-honest. Ideally
@@ -118,12 +111,7 @@ impl<'a, F: Field> SpecialAccessToMaliciousContext<'a, F> for MaliciousContext<'
         // is not
         // For the same reason, it is not possible to implement Context<F, Share = Replicated<F>>
         // for `MaliciousContext`. Deep clone is the only option
-        let mut ctx = SemiHonestContext::new(
-            self.inner.role,
-            self.inner.prss,
-            self.inner.gateway,
-            self.inner.random_bits_generator,
-        );
+        let mut ctx = SemiHonestContext::new(self.inner.role, self.inner.prss, self.inner.gateway);
         ctx.step = self.step;
 
         ctx
@@ -138,7 +126,6 @@ struct ContextInner<'a, F: Field> {
     upgrade_ctx: SemiHonestContext<'a, F>,
     accumulator: MaliciousValidatorAccumulator<F>,
     r_share: Replicated<F>,
-    random_bits_generator: &'a RandomBitsGenerator<F>,
 }
 
 impl<'a, F: Field> ContextInner<'a, F> {
@@ -151,7 +138,6 @@ impl<'a, F: Field> ContextInner<'a, F> {
             role: upgrade_ctx.inner.role,
             prss: upgrade_ctx.inner.prss,
             gateway: upgrade_ctx.inner.gateway,
-            random_bits_generator: upgrade_ctx.inner.random_bits_generator,
             upgrade_ctx,
             accumulator,
             r_share,

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -15,7 +15,6 @@ pub use malicious::MaliciousContext;
 pub(super) use malicious::SpecialAccessToMaliciousContext;
 pub use semi_honest::SemiHonestContext;
 
-use super::boolean::random_bits_generator::RandomBitsGenerator;
 use super::sort::reshare::Reshare;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
@@ -65,7 +64,4 @@ pub trait Context<F: Field>:
 
     /// Generates a new share of one
     fn share_of_one(&self) -> <Self as Context<F>>::Share;
-
-    /// Get the random bits generator instance.
-    fn random_bits_generator(&self) -> RandomBitsGenerator<F>;
 }

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -1,7 +1,6 @@
 use crate::ff::Field;
 use crate::helpers::messaging::{Gateway, Mesh};
 use crate::helpers::Role;
-use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
 use crate::protocol::context::{Context, MaliciousContext};
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::prss::{
@@ -18,20 +17,15 @@ use std::marker::PhantomData;
 pub struct SemiHonestContext<'a, F: Field> {
     /// TODO (alex): Arc is required here because of the `TestWorld` structure. Real world
     /// may operate with raw references and be more efficient
-    pub(super) inner: Arc<ContextInner<'a, F>>,
+    pub(super) inner: Arc<ContextInner<'a>>,
     pub(super) step: Step,
     _marker: PhantomData<F>,
 }
 
 impl<'a, F: Field> SemiHonestContext<'a, F> {
-    pub fn new(
-        role: Role,
-        participant: &'a PrssEndpoint,
-        gateway: &'a Gateway,
-        random_bits_generator: &'a RandomBitsGenerator<F>,
-    ) -> Self {
+    pub fn new(role: Role, participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self {
-            inner: ContextInner::new(role, participant, gateway, random_bits_generator),
+            inner: ContextInner::new(role, participant, gateway),
             step: Step::default(),
             _marker: PhantomData::default(),
         }
@@ -89,34 +83,21 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
         Replicated::one(self.role())
     }
-
-    fn random_bits_generator(&self) -> RandomBitsGenerator<F> {
-        // RandomBitsGenerator has only one direct member which is wrapped in
-        // `Arc`. This `clone()` will only increment the ref count.
-        self.inner.random_bits_generator.clone()
-    }
 }
 
 #[derive(Debug)]
-pub(super) struct ContextInner<'a, F: Field> {
+pub(super) struct ContextInner<'a> {
     pub role: Role,
     pub prss: &'a PrssEndpoint,
     pub gateway: &'a Gateway,
-    pub random_bits_generator: &'a RandomBitsGenerator<F>,
 }
 
-impl<'a, F: Field> ContextInner<'a, F> {
-    fn new(
-        role: Role,
-        prss: &'a PrssEndpoint,
-        gateway: &'a Gateway,
-        random_bits_generator: &'a RandomBitsGenerator<F>,
-    ) -> Arc<Self> {
+impl<'a> ContextInner<'a> {
+    fn new(role: Role, prss: &'a PrssEndpoint, gateway: &'a Gateway) -> Arc<Self> {
         Arc::new(Self {
             role,
             prss,
             gateway,
-            random_bits_generator,
         })
     }
 }

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -274,8 +274,8 @@ mod tests {
     /// There is a small chance of failure which is `2 / |F|`, where `|F|` is the cardinality of the prime field.
     #[tokio::test]
     async fn simplest_circuit() -> Result<(), Error> {
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let context = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let context = world.contexts::<Fp31>();
         let mut rng = thread_rng();
 
         let a = rng.gen::<Fp31>();
@@ -342,8 +342,8 @@ mod tests {
     /// There is a small chance of failure which is `2 / |F|`, where `|F|` is the cardinality of the prime field.
     #[tokio::test]
     async fn complex_circuit() -> Result<(), Error> {
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let context = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let context = world.contexts::<Fp31>();
         let mut rng = thread_rng();
 
         let mut original_inputs = Vec::with_capacity(100);

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -165,6 +165,7 @@ pub async fn convert_shares_for_a_bit<F: Field>(
 mod tests {
 
     use crate::rand::thread_rng;
+    use crate::secret_sharing::Replicated;
     use crate::{
         ff::Fp31,
         protocol::{modulus_conversion::convert_one_bit, QueryId, RecordId},
@@ -177,9 +178,9 @@ mod tests {
         const BITNUM: u32 = 4;
         let mut rng = thread_rng();
 
-        let world = TestWorld::<Fp31>::new(QueryId);
+        let world = TestWorld::new(QueryId);
         let match_key = MaskedMatchKey::mask(rng.gen());
-        let result = world
+        let result: [Replicated<Fp31>; 3] = world
             .semi_honest(match_key, |ctx, mk_share| async move {
                 convert_one_bit(ctx, RecordId::from(0), &mk_share, BITNUM)
                     .await

--- a/src/protocol/mul/semi_honest.rs
+++ b/src/protocol/mul/semi_honest.rs
@@ -276,7 +276,7 @@ mod regular_mul_tests {
         assert_eq!(expected, results.reconstruct());
     }
 
-    async fn multiply_sync<F>(world: &TestWorld<F>, a: u128, b: u128) -> u128
+    async fn multiply_sync<F>(world: &TestWorld, a: u128, b: u128) -> u128
     where
         F: Field,
         (F, F): Sized,

--- a/src/protocol/reveal/mod.rs
+++ b/src/protocol/reveal/mod.rs
@@ -133,8 +133,8 @@ mod tests {
     #[tokio::test]
     pub async fn simple() -> Result<(), Error> {
         let mut rng = thread_rng();
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let ctx = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let ctx = world.contexts::<Fp31>();
 
         for i in 0..10_u32 {
             let secret = rng.gen::<u128>();
@@ -158,8 +158,8 @@ mod tests {
     #[tokio::test]
     pub async fn malicious() -> Result<(), Error> {
         let mut rng = thread_rng();
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let sh_ctx = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let sh_ctx = world.contexts::<Fp31>();
         let v = sh_ctx.map(MaliciousValidator::new);
 
         for i in 0..10_u32 {
@@ -188,8 +188,8 @@ mod tests {
     #[tokio::test]
     pub async fn malicious_validation_fail() -> Result<(), Error> {
         let mut rng = thread_rng();
-        let world = TestWorld::<Fp31>::new(QueryId);
-        let sh_ctx = world.contexts();
+        let world = TestWorld::new(QueryId);
+        let sh_ctx = world.contexts::<Fp31>();
         let v = sh_ctx.map(MaliciousValidator::new);
 
         for i in 0..10 {

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -141,6 +141,7 @@ mod tests {
     use std::iter::zip;
 
     use crate::rand::{thread_rng, Rng};
+    use crate::secret_sharing::Replicated;
     use rand::seq::SliceRandom;
 
     use crate::protocol::context::Context;
@@ -159,7 +160,7 @@ mod tests {
         const COUNT: usize = 5;
 
         logging::setup();
-        let world = TestWorld::<Fp32BitPrime>::new(QueryId);
+        let world = TestWorld::new(QueryId);
         let mut rng = thread_rng();
 
         let mut match_keys = Vec::with_capacity(COUNT);
@@ -171,7 +172,7 @@ mod tests {
             .collect::<Vec<_>>();
         expected.sort_unstable();
 
-        let result = world
+        let result: [Vec<Replicated<Fp32BitPrime>>; 3] = world
             .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
                 generate_permutation(ctx, &mk_shares, MaskedMatchKey::BITS)
                     .await

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -29,7 +29,7 @@ pub async fn arithmetic<F: Field>(width: u32, depth: u8) {
     assert_eq!(sum, u128::from(width));
 }
 
-async fn circuit(world: &TestWorld<Fp31>, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
+async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
     let top_ctx = world.contexts();
     let mut a = share(Fp31::ONE, &mut thread_rng());
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -11,7 +11,6 @@ use crate::{
         Role, SendBufferConfig,
     },
     protocol::{
-        boolean::random_bits_generator::RandomBitsGenerator,
         context::{Context, MaliciousContext, SemiHonestContext},
         malicious::MaliciousValidator,
         prss::Endpoint as PrssEndpoint,
@@ -32,13 +31,12 @@ use super::{
 /// there is no need to associate each of them with `QueryId`, but this API makes it possible
 /// to do if we need it.
 #[derive(Debug)]
-pub struct TestWorld<F: Field> {
+pub struct TestWorld {
     pub query_id: QueryId,
     pub gateways: [Gateway; 3],
     pub participants: [PrssEndpoint; 3],
     pub(super) executions: AtomicUsize,
     _network: Arc<InMemoryNetwork>,
-    pub rbg: [RandomBitsGenerator<F>; 3],
 }
 
 #[derive(Copy, Clone)]
@@ -69,11 +67,11 @@ impl Default for TestWorldConfig {
     }
 }
 
-impl<F: Field> TestWorld<F> {
+impl TestWorld {
     /// Creates a new `TestWorld` instance using the provided `config`.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn new_with(query_id: QueryId, config: TestWorldConfig) -> TestWorld<F> {
+    pub fn new_with(query_id: QueryId, config: TestWorldConfig) -> TestWorld {
         logging::setup();
 
         let participants = make_participants();
@@ -85,12 +83,6 @@ impl<F: Field> TestWorld<F> {
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
-        let rbg = (0..)
-            .take(3)
-            .map(|_| RandomBitsGenerator::new())
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
 
         TestWorld {
             query_id,
@@ -98,14 +90,13 @@ impl<F: Field> TestWorld<F> {
             participants,
             executions: AtomicUsize::new(0),
             _network: network,
-            rbg,
         }
     }
 
     /// Creates a new `TestWorld` instance.
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn new(query_id: QueryId) -> TestWorld<F> {
+    pub fn new(query_id: QueryId) -> TestWorld {
         let config = TestWorldConfig::default();
         Self::new_with(query_id, config)
     }
@@ -115,19 +106,16 @@ impl<F: Field> TestWorld<F> {
     /// # Panics
     /// Panics if world has more or less than 3 gateways/participants
     #[must_use]
-    pub fn contexts(&self) -> [SemiHonestContext<'_, F>; 3] {
+    pub fn contexts<F: Field>(&self) -> [SemiHonestContext<'_, F>; 3] {
         let execution = self.executions.fetch_add(1, Ordering::Release);
         let run = format!("run-{execution}");
-        zip(
-            Role::all(),
-            zip(&self.participants, zip(&self.gateways, &self.rbg)),
-        )
-        .map(|(role, (participant, (gateway, rbg)))| {
-            SemiHonestContext::new(*role, participant, gateway, rbg).narrow(&run)
-        })
-        .collect::<Vec<_>>()
-        .try_into()
-        .unwrap()
+        zip(Role::all(), zip(&self.participants, &self.gateways))
+            .map(|(role, (participant, gateway))| {
+                SemiHonestContext::new(*role, participant, gateway).narrow(&run)
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -155,7 +143,7 @@ pub trait Runner<I, A, F> {
 }
 
 #[async_trait]
-impl<I, A, F> Runner<I, A, F> for TestWorld<F>
+impl<I, A, F> Runner<I, A, F> for TestWorld
 where
     I: 'static + IntoShares<A> + Send,
     A: Send,


### PR DESCRIPTION
This was awfully messy being in context. Given that we currently only expect the user contribution capping step to use this, let's just have that protocol generate this object and pass it in.