### PR TITLE
Remove roles from helper config

### DIFF
--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -9,7 +9,7 @@ use raw_ipa::{
     protocol::{QueryId, Step},
 };
 use std::error::Error;
-use std::str::FromStr;
+
 use tracing::info;
 
 #[derive(Debug, Parser)]
@@ -39,8 +39,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let peer_discovery_str =
         std::fs::read_to_string("./peer_conf.toml").expect("unable to read file");
-    let peer_discovery =
-        discovery::conf::Conf::from_str(&peer_discovery_str).expect("unable to parse config file");
+    let peer_discovery = discovery::conf::Conf::from_toml_str(&peer_discovery_str)
+        .expect("unable to parse config file");
     let gateway_config = GatewayConfig {
         send_buffer_config: SendBufferConfig {
             items_in_batch: 1,

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -45,8 +45,10 @@ impl<'p> HttpHelper<'p> {
     /// # Panics
     /// if peers config does not specify port
     pub async fn bind(&self) -> (SocketAddr, JoinHandle<()>) {
+        // TODO: using role as index in the peer configuration is wrong (roles are configured per query),
+        // but we are getting rid of this struct anyway, so no point in fixing it
         let this_conf = &self.peers[self.role];
-        let port = this_conf.http.origin.port().unwrap();
+        let port = this_conf.origin.port().unwrap();
         let target = BindTarget::Http(format!("127.0.0.1:{}", port.as_str()).parse().unwrap());
         tracing::info!("starting server; binding to port {}", port.as_str());
         self.server.bind(target).await
@@ -160,24 +162,24 @@ mod e2e_tests {
     fn peer_discovery() -> discovery::literal::Literal {
         discovery::literal::Literal::new(
             peer::Config {
-                http: peer::HttpConfig {
-                    origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                tls: peer::HttpConfig {
                     public_key: public_key_from_hex(
                         "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924",
                     ),
                 },
             },
             peer::Config {
-                http: peer::HttpConfig {
-                    origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                tls: peer::HttpConfig {
                     public_key: public_key_from_hex(
                         "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b",
                     ),
                 },
             },
             peer::Config {
-                http: peer::HttpConfig {
-                    origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                origin: format!("http://127.0.0.1:{}", open_port()).parse().unwrap(),
+                tls: peer::HttpConfig {
                     public_key: public_key_from_hex(
                         "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074",
                     ),

--- a/src/helpers/http/network.rs
+++ b/src/helpers/http/network.rs
@@ -91,7 +91,7 @@ impl HttpNetwork {
             .iter()
             .map(|peer_conf| {
                 // no https for now
-                MpcHelperClient::new(peer_conf.http.origin.clone(), role)
+                MpcHelperClient::new(peer_conf.origin.clone(), role)
             })
             .collect::<Vec<_>>()
             .try_into()
@@ -122,46 +122,14 @@ impl Network for HttpNetwork {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixture::net::localhost_config;
     use crate::{
         helpers::{network::ChannelId, Direction, MESSAGE_PAYLOAD_SIZE_BYTES},
-        net::{
-            discovery::{conf::Conf, PeerDiscovery},
-            BindTarget, MessageSendMap, MpcHelperServer,
-        },
+        net::{discovery::PeerDiscovery, BindTarget, MessageSendMap, MpcHelperServer},
         protocol::Step,
     };
     use futures::{Stream, StreamExt};
     use futures_util::SinkExt;
-    use std::str::FromStr;
-
-    fn localhost_peers(h1_port: u16, h2_port: u16, h3_port: u16) -> Conf {
-        let peer_discovery_str = format!(
-            r#"
-[h1]
-    [h1.http]
-        origin = "http://localhost:{}"
-        public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
-    [h1.prss]
-        public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
-
-[h2]
-    [h2.http]
-        origin = "http://localhost:{}"
-        public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
-    [h2.prss]
-        public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
-
-[h3]
-    [h3.http]
-        origin = "http://localhost:{}"
-        public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
-    [h3.prss]
-        public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
-"#,
-            h1_port, h2_port, h3_port
-        );
-        Conf::from_str(&peer_discovery_str).unwrap()
-    }
 
     async fn setup() -> (Role, [peer::Config; 3], impl Stream<Item = MessageChunks>) {
         // setup server
@@ -175,7 +143,7 @@ mod tests {
             .await;
 
         // only H2 is valid
-        let peer_discovery = localhost_peers(0, addr.port(), 0);
+        let peer_discovery = localhost_config([0, addr.port(), 0]);
 
         (Role::H2, peer_discovery.peers().clone(), rx_stream)
     }

--- a/src/net/discovery/conf.rs
+++ b/src/net/discovery/conf.rs
@@ -32,16 +32,15 @@ impl PeerDiscovery for Conf {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::helpers::Role;
     use crate::test_fixture::net::localhost_config;
     use hyper::Uri;
 
-    const H1_PUBLIC_KEY: &str = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924";
-    const H2_PUBLIC_KEY: &str = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b";
-    const H3_PUBLIC_KEY: &str = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074";
-    const H1_URI: &str = "http://localhost:3000/";
-    const H2_URI: &str = "http://localhost:3001/";
-    const H3_URI: &str = "http://localhost:3002/";
+    const PUBLIC_KEY_1: &str = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924";
+    const PUBLIC_KEY_2: &str = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b";
+    const PUBLIC_KEY_3: &str = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074";
+    const URI_1: &str = "http://localhost:3000/";
+    const URI_2: &str = "http://localhost:3001/";
+    const URI_3: &str = "http://localhost:3002/";
 
     fn hex_str_to_public_key(hex_str: &str) -> x25519_dalek::PublicKey {
         let pk_bytes: [u8; 32] = hex::decode(hex_str)
@@ -55,25 +54,22 @@ mod tests {
     fn parse_config() {
         let conf = localhost_config([3000, 3001, 3002]);
 
-        // H1
-        assert_eq!(conf.peers[Role::H1].origin, H1_URI.parse::<Uri>().unwrap());
+        assert_eq!(conf.peers[0].origin, URI_1.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H1].tls.public_key,
-            hex_str_to_public_key(H1_PUBLIC_KEY)
+            conf.peers[0].tls.public_key,
+            hex_str_to_public_key(PUBLIC_KEY_1)
         );
 
-        // H2
-        assert_eq!(conf.peers[Role::H2].origin, H2_URI.parse::<Uri>().unwrap());
+        assert_eq!(conf.peers[1].origin, URI_2.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H2].tls.public_key,
-            hex_str_to_public_key(H2_PUBLIC_KEY)
+            conf.peers[1].tls.public_key,
+            hex_str_to_public_key(PUBLIC_KEY_2)
         );
 
-        // H3
-        assert_eq!(conf.peers[Role::H3].origin, H3_URI.parse::<Uri>().unwrap());
+        assert_eq!(conf.peers[2].origin, URI_3.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H3].tls.public_key,
-            hex_str_to_public_key(H3_PUBLIC_KEY)
+            conf.peers[2].tls.public_key,
+            hex_str_to_public_key(PUBLIC_KEY_3)
         );
     }
 }

--- a/src/net/discovery/conf.rs
+++ b/src/net/discovery/conf.rs
@@ -1,69 +1,26 @@
 use crate::net::discovery::{peer, Error, PeerDiscovery};
-use std::str::FromStr;
-
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
-struct ToPeerHttpConfig {
-    origin: String,
-    #[serde(with = "hex")]
-    public_key: [u8; 32],
-}
-
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
-struct ToPeerConfig {
-    http: ToPeerHttpConfig,
-}
-
-/// Values that are serializable and read from config. May need further processing when translating
-/// to [`peer::Config`].
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
-struct ToConf {
-    h1: ToPeerConfig,
-    h2: ToPeerConfig,
-    h3: ToPeerConfig,
-}
 
 /// All config value necessary to discover other peer helpers of the MPC ring
+#[cfg_attr(feature = "enable-serde", derive(serde::Deserialize))]
 pub struct Conf {
     peers: [peer::Config; 3],
 }
 
 impl Conf {
-    fn from_file_conf(to_conf: &ToConf) -> Result<Self, Error> {
-        Ok(Self {
-            peers: [
-                Self::peer_config(&to_conf.h1)?,
-                Self::peer_config(&to_conf.h2)?,
-                Self::peer_config(&to_conf.h3)?,
-            ],
-        })
-    }
-
-    fn peer_config(to_peer_config: &ToPeerConfig) -> Result<peer::Config, Error> {
-        Ok(peer::Config {
-            http: peer::HttpConfig {
-                origin: to_peer_config.http.origin.parse()?,
-                public_key: to_peer_config.http.public_key.into(),
-            },
-        })
-    }
-}
-
-impl FromStr for Conf {
-    type Err = Error;
-
     /// Reads config from string. Expects config to be toml format.
     /// To read file, use `fs::read_to_string`
+    ///
     /// # Errors
-    /// if the file does not exist, or is in an invalid format
-    fn from_str(config_str: &str) -> Result<Self, Self::Err> {
+    /// if `input` is in an invalid format
+    pub fn from_toml_str(input: &str) -> Result<Self, Error> {
         use config::{Config, File, FileFormat};
 
-        let to_conf: ToConf = Config::builder()
-            .add_source(File::from_str(config_str, FileFormat::Toml))
+        let conf: Self = Config::builder()
+            .add_source(File::from_str(input, FileFormat::Toml))
             .build()?
             .try_deserialize()?;
 
-        Self::from_file_conf(&to_conf)
+        Ok(conf)
     }
 }
 
@@ -75,8 +32,8 @@ impl PeerDiscovery for Conf {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::*;
     use crate::helpers::Role;
+    use crate::test_fixture::net::localhost_config;
     use hyper::Uri;
 
     const H1_PUBLIC_KEY: &str = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924";
@@ -85,22 +42,6 @@ mod tests {
     const H1_URI: &str = "http://localhost:3000/";
     const H2_URI: &str = "http://localhost:3001/";
     const H3_URI: &str = "http://localhost:3002/";
-    const EXAMPLE_CONFIG: &str = r#"
-[h1]
-    [h1.http]
-        origin = "http://localhost:3000"
-        public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
-
-[h2]
-    [h2.http]
-        origin = "http://localhost:3001"
-        public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
-
-[h3]
-    [h3.http]
-        origin = "http://localhost:3002"
-        public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
-"#;
 
     fn hex_str_to_public_key(hex_str: &str) -> x25519_dalek::PublicKey {
         let pk_bytes: [u8; 32] = hex::decode(hex_str)
@@ -112,43 +53,26 @@ mod tests {
 
     #[test]
     fn parse_config() {
-        use config::{Config, File, FileFormat};
-
-        let to_conf: ToConf = Config::builder()
-            .add_source(File::from_str(EXAMPLE_CONFIG, FileFormat::Toml))
-            .build()
-            .unwrap()
-            .try_deserialize()
-            .expect("config should be valid");
-        let conf = Conf::from_file_conf(&to_conf).expect("file should contain valid values");
+        let conf = localhost_config([3000, 3001, 3002]);
 
         // H1
+        assert_eq!(conf.peers[Role::H1].origin, H1_URI.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H1].http.origin,
-            H1_URI.parse::<Uri>().unwrap()
-        );
-        assert_eq!(
-            conf.peers[Role::H1].http.public_key,
+            conf.peers[Role::H1].tls.public_key,
             hex_str_to_public_key(H1_PUBLIC_KEY)
         );
 
         // H2
+        assert_eq!(conf.peers[Role::H2].origin, H2_URI.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H2].http.origin,
-            H2_URI.parse::<Uri>().unwrap()
-        );
-        assert_eq!(
-            conf.peers[Role::H2].http.public_key,
+            conf.peers[Role::H2].tls.public_key,
             hex_str_to_public_key(H2_PUBLIC_KEY)
         );
 
         // H3
+        assert_eq!(conf.peers[Role::H3].origin, H3_URI.parse::<Uri>().unwrap());
         assert_eq!(
-            conf.peers[Role::H3].http.origin,
-            H3_URI.parse::<Uri>().unwrap()
-        );
-        assert_eq!(
-            conf.peers[Role::H3].http.public_key,
+            conf.peers[Role::H3].tls.public_key,
             hex_str_to_public_key(H3_PUBLIC_KEY)
         );
     }

--- a/src/net/discovery/mod.rs
+++ b/src/net/discovery/mod.rs
@@ -12,28 +12,52 @@ pub enum Error {
 }
 
 pub mod peer {
-    use axum::http::Uri;
+    use hyper::Uri;
+    #[cfg(feature = "enable-serde")]
+    use serde::de::Error;
+    #[cfg(feature = "enable-serde")]
+    use serde::{Deserialize, Deserializer};
     use x25519_dalek::PublicKey;
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
+    #[cfg_attr(feature = "enable-serde", derive(serde::Deserialize))]
     pub struct HttpConfig {
-        pub origin: Uri,
+        #[cfg_attr(feature = "enable-serde", serde(deserialize_with = "pk_from_str"))]
         pub public_key: PublicKey,
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
+    #[cfg_attr(feature = "enable-serde", derive(serde::Deserialize))]
     pub struct Config {
-        pub http: HttpConfig,
+        #[cfg_attr(feature = "enable-serde", serde(deserialize_with = "uri_from_str"))]
+        pub origin: Uri,
+        pub tls: HttpConfig,
+    }
+
+    #[cfg(feature = "enable-serde")]
+    fn uri_from_str<'de, D>(deserializer: D) -> Result<Uri, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        s.parse().map_err(D::Error::custom)
+    }
+
+    #[cfg(feature = "enable-serde")]
+    fn pk_from_str<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        let mut buf = [0_u8; 32];
+        hex::decode_to_slice(s, &mut buf).map_err(D::Error::custom)?;
+
+        Ok(PublicKey::from(buf))
     }
 }
 
-/// Provides a set of peer helpers for an MPC computation. Also includes the client pointing to the
-/// running server. Since the running server is aware of which [`crate::helpers::Role`] it is (`H1`, `H2`, or
-/// `H3`), it should be able to use only the references to other servers. However, it's possible for
-/// a server to send data to itself.
-///
+/// Provides a set of peer helpers for an MPC computation.
 /// Any potential failures should be captured in the initialization of the implementer.
-#[allow(clippy::module_name_repetitions)] // following standard naming convention
 pub trait PeerDiscovery {
     fn peers(&self) -> &[peer::Config; 3];
 }

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -5,6 +5,7 @@ pub mod circuit;
 pub mod ipa_input_row;
 pub mod logging;
 pub mod metrics;
+pub mod net;
 pub mod network;
 
 use crate::ff::{Field, Fp31};

--- a/src/test_fixture/net.rs
+++ b/src/test_fixture/net.rs
@@ -1,0 +1,35 @@
+use crate::net::discovery::conf::Conf;
+use std::fmt::Debug;
+
+/// Creates a new config for helpers configured to run on local machine using unique port.
+#[allow(clippy::missing_panics_doc)]
+pub fn localhost_config<P: TryInto<u16>>(ports: [P; 3]) -> Conf
+where
+    P::Error: Debug,
+{
+    let ports = ports.map(|v| v.try_into().expect("Failed to parse the value into u16"));
+    let config_str = format!(
+        r#"
+    [[peers]]
+        origin = "http://localhost:{}"
+
+        [peers.tls]
+        public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
+
+    [[peers]]
+        origin = "http://localhost:{}"
+
+        [peers.tls]
+        public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
+
+    [[peers]]
+        origin = "http://localhost:{}"
+
+        [peers.tls]
+        public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
+"#,
+        ports[0], ports[1], ports[2]
+    );
+
+    Conf::from_toml_str(&config_str).unwrap()
+}


### PR DESCRIPTION
As we discussed, each helper will be assigned a role when query processing starts. That means helpers may have different roles in different queries it participates in. Helper configuration therefore must be configured around its endpoint that stays the same regardless of number of queries it processes.

This change also removes interim structs that mirrored the end config struct, but used raw types (str, [u8]). With custom deserialize implementation it is easy to support only one hierarchy of configs