### PR TITLE
Malicious SolvedBits

### DIFF
--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -4,10 +4,9 @@ use super::random_bits_generator::RandomBitsGenerator;
 use crate::error::Error;
 use crate::ff::{Field, Int};
 use crate::protocol::boolean::local_secret_shared_bits;
-use crate::protocol::context::{Context, SemiHonestContext};
-use crate::protocol::reveal::Reveal;
+use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::SecretSharing;
 
 /// This is an implementation of "3. Bit-Decomposition" from I. Damgård et al..
 ///
@@ -25,12 +24,17 @@ impl BitDecomposition {
     /// ## Errors
     /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
     /// back via the error response
-    pub async fn execute<F: Field>(
-        ctx: SemiHonestContext<'_, F>,
+    pub async fn execute<F, S, C>(
+        ctx: C,
         record_id: RecordId,
-        rbg: RandomBitsGenerator<F>,
-        a_p: &Replicated<F>,
-    ) -> Result<Vec<Replicated<F>>, Error> {
+        rbg: RandomBitsGenerator<F, S>,
+        a_p: &S,
+    ) -> Result<Vec<S>, Error>
+    where
+        F: Field,
+        S: SecretSharing<F>,
+        C: Context<F, Share = S>,
+    {
         // step 1 in the paper is just describing the input, `[a]_p` where `a ∈ F_p`
 
         // Step 2. Generate random bitwise shares
@@ -39,7 +43,7 @@ impl BitDecomposition {
         // Step 3, 4. Reveal c = [a - b]_p
         let c = ctx
             .narrow(&Step::RevealAMinusB)
-            .reveal(record_id, &(a_p - &r.b_p))
+            .reveal(record_id, &(a_p.clone() - &r.b_p))
             .await?;
         let c_b = local_secret_shared_bits(&ctx, c.as_u128());
 

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -1,0 +1,57 @@
+use super::{RandomBits, Step};
+use crate::error::Error;
+use crate::ff::{Field, Int};
+use crate::protocol::context::MaliciousContext;
+use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local};
+use crate::protocol::{context::Context, BitOpStep, RecordId};
+use crate::secret_sharing::{MaliciousReplicated, XorReplicated};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::iter::repeat;
+
+#[async_trait]
+impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
+    type Share = MaliciousReplicated<F>;
+
+    /// Generates a sequence of `l` random bit sharings in the target field `F`.
+    async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {
+        // Calculate the number of bits we need to form a random number that
+        // has the same number of bits as the prime.
+        let l = u128::BITS - F::PRIME.into().leading_zeros();
+        let leading_zero_bits = F::Integer::BITS - l;
+
+        // Generate a pair of random numbers. We'll use these numbers as
+        // the source of `l`-bit long uniformly random sequence of bits.
+        let (b_bits_left, b_bits_right) = self
+            .narrow(&Step::RandomValues)
+            .prss()
+            .generate_values(record_id);
+
+        // Same here. For now, 256-bit is enough for our F_p
+        let xor_share = XorReplicated::new(
+            u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
+            u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
+        );
+
+        // Convert each bit to secret sharings of that bit in the target field
+        let c = self.narrow(&Step::ConvertShares);
+        let futures = (0..l).map(|i| {
+            let c = c.narrow(&BitOpStep::from(i));
+            let triple = convert_bit_local::<F>(c.role(), i, &xor_share);
+            async move {
+                let malicious_triple = c.upgrade_bit_triple(record_id, i, triple).await?;
+                convert_bit(c, record_id, &malicious_triple).await
+            }
+        });
+
+        // Pad 0's at the end to return `F::Integer::BITS` long bits
+        let mut b_b = try_join_all(futures).await?;
+        b_b.append(
+            &mut repeat(Self::Share::ZERO)
+                .take(usize::try_from(leading_zero_bits).unwrap())
+                .collect::<Vec<_>>(),
+        );
+
+        Ok(b_b)
+    }
+}

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -1,13 +1,11 @@
-use super::{RandomBits, Step};
+use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::error::Error;
-use crate::ff::{Field, Int};
+use crate::ff::Field;
 use crate::protocol::context::MaliciousContext;
-use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local};
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{MaliciousReplicated, XorReplicated};
+use crate::secret_sharing::MaliciousReplicated;
 use async_trait::async_trait;
 use futures::future::try_join_all;
-use std::iter::repeat;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
@@ -15,43 +13,24 @@ impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {
-        // Calculate the number of bits we need to form a random number that
-        // has the same number of bits as the prime.
-        let l = u128::BITS - F::PRIME.into().leading_zeros();
-        let leading_zero_bits = F::Integer::BITS - l;
+        let triples = random_bits_triples(&self, record_id);
 
-        // Generate a pair of random numbers. We'll use these numbers as
-        // the source of `l`-bit long uniformly random sequence of bits.
-        let (b_bits_left, b_bits_right) = self
-            .narrow(&Step::RandomValues)
-            .prss()
-            .generate_values(record_id);
-
-        // Same here. For now, 256-bit is enough for our F_p
-        let xor_share = XorReplicated::new(
-            u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
-            u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
-        );
-
-        // Convert each bit to secret sharings of that bit in the target field
-        let c = self.narrow(&Step::ConvertShares);
-        let futures = (0..l).map(|i| {
+        // upgrade the replicated shares to malicious
+        let c = self.narrow(&Step::UpgradeBitTriples);
+        let malicious_triples = try_join_all(triples.into_iter().enumerate().map(|(i, t)| {
             let c = c.narrow(&BitOpStep::from(i));
-            let triple = convert_bit_local::<F>(c.role(), i, &xor_share);
             async move {
-                let malicious_triple = c.upgrade_bit_triple(record_id, i, triple).await?;
-                convert_bit(c, record_id, &malicious_triple).await
+                c.upgrade_bit_triple(record_id, u32::try_from(i).unwrap(), t)
+                    .await
             }
-        });
+        }))
+        .await?;
 
-        // Pad 0's at the end to return `F::Integer::BITS` long bits
-        let mut b_b = try_join_all(futures).await?;
-        b_b.append(
-            &mut repeat(Self::Share::ZERO)
-                .take(usize::try_from(leading_zero_bits).unwrap())
-                .collect::<Vec<_>>(),
-        );
-
-        Ok(b_b)
+        convert_triples_to_shares(
+            self.narrow(&Step::ConvertShares),
+            record_id,
+            &malicious_triples,
+        )
+        .await
     }
 }

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,0 +1,32 @@
+use crate::error::Error;
+use crate::ff::Field;
+use crate::protocol::RecordId;
+use crate::secret_sharing::SecretSharing;
+use async_trait::async_trait;
+
+mod malicious;
+mod semi_honest;
+
+#[async_trait]
+pub trait RandomBits<F: Field> {
+    type Share: SecretSharing<F>;
+
+    async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    RandomValues,
+    ConvertShares,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::RandomValues => "random_values",
+            Self::ConvertShares => "convert_shares",
+        }
+    }
+}

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,8 +1,11 @@
 use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::RecordId;
