### PR TITLE
XorSecretShare struct

### DIFF
--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -1,14 +1,15 @@
+use crate::ff::Field;
+use std::fmt::Debug;
+use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+
 mod malicious_replicated;
 mod replicated;
 mod xor;
 
-use crate::ff::Field;
 pub(crate) use malicious_replicated::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 pub use malicious_replicated::{Downgrade as DowngradeMalicious, MaliciousReplicated};
 pub use replicated::Replicated;
-use std::fmt::Debug;
-use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
-pub use xor::XorReplicated;
+pub use xor::{XorReplicated, XorSecretShare};
 
 /// Secret share of a secret has additive and multiplicative properties.
 pub trait SecretSharing<F>:

--- a/src/secret_sharing/xor.rs
+++ b/src/secret_sharing/xor.rs
@@ -29,6 +29,7 @@ impl XorReplicated {
 
 /// Bit store size of `XorSecretShare` in bytes.
 const BIT_STORE_SIZE_IN_BYTES: usize = 4;
+type BitStore = BitArr!(for BIT_STORE_SIZE_IN_BYTES * 8, in u8, Lsb0);
 
 /// XOR secret share.
 ///
@@ -47,12 +48,12 @@ const BIT_STORE_SIZE_IN_BYTES: usize = 4;
 /// assert_eq!(b1, 1);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct XorSecretShare(BitArray<[u8; BIT_STORE_SIZE_IN_BYTES], Lsb0>);
+pub struct XorSecretShare(BitStore);
 
 impl XorSecretShare {
     const SIZE_IN_BYTES: usize = BIT_STORE_SIZE_IN_BYTES;
     #[allow(dead_code)]
-    const ZERO: Self = Self(BitArray::<[u8; Self::SIZE_IN_BYTES], Lsb0>::ZERO);
+    const ZERO: Self = Self(BitStore::ZERO);
 }
 
 impl BitXor for XorSecretShare {
@@ -72,7 +73,7 @@ impl BitXorAssign for XorSecretShare {
 
 impl<T: Into<u128>> From<T> for XorSecretShare {
     fn from(v: T) -> Self {
-        Self(BitArray::<_, Lsb0>::new(
+        Self(BitStore::new(
             v.into().to_le_bytes()[0..Self::SIZE_IN_BYTES]
                 .try_into()
                 .unwrap(),

--- a/src/secret_sharing/xor.rs
+++ b/src/secret_sharing/xor.rs
@@ -27,6 +27,9 @@ impl XorReplicated {
     }
 }
 
+/// Bit store size of `XorSecretShare` in bytes.
+const BIT_STORE_SIZE_IN_BYTES: usize = 4;
+
 /// XOR secret share.
 ///
 /// Bits are stored in the Little-Endian format. Accessing the first element
@@ -36,7 +39,7 @@ impl XorReplicated {
 /// ```
 /// use raw_ipa::secret_sharing::XorSecretShare;
 ///
-/// let s = XorSecretShare::<64>::from(2_u128);
+/// let s = XorSecretShare::from(2_u128);
 /// let b0 = s[0];
 /// let b1 = s[1];
 ///
@@ -44,29 +47,15 @@ impl XorReplicated {
 /// assert_eq!(b1, 1);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct XorSecretShare<const N: usize>(BitVec<u8, Lsb0>);
+pub struct XorSecretShare(BitArray<[u8; BIT_STORE_SIZE_IN_BYTES], Lsb0>);
 
-// BitVec uses `usize` as its default store type in memory. Using `u8`
-// here allows us to store bits larger than 32 but less than 64 most
-// effectively (i.e., 40-bit = 5 * `u8` blocks).
-
-impl<const N: usize> XorSecretShare<N> {
-    const BITS: usize = N;
-    const SIZE_IN_BYTES: usize = Self::BITS / 8;
-
+impl XorSecretShare {
+    const SIZE_IN_BYTES: usize = BIT_STORE_SIZE_IN_BYTES;
     #[allow(dead_code)]
-    #[must_use]
-    pub fn new(v: BitVec<u8, Lsb0>) -> Self {
-        Self(v)
-    }
-
-    #[must_use]
-    pub fn zero() -> Self {
-        Self(BitVec::from_element(0))
-    }
+    const ZERO: Self = Self(BitArray::<[u8; Self::SIZE_IN_BYTES], Lsb0>::ZERO);
 }
 
-impl<const N: usize> BitXor for XorSecretShare<N> {
+impl BitXor for XorSecretShare {
     type Output = Self;
 
     fn bitxor(mut self, rhs: Self) -> Self::Output {
@@ -75,24 +64,23 @@ impl<const N: usize> BitXor for XorSecretShare<N> {
     }
 }
 
-impl<const N: usize> BitXorAssign for XorSecretShare<N> {
+impl BitXorAssign for XorSecretShare {
     fn bitxor_assign(&mut self, rhs: Self) {
         *self.0.as_mut_bitslice() ^= rhs.0;
     }
 }
 
-/// Converts from `u128` to `XorSecretShare`. If you wish to create a share
-/// that holds more than 128 bits, use `XorSecretShare::new()` with `bitvec!`
-/// instead.
-impl<const N: usize, T: Into<u128>> From<T> for XorSecretShare<N> {
+impl<T: Into<u128>> From<T> for XorSecretShare {
     fn from(v: T) -> Self {
-        Self(BitVec::from_slice(
-            &v.into().to_le_bytes()[0..Self::SIZE_IN_BYTES],
+        Self(BitArray::<_, Lsb0>::new(
+            v.into().to_le_bytes()[0..Self::SIZE_IN_BYTES]
+                .try_into()
+                .unwrap(),
         ))
     }
 }
 
-impl<const N: usize> Index<usize> for XorSecretShare<N> {
+impl Index<usize> for XorSecretShare {
     type Output = u8;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -104,23 +92,15 @@ impl<const N: usize> Index<usize> for XorSecretShare<N> {
     }
 }
 
-impl<const N: usize> Default for XorSecretShare<N> {
-    fn default() -> Self {
-        XorSecretShare::zero()
-    }
-}
-
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
+    use crate::secret_sharing::xor::BIT_STORE_SIZE_IN_BYTES;
+
     use super::XorSecretShare;
     use bitvec::prelude::*;
     use rand::{thread_rng, Rng};
 
-    fn secret_share(
-        a: u128,
-        b: u128,
-        c: u128,
-    ) -> (XorSecretShare<40>, XorSecretShare<40>, XorSecretShare<40>) {
+    fn secret_share(a: u128, b: u128, c: u128) -> (XorSecretShare, XorSecretShare, XorSecretShare) {
         (
             XorSecretShare::from(a),
             XorSecretShare::from(b),
@@ -130,31 +110,29 @@ mod tests {
 
     #[test]
     pub fn basic() {
+        assert_eq!(XorSecretShare::ZERO.0, bitarr!(u32, Lsb0; 0));
         assert_eq!(
-            XorSecretShare::<8>::zero().0.as_bitslice(),
-            bits![0, 0, 0, 0, 0, 0, 0, 0],
+            XorSecretShare::from(1_u128).0.as_bitslice(),
+            bits![
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ],
         );
-
         assert_eq!(
-            XorSecretShare::<8>::from(1_u128).0.as_bitslice(),
-            bits![1, 0, 0, 0, 0, 0, 0, 0],
-        );
-
-        assert_eq!(
-            XorSecretShare::<8>::from(65793_u128).0.as_bitslice(),
-            bits![1, 0, 0, 0, 0, 0, 0, 0],
-        );
-
-        assert_eq!(
-            XorSecretShare::<24>::from(65793_u128).0.as_bitslice(),
-            bits![1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+            XorSecretShare::from((1_u128 << (BIT_STORE_SIZE_IN_BYTES * 8)) + 1)
+                .0
+                .as_bitslice(),
+            bits![
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ],
         );
     }
 
     #[test]
     pub fn index() {
         let byte: u8 = 0b1010_1010;
-        let s = XorSecretShare::<8>::from(byte);
+        let s = XorSecretShare::from(byte);
         assert_eq!(s[0], 0);
         assert_eq!(s[1], 1);
         assert_eq!(s[2], 0);

--- a/src/secret_sharing/xor.rs
+++ b/src/secret_sharing/xor.rs
@@ -1,3 +1,9 @@
+use bitvec::prelude::*;
+use std::{
+    fmt::Debug,
+    ops::{BitXor, BitXorAssign, Index},
+};
+
 #[derive(Clone, Copy, Debug)]
 pub struct XorReplicated {
     left: u64,
@@ -18,5 +24,157 @@ impl XorReplicated {
     #[must_use]
     pub fn right(&self) -> u64 {
         self.right
+    }
+}
+
+/// XOR secret share.
+///
+/// Bits are stored in the Little-Endian format. Accessing the first element
+/// like `s[0]` will return the LSB.
+///
+/// ## Example
+/// ```
+/// use raw_ipa::secret_sharing::XorSecretShare;
+///
+/// let s = XorSecretShare::<64>::from(2_u128);
+/// let b0 = s[0];
+/// let b1 = s[1];
+///
+/// assert_eq!(b0, 0);
+/// assert_eq!(b1, 1);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct XorSecretShare<const N: usize>(BitVec<u8, Lsb0>);
+
+// BitVec uses `usize` as its default store type in memory. Using `u8`
+// here allows us to store bits larger than 32 but less than 64 most
+// effectively (i.e., 40-bit = 5 * `u8` blocks).
+
+impl<const N: usize> XorSecretShare<N> {
+    const BITS: usize = N;
+    const SIZE_IN_BYTES: usize = Self::BITS / 8;
+
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn new(v: BitVec<u8, Lsb0>) -> Self {
+        Self(v)
+    }
+
+    #[must_use]
+    pub fn zero() -> Self {
+        Self(BitVec::from_element(0))
+    }
+}
+
+impl<const N: usize> BitXor for XorSecretShare<N> {
+    type Output = Self;
+
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+impl<const N: usize> BitXorAssign for XorSecretShare<N> {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self.0.as_mut_bitslice() ^= rhs.0;
+    }
+}
+
+/// Converts from `u128` to `XorSecretShare`. If you wish to create a share
+/// that holds more than 128 bits, use `XorSecretShare::new()` with `bitvec!`
+/// instead.
+impl<const N: usize, T: Into<u128>> From<T> for XorSecretShare<N> {
+    fn from(v: T) -> Self {
+        Self(BitVec::from_slice(
+            &v.into().to_le_bytes()[0..Self::SIZE_IN_BYTES],
+        ))
+    }
+}
+
+impl<const N: usize> Index<usize> for XorSecretShare<N> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if self.0.as_bitslice()[index] {
+            &1
+        } else {
+            &0
+        }
+    }
+}
+
+impl<const N: usize> Default for XorSecretShare<N> {
+    fn default() -> Self {
+        XorSecretShare::zero()
+    }
+}
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
+    use super::XorSecretShare;
+    use bitvec::prelude::*;
+    use rand::{thread_rng, Rng};
+
+    fn secret_share(
+        a: u128,
+        b: u128,
+        c: u128,
+    ) -> (XorSecretShare<40>, XorSecretShare<40>, XorSecretShare<40>) {
+        (
+            XorSecretShare::from(a),
+            XorSecretShare::from(b),
+            XorSecretShare::from(c),
+        )
+    }
+
+    #[test]
+    pub fn basic() {
+        assert_eq!(
+            XorSecretShare::<8>::zero().0.as_bitslice(),
+            bits![0, 0, 0, 0, 0, 0, 0, 0],
+        );
+
+        assert_eq!(
+            XorSecretShare::<8>::from(1_u128).0.as_bitslice(),
+            bits![1, 0, 0, 0, 0, 0, 0, 0],
+        );
+
+        assert_eq!(
+            XorSecretShare::<8>::from(65793_u128).0.as_bitslice(),
+            bits![1, 0, 0, 0, 0, 0, 0, 0],
+        );
+
+        assert_eq!(
+            XorSecretShare::<24>::from(65793_u128).0.as_bitslice(),
+            bits![1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        );
+    }
+
+    #[test]
+    pub fn index() {
+        let byte: u8 = 0b1010_1010;
+        let s = XorSecretShare::<8>::from(byte);
+        assert_eq!(s[0], 0);
+        assert_eq!(s[1], 1);
+        assert_eq!(s[2], 0);
+        assert_eq!(s[3], 1);
+        assert_eq!(s[4], 0);
+        assert_eq!(s[5], 1);
+        assert_eq!(s[6], 0);
+        assert_eq!(s[7], 1);
+    }
+
+    #[test]
+    pub fn xor_secret_sharing() {
+        let mut rng = thread_rng();
+        for _ in 0..1000 {
+            let secret = rng.gen::<u128>();
+            let a = rng.gen::<u128>();
+            let b = rng.gen::<u128>();
+            let c = secret ^ a ^ b;
+            let (s0, s1, s2) = secret_share(a, b, c);
+            assert_eq!(XorSecretShare::from(secret), s0 ^ s1 ^ s2);
+        }
     }
 }


### PR DESCRIPTION
Implement `XorSecretShare`. Internally, it uses `BitVec` as the storage, and stores an arbitrary number of bits specified by `N`.

This will soon replace the current `XorReplicated` struct, which is a mix of replicated secret sharing and xor secret sharing. Below is an overview of the new secret sharing arrangement.

![Untitled-2022-12-08-1530](https://user-images.githubusercontent.com/8149758/206558335-fd37c916-9df8-4e61-ae09-ee643b3e2545.png)
