### PR TITLE
Buffer the send/recv channels

### DIFF
--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -46,6 +46,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             items_in_batch: 1,
             batch_count: 40,
         },
+        send_outstanding: 16,
+        recv_outstanding: 16,
     };
     let helper = HttpHelper::new(args.role, &peer_discovery, gateway_config);
     let (addr, server_handle) = helper.bind().await;

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -195,6 +195,8 @@ mod e2e_tests {
                 items_in_batch: 1,
                 batch_count: 40,
             },
+            send_outstanding: 16,
+            recv_outstanding: 16,
         }
     }
 

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -153,12 +153,16 @@ impl Mesh<'_, '_> {
 pub struct GatewayConfig {
     /// Configuration for send buffers. See `SendBufferConfig` for more details
     pub send_buffer_config: SendBufferConfig,
+    /// The maximum number of items that can be outstanding for sending.
+    pub send_outstanding: usize,
+    /// The maximum number of items that can be outstanding for receiving.
+    pub recv_outstanding: usize,
 }
 
 impl Gateway {
     pub fn new<N: Network>(role: Role, network: &N, config: GatewayConfig) -> Self {
-        let (recv_tx, mut recv_rx) = mpsc::channel::<ReceiveRequest>(1);
-        let (send_tx, mut send_rx) = mpsc::channel::<SendRequest>(1);
+        let (recv_tx, mut recv_rx) = mpsc::channel::<ReceiveRequest>(config.recv_outstanding);
+        let (send_tx, mut send_rx) = mpsc::channel::<SendRequest>(config.send_outstanding);
         let mut message_stream = network.recv_stream();
         let mut network_sink = network.sink();
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -77,6 +77,8 @@ impl Default for TestWorldConfig {
                     /// to be problematic from memory perspective.
                     batch_count: 40,
                 },
+                send_outstanding: 16,
+                recv_outstanding: 16,
             },
             /// Disable metrics by default because `logging` only enables `Level::INFO` spans.
             /// Can be overridden by setting `RUST_LOG` environment variable to match this level.


### PR DESCRIPTION
This turns out to have a measurable effect on test running time, at least on my machine.  It's worth about a second overall.

I considered tuning this with more runs, but we've got enough churn ahead of us that I am going to suggest we hold off.