### PR TITLE
`SharedValue` trait for secret shared value types

### DIFF
--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -1,4 +1,5 @@
 use super::BitArray;
+use crate::secret_sharing::SharedValue;
 use bitvec::prelude::{BitArr, Lsb0};
 use std::{
     fmt::Debug,
@@ -43,6 +44,8 @@ impl BitArray for BitArray64 {
         ))
     }
 }
+
+impl SharedValue for BitArray64 {}
 
 impl BitAnd for BitArray64 {
     type Output = Self;

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -29,23 +29,23 @@ type U8_8 = BitArr!(for 64, in u8, Lsb0);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BitArray64(U8_8);
 
-impl BitArray for BitArray64 {
+impl SharedValue for BitArray64 {
     const SIZE_IN_BYTES: usize = std::mem::size_of::<Self>();
     const BITS: u32 = 64;
+}
 
+impl BitArray for BitArray64 {
     #[allow(dead_code)]
     const ZERO: Self = Self(U8_8::ZERO);
 
     fn truncate_from<T: Into<u128>>(v: T) -> Self {
         Self(U8_8::new(
-            v.into().to_le_bytes()[0..<Self as BitArray>::SIZE_IN_BYTES]
+            v.into().to_le_bytes()[0..<Self as SharedValue>::SIZE_IN_BYTES]
                 .try_into()
                 .unwrap(),
         ))
     }
 }
-
-impl SharedValue for BitArray64 {}
 
 impl BitAnd for BitArray64 {
     type Output = Self;
@@ -135,7 +135,7 @@ impl Index<u32> for BitArray64 {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::BitArray64;
-    use crate::bits::BitArray;
+    use crate::{bits::BitArray, secret_sharing::SharedValue};
     use bitvec::prelude::*;
     use rand::{thread_rng, Rng};
 

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,4 +1,4 @@
-use crate::secret_sharing::SharedValue;
+use crate::secret_sharing::BooleanShare;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
 
 mod bit_array;
@@ -7,14 +7,7 @@ pub use bit_array::BitArray64;
 
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`
-pub trait BitArray: SharedValue + BooleanOps + TryFrom<u128> + Index<usize> {
-    /// Size of this data type in bytes. This is the size in memory allocated
-    /// for this data type to store the number of bits specified by `BITS`.
-    /// `SIZE_IN_BYTES * 8` could be larger than `BITS`, but this type will
-    /// store exactly `BITS` number of bits.
-    const SIZE_IN_BYTES: usize;
-    /// Number of bits stored in this data type.
-    const BITS: u32;
+pub trait BitArray: BooleanShare + TryFrom<u128> + Index<usize> {
     /// A bit array with all its elements initialized to 0.
     const ZERO: Self;
 

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use crate::secret_sharing::SharedValue;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
 
 mod bit_array;
@@ -7,19 +7,7 @@ pub use bit_array::BitArray64;
 
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`
-pub trait BitArray:
-    BooleanOps
-    + TryFrom<u128>
-    + Index<usize>
-    + Clone
-    + Copy
-    + PartialEq
-    + Debug
-    + Send
-    + Sync
-    + Sized
-    + 'static
-{
+pub trait BitArray: SharedValue + BooleanOps + TryFrom<u128> + Index<usize> {
     /// Size of this data type in bytes. This is the size in memory allocated
     /// for this data type to store the number of bits specified by `BITS`.
     /// `SIZE_IN_BYTES * 8` could be larger than `BITS`, but this type will

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -2,7 +2,9 @@ use std::any::type_name;
 use std::fmt::Debug;
 use std::io;
 use std::io::ErrorKind;
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
+
+use crate::bits::BooleanOps;
+use crate::secret_sharing::SharedValue;
 
 use super::ArithmeticOps;
 
@@ -19,19 +21,7 @@ impl Int for u32 {
     const BITS: u32 = u32::BITS;
 }
 
-pub trait Field:
-    ArithmeticOps
-    + From<u128>
-    + Into<Self::Integer>
-    + Clone
-    + Copy
-    + PartialEq
-    + Debug
-    + Send
-    + Sync
-    + Sized
-    + 'static
-{
+pub trait Field: SharedValue + ArithmeticOps + From<u128> + Into<Self::Integer> {
     type Integer: Int;
 
     const PRIME: Self::Integer;
@@ -102,14 +92,4 @@ pub trait Field:
     }
 }
 
-pub trait BinaryField:
-    Field
-    + BitAnd<Output = Self>
-    + BitAndAssign
-    + BitOr<Output = Self>
-    + BitOrAssign
-    + BitXor<Output = Self>
-    + BitXorAssign
-    + Not<Output = Self>
-{
-}
+pub trait BinaryField: Field + BooleanOps {}

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -43,10 +43,10 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     /// ## Errors
     /// Returns an error if buffer did not have enough capacity to store this field value
     fn serialize(&self, buf: &mut [u8]) -> io::Result<()> {
-        let raw_value = &self.as_u128().to_le_bytes()[..Self::SIZE_IN_BYTES as usize];
+        let raw_value = &self.as_u128().to_le_bytes()[..Self::SIZE_IN_BYTES];
 
         if buf.len() >= raw_value.len() {
-            buf[..Self::SIZE_IN_BYTES as usize].copy_from_slice(raw_value);
+            buf[..Self::SIZE_IN_BYTES].copy_from_slice(raw_value);
             Ok(())
         } else {
             let error_text = format!(
@@ -71,10 +71,9 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     /// ## Errors
     /// Returns an error if buffer did not have enough capacity left to read the field value.
     fn deserialize(buf_from: &mut [u8]) -> io::Result<Self> {
-        if Self::SIZE_IN_BYTES as usize <= buf_from.len() {
+        if Self::SIZE_IN_BYTES <= buf_from.len() {
             let mut buf_to = [0; 16]; // one day...
-            buf_to[..Self::SIZE_IN_BYTES as usize]
-                .copy_from_slice(&buf_from[..Self::SIZE_IN_BYTES as usize]);
+            buf_to[..Self::SIZE_IN_BYTES].copy_from_slice(&buf_from[..Self::SIZE_IN_BYTES]);
 
             Ok(Self::from(u128::from_le_bytes(buf_to)))
         } else {

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -4,9 +4,7 @@ use std::io;
 use std::io::ErrorKind;
 
 use crate::bits::BooleanOps;
-use crate::secret_sharing::SharedValue;
-
-use super::ArithmeticOps;
+use crate::secret_sharing::ArithmeticShare;
 
 // Trait for primitive integer types used to represent the underlying type for field values
 pub trait Int: Sized + Copy + Debug + Into<u128> {
@@ -21,7 +19,7 @@ impl Int for u32 {
     const BITS: u32 = u32::BITS;
 }
 
-pub trait Field: SharedValue + ArithmeticOps + From<u128> + Into<Self::Integer> {
+pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     type Integer: Int;
 
     const PRIME: Self::Integer;
@@ -29,9 +27,6 @@ pub trait Field: SharedValue + ArithmeticOps + From<u128> + Into<Self::Integer> 
     const ZERO: Self;
     /// Multiplicative identity element
     const ONE: Self;
-    /// Derived from the size of the backing field, this constant indicates how much
-    /// space is required to store this field value
-    const SIZE_IN_BYTES: u32 = Self::Integer::BITS / 8;
 
     /// Blanket implementation to represent the instance of this trait as 16 byte integer.
     /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -7,7 +7,7 @@ mod prime_field;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use field::{BinaryField, Field, Int};
-pub use prime_field::{Fp2, Fp31, Fp32BitPrime};
+pub use prime_field::{Fp31, Fp32BitPrime};
 
 pub trait ArithmeticOps:
     Add<Output = Self>

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -1,4 +1,5 @@
 use super::{field::BinaryField, Field};
+use crate::secret_sharing::SharedValue;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 macro_rules! field_impl {
@@ -14,6 +15,8 @@ macro_rules! field_impl {
             const ZERO: Self = $field(0);
             const ONE: Self = $field(1);
         }
+
+        impl SharedValue for $field {}
 
         impl std::ops::Add for $field {
             type Output = Self;

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
-use crate::ff::Field;
+use crate::ff::{ArithmeticOps, Field};
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing};
+use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing, SharedValue};
 use async_trait::async_trait;
 
 pub(crate) mod malicious;
@@ -13,8 +13,8 @@ pub use sparse::{MultiplyZeroPositions, ZeroPositions};
 
 /// Trait to multiply secret shares. That requires communication and `multiply` function is async.
 #[async_trait]
-pub trait SecureMul<F: Field>: Sized {
-    type Share: SecretSharing<F>;
+pub trait SecureMul<V: SharedValue + ArithmeticOps>: Sized {
+    type Share: SecretSharing<V>;
 
     /// Multiply and return the result of `a` * `b`.
     async fn multiply(

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
-use crate::ff::{ArithmeticOps, Field};
+use crate::ff::Field;
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing, SharedValue};
+use crate::secret_sharing::{ArithmeticShare, MaliciousReplicated, Replicated, SecretSharing};
 use async_trait::async_trait;
 
 pub(crate) mod malicious;
@@ -13,7 +13,7 @@ pub use sparse::{MultiplyZeroPositions, ZeroPositions};
 
 /// Trait to multiply secret shares. That requires communication and `multiply` function is async.
 #[async_trait]
-pub trait SecureMul<V: SharedValue + ArithmeticOps>: Sized {
+pub trait SecureMul<V: ArithmeticShare>: Sized {
     type Share: SecretSharing<V>;
 
     /// Multiply and return the result of `a` * `b`.

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -1,8 +1,8 @@
-use crate::ff::Field;
+use crate::ff::{ArithmeticOps, Field};
 use crate::protocol::context::{Context, MaliciousContext};
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::sort::ReshareStep::RandomnessForValidation;
-use crate::secret_sharing::{MaliciousReplicated, SecretSharing};
+use crate::secret_sharing::{MaliciousReplicated, SecretSharing, SharedValue};
 use crate::{
     error::Error,
     helpers::{Direction, Role},
@@ -28,8 +28,11 @@ use futures::future::try_join;
 ///    `to_helper`       = (`rand_left`, `rand_right`)     = (r0, r1)
 ///    `to_helper.right` = (`rand_right`, part1 + part2) = (r0, part1 + part2)
 #[async_trait]
-pub trait Reshare<F: Field> {
-    type Share: SecretSharing<F>;
+pub trait Reshare<V>
+where
+    V: SharedValue + ArithmeticOps,
+{
+    type Share: SecretSharing<V>;
 
     async fn reshare(
         self,

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -1,8 +1,8 @@
-use crate::ff::{ArithmeticOps, Field};
+use crate::ff::Field;
 use crate::protocol::context::{Context, MaliciousContext};
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::sort::ReshareStep::RandomnessForValidation;
-use crate::secret_sharing::{MaliciousReplicated, SecretSharing, SharedValue};
+use crate::secret_sharing::{ArithmeticShare, MaliciousReplicated, SecretSharing};
 use crate::{
     error::Error,
     helpers::{Direction, Role},
@@ -30,7 +30,7 @@ use futures::future::try_join;
 #[async_trait]
 pub trait Reshare<V>
 where
-    V: SharedValue + ArithmeticOps,
+    V: ArithmeticShare,
 {
     type Share: SecretSharing<V>;
 

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -1,8 +1,8 @@
 use std::iter::{repeat, zip};
 
-use crate::ff::Field;
+use crate::ff::{ArithmeticOps, Field};
 use crate::protocol::context::{Context, MaliciousContext, SemiHonestContext};
-use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing};
+use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing, SharedValue};
 use crate::{error::Error, helpers::Direction, protocol::RecordId};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
@@ -10,15 +10,15 @@ use futures::future::{try_join, try_join_all};
 
 /// Trait for reveal protocol to open a shared secret to all helpers inside the MPC ring.
 #[async_trait]
-pub trait Reveal<F: Field> {
+pub trait Reveal<V: SharedValue + ArithmeticOps> {
     /// Secret sharing type that reveal implementation works with. Note that field type does not
     /// matter - implementations must be able to reveal secret value from any field.
-    type Share: SecretSharing<F>;
+    type Share: SecretSharing<V>;
 
     /// reveal the secret to all helpers in MPC circuit. Note that after method is called,
     /// it must be assumed that the secret value has been revealed to at least one of the helpers.
     /// Even in case when method never terminates, returns an error, etc.
-    async fn reveal(self, record: RecordId, input: &Self::Share) -> Result<F, Error>;
+    async fn reveal(self, record: RecordId, input: &Self::Share) -> Result<V, Error>;
 }
 
 /// This implements a semi-honest reveal algorithm for replicated secret sharing.

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -1,8 +1,8 @@
 use std::iter::{repeat, zip};
 
-use crate::ff::{ArithmeticOps, Field};
+use crate::ff::Field;
 use crate::protocol::context::{Context, MaliciousContext, SemiHonestContext};
-use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing, SharedValue};
+use crate::secret_sharing::{ArithmeticShare, MaliciousReplicated, Replicated, SecretSharing};
 use crate::{error::Error, helpers::Direction, protocol::RecordId};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
@@ -10,7 +10,7 @@ use futures::future::{try_join, try_join_all};
 
 /// Trait for reveal protocol to open a shared secret to all helpers inside the MPC ring.
 #[async_trait]
-pub trait Reveal<V: SharedValue + ArithmeticOps> {
+pub trait Reveal<V: ArithmeticShare> {
     /// Secret sharing type that reveal implementation works with. Note that field type does not
     /// matter - implementations must be able to reveal secret value from any field.
     type Share: SecretSharing<V>;

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,9 +1,9 @@
 use crate::error::Error;
-use crate::ff::{Field, Int};
+use crate::ff::{ArithmeticOps, Field, Int};
 use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple};
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{Replicated, SecretSharing, XorReplicated};
+use crate::secret_sharing::{Replicated, SecretSharing, SharedValue, XorReplicated};
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -12,8 +12,8 @@ mod malicious;
 mod semi_honest;
 
 #[async_trait]
-pub trait RandomBits<F: Field> {
-    type Share: SecretSharing<F>;
+pub trait RandomBits<V: SharedValue + ArithmeticOps> {
+    type Share: SecretSharing<V>;
 
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error>;
 }

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,9 +1,9 @@
 use crate::error::Error;
-use crate::ff::{ArithmeticOps, Field, Int};
+use crate::ff::{Field, Int};
 use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple};
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{Replicated, SecretSharing, SharedValue, XorReplicated};
+use crate::secret_sharing::{ArithmeticShare, Replicated, SecretSharing, XorReplicated};
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -12,7 +12,7 @@ mod malicious;
 mod semi_honest;
 
 #[async_trait]
-pub trait RandomBits<V: SharedValue + ArithmeticOps> {
+pub trait RandomBits<V: ArithmeticShare> {
     type Share: SecretSharing<V>;
 
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error>;

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,10 +1,9 @@
-use crate::ff::ArithmeticOps;
 use crate::helpers::messaging::Mesh;
 use crate::helpers::Role;
 use crate::protocol::basics::{Reveal, SecureMul};
 
 use crate::protocol::{Step, Substep};
-use crate::secret_sharing::{SecretSharing, SharedValue};
+use crate::secret_sharing::{ArithmeticShare, SecretSharing};
 
 mod malicious;
 mod prss;
@@ -20,7 +19,7 @@ use super::boolean::RandomBits;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
 /// generator and communication channel.
-pub trait Context<V: SharedValue + ArithmeticOps>:
+pub trait Context<V: ArithmeticShare>:
     SecureMul<V, Share = <Self as Context<V>>::Share>
     + Reshare<V, Share = <Self as Context<V>>::Share>
     + Reveal<V, Share = <Self as Context<V>>::Share>

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,10 +1,10 @@
-use crate::ff::Field;
+use crate::ff::ArithmeticOps;
 use crate::helpers::messaging::Mesh;
 use crate::helpers::Role;
 use crate::protocol::basics::{Reveal, SecureMul};
 
 use crate::protocol::{Step, Substep};
-use crate::secret_sharing::SecretSharing;
+use crate::secret_sharing::{SecretSharing, SharedValue};
 
 mod malicious;
 mod prss;
@@ -20,17 +20,17 @@ use super::boolean::RandomBits;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
 /// generator and communication channel.
-pub trait Context<F: Field>:
-    SecureMul<F, Share = <Self as Context<F>>::Share>
-    + Reshare<F, Share = <Self as Context<F>>::Share>
-    + Reveal<F, Share = <Self as Context<F>>::Share>
-    + RandomBits<F, Share = <Self as Context<F>>::Share>
+pub trait Context<V: SharedValue + ArithmeticOps>:
+    SecureMul<V, Share = <Self as Context<V>>::Share>
+    + Reshare<V, Share = <Self as Context<V>>::Share>
+    + Reveal<V, Share = <Self as Context<V>>::Share>
+    + RandomBits<V, Share = <Self as Context<V>>::Share>
     + Clone
     + Send
     + Sync
 {
     /// Secret sharing type this context supports.
-    type Share: SecretSharing<F>;
+    type Share: SecretSharing<V>;
 
     /// The role of this context.
     fn role(&self) -> Role;
@@ -72,7 +72,7 @@ pub trait Context<F: Field>:
     fn mesh(&self) -> Mesh<'_, '_>;
 
     /// Generates a new share of one
-    fn share_of_one(&self) -> <Self as Context<F>>::Share;
+    fn share_of_one(&self) -> <Self as Context<V>>::Share;
 }
 
 #[cfg(test)]

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,7 +1,8 @@
 use std::iter::{repeat, zip};
 
+use crate::ff::ArithmeticOps;
 use crate::repeat64str;
-use crate::secret_sharing::{Replicated, SecretSharing};
+use crate::secret_sharing::{Replicated, SecretSharing, SharedValue};
 use crate::{
     error::Error,
     ff::Field,
@@ -19,12 +20,12 @@ use crate::protocol::sort::{
 };
 
 #[async_trait]
-pub trait Resharable<F: Field>: Sized {
-    type Share: SecretSharing<F>;
+pub trait Resharable<V: SharedValue + ArithmeticOps>: Sized {
+    type Share: SecretSharing<V>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
-        C: Context<F, Share = <Self as Resharable<F>>::Share> + Send;
+        C: Context<V, Share = <Self as Resharable<V>>::Share> + Send;
 }
 
 pub struct InnerVectorElementStep(usize);

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,8 +1,7 @@
 use std::iter::{repeat, zip};
 
-use crate::ff::ArithmeticOps;
 use crate::repeat64str;
-use crate::secret_sharing::{Replicated, SecretSharing, SharedValue};
+use crate::secret_sharing::{ArithmeticShare, Replicated, SecretSharing};
 use crate::{
     error::Error,
     ff::Field,
@@ -20,7 +19,7 @@ use crate::protocol::sort::{
 };
 
 #[async_trait]
-pub trait Resharable<V: SharedValue + ArithmeticOps>: Sized {
+pub trait Resharable<V: ArithmeticShare>: Sized {
     type Share: SecretSharing<V>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -15,14 +15,16 @@ use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 pub use xor::XorReplicated;
 
+pub trait SharedValue: Clone + Copy + PartialEq + Debug + Send + Sync + Sized + 'static {}
+
 /// Secret share of a secret has additive and multiplicative properties.
-pub trait SecretSharing<F>:
+pub trait SecretSharing<V: SharedValue>:
     for<'a> Add<&'a Self, Output = Self>
     + for<'a> AddAssign<&'a Self>
     + Neg<Output = Self>
     + for<'a> Sub<&'a Self, Output = Self>
     + for<'a> SubAssign<&'a Self>
-    + Mul<F, Output = Self>
+    + Mul<V, Output = Self>
     + Clone
     + Debug
     + Sized

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -5,7 +5,8 @@ mod xor;
 #[cfg(any(feature = "test-fixture", feature = "cli"))]
 pub use into_shares::IntoShares;
 
-use crate::ff::Field;
+use crate::bits::BooleanOps;
+use crate::ff::{ArithmeticOps, Field};
 pub use malicious_replicated::{Downgrade as DowngradeMalicious, MaliciousReplicated};
 pub(crate) use malicious_replicated::{
     ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
@@ -15,7 +16,22 @@ use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 pub use xor::XorReplicated;
 
-pub trait SharedValue: Clone + Copy + PartialEq + Debug + Send + Sync + Sized + 'static {}
+pub trait SharedValue: Clone + Copy + PartialEq + Debug + Send + Sync + Sized + 'static {
+    /// Number of bits stored in this data type.
+    const BITS: u32;
+
+    /// Size of this data type in bytes. This is the size in memory allocated
+    /// for this data type to store the number of bits specified by `BITS`.
+    const SIZE_IN_BYTES: usize;
+}
+
+pub trait ArithmeticShare: SharedValue + ArithmeticOps {}
+
+pub trait BooleanShare: SharedValue + BooleanOps {}
+
+impl<T> ArithmeticShare for T where T: SharedValue + ArithmeticOps {}
+
+impl<T> BooleanShare for T where T: SharedValue + BooleanOps {}
 
 /// Secret share of a secret has additive and multiplicative properties.
 pub trait SecretSharing<V: SharedValue>:


### PR DESCRIPTION
## Overview
Another refactoring towards supporting XOR replicated shares (see the diagram below for the overall design). This diff adds a new intermediate trait for secret shared values i.e., fields, bit arrays, that helps abstract away the implementations of the secrets from contexts and context dependent protocols such as `SecureMul` (red box in the diagram).

For now, I bounded the context to `Context<V: SharedValue + ArithmeticOps>`, basically equivalent to `F: Field` leaving the current behavior intact.

## Design
![Untitled-2022-12-08-1530](https://user-images.githubusercontent.com/8149758/210496454-9d2258d8-2fb7-499b-8893-883fccb46e98.png)