-use crate::secret_sharing::SecretSharing;
+use crate::ff::{Field, Int};
+use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple};
+use crate::protocol::{context::Context, BitOpStep, RecordId};
+use crate::secret_sharing::{Replicated, SecretSharing, XorReplicated};
 use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::iter::repeat;
 
 mod malicious;
 mod semi_honest;
@@ -14,10 +17,70 @@ pub trait RandomBits<F: Field> {
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error>;
 }
 
+fn random_bits_triples<F, C, S>(
+    ctx: &C,
+    record_id: RecordId,
+) -> Vec<BitConversionTriple<Replicated<F>>>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: SecretSharing<F>,
+{
+    // Calculate the number of bits we need to form a random number that
+    // has the same number of bits as the prime.
+    let l = u128::BITS - F::PRIME.into().leading_zeros();
+
+    // Generate a pair of random numbers. We'll use these numbers as
+    // the source of `l`-bit long uniformly random sequence of bits.
+    let (b_bits_left, b_bits_right) = ctx.prss().generate_values(record_id);
+
+    // Same here. For now, 256-bit is enough for our F_p
+    let xor_share = XorReplicated::new(
+        u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
+        u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
+    );
+
+    // Convert each bit to secret sharings of that bit in the target field
+    (0..l)
+        .map(|i| convert_bit_local::<F>(ctx.role(), i, &xor_share))
+        .collect::<Vec<_>>()
+}
+
+async fn convert_triples_to_shares<F, C, S>(
+    ctx: C,
+    record_id: RecordId,
+    triples: &[BitConversionTriple<S>],
+) -> Result<Vec<S>, Error>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: SecretSharing<F>,
+{
+    // Calculate the number of bits we need to form a random number that
+    // has the same number of bits as the prime.
+    let l = u128::BITS - F::PRIME.into().leading_zeros();
+    let leading_zero_bits = F::Integer::BITS - l;
+
+    let futures = triples.iter().enumerate().map(|(i, t)| {
+        let c = ctx.narrow(&BitOpStep::from(i));
+        async move { convert_bit(c, record_id, t).await }
+    });
+
+    // Pad 0's at the end to return `F::Integer::BITS` long bits
+    let mut b_b = try_join_all(futures).await?;
+    b_b.append(
+        &mut repeat(S::ZERO)
+            .take(usize::try_from(leading_zero_bits).unwrap())
+            .collect::<Vec<_>>(),
+    );
+
+    Ok(b_b)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
-    RandomValues,
     ConvertShares,
+    UpgradeBitTriples,
 }
 
 impl crate::protocol::Substep for Step {}
