### PR TITLE
Gateway: do not report buffers that are 100% empty

### DIFF
--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -125,12 +125,14 @@ impl SendBuffer {
             let range = Range::from(buf);
             let taken = u32::try_from(buf.taken()).unwrap();
             let range = (u32::from(range.start) - taken)..(u32::from(range.end) - taken);
-            // Only report any gaps ahead of the first available value.
+            // Only report any gaps ahead of the first available value. If buffer is entirely empty
+            // there are no waiting tasks.
             let missing = range
                 .take_while(|&i| !buf.added(usize::try_from(i).unwrap()))
                 .map(|i| taken + i)
                 .collect::<Vec<_>>();
-            if !missing.is_empty() {
+
+            if !missing.is_empty() && missing.len() < buf.capacity() {
                 tasks.insert(channel, missing);
             }
         }


### PR DESCRIPTION
It causes noise when we have long running tests. The proper solution would be to implement channel closure https://github.com/private-attribution/ipa/issues/168 as it can be seen how much memory we're wasting by not doing it.

Skipping empty buffers is correct because there is no error on the protocol side