### PR TITLE
Print helper state if nothing is going on

### DIFF
--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -80,11 +80,6 @@ impl<const N: usize> FixedSizeByteVec<N> {
         Some(r)
     }
 
-    /// TODO: tests and documentation. Properly implemented in #314
-    pub fn added(&self, index: usize) -> bool {
-        self.added[index]
-    }
-
     /// Returns total number of elements evicted from this buffer since the creation.
     pub fn taken(&self) -> usize {
         self.taken

--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -75,6 +75,11 @@ impl<const N: usize> FixedSizeByteVec<N> {
         Some(r)
     }
 
+    /// TODO: tests and documentation. Properly implemented in #314
+    pub fn added(&self, index: usize) -> bool {
+        self.added[index]
+    }
+
     /// Returns total number of elements evicted from this buffer since the creation.
     pub fn taken(&self) -> usize {
         self.taken

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -2,36 +2,37 @@ mod fsv;
 mod receive;
 mod send;
 
-#[cfg(debug_assertions)]
-use crate::helpers::network::ChannelId;
-
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-
 pub use receive::ReceiveBuffer;
 pub use {send::Config as SendBufferConfig, send::SendBuffer};
 
 #[cfg(debug_assertions)]
-pub(in crate::helpers) struct WaitingTasks<'a> {
-    tasks: HashMap<&'a ChannelId, Vec<u32>>,
-}
+mod waiting {
+    use crate::helpers::network::ChannelId;
+    use std::collections::HashMap;
 
-#[cfg(debug_assertions)]
-impl WaitingTasks<'_> {
-    pub fn is_empty(&self) -> bool {
-        self.tasks.is_empty()
+    pub(in crate::helpers) struct WaitingTasks<'a> {
+        tasks: HashMap<&'a ChannelId, Vec<u32>>,
     }
-}
 
-#[cfg(debug_assertions)]
-impl std::fmt::Debug for WaitingTasks<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[")?;
-        for (channel, records) in &self.tasks {
-            write!(f, "\n{:?}: {:?}", channel, records)?;
+    impl<'a> WaitingTasks<'a> {
+        pub fn new(tasks: HashMap<&'a ChannelId, Vec<u32>>) -> Self {
+            Self { tasks }
         }
-        write!(f, "\n]")?;
 
-        Ok(())
+        pub fn is_empty(&self) -> bool {
+            self.tasks.is_empty()
+        }
+    }
+
+    impl std::fmt::Debug for WaitingTasks<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "[")?;
+            for (channel, records) in &self.tasks {
+                write!(f, "\n    {:?}: {:?}", channel, records)?;
+            }
+            write!(f, "\n]")?;
+
+            Ok(())
+        }
     }
 }

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -2,5 +2,32 @@ mod fsv;
 mod receive;
 mod send;
 
+use crate::helpers::network::ChannelId;
+
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+
 pub use receive::ReceiveBuffer;
 pub use {send::Config as SendBufferConfig, send::SendBuffer};
+
+pub(in crate::helpers) struct WaitingTasks<'a> {
+    tasks: HashMap<&'a ChannelId, Vec<u32>>,
+}
+
+impl WaitingTasks<'_> {
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
+    }
+}
+
+impl Debug for WaitingTasks<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        for (channel, records) in &self.tasks {
+            write!(f, "\n{:?}: {:?}", channel, records)?;
+        }
+        write!(f, "\n]")?;
+
+        Ok(())
+    }
+}

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -2,26 +2,30 @@ mod fsv;
 mod receive;
 mod send;
 
+#[cfg(debug_assertions)]
 use crate::helpers::network::ChannelId;
 
+#[cfg(debug_assertions)]
 use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
 
 pub use receive::ReceiveBuffer;
 pub use {send::Config as SendBufferConfig, send::SendBuffer};
 
+#[cfg(debug_assertions)]
 pub(in crate::helpers) struct WaitingTasks<'a> {
     tasks: HashMap<&'a ChannelId, Vec<u32>>,
 }
 
+#[cfg(debug_assertions)]
 impl WaitingTasks<'_> {
     pub fn is_empty(&self) -> bool {
         self.tasks.is_empty()
     }
 }
 