@@ -25,8 +88,8 @@ impl crate::protocol::Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
-            Self::RandomValues => "random_values",
             Self::ConvertShares => "convert_shares",
+            Self::UpgradeBitTriples => "upgrade_bit_triples",
         }
     }
 }

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -1,0 +1,54 @@
+use super::{RandomBits, Step};
+use crate::error::Error;
+use crate::ff::{Field, Int};
+use crate::protocol::context::SemiHonestContext;
+use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local};
+use crate::protocol::{context::Context, BitOpStep, RecordId};
+use crate::secret_sharing::{Replicated, XorReplicated};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::iter::repeat;
+
+#[async_trait]
+impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
+    type Share = Replicated<F>;
+
+    /// Generates a sequence of `l` random bit sharings in the target field `F`.
+    async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {
+        // Calculate the number of bits we need to form a random number that
+        // has the same number of bits as the prime.
+        let l = u128::BITS - F::PRIME.into().leading_zeros();
+        let leading_zero_bits = F::Integer::BITS - l;
+
+        // Generate a pair of random numbers. We'll use these numbers as
+        // the source of `l`-bit long uniformly random sequence of bits.
+        let (b_bits_left, b_bits_right) = self
+            .narrow(&Step::RandomValues)
+            .prss()
+            .generate_values(record_id);
+
+        // Same here. For now, 256-bit is enough for our F_p
+        let xor_share = XorReplicated::new(
+            u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
+            u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
+        );
+
+        // Convert each bit to secret sharings of that bit in the target field
+        let c = self.narrow(&Step::ConvertShares);
+        let futures = (0..l).map(|i| {
+            let c = c.narrow(&BitOpStep::from(i));
+            let triple = convert_bit_local::<F>(c.role(), i, &xor_share);
+            async move { convert_bit(c, record_id, &triple).await }
+        });
+
+        // Pad 0's at the end to return `F::Integer::BITS` long bits
+        let mut b_b = try_join_all(futures).await?;
+        b_b.append(
+            &mut repeat(Self::Share::ZERO)
+                .take(usize::try_from(leading_zero_bits).unwrap())
+                .collect::<Vec<_>>(),
+        );
+
+        Ok(b_b)
+    }
+}

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -1,13 +1,10 @@
-use super::{RandomBits, Step};
+use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::error::Error;
-use crate::ff::{Field, Int};
+use crate::ff::Field;
 use crate::protocol::context::SemiHonestContext;
-use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local};
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{Replicated, XorReplicated};
+use crate::protocol::{context::Context, RecordId};
+use crate::secret_sharing::Replicated;
 use async_trait::async_trait;
