### PR TITLE
Improve error message for duplicate records sent to Infra

### DIFF
--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -56,6 +56,11 @@ impl<const N: usize> FixedSizeByteVec<N> {
         self.data[offset].copy_from_slice(elem);
     }
 
+    /// Returns `true` if record at the given index exists.
+    pub fn added(&self, index: usize) -> bool {
+        self.added[index]
+    }
+
     /// Takes a block of elements from the beginning of the vector, or `None` if
     /// fewer than `min_count` elements have been inserted at the start of the buffer.
     pub fn take(&mut self, min_count: usize) -> Option<Vec<u8>> {
@@ -117,7 +122,10 @@ mod tests {
     fn insert() {
         let mut v = FixedSizeByteVec::<ELEMENT_SIZE>::new(3);
         v.insert_test_data(0);
+        assert!(v.added(0));
         v.insert_test_data(2);
+        assert!(v.added(2));
+        assert!(!v.added(1));
 
         assert_eq!(v.take(1), Some(test_data_at(0).to_vec()));
 

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -4,3 +4,5 @@ mod send;
 
 pub use receive::ReceiveBuffer;
 pub use {send::Config as SendBufferConfig, send::SendBuffer};
+
+pub(super) use send::PushError;

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -25,6 +25,11 @@ pub struct SendBuffer {
 
 #[derive(thiserror::Error, Debug)]
 pub enum PushError {
+    #[error("Record {record_id:?} has been received twice")]
+    Duplicate {
+        channel_id: ChannelId,
+        record_id: RecordId,
+    },
     #[error("Record {record_id:?} is out of accepted range {accepted_range:?}")]
     OutOfRange {
         channel_id: ChannelId,
@@ -101,8 +106,15 @@ impl SendBuffer {
         // TODO: avoid the copy here and size the element size to the message type.
         let mut payload = [0; ByteBuf::ELEMENT_SIZE_BYTES];
         payload[..msg.payload.len()].copy_from_slice(&msg.payload);
-        buf.insert(index, &payload);
-        Ok(buf.take(self.items_in_batch))
+        if buf.added(index) {
+            Err(PushError::Duplicate {
+                channel_id: channel_id.clone(),
+                record_id: msg.record_id,
+            })
+        } else {
+            buf.insert(index, &payload);
+            Ok(buf.take(self.items_in_batch))
+        }
     }
 }
 
@@ -131,7 +143,7 @@ mod tests {
     use crate::helpers::network::{ChannelId, MessageEnvelope};
     use crate::helpers::Role;
     use crate::protocol::{RecordId, Step};
-    use std::mem::drop;
+
     use tinyvec::array_vec;
 
     impl Clone for MessageEnvelope {
@@ -198,7 +210,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn rejects_duplicates() {
         let mut buf = SendBuffer::new(Config::default().items_in_batch(10));
         let channel = ChannelId::new(Role::H1, Step::default());
@@ -207,7 +218,10 @@ mod tests {
         let m2 = empty_msg(record_id);
 
         assert!(matches!(buf.push(&channel, &m1), Ok(None)));
-        drop(buf.push(&channel, &m2));
+        assert!(matches!(
+            buf.push(&channel, &m2),
+            Err(PushError::Duplicate { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Before this change, infrastructure did not allow duplicates to be inserted (duplicate is a message with the same record id sent to the same channel more than once). That is expected but the error did not get propagated back to the caller (protocol in this case). `send` method did not wait for the status of the operation - regardless whether gateway can actually accept this message or no, it allowed protocols to move forward immediately after send.

New behavior provides the essential mechanism to built the backpressure later, but currently it is used to propagate errors from the send buffers.

Protocols that attempt to insert the same message twice to the infrastructure will get an error at the point where this insertion occurs and will get the proper message

```
An error occurred while sending data to channel[peer=H2,step=step=protocol/run-0]: Record RecordId(1) has been received twice
```