### PR TITLE
Move IntoShares trait and friends to secret_sharing mod

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -212,8 +212,8 @@ pub(crate) mod tests {
 
     use crate::protocol::sort::apply_sort::shuffle::Resharable;
     use crate::rand::{thread_rng, Rng};
+    use crate::secret_sharing::IntoShares;
     use crate::secret_sharing::Replicated;
-    use crate::test_fixture::IntoShares;
     use crate::{
         ff::{Field, Fp31},
         helpers::Role,

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -344,8 +344,8 @@ pub(crate) mod tests {
     };
     use crate::protocol::QueryId;
     use crate::rand::Rng;
-    use crate::secret_sharing::Replicated;
-    use crate::test_fixture::{IntoShares, Reconstruct, Runner, TestWorld};
+    use crate::secret_sharing::{IntoShares, Replicated};
+    use crate::test_fixture::{Reconstruct, Runner, TestWorld};
     use rand::{distributions::Standard, prelude::Distribution};
 
     // TODO: There are now too many xxxInputRow and yyyOutputRow. Combine them into one

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -154,7 +154,7 @@ impl AsRef<str> for AttributionResharableStep {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ff::Field, protocol::attribution::AttributionInputRow, test_fixture::share};
+    use crate::{ff::Field, protocol::attribution::AttributionInputRow, secret_sharing::share};
     use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
     use std::iter::zip;
 

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -154,7 +154,8 @@ impl AsRef<str> for AttributionResharableStep {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ff::Field, protocol::attribution::AttributionInputRow, secret_sharing::share};
+    use crate::secret_sharing::IntoShares;
+    use crate::{ff::Field, protocol::attribution::AttributionInputRow};
     use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
     use std::iter::zip;
 
@@ -181,10 +182,10 @@ mod tests {
         ];
 
         for x in input {
-            let itb = share(F::from(x[0]), rng);
-            let hb = share(F::from(x[1]), rng);
-            let bk = share(F::from(x[2]), rng);
-            let val = share(F::from(x[3]), rng);
+            let itb = F::from(x[0]).share_with(rng);
+            let hb = F::from(x[1]).share_with(rng);
+            let bk = F::from(x[2]).share_with(rng);
+            let val = F::from(x[3]).share_with(rng);
             for (i, ((itb, hb), (bk, val))) in zip(zip(itb, hb), zip(bk, val)).enumerate() {
                 shares[i].push(AttributionInputRow {
                     is_trigger_bit: itb,

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -87,7 +87,7 @@ mod tests {
     use crate::protocol::context::Context;
     use crate::protocol::{basics::check_zero, QueryId, RecordId};
     use crate::rand::thread_rng;
-    use crate::secret_sharing::share;
+    use crate::secret_sharing::IntoShares;
     use crate::test_fixture::TestWorld;
 
     #[tokio::test]
@@ -101,7 +101,7 @@ mod tests {
             let v = Fp31::from(v);
             let mut num_false_positives = 0;
             for _ in 0..10 {
-                let v_shares = share(v, &mut rng);
+                let v_shares = v.share_with(&mut rng);
                 let record_id = RecordId::from(0_u32);
                 let iteration = format!("{}", counter);
                 counter += 1;

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -87,7 +87,8 @@ mod tests {
     use crate::protocol::context::Context;
     use crate::protocol::{basics::check_zero, QueryId, RecordId};
     use crate::rand::thread_rng;
-    use crate::test_fixture::{share, TestWorld};
+    use crate::secret_sharing::share;
+    use crate::test_fixture::TestWorld;
 
     #[tokio::test]
     async fn basic() -> Result<(), Error> {

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -182,6 +182,7 @@ impl MultiplyWork for MultiplyZeroPositions {
 
 #[cfg(test)]
 pub(in crate::protocol) mod test {
+    use crate::secret_sharing::IntoShares;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         helpers::{
@@ -195,7 +196,7 @@ pub(in crate::protocol) mod test {
         },
         rand::{thread_rng, Rng},
         secret_sharing::Replicated,
-        test_fixture::{IntoShares, Reconstruct, Runner, TestWorld},
+        test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use futures::future::try_join;
     use rand::distributions::{Distribution, Standard};

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -121,7 +121,7 @@ mod tests {
     use proptest::prelude::Rng;
     use std::iter::zip;
 
-    use crate::secret_sharing::share;
+    use crate::secret_sharing::IntoShares;
     use crate::{
         error::Error,
         ff::{Field, Fp31},
@@ -144,7 +144,7 @@ mod tests {
         for i in 0..10_u32 {
             let secret = rng.gen::<u128>();
             let input = Fp31::from(secret);
-            let share = share(input, &mut rng);
+            let share = input.share_with(&mut rng);
             let record_id = RecordId::from(i);
             let results = join3(
                 ctx[0].clone().reveal(record_id, &share[0]),
@@ -172,7 +172,7 @@ mod tests {
             let input: Fp31 = rng.gen();
 
             let m_shares = join3v(
-                zip(v.iter(), share(input, &mut rng))
+                zip(v.iter(), input.share_with(&mut rng))
                     .map(|(v, share)| async { v.context().upgrade(record_id, share).await }),
             )
             .await;
@@ -202,7 +202,7 @@ mod tests {
             let input: Fp31 = rng.gen();
 
             let m_shares = join3v(
-                zip(v.iter(), share(input, &mut rng))
+                zip(v.iter(), input.share_with(&mut rng))
                     .map(|(v, share)| async { v.context().upgrade(record_id, share).await }),
             )
             .await;

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -121,6 +121,7 @@ mod tests {
     use proptest::prelude::Rng;
     use std::iter::zip;
 
+    use crate::secret_sharing::share;
     use crate::{
         error::Error,
         ff::{Field, Fp31},
@@ -131,7 +132,7 @@ mod tests {
             QueryId, RecordId,
         },
         secret_sharing::{MaliciousReplicated, ThisCodeIsAuthorizedToDowngradeFromMalicious},
-        test_fixture::{join3, join3v, share, TestWorld},
+        test_fixture::{join3, join3v, TestWorld},
     };
 
     #[tokio::test]

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -222,11 +222,12 @@ mod tests {
     use rand::{distributions::Standard, prelude::Distribution, Rng};
 
     use super::{ipa, IPAInputRow};
+    use crate::secret_sharing::IntoShares;
     use crate::{
         ff::{Field, Fp31},
         protocol::QueryId,
         secret_sharing::Replicated,
-        test_fixture::{IntoShares, MaskedMatchKey, Reconstruct, Runner, TestWorld},
+        test_fixture::{MaskedMatchKey, Reconstruct, Runner, TestWorld},
     };
 
     struct IPAInputTestRow {

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -252,8 +252,8 @@ mod tests {
     use crate::protocol::context::Context;
     use crate::protocol::{malicious::MaliciousValidator, QueryId, RecordId};
     use crate::rand::thread_rng;
-    use crate::secret_sharing::{Replicated, ThisCodeIsAuthorizedToDowngradeFromMalicious};
-    use crate::test_fixture::{join3v, share, Reconstruct, Runner, TestWorld};
+    use crate::secret_sharing::{share, Replicated, ThisCodeIsAuthorizedToDowngradeFromMalicious};
+    use crate::test_fixture::{join3v, Reconstruct, Runner, TestWorld};
     use futures::future::try_join_all;
     use proptest::prelude::Rng;
 

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -252,7 +252,9 @@ mod tests {
     use crate::protocol::context::Context;
     use crate::protocol::{malicious::MaliciousValidator, QueryId, RecordId};
     use crate::rand::thread_rng;
-    use crate::secret_sharing::{share, Replicated, ThisCodeIsAuthorizedToDowngradeFromMalicious};
+    use crate::secret_sharing::{
+        IntoShares, Replicated, ThisCodeIsAuthorizedToDowngradeFromMalicious,
+    };
     use crate::test_fixture::{join3v, Reconstruct, Runner, TestWorld};
     use futures::future::try_join_all;
     use proptest::prelude::Rng;
@@ -280,8 +282,8 @@ mod tests {
         let a = rng.gen::<Fp31>();
         let b = rng.gen::<Fp31>();
 
-        let a_shares = share(a, &mut rng);
-        let b_shares = share(b, &mut rng);
+        let a_shares = a.share_with(&mut rng);
+        let b_shares = b.share_with(&mut rng);
 
         let futures =
             zip(context, zip(a_shares, b_shares)).map(|(ctx, (a_share, b_share))| async move {
@@ -396,7 +398,7 @@ mod tests {
         }
         let shared_inputs: Vec<[Replicated<Fp31>; 3]> = original_inputs
             .iter()
-            .map(|x| share(*x, &mut rng))
+            .map(|x| x.share_with(&mut rng))
             .collect();
         let h1_shares: Vec<Replicated<Fp31>> = shared_inputs.iter().map(|x| x[0].clone()).collect();
         let h2_shares: Vec<Replicated<Fp31>> = shared_inputs.iter().map(|x| x[1].clone()).collect();

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -1,0 +1,76 @@
+use crate::ff::Field;
+use crate::rand::{thread_rng, Rng, RngCore};
+use crate::secret_sharing::Replicated;
+use rand::distributions::{Distribution, Standard};
+
+#[cfg(any(feature = "test-fixture", feature = "cli"))]
+pub trait IntoShares<T>: Sized {
+    fn share(self) -> [T; 3] {
+        self.share_with(&mut thread_rng())
+    }
+    fn share_with<R: Rng>(self, rng: &mut R) -> [T; 3];
+}
+
+impl<F> IntoShares<Replicated<F>> for F
+where
+    F: Field,
+    Standard: Distribution<F>,
+{
+    fn share_with<R: Rng>(self, rng: &mut R) -> [Replicated<F>; 3] {
+        share(self, rng)
+    }
+}
+
+impl<U, V, T> IntoShares<Vec<T>> for V
+where
+    U: IntoShares<T>,
+    V: IntoIterator<Item = U>,
+{
+    fn share_with<R: Rng>(self, rng: &mut R) -> [Vec<T>; 3] {
+        let it = self.into_iter();
+        let (lower_bound, upper_bound) = it.size_hint();
+        let len = upper_bound.unwrap_or(lower_bound);
+        let mut res = [
+            Vec::with_capacity(len),
+            Vec::with_capacity(len),
+            Vec::with_capacity(len),
+        ];
+        for u in it {
+            for (i, s) in u.share_with(rng).into_iter().enumerate() {
+                res[i].push(s);
+            }
+        }
+        res
+    }
+}
+
+// TODO: make a macro so we can use arbitrary-sized tuples
+impl<T, U, V, W> IntoShares<(T, U)> for (V, W)
+where
+    T: Sized,
+    U: Sized,
+    V: IntoShares<T>,
+    W: IntoShares<U>,
+{
+    fn share_with<R: Rng>(self, rng: &mut R) -> [(T, U); 3] {
+        let [a0, a1, a2] = self.0.share_with(rng);
+        let [b0, b1, b2] = self.1.share_with(rng);
+        [(a0, b0), (a1, b1), (a2, b2)]
+    }
+}
+
+/// Shares `input` into 3 replicated secret shares using the provided `rng` implementation
+pub fn share<F: Field, R: RngCore>(input: F, rng: &mut R) -> [Replicated<F>; 3]
+where
+    Standard: Distribution<F>,
+{
+    let x1 = rng.gen::<F>();
+    let x2 = rng.gen::<F>();
+    let x3 = input - (x1 + x2);
+
+    [
+        Replicated::new(x1, x2),
+        Replicated::new(x2, x3),
+        Replicated::new(x3, x1),
+    ]
+}

--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -187,8 +187,8 @@ mod tests {
     use crate::ff::{Field, Fp31};
     use crate::helpers::Role;
     use crate::rand::thread_rng;
-    use crate::secret_sharing::Replicated;
-    use crate::test_fixture::{share, Reconstruct};
+    use crate::secret_sharing::{share, Replicated};
+    use crate::test_fixture::Reconstruct;
     use proptest::prelude::Rng;
 
     #[test]

--- a/src/secret_sharing/malicious_replicated.rs
+++ b/src/secret_sharing/malicious_replicated.rs
@@ -187,7 +187,7 @@ mod tests {
     use crate::ff::{Field, Fp31};
     use crate::helpers::Role;
     use crate::rand::thread_rng;
-    use crate::secret_sharing::{share, Replicated};
+    use crate::secret_sharing::{IntoShares, Replicated};
     use crate::test_fixture::Reconstruct;
     use proptest::prelude::Rng;
 
@@ -205,14 +205,14 @@ mod tests {
         // Randomization constant
         let r = rng.gen::<Fp31>();
 
-        let a_shared = share(a, &mut rng);
-        let b_shared = share(b, &mut rng);
-        let c_shared = share(c, &mut rng);
-        let d_shared = share(d, &mut rng);
-        let e_shared = share(e, &mut rng);
-        let f_shared = share(f, &mut rng);
+        let a_shared = a.share_with(&mut rng);
+        let b_shared = b.share_with(&mut rng);
+        let c_shared = c.share_with(&mut rng);
+        let d_shared = d.share_with(&mut rng);
+        let e_shared = e.share_with(&mut rng);
+        let f_shared = f.share_with(&mut rng);
         // Randomization constant
-        let r_shared = share(r, &mut rng);
+        let r_shared = r.share_with(&mut rng);
 
         let ra = a * r;
         let rb = b * r;
@@ -221,12 +221,12 @@ mod tests {
         let re = e * r;
         let rf = f * r;
 
-        let ra_shared = share(ra, &mut rng);
-        let rb_shared = share(rb, &mut rng);
-        let rc_shared = share(rc, &mut rng);
-        let rd_shared = share(rd, &mut rng);
-        let re_shared = share(re, &mut rng);
-        let rf_shared = share(rf, &mut rng);
+        let ra_shared = ra.share_with(&mut rng);
+        let rb_shared = rb.share_with(&mut rng);
+        let rc_shared = rc.share_with(&mut rng);
+        let rd_shared = rd.share_with(&mut rng);
+        let re_shared = re.share_with(&mut rng);
+        let rf_shared = rf.share_with(&mut rng);
 
         let roles = [Role::H1, Role::H2, Role::H3];
         let mut results = Vec::with_capacity(3);

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -3,7 +3,7 @@ mod malicious_replicated;
 mod replicated;
 mod xor;
 #[cfg(any(feature = "test-fixture", feature = "cli"))]
-pub use {into_shares::share, into_shares::IntoShares};
+pub use into_shares::IntoShares;
 
 use crate::ff::Field;
 pub(crate) use malicious_replicated::ThisCodeIsAuthorizedToDowngradeFromMalicious;

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -1,6 +1,9 @@
+mod into_shares;
 mod malicious_replicated;
 mod replicated;
 mod xor;
+#[cfg(any(feature = "test-fixture", feature = "cli"))]
+pub use {into_shares::share, into_shares::IntoShares};
 
 use crate::ff::Field;
 pub(crate) use malicious_replicated::ThisCodeIsAuthorizedToDowngradeFromMalicious;

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -3,7 +3,7 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::{QueryId, RecordId};
 use crate::rand::thread_rng;
-use crate::secret_sharing::{share, Replicated};
+use crate::secret_sharing::{IntoShares, Replicated};
 use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
 
@@ -31,10 +31,10 @@ pub async fn arithmetic<F: Field>(width: u32, depth: u8) {
 
 async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
     let top_ctx = world.contexts();
-    let mut a = share(Fp31::ONE, &mut thread_rng());
+    let mut a = Fp31::ONE.share_with(&mut thread_rng());
 
     for bit in 0..depth {
-        let b = share(Fp31::ONE, &mut thread_rng());
+        let b = Fp31::ONE.share_with(&mut thread_rng());
         let bit_ctx = narrow_contexts(&top_ctx, &format!("b{bit}"));
         a = async move {
             let mut coll = Vec::new();

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -3,8 +3,8 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::{QueryId, RecordId};
 use crate::rand::thread_rng;
-use crate::secret_sharing::Replicated;
-use crate::test_fixture::{narrow_contexts, share, Fp31, Reconstruct, TestWorld};
+use crate::secret_sharing::{share, Replicated};
+use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
 
 /// Creates an arithmetic circuit with the given width and depth.

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -11,7 +11,7 @@ use crate::protocol::context::Context;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{share, Replicated, SecretSharing};
+use crate::secret_sharing::{IntoShares, Replicated, SecretSharing};
 use futures::future::try_join_all;
 use futures::TryFuture;
 use rand::distributions::Standard;
@@ -75,7 +75,7 @@ where
     let mut shares2 = Vec::with_capacity(len);
 
     for i in input {
-        let [s0, s1, s2] = share(F::from(*i), &mut rand);
+        let [s0, s1, s2] = F::from(*i).share_with(&mut rand);
         shares0.push(s0);
         shares1.push(s1);
         shares2.push(s2);

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -11,13 +11,13 @@ use crate::protocol::context::Context;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{Replicated, SecretSharing};
+use crate::secret_sharing::{share, Replicated, SecretSharing};
 use futures::future::try_join_all;
 use futures::TryFuture;
 use rand::distributions::Standard;
 use rand::prelude::Distribution;
 use rand::rngs::mock::StepRng;
-pub use sharing::{get_bits, into_bits, share, IntoShares, MaskedMatchKey, Reconstruct};
+pub use sharing::{get_bits, into_bits, MaskedMatchKey, Reconstruct};
 use std::fmt::Debug;
 pub use world::{Runner, TestWorld, TestWorldConfig};
 

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,14 +1,10 @@
 use crate::ff::Field;
 use crate::protocol::context::MaliciousContext;
 use crate::protocol::{BitOpStep, RecordId, Substep};
-use crate::rand::thread_rng;
-use crate::secret_sharing::{MaliciousReplicated, Replicated, XorReplicated};
+use crate::rand::Rng;
+use crate::secret_sharing::{IntoShares, MaliciousReplicated, Replicated, XorReplicated};
 use async_trait::async_trait;
 use futures::future::{join, try_join_all};
-use rand::{
-    distributions::{Distribution, Standard},
-    Rng, RngCore,
-};
 use std::borrow::Borrow;
 use std::iter::{repeat, zip};
 
@@ -36,61 +32,6 @@ impl From<MaskedMatchKey> for u64 {
     }
 }
 
-pub trait IntoShares<T>: Sized {
-    fn share(self) -> [T; 3] {
-        self.share_with(&mut thread_rng())
-    }
-    fn share_with<R: Rng>(self, rng: &mut R) -> [T; 3];
-}
-
-impl<F> IntoShares<Replicated<F>> for F
-where
-    F: Field,
-    Standard: Distribution<F>,
-{
-    fn share_with<R: Rng>(self, rng: &mut R) -> [Replicated<F>; 3] {
-        share(self, rng)
-    }
-}
-
-impl<U, V, T> IntoShares<Vec<T>> for V
-where
-    U: IntoShares<T>,
-    V: IntoIterator<Item = U>,
-{
-    fn share_with<R: Rng>(self, rng: &mut R) -> [Vec<T>; 3] {
-        let it = self.into_iter();
-        let (lower_bound, upper_bound) = it.size_hint();
-        let len = upper_bound.unwrap_or(lower_bound);
-        let mut res = [
-            Vec::with_capacity(len),
-            Vec::with_capacity(len),
-            Vec::with_capacity(len),
-        ];
-        for u in it {
-            for (i, s) in u.share_with(rng).into_iter().enumerate() {
-                res[i].push(s);
-            }
-        }
-        res
-    }
-}
-
-// TODO: make a macro so we can use arbitrary-sized tuples
-impl<T, U, V, W> IntoShares<(T, U)> for (V, W)
-where
-    T: Sized,
-    U: Sized,
-    V: IntoShares<T>,
-    W: IntoShares<U>,
-{
-    fn share_with<R: Rng>(self, rng: &mut R) -> [(T, U); 3] {
-        let [a0, a1, a2] = self.0.share_with(rng);
-        let [b0, b1, b2] = self.1.share_with(rng);
-        [(a0, b0), (a1, b1), (a2, b2)]
-    }
-}
-
 impl IntoShares<XorReplicated> for MaskedMatchKey {
     fn share_with<R: Rng>(self, rng: &mut R) -> [XorReplicated; 3] {
         debug_assert_eq!(self.0, self.0 & Self::MASK);
@@ -103,22 +44,6 @@ impl IntoShares<XorReplicated> for MaskedMatchKey {
             XorReplicated::new(s2, s0),
         ]
     }
-}
-
-/// Shares `input` into 3 replicated secret shares using the provided `rng` implementation
-pub fn share<F: Field, R: RngCore>(input: F, rng: &mut R) -> [Replicated<F>; 3]
-where
-    Standard: Distribution<F>,
-{
-    let x1 = rng.gen::<F>();
-    let x2 = rng.gen::<F>();
-    let x3 = input - (x1 + x2);
-
-    [
-        Replicated::new(x1, x2),
-        Replicated::new(x2, x3),
-        Replicated::new(x3, x1),
-    ]
 }
 
 /// Deconstructs a value into N values, one for each bit.

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -18,7 +18,7 @@ use crate::{
         QueryId,
     },
     secret_sharing::DowngradeMalicious,
-    test_fixture::{logging, make_participants, network::InMemoryNetwork, sharing::IntoShares},
+    test_fixture::{logging, make_participants, network::InMemoryNetwork},
 };
 
 use std::io::stdout;
@@ -28,6 +28,7 @@ use std::sync::atomic::AtomicBool;
 use std::{fmt::Debug, iter::zip, sync::Arc};
 
 use crate::protocol::Substep;
+use crate::secret_sharing::IntoShares;
 use crate::telemetry::stats::Metrics;
 use crate::telemetry::StepStatsCsvExporter;
 use tracing::Level;


### PR DESCRIPTION
Test client I am making to benchmark and execute different scenarios needs to be able to secret share user input before sending it to different helpers.

Helper server implementation does not need that, so trait is hidden behind a feature flag

@martinthomson we discussed this and my initial approach was to implement a similar trait for CLI use, but it turned out to be exactly the same as `IntoShares`  and its implementations. Hope that exposing it to `cli` and `test_fixture` is good enough to prevent it from leaking to prod code