-use futures::future::try_join_all;
-use std::iter::repeat;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
@@ -15,40 +12,8 @@ impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {
-        // Calculate the number of bits we need to form a random number that
-        // has the same number of bits as the prime.
-        let l = u128::BITS - F::PRIME.into().leading_zeros();
-        let leading_zero_bits = F::Integer::BITS - l;
+        let triples = random_bits_triples(&self, record_id);
 
-        // Generate a pair of random numbers. We'll use these numbers as
-        // the source of `l`-bit long uniformly random sequence of bits.
-        let (b_bits_left, b_bits_right) = self
-            .narrow(&Step::RandomValues)
-            .prss()
-            .generate_values(record_id);
-
-        // Same here. For now, 256-bit is enough for our F_p
-        let xor_share = XorReplicated::new(
-            u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
-            u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
-        );
-
-        // Convert each bit to secret sharings of that bit in the target field
-        let c = self.narrow(&Step::ConvertShares);
-        let futures = (0..l).map(|i| {
-            let c = c.narrow(&BitOpStep::from(i));
-            let triple = convert_bit_local::<F>(c.role(), i, &xor_share);
-            async move { convert_bit(c, record_id, &triple).await }
-        });
-
-        // Pad 0's at the end to return `F::Integer::BITS` long bits
-        let mut b_b = try_join_all(futures).await?;
-        b_b.append(
-            &mut repeat(Self::Share::ZERO)
-                .take(usize::try_from(leading_zero_bits).unwrap())
-                .collect::<Vec<_>>(),
-        );
-
-        Ok(b_b)
+        convert_triples_to_shares(self.narrow(&Step::ConvertShares), record_id, &triples).await
     }
 }

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -13,11 +13,15 @@ mod bitwise_equal;
 mod bitwise_less_than_prime;
 mod dumb_bitwise_lt;
 mod dumb_bitwise_sum;
+mod generate_random_bits;
 mod or;
 pub mod random_bits_generator;
 mod solved_bits;
 
-pub use {bit_decomposition::BitDecomposition, dumb_bitwise_lt::BitwiseLessThan};
+pub use {
+    bit_decomposition::BitDecomposition, dumb_bitwise_lt::BitwiseLessThan,
+    generate_random_bits::RandomBits,
+};
 
 /// Converts the given number to a sequence of `{0,1} ⊆ F`, and creates a
 /// local replicated share.

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,20 +1,20 @@
 use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use crate::error::Error;
