### PR TITLE
pass context once to RandomBitsGenerator::new

### DIFF
--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -223,7 +223,7 @@ async fn bit_decompose_breakdown_key<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CappedCreditsWithAggregationBit<F>],
 ) -> Result<Vec<Vec<Replicated<F>>>, Error> {
-    let random_bits_generator = RandomBitsGenerator::new();
+    let random_bits_generator = RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
     try_join_all(
         input
             .iter()
@@ -303,6 +303,7 @@ enum Step {
     SortByAttributionBit,
     AggregateCreditBTimesSuccessorCredit,
     BitDecomposeBreakdownKey,
+    RandomBitsForBitDecomposition,
     GeneratePermutationByBreakdownKey,
     ApplyPermutationOnBreakdownKey,
     GeneratePermutationByAttributionBit,
@@ -322,6 +323,7 @@ impl AsRef<str> for Step {
                 "aggregate_credit_b_times_successor_credit"
             }
             Self::BitDecomposeBreakdownKey => "bit_decompose_breakdown_key",
+            Self::RandomBitsForBitDecomposition => "random_bits_for_bit_decomposition",
             Self::GeneratePermutationByBreakdownKey => "generate_permutation_by_breakdown_key",
             Self::ApplyPermutationOnBreakdownKey => "apply_permutation_by_breakdown_key",
             Self::GeneratePermutationByAttributionBit => "generate_permutation_by_attribution_bit",

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -223,7 +223,8 @@ async fn bit_decompose_breakdown_key<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CappedCreditsWithAggregationBit<F>],
 ) -> Result<Vec<Vec<Replicated<F>>>, Error> {
-    let random_bits_generator = RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
+    let random_bits_generator =
+        RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
     try_join_all(
         input
             .iter()

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -169,7 +169,7 @@ async fn is_credit_larger_than_cap<F: Field>(
 ) -> Result<Vec<Replicated<F>>, Error> {
     //TODO: `cap` is publicly known value for each query. We can avoid creating shares every time.
     let cap = local_secret_shared_bits(&ctx, cap.into());
-    let random_bits_generator = RandomBitsGenerator::new();
+    let random_bits_generator = RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
 
     try_join_all(
         prefix_summed_credits
@@ -279,6 +279,7 @@ enum Step {
     MaskSourceCredits,
     CurrentContributionBTimesSuccessorCredit,
     BitDecomposeCurrentContribution,
+    RandomBitsForBitDecomposition,
     IsCapLessThanCurrentContribution,
     IfCurrentExceedsCapOrElse,
     IfNextExceedsCapOrElse,
@@ -297,6 +298,7 @@ impl AsRef<str> for Step {
                 "current_contribution_b_times_successor_credit"
             }
             Self::BitDecomposeCurrentContribution => "bit_decompose_current_contribution",
+            Self::RandomBitsForBitDecomposition => "random_bits_for_bit_decomposition",
             Self::IsCapLessThanCurrentContribution => "is_cap_less_than_current_contribution",
             Self::IfCurrentExceedsCapOrElse => "if_current_exceeds_cap_or_else",
             Self::IfNextExceedsCapOrElse => "if_next_exceeds_cap_or_else",

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -169,7 +169,8 @@ async fn is_credit_larger_than_cap<F: Field>(
 ) -> Result<Vec<Replicated<F>>, Error> {
     //TODO: `cap` is publicly known value for each query. We can avoid creating shares every time.
     let cap = local_secret_shared_bits(&ctx, cap.into());
-    let random_bits_generator = RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
+    let random_bits_generator =
+        RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
 
     try_join_all(
         prefix_summed_credits

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -110,7 +110,10 @@ mod tests {
     use super::BitDecomposition;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Int},
-        protocol::{boolean::random_bits_generator::RandomBitsGenerator, QueryId, RecordId, context::Context},
+        protocol::{
+            boolean::random_bits_generator::RandomBitsGenerator, context::Context, QueryId,
+            RecordId,
+        },
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -215,12 +215,7 @@ mod tests {
         let rbg1 = RandomBitsGenerator::new(c1);
         let rbg2 = RandomBitsGenerator::new(c2);
 
-        let _result = join3(
-            rbg0.take_one(),
-            rbg1.take_one(),
-            rbg2.take_one(),
-        )
-        .await;
+        let _result = join3(rbg0.take_one(), rbg1.take_one(), rbg2.take_one()).await;
 
         // From the initial pointer positions r=0, w=0, the buffer is replenished
         // until we fill `MAX_SIZE` items. We called `take_one()` once, so the
@@ -239,12 +234,7 @@ mod tests {
 
         // Now we `take_one()` until 16 items left in the buffer
         for _ in 0..take_n {
-            let _result = join3(
-                rbg0.take_one(),
-                rbg1.take_one(),
-                rbg2.take_one(),
-            )
-            .await;
+            let _result = join3(rbg0.take_one(), rbg1.take_one(), rbg2.take_one()).await;
         }
 
         // There should be 16 items left in the buffer. It hasn't triggered a
@@ -259,12 +249,7 @@ mod tests {
         let last_abort_count = abort_count;
 
         // One more `take_one()` will trigger the replenishment
-        let _result = join3(
-            rbg0.take_one(),
-            rbg1.take_one(),
-            rbg2.take_one(),
-        )
-        .await;
+        let _result = join3(rbg0.take_one(), rbg1.take_one(), rbg2.take_one()).await;
 
         // Now, RBG tried to fill the remaining empty slots (`256 - 16`),
         // aborted N times in this round (last_about_count - abort_count),

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -59,39 +59,40 @@ impl<T> RingBuffer<T> {
 }
 
 #[derive(Debug)]
-struct State<F, S>
+struct State<F, S, C>
 where
     F: Field,
     S: SecretSharing<F>,
+    C: Context<F, Share = S>,
 {
     buffer: RingBuffer<RandomBitsShare<F, S>>,
     next_index: u32,
     abort_count: u32,
+    context: C,
     _marker: PhantomData<F>,
 }
 
-impl<F, S> State<F, S>
+impl<F, S, C> State<F, S, C>
 where
     F: Field,
     S: SecretSharing<F>,
+    C: Context<F, Share = S>,
 {
     const REFILL_THRESHOLD: usize = 16;
 
-    pub fn new() -> Self {
+    pub fn new(context: C) -> Self {
         Self {
             buffer: RingBuffer::new(),
             next_index: 0,
             abort_count: 0,
+            context,
             _marker: PhantomData::default(),
         }
     }
 
     /// Returns a `RandomBitsShare` instance out of the buffer. If the number
     /// of buffered items fall below a threshold, it'll replenish.
-    pub async fn get<C: Context<F, Share = S>>(
-        &mut self,
-        context: C,
-    ) -> Result<RandomBitsShare<F, S>, Error> {
+    pub async fn get(&mut self) -> Result<RandomBitsShare<F, S>, Error> {
         // If we have enough shares, take one immediately return
         if self.buffer.len() > Self::REFILL_THRESHOLD {
             return Ok(self.buffer.take());
@@ -101,7 +102,7 @@ where
         // one `RandomBitsShare` instance.
         let available_space = self.buffer.available_space();
         try_join_all((0..available_space).map(|_| {
-            let c = context.clone();
+            let c = self.context.clone();
             let record_id = RecordId::from(self.next_index);
 
             // Current implementation will cause the context to panic once u32
@@ -132,33 +133,25 @@ where
 /// one by calling `take_one()`. It will call `SolvedBits` once the stock falls
 /// below `REFILL_THRESHOLD` until it fills up the empty slots.
 #[derive(Debug)]
-pub struct RandomBitsGenerator<F, S>
+pub struct RandomBitsGenerator<F, S, C>
 where
     F: Field,
     S: SecretSharing<F>,
+    C: Context<F, Share = S>,
 {
-    state: Arc<Mutex<State<F, S>>>,
+    state: Arc<Mutex<State<F, S, C>>>,
 }
 
-impl<F, S> Default for RandomBitsGenerator<F, S>
+impl<F, S, C> RandomBitsGenerator<F, S, C>
 where
     F: Field,
     S: SecretSharing<F>,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<F, S> RandomBitsGenerator<F, S>
-where
-    F: Field,
-    S: SecretSharing<F>,
+    C: Context<F, Share = S>,
 {
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(context: C) -> Self {
         Self {
-            state: Arc::new(Mutex::new(State::new())),
+            state: Arc::new(Mutex::new(State::new(context))),
         }
     }
 
@@ -168,12 +161,9 @@ where
     /// This method mail fail for number of reasons. Errors include locking the
     /// inner members multiple times, I/O errors while executing MPC protocols,
     /// read from an empty buffer, etc.
-    pub async fn take_one<C: Context<F, Share = S>>(
-        &self,
-        context: C,
-    ) -> Result<RandomBitsShare<F, S>, Error> {
+    pub async fn take_one(&self) -> Result<RandomBitsShare<F, S>, Error> {
         let mut state = self.state.lock().await;
-        state.get(context).await
+        state.get().await
     }
 
     // Used for unit tests only. Takes a lock and returns the internal counters
@@ -191,10 +181,11 @@ where
     }
 }
 
-impl<F, S> Clone for RandomBitsGenerator<F, S>
+impl<F, S, C> Clone for RandomBitsGenerator<F, S, C>
 where
     F: Field,
     S: SecretSharing<F>,
+    C: Context<F, Share = S>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -220,14 +211,14 @@ mod tests {
         let world = TestWorld::new(QueryId);
         let [c0, c1, c2] = world.contexts::<Fp31>();
 
-        let rbg0 = RandomBitsGenerator::new();
-        let rbg1 = RandomBitsGenerator::new();
-        let rbg2 = RandomBitsGenerator::new();
+        let rbg0 = RandomBitsGenerator::new(c0);
+        let rbg1 = RandomBitsGenerator::new(c1);
+        let rbg2 = RandomBitsGenerator::new(c2);
 
         let _result = join3(
-            rbg0.take_one(c0.clone()),
-            rbg1.take_one(c1.clone()),
-            rbg2.take_one(c2.clone()),
+            rbg0.take_one(),
+            rbg1.take_one(),
+            rbg2.take_one(),
         )
         .await;
 
@@ -249,9 +240,9 @@ mod tests {
         // Now we `take_one()` until 16 items left in the buffer
         for _ in 0..take_n {
             let _result = join3(
-                rbg0.take_one(c0.clone()),
-                rbg1.take_one(c1.clone()),
-                rbg2.take_one(c2.clone()),
+                rbg0.take_one(),
+                rbg1.take_one(),
+                rbg2.take_one(),
             )
             .await;
         }
@@ -269,9 +260,9 @@ mod tests {
 
         // One more `take_one()` will trigger the replenishment
         let _result = join3(
-            rbg0.take_one(c0.clone()),
-            rbg1.take_one(c1.clone()),
-            rbg2.take_one(c2.clone()),
+            rbg0.take_one(),
+            rbg1.take_one(),
+            rbg2.take_one(),
         )
         .await;
 


### PR DESCRIPTION
This changes random bits generator to accept a context once when the context is created, rather than each time randomness is requested. Because bits are generated in batches, this seems more appropriate -- the context that was supplied to the individual `get()` call where a batch happened to be generated may or may not have anything to do with the context where the bits are ultimately used.

There is still a problem for closing the communication channels associated with random bits generation since the total record count is less well defined than in some other cases. But isolating the context for random bits in this way I think offers more flexibility to solve that.

And there are still problems related to sampling the random bits in a deterministic order on each helper, that we discussed last week. Those are not addressed by this change, but again, I think this change may make an eventual solution easier.