### PR TITLE
`BitArray64` data type

### DIFF
--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -18,7 +18,7 @@ type U8_8 = BitArr!(for 64, in u8, Lsb0);
 /// ```
 /// use raw_ipa::bits::BitArray64;
 ///
-/// let s = BitArray64::from(2_u128);
+/// let s = BitArray64::try_from(2_u128).unwrap();
 /// let b0 = s[0_usize];
 /// let b1 = s[1_usize];
 ///
@@ -30,9 +30,18 @@ pub struct BitArray64(U8_8);
 
 impl BitArray for BitArray64 {
     const SIZE_IN_BYTES: usize = std::mem::size_of::<Self>();
+    const BITS: u32 = 64;
 
     #[allow(dead_code)]
     const ZERO: Self = Self(U8_8::ZERO);
+
+    fn truncate_from<T: Into<u128>>(v: T) -> Self {
+        Self(U8_8::new(
+            v.into().to_le_bytes()[0..<Self as BitArray>::SIZE_IN_BYTES]
+                .try_into()
+                .unwrap(),
+        ))
+    }
 }
 
 impl BooleanOps for BitArray64 {}
@@ -83,13 +92,22 @@ impl Not for BitArray64 {
     }
 }
 
-impl<T: Into<u128>> From<T> for BitArray64 {
-    fn from(v: T) -> Self {
-        Self(U8_8::new(
-            v.into().to_le_bytes()[0..<Self as BitArray>::SIZE_IN_BYTES]
-                .try_into()
-                .unwrap(),
-        ))
+impl TryFrom<u128> for BitArray64 {
+    type Error = String;
+
+    /// Fallible conversion from `u128` to this data type. The input value must
+    /// be `Self::BITS` long. That is, leading 0's must be longer or equal to
+    /// `Self::BITS`, or it will return an error.
+    fn try_from(v: u128) -> Result<Self, Self::Error> {
+        if 128 - v.leading_zeros() <= Self::BITS {
+            Ok(Self::truncate_from(v))
+        } else {
+            Err(format!(
+                "Bit array size {} is too small to hold the value {}.",
+                Self::BITS,
+                v
+            ))
+        }
     }
 }
 
@@ -122,17 +140,24 @@ mod tests {
 
     #[test]
     pub fn basic() {
+        let one = bitarr!(u64, Lsb0; 1);
+
         assert_eq!(BitArray64::ZERO.0, bitarr!(u64, Lsb0; 0));
-        assert_eq!(BitArray64::from(1_u128).0, bitarr!(u64, Lsb0; 1));
+        assert_eq!(BitArray64::try_from(1_u128).unwrap().0, one);
+
+        let b65 = (1_u128 << BitArray64::BITS) + 1;
+        assert!(BitArray64::try_from(b65).is_err());
         assert_eq!(
-            BitArray64::from((1_u128 << (BitArray64::SIZE_IN_BYTES * 8)) + 1).0,
-            bitarr!(u64, Lsb0; 1)
+            BitArray64::try_from(b65 & u128::from(u64::MAX)).unwrap().0,
+            one
         );
+
+        assert_eq!(BitArray64::truncate_from(b65).0, one);
     }
 
     #[test]
     pub fn index() {
-        let s = BitArray64::from((1_u128 << (BitArray64::SIZE_IN_BYTES * 8)) + 1);
+        let s = BitArray64::try_from(1_u128).unwrap();
         assert_eq!(s[0_usize], 1);
         assert_eq!(s[63_u32], 0);
     }
@@ -140,7 +165,7 @@ mod tests {
     #[test]
     #[should_panic]
     pub fn out_of_count_index() {
-        let s = BitArray64::from(1_u128);
+        let s = BitArray64::try_from(1_u128).unwrap();
         // Below assert doesn't matter. The indexing should panic
         assert_eq!(s[64_usize], 0);
     }
@@ -152,13 +177,13 @@ mod tests {
             let a = rng.gen::<u128>();
             let b = rng.gen::<u128>();
 
-            let and = BitArray64::from(a & b);
-            let or = BitArray64::from(a | b);
-            let xor = BitArray64::from(a ^ b);
-            let not = BitArray64::from(!a);
+            let and = BitArray64::truncate_from(a & b);
+            let or = BitArray64::truncate_from(a | b);
+            let xor = BitArray64::truncate_from(a ^ b);
+            let not = BitArray64::truncate_from(!a);
 
-            let a = BitArray64::from(a);
-            let b = BitArray64::from(b);
+            let a = BitArray64::try_from(a & u128::from(u64::MAX)).unwrap();
+            let b = BitArray64::try_from(b & u128::from(u64::MAX)).unwrap();
 
             assert_eq!(a & b, and);
             assert_eq!(a | b, or);

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -173,22 +173,20 @@ mod tests {
     #[test]
     pub fn boolean_ops() {
         let mut rng = thread_rng();
-        for _ in 0..1000 {
-            let a = rng.gen::<u128>();
-            let b = rng.gen::<u128>();
+        let a = rng.gen::<u128>();
+        let b = rng.gen::<u128>();
 
-            let and = BitArray64::truncate_from(a & b);
-            let or = BitArray64::truncate_from(a | b);
-            let xor = BitArray64::truncate_from(a ^ b);
-            let not = BitArray64::truncate_from(!a);
+        let and = BitArray64::truncate_from(a & b);
+        let or = BitArray64::truncate_from(a | b);
+        let xor = BitArray64::truncate_from(a ^ b);
+        let not = BitArray64::truncate_from(!a);
 
-            let a = BitArray64::try_from(a & u128::from(u64::MAX)).unwrap();
-            let b = BitArray64::try_from(b & u128::from(u64::MAX)).unwrap();
+        let a = BitArray64::try_from(a & u128::from(u64::MAX)).unwrap();
+        let b = BitArray64::try_from(b & u128::from(u64::MAX)).unwrap();
 
-            assert_eq!(a & b, and);
-            assert_eq!(a | b, or);
-            assert_eq!(a ^ b, xor);
-            assert_eq!(!a, not);
-        }
+        assert_eq!(a & b, and);
+        assert_eq!(a | b, or);
+        assert_eq!(a ^ b, xor);
+        assert_eq!(!a, not);
     }
 }

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -1,0 +1,181 @@
+use super::{BitArray, BooleanOps};
+use bitvec::prelude::{BitArr, Lsb0};
+use std::{
+    fmt::Debug,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not},
+};
+
+/// Bit store size of `XorSecretShare` in bytes.
+const BIT_STORE_SIZE_IN_BYTES: usize = 4;
+type U8_4 = BitArr!(for BIT_STORE_SIZE_IN_BYTES * 8, in u8, Lsb0);
+
+/// 32-bit array of bits. Similar to `u32`, but supports boolean algebra, and
+/// provides access to individual bits via index.
+///
+/// Bits are stored in the Little-Endian format. Accessing the first element
+/// like `s[0]` will return the LSB.
+///
+/// ## Example
+/// ```
+/// use raw_ipa::bits::BitArray32;
+///
+/// let s = BitArray32::from(2_u128);
+/// let b0 = s[0];
+/// let b1 = s[1];
+///
+/// assert_eq!(b0, 0);
+/// assert_eq!(b1, 1);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BitArray32(U8_4);
+
+impl BitArray for BitArray32 {
+    const SIZE_IN_BYTES: usize = BIT_STORE_SIZE_IN_BYTES;
+
+    #[allow(dead_code)]
+    const ZERO: Self = Self(U8_4::ZERO);
+}
+
+impl BooleanOps for BitArray32 {}
+
+impl BitAnd for BitArray32 {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitAndAssign for BitArray32 {
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self.0.as_mut_bitslice() &= rhs.0;
+    }
+}
+
+impl BitOr for BitArray32 {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for BitArray32 {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self.0.as_mut_bitslice() |= rhs.0;
+    }
+}
+
+impl BitXor for BitArray32 {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl BitXorAssign for BitArray32 {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self.0.as_mut_bitslice() ^= rhs.0;
+    }
+}
+
+impl Not for BitArray32 {
+    type Output = Self;
+    fn not(self) -> Self::Output {
+        Self(!self.0)
+    }
+}
+
+impl<T: Into<u128>> From<T> for BitArray32 {
+    fn from(v: T) -> Self {
+        Self(U8_4::new(
+            v.into().to_le_bytes()[0..<Self as BitArray>::SIZE_IN_BYTES]
+                .try_into()
+                .unwrap(),
+        ))
+    }
+}
+
+impl Index<usize> for BitArray32 {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if self.0.as_bitslice()[index] {
+            &1
+        } else {
+            &0
+        }
+    }
+}
+
+#[cfg(test)]
+impl PartialEq<u128> for BitArray32 {
+    fn eq(&self, other: &u128) -> bool {
+        self.0 == Self::from(*other).0
+    }
+}
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
+    use super::BitArray32;
+    use crate::bits::BitArray;
+    use bitvec::prelude::*;
+    use rand::{thread_rng, Rng};
+
+    #[test]
+    pub fn basic() {
+        assert_eq!(BitArray32::ZERO.0, bitarr!(u32, Lsb0; 0));
+        assert_eq!(
+            BitArray32::from(1_u128).0.as_bitslice(),
+            bits![
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ],
+        );
+        assert_eq!(
+            BitArray32::from((1_u128 << (BitArray32::SIZE_IN_BYTES * 8)) + 1)
+                .0
+                .as_bitslice(),
+            bits![
+                1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0
+            ],
+        );
+    }
+
+    #[test]
+    pub fn index() {
+        let s = BitArray32::from((1_u128 << (BitArray32::SIZE_IN_BYTES * 8)) + 1);
+        assert_eq!(s[0], 1);
+        assert_eq!(s[31], 0);
+    }
+
+    #[test]
+    #[should_panic]
+    pub fn out_of_count_index() {
+        let s = BitArray32::from(1_u128);
+        // below assert should panic
+        assert_eq!(s[32], 0);
+    }
+
+    #[test]
+    pub fn boolean_ops() {
+        let mut rng = thread_rng();
+        for _ in 0..1000 {
+            let a = rng.gen::<u128>();
+            let b = rng.gen::<u128>();
+
+            // Mask the first 32 bits
+            let and = (a & b) & u128::from(u32::MAX);
+            let or = (a | b) & u128::from(u32::MAX);
+            let xor = (a ^ b) & u128::from(u32::MAX);
+            let not = !a & u128::from(u32::MAX);
+
+            let a = BitArray32::from(a);
+            let b = BitArray32::from(b);
+
+            assert_eq!(a & b, and);
+            assert_eq!(a | b, or);
+            assert_eq!(a ^ b, xor);
+            assert_eq!(!a, not);
+        }
+    }
+}

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -96,8 +96,8 @@ impl TryFrom<u128> for BitArray64 {
     type Error = String;
 
     /// Fallible conversion from `u128` to this data type. The input value must
-    /// be `Self::BITS` long. That is, leading 0's must be longer or equal to
-    /// `Self::BITS`, or it will return an error.
+    /// be at most `Self::BITS` long. That is, the integer value must be less
+    /// than or equal to  `2^{Self::BITS}`, or it will return an error.
     fn try_from(v: u128) -> Result<Self, Self::Error> {
         if 128 - v.leading_zeros() <= Self::BITS {
             Ok(Self::truncate_from(v))

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -9,7 +9,7 @@ pub use bit_array::BitArray64;
 // TODO: Implement `Message`
 pub trait BitArray:
     BooleanOps
-    + From<u128>
+    + TryFrom<u128>
     + Index<usize>
     + Clone
     + Copy
@@ -20,8 +20,20 @@ pub trait BitArray:
     + Sized
     + 'static
 {
+    /// Size of this data type in bytes. This is the size in memory allocated
+    /// for this data type to store the number of bits specified by `BITS`.
+    /// `SIZE_IN_BYTES * 8` could be larger than `BITS`, but this type will
+    /// store exactly `BITS` number of bits.
     const SIZE_IN_BYTES: usize;
+    /// Number of bits stored in this data type.
+    const BITS: u32;
+    /// A bit array with all its elements initialized to 0.
     const ZERO: Self;
+
+    /// Truncates the higher-order bits larger than `Self::BITS`, and converts
+    /// into this data type. This conversion is lossy. Callers are encouraged
+    /// to use `try_from` if the input is not known in advance.
+    fn truncate_from<T: Into<u128>>(v: T) -> Self;
 }
 
 pub trait BooleanOps:

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,0 +1,37 @@
+use std::fmt::Debug;
+use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
+
+mod bit_array;
+
+pub use bit_array::BitArray32;
+
+/// Trait for data types storing arbitrary number of bits.
+// TODO: Implement `Message`
+pub trait BitArray:
+    BooleanOps
+    + From<u128>
+    + Index<usize>
+    + Clone
+    + Copy
+    + PartialEq
+    + Debug
+    + Send
+    + Sync
+    + Sized
+    + 'static
+{
+    const SIZE_IN_BYTES: usize;
+    const ZERO: Self;
+}
+
+pub trait BooleanOps:
+    BitAnd<Output = Self>
+    + BitAndAssign
+    + BitOr<Output = Self>
+    + BitOrAssign
+    + BitXor<Output = Self>
+    + BitXorAssign
+    + Not<Output = Self>
+    + Sized
+{
+}

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -3,7 +3,7 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, I
 
 mod bit_array;
 
-pub use bit_array::BitArray32;
+pub use bit_array::BitArray64;
 
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::similar_names)]
 #![allow(clippy::module_name_repetitions)]
 
+pub mod bits;
 pub mod chunkscan;
 pub mod cli;
 pub mod error;


### PR DESCRIPTION
A backing data type for xor secret shares.

This is a boolean variant of `Field` backing `Replicated`. The diagram below shows the overview of the new secret sharing arrangement. This PR implements red-boxed parts.

![Untitled-2022-12-08-1530](https://user-images.githubusercontent.com/8149758/207368985-8bfc982d-3fa7-4793-a22b-8a4038843abc.png)