-use crate::ff::{Field, Int};
-use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local};
-use crate::protocol::{
-    context::{Context, SemiHonestContext},
-    BitOpStep, RecordId,
-};
-use crate::secret_sharing::{Replicated, SecretSharing, XorReplicated};
-use futures::future::try_join_all;
-use std::iter::repeat;
+use crate::ff::Field;
+use crate::protocol::{context::Context, RecordId};
+use crate::secret_sharing::SecretSharing;
+use std::marker::PhantomData;
 
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct RandomBitsShare<F: Field> {
-    pub b_b: Vec<Replicated<F>>,
-    pub b_p: Replicated<F>,
+pub struct RandomBitsShare<F, S>
+where
+    F: Field,
+    S: SecretSharing<F>,
+{
+    pub b_b: Vec<S>,
+    pub b_p: S,
+    _marker: PhantomData<F>,
 }
 
 /// This protocol tries to generate a sequence of uniformly random sharing of
@@ -30,111 +30,74 @@ pub struct RandomBitsShare<F: Field> {
 /// 3.1 Generating random solved BITS
 /// "Unconditionally Secure Constant-Rounds Multi-party Computation for Equality, Comparison, Bits, and Exponentiation"
 /// I. Damgård et al.
-pub struct SolvedBits {}
 
-impl SolvedBits {
-    // Try generating random sharing of bits, `[b]_B`, and `l`-bit long.
-    // Each bit has a 50% chance of being a 0 or 1, so there are
-    // `F::Integer::MAX - p` cases where `b` may become larger than `p`.
-    // However, we calculate the number of bits needed to form a random
-    // number that has the same number of bits as the prime.
-    // With `Fp32BitPrime` (prime is `2^32 - 5`), that chance is around
-    // 1 * 10^-9. For Fp31, the chance is 1 out of 32 =~ 3%.
-    #[allow(dead_code)]
-    pub async fn execute<F: Field>(
-        ctx: SemiHonestContext<'_, F>,
-        record_id: RecordId,
-    ) -> Result<Option<RandomBitsShare<F>>, Error> {
-        //
-        // step 1 & 2
-        //
-        let b_b = Self::generate_random_bits(ctx.clone(), record_id).await?;
+// Try generating random sharing of bits, `[b]_B`, and `l`-bit long.
+// Each bit has a 50% chance of being a 0 or 1, so there are
+// `F::Integer::MAX - p` cases where `b` may become larger than `p`.
+// However, we calculate the number of bits needed to form a random
+// number that has the same number of bits as the prime.
+// With `Fp32BitPrime` (prime is `2^32 - 5`), that chance is around
+// 1 * 10^-9. For Fp31, the chance is 1 out of 32 =~ 3%.
+#[allow(dead_code)]
+pub async fn solved_bits<F, S, C>(
+    ctx: C,
+    record_id: RecordId,
+) -> Result<Option<RandomBitsShare<F, S>>, Error>
+where
+    F: Field,
+    S: SecretSharing<F>,
+    C: Context<F, Share = S>,
+{
+    //
+    // step 1 & 2
+    //
+    let b_b = ctx
+        .narrow(&Step::RandomBits)
+        .generate_random_bits(record_id)
+        .await?;
 
-        //
-        // step 3, 4 & 5
-        //
-        // if b >= p, then abort by returning `None`
-        if !Self::is_less_than_p(ctx.clone(), record_id, &b_b).await? {
-            return Ok(None);
-        }
-
-        //
-        // step 6
-        //
-        // if success, then compute `[b_p]` by `Σ 2^i * [b_i]_B`
-        #[allow(clippy::cast_possible_truncation)]
-        let b_p: Replicated<F> = b_b
-            .iter()
-            .enumerate()
-            .fold(Replicated::ZERO, |acc, (i, x)| {
-                acc + &(x.clone() * F::from(2_u128.pow(i as u32)))
-            });
-
-        Ok(Some(RandomBitsShare { b_b, b_p }))
+    //
+    // step 3, 4 & 5
+    //
+    // if b >= p, then abort by returning `None`
+    if !is_less_than_p(ctx.clone(), record_id, &b_b).await? {
+        return Ok(None);
     }
 
-    /// Generates a sequence of `l` random bit sharings in the target field `F`.
-    async fn generate_random_bits<F: Field>(
-        ctx: SemiHonestContext<'_, F>,
-        record_id: RecordId,
-    ) -> Result<Vec<Replicated<F>>, Error> {
-        // Calculate the number of bits we need to form a random number that
-        // has the same number of bits as the prime.
-        let l = u128::BITS - F::PRIME.into().leading_zeros();
-        let leading_zero_bits = F::Integer::BITS - l;
+    //
+    // step 6
+    //
+    // if success, then compute `[b_p]` by `Σ 2^i * [b_i]_B`
+    #[allow(clippy::cast_possible_truncation)]
+    let b_p: S = b_b.iter().enumerate().fold(S::ZERO, |acc, (i, x)| {
+        acc + &(x.clone() * F::from(2_u128.pow(i as u32)))
+    });
 
-        // Generate a pair of random numbers. We'll use these numbers as
-        // the source of `l`-bit long uniformly random sequence of bits.
-        let (b_bits_left, b_bits_right) = ctx
-            .narrow(&Step::RandomValues)
-            .prss()
-            .generate_values(record_id);
+    Ok(Some(RandomBitsShare {
+        b_b,
+        b_p,
+        _marker: PhantomData::default(),
+    }))
+}
 
-        // Same here. For now, 256-bit is enough for our F_p
-        let xor_share = XorReplicated::new(
-            u64::try_from(b_bits_left & u128::from(u64::MAX)).unwrap(),
-            u64::try_from(b_bits_right & u128::from(u64::MAX)).unwrap(),
-        );
-
-        // Convert each bit to secret sharings of that bit in the target field
-        let c = ctx.narrow(&Step::ConvertShares);
-        let futures = (0..l).map(|i| {
-            let c = c.narrow(&BitOpStep::from(i));
-            let triple = convert_bit_local::<F>(c.role(), i, &xor_share);
-            async move { convert_bit(c, record_id, &triple).await }
-        });
-
-        // Pad 0's at the end to return `F::Integer::BITS` long bits
-        let mut b_b = try_join_all(futures).await?;
-        b_b.append(
-            &mut repeat(Replicated::ZERO)
-                .take(usize::try_from(leading_zero_bits).unwrap())
-                .collect::<Vec<_>>(),
-        );
-
-        Ok(b_b)
+async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Result<bool, Error>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: SecretSharing<F>,
+{
+    let c_b =
+        BitwiseLessThanPrime::less_than_prime(ctx.narrow(&Step::IsPLessThanB), record_id, b_b)
+            .await?;
+    if ctx.narrow(&Step::RevealC).reveal(record_id, &c_b).await? == F::ZERO {
+        return Ok(false);
     }
-
-    async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Result<bool, Error>
-    where
-        F: Field,
-        C: Context<F, Share = S>,
-        S: SecretSharing<F>,
-    {
-        let c_b =
-            BitwiseLessThanPrime::less_than_prime(ctx.narrow(&Step::IsPLessThanB), record_id, b_b)
-                .await?;
-        if ctx.narrow(&Step::RevealC).reveal(record_id, &c_b).await? == F::ZERO {
-            return Ok(false);
-        }
-        Ok(true)
-    }
+    Ok(true)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
-    RandomValues,
-    ConvertShares,
+    RandomBits,
     IsPLessThanB,
     RevealC,
 }
@@ -144,8 +107,7 @@ impl crate::protocol::Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
-            Self::RandomValues => "random_values",
-            Self::ConvertShares => "convert_shares",
+            Self::RandomBits => "random_bits",
             Self::IsPLessThanB => "is_p_less_than_b",
             Self::RevealC => "reveal_c",
         }
@@ -154,8 +116,9 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::SolvedBits;
+    use crate::protocol::boolean::solved_bits::solved_bits;
     use crate::protocol::context::SemiHonestContext;
+    use crate::test_fixture::Runner;
     use crate::{
         error::Error,
         ff::{Field, Fp31, Fp32BitPrime},
@@ -163,6 +126,7 @@ mod tests {
         test_fixture::{bits_to_value, join3, Reconstruct, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};
+    use std::iter::zip;
 
     async fn random_bits<F: Field>(
         ctx: [SemiHonestContext<'_, F>; 3],
@@ -175,9 +139,9 @@ mod tests {
 
         // Execute
         let [result0, result1, result2] = join3(
-            SolvedBits::execute(c0, record_id),
-            SolvedBits::execute(c1, record_id),
-            SolvedBits::execute(c2, record_id),
+            solved_bits(c0, record_id),
+            solved_bits(c1, record_id),
+            solved_bits(c2, record_id),
         )
         .await;
 
@@ -251,8 +215,63 @@ mod tests {
                 success += 1;
             }
         }
+        // The chance of this protocol aborting 4 out of 4 tries in Fp32BitPrime
+        // is about 2^-100. Assert that at least one run has succeeded.
         assert!(success > 0);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    pub async fn malicious() {
+        let world = TestWorld::new(QueryId);
+        let mut success = 0;
+
+        for _ in 0..4 {
+            let results = world
+                .malicious(Fp32BitPrime::ZERO, |ctx, share_of_zero| async move {
+                    let share_option = solved_bits(ctx, RecordId::from(0)).await.unwrap();
+                    match share_option {
+                        None => {
+                            // This is a 5 in 4B case where `solved_bits()`
+                            // generated a random number > prime.
+                            //
+                            // `malicious()` requires its closure to return `Downgrade`
+                            // so we indicate the abort case with (0, [0]), instead
+                            // of (0, [0, 32]). But this isn't ideal because we can't
+                            // catch a bug where solved_bits returns a 1-bit random bits
+                            // of 0.
+                            (share_of_zero.clone(), vec![share_of_zero.clone()])
+                        }
+                        Some(share) => (share.b_p, share.b_b),
+                    }
+                })
+                .await;
+
+            let [result0, result1, result2] = results;
+            let ((s0, v0), (s1, v1), (s2, v2)) = (result0, result1, result2);
+
+            // bit lengths must be the same
+            assert_eq!(v0.len(), v1.len());
+            assert_eq!(v0.len(), v2.len());
+
+            let s = (s0, s1, s2).reconstruct();
+            let v = zip(v0, zip(v1, v2))
+                .map(|(b0, (b1, b2))| {
+                    let bit = (b0, b1, b2).reconstruct();
+                    assert!(bit == Fp32BitPrime::ZERO || bit == Fp32BitPrime::ONE);
+                    bit
+                })
+                .collect::<Vec<_>>();
+
+            if v.len() > 1 {
+                // Base10 of `b_B ⊆ Z` must equal `b_P`
+                assert_eq!(s.as_u128(), bits_to_value(&v));
+                success += 1;
+            }
+        }
+        // The chance of this protocol aborting 4 out of 4 tries in Fp32BitPrime
+        // is about 2^-100. Assert that at least one run has succeeded.
+        assert!(success > 0);
     }
 }

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -77,9 +77,12 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
     pub async fn upgrade_bit_triple(
         &self,
         record_id: RecordId,
+        bit_index: u32,
         triple: BitConversionTriple<Replicated<F>>,
     ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
-        self.inner.upgrade_bit_triple(record_id, triple).await
+        self.inner
+            .upgrade_bit_triple(record_id, bit_index, triple)
+            .await
     }
 }
 
@@ -230,26 +233,16 @@ impl<'a, F: Field> ContextInner<'a, F> {
     async fn upgrade_bit_triple(
         &self,
         record_id: RecordId,
+        bit_index: u32,
         triple: BitConversionTriple<Replicated<F>>,
     ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
         let [v0, v1, v2] = triple.0;
+        let c = self.upgrade_ctx.narrow(&BitOpStep::from(bit_index));
         Ok(BitConversionTriple(
             try_join_all([
-                self.upgrade_one(
-                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V0),
-                    record_id,
-                    v0,
-                ),
-                self.upgrade_one(
-                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V1),
-                    record_id,
-                    v1,
-                ),
-                self.upgrade_one(
-                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V2),
-                    record_id,
-                    v2,
-                ),
+                self.upgrade_one(c.narrow(&UpgradeTripleStep::V0), record_id, v0),
+                self.upgrade_one(c.narrow(&UpgradeTripleStep::V1), record_id, v1),
+                self.upgrade_one(c.narrow(&UpgradeTripleStep::V2), record_id, v2),
             ])
             .await?
             .try_into()

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -15,6 +15,7 @@ pub use malicious::MaliciousContext;
 pub(super) use malicious::SpecialAccessToMaliciousContext;
 pub use semi_honest::SemiHonestContext;
 
+use super::boolean::RandomBits;
 use super::sort::reshare::Reshare;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
@@ -23,6 +24,7 @@ pub trait Context<F: Field>:
     SecureMul<F, Share = <Self as Context<F>>::Share>
     + Reshare<F, Share = <Self as Context<F>>::Share>
     + Reveal<F, Share = <Self as Context<F>>::Share>
+    + RandomBits<F, Share = <Self as Context<F>>::Share>
     + Clone
     + Send
     + Sync

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -277,7 +277,7 @@ mod tests {
                 let v = MaliciousValidator::new(ctx);
                 let m_ctx = v.context();
                 let m_triple = m_ctx
-                    .upgrade_bit_triple(RecordId::from(0), triple)
+                    .upgrade_bit_triple(RecordId::from(0), 0, triple)
                     .await
                     .unwrap();
                 let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)
@@ -339,7 +339,7 @@ mod tests {
                     let v = MaliciousValidator::new(ctx);
                     let m_ctx = v.context();
                     let m_triple = m_ctx
-                        .upgrade_bit_triple(RecordId::from(0), tweaked)
+                        .upgrade_bit_triple(RecordId::from(0), 0, tweaked)
                         .await
                         .unwrap();
                     let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -328,3 +328,13 @@ impl<F: Field> ValidateMalicious<F> for [Vec<MaliciousReplicated<F>>; 3] {
         }
     }
 }
+
+impl<F: Field> ValidateMalicious<F> for [(MaliciousReplicated<F>, Vec<MaliciousReplicated<F>>); 3] {
+    fn validate(&self, r: F) {
+        let [t0, t1, t2] = self;
+        let ((s0, v0), (s1, v1), (s2, v2)) = (t0, t1, t2);
+
+        [s0, s1, s2].validate(r);
+        [v0.clone(), v1.clone(), v2.clone()].validate(r);
+    }
+}


### PR DESCRIPTION
As it's implemented now, `generate_random_bits()` calls `convert_bit_local()` which creates `Replicated<F>` instances. I'm moving `generate_random_bits()` as a trait and implement it for SemiHonestContext and MaliciousContext, so that protocols calling this method can be upgraded to malicious as well.

* Created `RandomBits` trait which has only one method 
* Malicious version of `generate_random_bits()` calls `upgrade_bit_triple()`
* Removed SolvedBits struct to align with other protocols. Now the protocol is just `solved_bits()` method
* Other mechanical changes for generics <F, S, C>