-impl Debug for WaitingTasks<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+#[cfg(debug_assertions)]
+impl std::fmt::Debug for WaitingTasks<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[")?;
         for (channel, records) in &self.tasks {
             write!(f, "\n{:?}: {:?}", channel, records)?;

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -90,8 +90,8 @@ impl ReceiveBuffer {
     }
 
     #[cfg(debug_assertions)]
-    pub(in crate::helpers) fn waiting(&self) -> super::WaitingTasks {
-        use super::WaitingTasks;
+    pub(in crate::helpers) fn waiting(&self) -> super::waiting::WaitingTasks {
+        use super::waiting::WaitingTasks;
 
         let mut tasks = HashMap::new();
         for (channel, receive_items) in &self.inner {
@@ -109,6 +109,6 @@ impl ReceiveBuffer {
             }
         }
 
-        WaitingTasks { tasks }
+        WaitingTasks::new(tasks)
     }
 }

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -1,4 +1,3 @@
-use crate::helpers::buffers::WaitingTasks;
 use crate::{
     helpers::{network::ChannelId, MessagePayload, MESSAGE_PAYLOAD_SIZE_BYTES},
     protocol::RecordId,
@@ -91,7 +90,9 @@ impl ReceiveBuffer {
     }
 
     #[cfg(debug_assertions)]
-    pub(in crate::helpers) fn waiting(&self) -> WaitingTasks {
+    pub(in crate::helpers) fn waiting(&self) -> super::WaitingTasks {
+        use super::WaitingTasks;
+
         let mut tasks = HashMap::new();
         for (channel, receive_items) in &self.inner {
             let mut vec = receive_items

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -102,8 +102,11 @@ impl ReceiveBuffer {
                     ReceiveBufItem::Received(_) => None,
                 })
                 .collect::<Vec<_>>();
-            vec.sort_unstable();
-            tasks.insert(channel, vec);
+
+            if !vec.is_empty() {
+                vec.sort_unstable();
+                tasks.insert(channel, vec);
+            }
         }
 
         WaitingTasks { tasks }

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -124,10 +124,11 @@ impl SendBuffer {
         for (channel, buf) in &self.inner {
             let range = Range::from(buf);
             let range: Range<u32> = range.start.into()..range.end.into();
+            let offset = range.start;
             let mut records = Vec::new();
             for i in range {
                 // we're only interested in things in the front of the buffer
-                if buf.added(usize::try_from(i).unwrap()) {
+                if buf.added(usize::try_from(i - offset).unwrap()) {
                     break;
                 }
 

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -1,4 +1,3 @@
-use crate::helpers::buffers::WaitingTasks;
 use crate::{
     helpers::{
         buffers::fsv::FixedSizeByteVec,
@@ -106,7 +105,9 @@ impl SendBuffer {
     }
 
     #[cfg(debug_assertions)]
-    pub(in crate::helpers) fn waiting(&self) -> WaitingTasks {
+    pub(in crate::helpers) fn waiting(&self) -> super::WaitingTasks {
+        use super::WaitingTasks;
+
         let mut tasks = HashMap::new();
         for (channel, buf) in &self.inner {
             let range = Range::from(buf);

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -165,8 +165,8 @@ impl Gateway {
             let mut receive_buf = ReceiveBuffer::default();
             let mut send_buf = SendBuffer::new(config.send_buffer_config);
 
-            let sleep = tokio::time::sleep(INTERVAL);
-            tokio::pin!(sleep);
+            let sleep = ::tokio::time::sleep(INTERVAL);
+            ::tokio::pin!(sleep);
 
             loop {
                 // Make a random choice what to process next:

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -162,7 +162,7 @@ impl Gateway {
         let mut network_sink = network.sink();
 
         let control_handle = tokio::spawn(async move {
-            const INTERVAL: Duration = Duration::from_secs(10);
+            const INTERVAL: Duration = Duration::from_secs(3);
 
             let mut receive_buf = ReceiveBuffer::default();
             let mut send_buf = SendBuffer::new(config.send_buffer_config);
@@ -303,10 +303,8 @@ fn print_state(role: Role, send_buf: &SendBuffer, receive_buf: &ReceiveBuffer) {
     if !send_tasks_waiting.is_empty() || !receive_tasks_waiting.is_empty() {
         tracing::error!(
             "List of tasks pending completion on {role:?}:\
-        \nwaiting to send: {:?},\
-        \nwaiting to receive: {:?}",
-            send_buf.waiting(),
-            receive_buf.waiting()
+        \nwaiting to send: {send_tasks_waiting:?},\
+        \nwaiting to receive: {receive_tasks_waiting:?}"
         );
     }
 }

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -193,7 +193,8 @@ impl Gateway {
                     _ = &mut sleep => {
                         // TODO: split this large spawn task into smaller chunks and create a function
                         // for it.
-                        if cfg!(debug_assertions) {
+                        #[cfg(debug_assertions)]
+                        {
                             let send_tasks_waiting = send_buf.waiting();
                             let receive_tasks_waiting = receive_buf.waiting();
                             if !send_tasks_waiting.is_empty() || !receive_tasks_waiting.is_empty() {

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -51,7 +51,7 @@ impl ChannelId {
 
 impl Debug for ChannelId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "channel[peer={:?},{:?}]", self.role, self.step)
+        write!(f, "channel[{:?},{:?}]", self.role, self.step)
     }
 }
 

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -51,7 +51,7 @@ impl ChannelId {
 
 impl Debug for ChannelId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "channel[peer={:?},step={:?}]", self.role, self.step)
+        write!(f, "channel[peer={:?},{:?}]", self.role, self.step)
     }
 }
 


### PR DESCRIPTION
It is an easy mistake to make to start counting records from 1 or miss sending a record. Infrastructure stays silent and does not output anything for it. This change sets up a timer for gateway loop that prints the state of helper (if there is something pending) every 10 seconds. The output looks like this

```bash
2022-12-05T05:48:59.379513Z ERROR raw_ipa::helpers::messaging: Nothing has happened on H1 in the last 10s. Here is the list of tasks pending completion:
 waiting to send: [
channel[peer=H2,step=step=protocol/run-0]: [0]
],
 waiting to receive: [
channel[peer=H2,step=step=protocol/run-0]: [1, 2, 3, 4, 5, 6, 7, 8, 9]
]
```