### PR TITLE
Aggregation Protocol [part 2 / 2] - Add the prefix sum aggregation

### DIFF
--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -67,15 +67,15 @@ pub async fn aggregate_credit<F: Field>(
 ) -> Result<Vec<AggregateCreditOutputRow<F>>, Error> {
     let one = ctx.share_of_one();
 
-    // Add aggregation bits and initialize with 1's. We create a new vector here
-    // because we need to push new rows needed for the aggregate computation.
+    //
+    // 1. Add aggregation bits and new rows per unique breakdown_key
+    //
     let capped_credits_with_aggregation_bits =
         add_aggregation_bits_and_breakdown_keys(&ctx, capped_credits);
 
     //
     // 2. Sort by `aggregation_bit` first, then by `breakdown_key`.
     //
-
     let sorted_input = sort_by_aggregation_bit_and_breakdown_key(
         ctx.narrow(&Step::SortByBreakdownKeyAndAttributionBit),
         &capped_credits_with_aggregation_bits,
@@ -163,7 +163,6 @@ pub async fn aggregate_credit<F: Field>(
     //
     // 4. Sort by `aggregation_bit`
     //
-
     let sorted_output =
         sort_by_aggregation_bit(ctx.narrow(&Step::SortByAttributionBit), &aggregated_credits)
             .await?;

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -1,10 +1,14 @@
-use super::CappedCreditsWithAggregationBit;
+use super::{
+    compute_b_bit, compute_stop_bit, AggregateCreditOutputRow, CappedCreditsWithAggregationBit,
+    CreditCappingOutputRow, InteractionPatternStep,
+};
 use crate::error::Error;
 use crate::ff::{Field, Int};
 use crate::helpers::Role;
 use crate::protocol::attribution::AttributionResharableStep::{
     AggregationBit, BreakdownKey, Credit, HelperBit,
 };
+use crate::protocol::basics::SecureMul;
 use crate::protocol::boolean::{random_bits_generator::RandomBitsGenerator, BitDecomposition};
 use crate::protocol::context::{Context, SemiHonestContext};
 use crate::protocol::sort::apply_sort::apply_sort_permutation;
@@ -13,7 +17,7 @@ use crate::protocol::sort::generate_permutation::generate_permutation_and_reveal
 use crate::protocol::{RecordId, Substep};
 use crate::secret_sharing::Replicated;
 use async_trait::async_trait;
-use futures::future::try_join_all;
+use futures::future::{try_join, try_join_all};
 use std::iter::repeat;
 
 #[async_trait]
@@ -52,6 +56,166 @@ where
     }
 }
 
+// The number of breakdown keys we expect to see, from 0 up to (MAX_BREAKDOWN_KEY - 1).
+const MAX_BREAKDOWN_KEY: u128 = 8;
+
+/// Aggregation step for Oblivious Attribution protocol.
+#[allow(dead_code)]
+pub async fn aggregate_credit<F: Field>(
+    ctx: SemiHonestContext<'_, F>,
+    capped_credits: &[CreditCappingOutputRow<F>],
+) -> Result<Vec<AggregateCreditOutputRow<F>>, Error> {
+    let one = ctx.share_of_one();
+
+    // Add aggregation bits and initialize with 1's. We create a new vector here
+    // because we need to push new rows needed for the aggregate computation.
+    let capped_credits_with_aggregation_bits =
+        add_aggregation_bits_and_breakdown_keys(&ctx, capped_credits);
+
+    //
+    // 2. Sort by `aggregation_bit` first, then by `breakdown_key`.
+    //
+
+    let sorted_input = sort_by_aggregation_bit_and_breakdown_key(
+        ctx.narrow(&Step::SortByBreakdownKeyAndAttributionBit),
+        &capped_credits_with_aggregation_bits,
+    )
+    .await?;
+
+    //
+    // 3. Aggregate by parallel prefix sum of credits per breakdown_key
+    //
+    //     b = current.stop_bit * successor.helper_bit;
+    //     new_credit[current_index] = current.credit + b * successor.credit;
+    //     new_stop_bit[current_index] = b * successor.stop_bit;
+    //
+    let num_rows = sorted_input.len();
+    let mut stop_bits = repeat(one.clone()).take(num_rows).collect::<Vec<_>>();
+
+    let mut credits = sorted_input
+        .iter()
+        .map(|x| x.credit.clone())
+        .collect::<Vec<_>>();
+
+    for (depth, step_size) in std::iter::successors(Some(1_usize), |prev| prev.checked_mul(2))
+        .take_while(|&v| v < num_rows)
+        .enumerate()
+    {
+        let end = num_rows - step_size;
+        let c = ctx.narrow(&InteractionPatternStep::from(depth));
+        let mut futures = Vec::with_capacity(end as usize);
+
+        for i in 0..end {
+            let c = c.clone();
+            let record_id = RecordId::from(i);
+            let sibling_helper_bit = &sorted_input[i + step_size].helper_bit;
+            let current_stop_bit = &stop_bits[i];
+            let sibling_stop_bit = &stop_bits[i + step_size];
+            let sibling_credit = &credits[i + step_size];
+            futures.push(async move {
+                let b = compute_b_bit(
+                    c.narrow(&Step::ComputeBBit),
+                    record_id,
+                    current_stop_bit,
+                    sibling_helper_bit,
+                    depth == 0,
+                )
+                .await?;
+
+                try_join(
+                    c.narrow(&Step::AggregateCreditBTimesSuccessorCredit)
+                        .multiply(record_id, &b, sibling_credit),
+                    compute_stop_bit(
+                        c.narrow(&Step::ComputeStopBit),
+                        record_id,
+                        &b,
+                        sibling_stop_bit,
+                        depth == 0,
+                    ),
+                )
+                .await
+            });
+        }
+
+        let results = try_join_all(futures).await?;
+
+        results
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, (credit, stop_bit))| {
+                credits[i] += &credit;
+                stop_bits[i] = stop_bit;
+            });
+    }
+
+    // Prepare the sidecar for sorting
+    let aggregated_credits = sorted_input
+        .iter()
+        .enumerate()
+        .map(|(i, x)| CappedCreditsWithAggregationBit {
+            helper_bit: x.helper_bit.clone(),
+            aggregation_bit: x.aggregation_bit.clone(),
+            breakdown_key: x.breakdown_key.clone(),
+            credit: credits[i].clone(),
+        })
+        .collect::<Vec<_>>();
+
+    //
+    // 4. Sort by `aggregation_bit`
+    //
+
+    let sorted_output =
+        sort_by_aggregation_bit(ctx.narrow(&Step::SortByAttributionBit), &aggregated_credits)
+            .await?;
+
+    // Take the first k elements, where k is the amount of breakdown keys.
+    let result = sorted_output
+        .iter()
+        .take(MAX_BREAKDOWN_KEY.try_into().unwrap())
+        .map(|x| AggregateCreditOutputRow {
+            breakdown_key: x.breakdown_key.clone(),
+            credit: x.credit.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(result)
+}
+
+fn add_aggregation_bits_and_breakdown_keys<F: Field>(
+    ctx: &SemiHonestContext<'_, F>,
+    capped_credits: &[CreditCappingOutputRow<F>],
+) -> Vec<CappedCreditsWithAggregationBit<F>> {
+    let zero = Replicated::ZERO;
+    let one = ctx.share_of_one();
+
+    // Add aggregation bits and initialize with 1's. We create a new vector here
+    // because we need to push new rows needed for the aggregate computation.
+    let mut capped_credits_with_aggregation_bits = capped_credits
+        .iter()
+        .map(|x| CappedCreditsWithAggregationBit {
+            helper_bit: one.clone(),
+            aggregation_bit: one.clone(),
+            breakdown_key: x.breakdown_key.clone(),
+            credit: x.credit.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    // Add additional breakdown_key values with all other fields initialized
+    // with 0's. Since we cannot see the actual breakdown key values, we'll
+    // need to append all possible values. For now, we assume breakdown_key
+    // is in the range of (0..MAX_BREAKDOWN_KEY).
+    (0..MAX_BREAKDOWN_KEY).for_each(|i| {
+        capped_credits_with_aggregation_bits.push(CappedCreditsWithAggregationBit {
+            helper_bit: zero.clone(),
+            aggregation_bit: zero.clone(),
+            breakdown_key: Replicated::from_scalar(ctx.role(), F::from(i)),
+            credit: zero.clone(),
+        });
+    });
+
+    capped_credits_with_aggregation_bits
+}
+
 /// Transpose rows of bits into bits of rows
 ///
 /// input:
@@ -70,10 +234,7 @@ where
 ///   [ row[0].bit31, row[1].bit31, ..., row[n].bit31 ],
 /// ]
 fn transpose<F: Field>(input: &[Vec<Replicated<F>>]) -> Vec<Vec<Replicated<F>>> {
-    let bit_length = input[0].len();
-    debug_assert_eq!(bit_length, F::Integer::BITS as usize);
-
-    (0..bit_length)
+    (0..input[0].len())
         .map(|i| input.iter().map(|b| b[i].clone()).collect::<Vec<_>>())
         .collect::<Vec<_>>()
 }
@@ -100,33 +261,35 @@ async fn bit_decompose_breakdown_key<F: Field>(
 }
 
 /// Sort the input by `aggregation_bit` first, then by `breakdown_key`
-#[allow(dead_code)]
 async fn sort_by_aggregation_bit_and_breakdown_key<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CappedCreditsWithAggregationBit<F>],
 ) -> Result<Vec<CappedCreditsWithAggregationBit<F>>, Error> {
-    // Sort by aggregation_bit
-    let sorted_by_aggregation_bit = sort_by_aggregation_bit(ctx.clone(), input).await?;
+    // Prepend the aggregation_bit bits with breakdown_key bits. This results
+    // in sorting the sidecar by aggregation_bit first, and then by breakdown_key.
 
-    // Next, sort by breakdown_key
+    let mut permutation_keys = vec![input
+        .iter()
+        .map(|x| x.aggregation_bit.clone())
+        .collect::<Vec<_>>()];
+
     // TODO: Change breakdown_keys to use XorReplicated to avoid bit-decomposition calls
-    let breakdown_keys = transpose(
-        &bit_decompose_breakdown_key(
-            ctx.narrow(&Step::BitDecomposeBreakdownKey),
-            &sorted_by_aggregation_bit,
-        )
-        .await?,
+    let mut breakdown_keys = transpose(
+        &bit_decompose_breakdown_key(ctx.narrow(&Step::BitDecomposeBreakdownKey), input).await?,
     );
+
+    permutation_keys.append(&mut breakdown_keys);
 
     let sort_permutation = generate_permutation_and_reveal_shuffled(
         ctx.narrow(&Step::GeneratePermutationByBreakdownKey),
-        &breakdown_keys,
-        F::Integer::BITS,
+        &permutation_keys,
+        F::Integer::BITS + 1, // breakdown_keys bits + aggregation_bit bit
     )
     .await?;
+
     apply_sort_permutation(
         ctx.narrow(&Step::ApplyPermutationOnBreakdownKey),
-        sorted_by_aggregation_bit.clone(),
+        input.to_vec(),
         &sort_permutation,
     )
     .await
@@ -160,6 +323,11 @@ async fn sort_by_aggregation_bit<F: Field>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
+    ComputeBBit,
+    ComputeStopBit,
+    SortByBreakdownKeyAndAttributionBit,
+    SortByAttributionBit,
+    AggregateCreditBTimesSuccessorCredit,
     BitDecomposeBreakdownKey,
     GeneratePermutationByBreakdownKey,
     ApplyPermutationOnBreakdownKey,
@@ -172,6 +340,13 @@ impl Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
+            Self::ComputeBBit => "compute_b_bit",
+            Self::ComputeStopBit => "compute_stop_bit",
+            Self::SortByBreakdownKeyAndAttributionBit => "sort_by_breakdown_key_and_attribution",
+            Self::SortByAttributionBit => "sort_by_attribution_bit",
+            Self::AggregateCreditBTimesSuccessorCredit => {
+                "aggregate_credit_b_times_successor_credit"
+            }
             Self::BitDecomposeBreakdownKey => "bit_decompose_breakdown_key",
             Self::GeneratePermutationByBreakdownKey => "generate_permutation_by_breakdown_key",
             Self::ApplyPermutationOnBreakdownKey => "apply_permutation_by_breakdown_key",
@@ -184,15 +359,67 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 pub(crate) mod tests {
     use super::super::tests::{BD, H};
-    use super::sort_by_aggregation_bit_and_breakdown_key;
+    use super::{aggregate_credit, sort_by_aggregation_bit_and_breakdown_key};
     use crate::ff::{Field, Fp31};
     use crate::protocol::attribution::accumulate_credit::tests::AttributionTestInput;
-    use crate::protocol::attribution::CappedCreditsWithAggregationBit;
+    use crate::protocol::attribution::{
+        AggregateCreditOutputRow, CappedCreditsWithAggregationBit, CreditCappingOutputRow,
+    };
     use crate::protocol::QueryId;
     use crate::rand::Rng;
     use crate::secret_sharing::Replicated;
     use crate::test_fixture::{IntoShares, Reconstruct, Runner, TestWorld};
     use rand::{distributions::Standard, prelude::Distribution};
+
+    // TODO: There are now too many xxxInputRow and yyyOutputRow. Combine them into one
+    impl<F> IntoShares<CreditCappingOutputRow<F>> for AttributionTestInput<F>
+    where
+        F: Field + IntoShares<Replicated<F>>,
+        Standard: Distribution<F>,
+    {
+        fn share_with<R: Rng>(self, rng: &mut R) -> [CreditCappingOutputRow<F>; 3] {
+            let [a0, a1, a2] = self.0[0].share_with(rng);
+            let [b0, b1, b2] = self.0[1].share_with(rng);
+            let [c0, c1, c2] = self.0[2].share_with(rng);
+            [
+                CreditCappingOutputRow {
+                    helper_bit: a0,
+                    breakdown_key: b0,
+                    credit: c0,
+                },
+                CreditCappingOutputRow {
+                    helper_bit: a1,
+                    breakdown_key: b1,
+                    credit: c1,
+                },
+                CreditCappingOutputRow {
+                    helper_bit: a2,
+                    breakdown_key: b2,
+                    credit: c2,
+                },
+            ]
+        }
+    }
+
+    impl<F: Field> Reconstruct<AttributionTestInput<F>> for [AggregateCreditOutputRow<F>; 3] {
+        fn reconstruct(&self) -> AttributionTestInput<F> {
+            [&self[0], &self[1], &self[2]].reconstruct()
+        }
+    }
+
+    impl<F: Field> Reconstruct<AttributionTestInput<F>> for [&AggregateCreditOutputRow<F>; 3] {
+        fn reconstruct(&self) -> AttributionTestInput<F> {
+            let s0 = &self[0];
+            let s1 = &self[1];
+            let s2 = &self[2];
+
+            let breakdown_key =
+                (&s0.breakdown_key, &s1.breakdown_key, &s2.breakdown_key).reconstruct();
+            let credit = (&s0.credit, &s1.credit, &s2.credit).reconstruct();
+
+            AttributionTestInput([breakdown_key, credit, F::ZERO, F::ZERO])
+        }
+    }
 
     impl<F> IntoShares<CappedCreditsWithAggregationBit<F>> for AttributionTestInput<F>
     where
@@ -253,6 +480,70 @@ pub(crate) mod tests {
                 .reconstruct();
 
             AttributionTestInput([helper_bit, breakdown_key, credit, aggregation_bit])
+        }
+    }
+
+    #[tokio::test]
+    pub async fn aggregate() {
+        const RAW_INPUT: &[[u128; 3]; 19] = &[
+            // helper_bit, breakdown_key, credit
+            [H[0], BD[3], 0],
+            [H[0], BD[4], 0],
+            [H[1], BD[4], 18],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[0], BD[1], 0],
+            [H[0], BD[0], 0],
+            [H[0], BD[2], 2],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[1], BD[2], 0],
+            [H[1], BD[2], 10],
+            [H[1], BD[0], 0],
+            [H[1], BD[0], 0],
+            [H[1], BD[5], 6],
+            [H[1], BD[0], 0],
+        ];
+        const EXPECTED: &[[u128; 2]] = &[
+            [0, 0],
+            [1, 0],
+            [2, 12],
+            [3, 0],
+            [4, 18],
+            [5, 6],
+            [6, 0],
+            [7, 0],
+        ];
+
+        let input = RAW_INPUT.map(|x| {
+            AttributionTestInput([
+                Fp31::from(x[0]),
+                Fp31::from(x[1]),
+                Fp31::from(x[2]),
+                Fp31::ZERO,
+            ])
+        });
+
+        let world = TestWorld::new(QueryId);
+        let result = world
+            .semi_honest(input, |ctx, share| async move {
+                aggregate_credit(ctx, &share).await.unwrap()
+            })
+            .await
+            .reconstruct();
+
+        assert_eq!(EXPECTED.len(), result.len());
+
+        for (i, expected) in EXPECTED.iter().enumerate() {
+            // Each element in the `result` is a general purpose `[F; 4]`.
+            // For this test case, the first two elements are `breakdown_key`
+            // and `credit` as defined by the implementation of `Reconstruct`
+            // for `[AggregateCreditOutputRow<F>; 3]`.
+            let result = result[i].0.map(|x| x.as_u128());
+            assert_eq!(*expected, [result[0], result[1]]);
         }
     }
 

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -1,5 +1,5 @@
 use super::{
-    compute_stop_bit, if_else, CreditCappingInputRow, CreditCappingOutputRow,
+    compute_b_bit, compute_stop_bit, if_else, CreditCappingInputRow, CreditCappingOutputRow,
     InteractionPatternStep,
 };
 use crate::error::Error;
@@ -158,25 +158,6 @@ async fn credit_prefix_sum<'a, F: Field>(
     }
 
     Ok(original_credits.clone())
-}
-
-async fn compute_b_bit<F: Field>(
-    ctx: SemiHonestContext<'_, F>,
-    record_id: RecordId,
-    current_stop_bit: &Replicated<F>,
-    sibling_helper_bit: &Replicated<F>,
-    first_iteration: bool,
-) -> Result<Replicated<F>, Error> {
-    // Compute `b = [this.stop_bit * sibling.helper_bit]`.
-    // Since `stop_bit` is initialized with all 1's, we only multiply in
-    // the second and later iterations.
-    let mut b = sibling_helper_bit.clone();
-    if !first_iteration {
-        b = ctx
-            .multiply(record_id, sibling_helper_bit, current_stop_bit)
-            .await?;
-    }
-    Ok(b)
 }
 
 async fn is_credit_larger_than_cap<F: Field>(

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -36,6 +36,13 @@ pub struct CappedCreditsWithAggregationBit<F: Field> {
     credit: Replicated<F>,
 }
 
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub struct AggregateCreditOutputRow<F: Field> {
+    breakdown_key: Replicated<F>,
+    credit: Replicated<F>,
+}
+
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.
 async fn if_else<F, C, S>(
     ctx: C,
@@ -82,6 +89,30 @@ where
         return Ok(b_bit.clone());
     }
     ctx.multiply(record_id, b_bit, sibling_stop_bit).await
+}
+
+async fn compute_b_bit<F, C, S>(
+    ctx: C,
+    record_id: RecordId,
+    current_stop_bit: &S,
+    sibling_helper_bit: &S,
+    first_iteration: bool,
+) -> Result<S, Error>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: SecretSharing<F>,
+{
+    // Compute `b = [this.stop_bit * sibling.helper_bit]`.
+    // Since `stop_bit` is initialized with all 1's, we only multiply in
+    // the second and later iterations.
+    let mut b = sibling_helper_bit.clone();
+    if !first_iteration {
+        b = ctx
+            .multiply(record_id, sibling_helper_bit, current_stop_bit)
+            .await?;
+    }
+    Ok(b)
 }
 
 struct InteractionPatternStep(usize);


### PR DESCRIPTION
This diff adds the prefix-sum computation of the credit values per breakdown key. The computation uses the same binary-tree prefix sum approach as other attribution protocols do.