### PR TITLE
Enable concurrency testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,5 @@ jobs:
       - name: Run Tests
         run: cargo test
 
-# Uncomment once infra bugs are fixed: https://github.com/private-attribution/ipa/issues/256
-#      - name: Run concurrency tests
-#        run: cargo test --features shuttle
+      - name: Run concurrency tests
+        run: cargo test --features shuttle

--- a/pre-commit
+++ b/pre-commit
@@ -51,3 +51,5 @@ cargo clippy --tests -- -D warnings || error "Clippy errors"
 cargo clippy --tests --features shuttle -- -D warnings || error "Clippy concurrency tests errors"
 
 cargo test || error "Test failures"
+
+cargo test --features shuttle || error "Concurrency test failures"

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -86,7 +86,7 @@ impl BufRead for InputSource {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::cli::playbook::input::InputItem;
     use crate::ff::{Fp31, Fp32BitPrime};

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -131,7 +131,7 @@ impl<'p> HttpHelper<'p> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod e2e_tests {
     use super::*;
     use crate::secret_sharing::IntoShares;

--- a/src/helpers/http/network.rs
+++ b/src/helpers/http/network.rs
@@ -119,7 +119,7 @@ impl Network for HttpNetwork {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/helpers/http/prss_exchange_protocol.rs
+++ b/src/helpers/http/prss_exchange_protocol.rs
@@ -123,8 +123,8 @@ impl PublicKeyBytesBuilder {
     }
 }
 
-#[cfg(test)]
-mod test {
+#[cfg(all(test, not(feature = "shuttle")))]
+mod tests {
     use super::*;
     use rand::thread_rng;
     use x25519_dalek::EphemeralSecret;

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -336,10 +336,8 @@ pub(crate) mod tests {
     use super::super::tests::{BD, H};
     use super::{aggregate_credit, sort_by_breakdown_key};
     use crate::ff::{Field, Fp31};
-    use crate::protocol::attribution::accumulate_credit::tests::AttributionTestInput;
-    use crate::protocol::attribution::{
-        AggregateCreditOutputRow, CappedCreditsWithAggregationBit, CreditCappingOutputRow,
-    };
+    use crate::protocol::attribution::accumulate_credit::input::AttributionTestInput;
+    use crate::protocol::attribution::{CappedCreditsWithAggregationBit, CreditCappingOutputRow};
     use crate::rand::Rng;
     use crate::secret_sharing::{IntoShares, Replicated};
     use crate::test_fixture::{Reconstruct, Runner, TestWorld};
@@ -368,26 +366,6 @@ pub(crate) mod tests {
                     credit: c2,
                 },
             ]
-        }
-    }
-
-    impl<F: Field> Reconstruct<AttributionTestInput<F>> for [AggregateCreditOutputRow<F>; 3] {
-        fn reconstruct(&self) -> AttributionTestInput<F> {
-            [&self[0], &self[1], &self[2]].reconstruct()
-        }
-    }
-
-    impl<F: Field> Reconstruct<AttributionTestInput<F>> for [&AggregateCreditOutputRow<F>; 3] {
-        fn reconstruct(&self) -> AttributionTestInput<F> {
-            let s0 = &self[0];
-            let s1 = &self[1];
-            let s2 = &self[2];
-
-            let breakdown_key =
-                (&s0.breakdown_key, &s1.breakdown_key, &s2.breakdown_key).reconstruct();
-            let credit = (&s0.credit, &s1.credit, &s2.credit).reconstruct();
-
-            AttributionTestInput([breakdown_key, credit, F::ZERO, F::ZERO])
         }
     }
 

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -308,7 +308,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::super::tests::generate_shared_input;
     use crate::{

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -152,7 +152,7 @@ impl AsRef<str> for AttributionResharableStep {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::secret_sharing::IntoShares;
     use crate::{ff::Field, protocol::attribution::AttributionInputRow};

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -180,7 +180,7 @@ impl MultiplyWork for MultiplyZeroPositions {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 pub(in crate::protocol) mod test {
     use crate::secret_sharing::IntoShares;
     use crate::{

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -59,7 +59,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::test_fixture::Runner;
     use crate::{

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -201,7 +201,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::BitwiseLessThanPrime;
     use crate::test_fixture::Runner;

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -74,7 +74,7 @@ pub trait Context<V: ArithmeticShare>:
     fn share_of_one(&self) -> <Self as Context<V>>::Share;
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::ff::{Field, Fp31};
     use crate::helpers::Direction;

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -43,7 +43,7 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
 
-    use crate::protocol::attribution::accumulate_credit::tests::AttributionTestInput;
+    use crate::protocol::attribution::accumulate_credit::input::AttributionTestInput;
     use crate::protocol::attribution::AttributionInputRow;
     use crate::protocol::context::Context;
     use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -167,7 +167,7 @@ mod tests {
         use crate::rand::{thread_rng, Rng};
 
         use crate::ff::{Fp31, Fp32BitPrime};
-        use crate::protocol::attribution::accumulate_credit::tests::AttributionTestInput;
+        use crate::protocol::attribution::accumulate_credit::input::AttributionTestInput;
         use crate::protocol::context::Context;
         use crate::protocol::sort::apply_sort::shuffle::shuffle_shares;
         use crate::protocol::sort::shuffle::get_two_of_three_random_permutations;

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -1,134 +1,131 @@
-#[cfg(all(feature = "shuttle", test))]
-mod randomized {
-    use crate::ff::Fp32BitPrime;
-    use crate::helpers::Direction;
-    use crate::protocol::context::{Context, SemiHonestContext};
-    use crate::protocol::RecordId;
-    use crate::secret_sharing::Replicated;
-    use crate::test_fixture::Reconstruct;
-    use crate::test_fixture::{Runner, TestWorld};
-    use futures_util::future::{try_join, try_join_all};
+#![cfg(all(feature = "shuttle", test))]
 
-    #[test]
-    fn send_receive_sequential() {
-        shuttle::check_random(
-            || {
-                shuttle::future::block_on(async {
-                    let world = TestWorld::new().await;
-                    let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
+use crate::ff::Fp32BitPrime;
+use crate::helpers::Direction;
+use crate::protocol::context::{Context, SemiHonestContext};
+use crate::protocol::RecordId;
+use crate::secret_sharing::Replicated;
+use crate::test_fixture::Reconstruct;
+use crate::test_fixture::{Runner, TestWorld};
+use futures_util::future::{try_join, try_join_all};
 
-                    let output = world
-                        .semi_honest(
-                            input.clone(),
-                            |ctx: SemiHonestContext<'_, Fp32BitPrime>, mut shares| async move {
-                                let (left_ctx, right_ctx) =
-                                    (ctx.narrow("left"), ctx.narrow("right"));
-                                let left_channel = left_ctx.mesh();
-                                let right_channel = right_ctx.mesh();
-                                let left_peer = ctx.role().peer(Direction::Left);
-                                let right_peer = ctx.role().peer(Direction::Right);
+#[test]
+fn send_receive_sequential() {
+    shuttle::check_random(
+        || {
+            shuttle::future::block_on(async {
+                let world = TestWorld::new().await;
+                let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
 
-                                // send all shares to the right peer
-                                for (i, share) in shares.iter().enumerate() {
-                                    let record_id = RecordId::from(i);
-                                    left_channel
-                                        .send(right_peer, record_id, share.left())
-                                        .await
-                                        .unwrap();
-                                    right_channel
-                                        .send(right_peer, record_id, share.right())
-                                        .await
-                                        .unwrap();
-                                }
+                let output = world
+                    .semi_honest(
+                        input.clone(),
+                        |ctx: SemiHonestContext<'_, Fp32BitPrime>, mut shares| async move {
+                            let (left_ctx, right_ctx) = (ctx.narrow("left"), ctx.narrow("right"));
+                            let left_channel = left_ctx.mesh();
+                            let right_channel = right_ctx.mesh();
+                            let left_peer = ctx.role().peer(Direction::Left);
+                            let right_peer = ctx.role().peer(Direction::Right);
 
-                                // receive all shares from the left peer
-                                for (i, share) in shares.iter_mut().enumerate() {
-                                    let record_id = RecordId::from(i);
-                                    let left: Fp32BitPrime =
-                                        left_channel.receive(left_peer, record_id).await.unwrap();
-                                    let right: Fp32BitPrime =
-                                        right_channel.receive(left_peer, record_id).await.unwrap();
-
-                                    *share = Replicated::new(left, right);
-                                }
-
-                                // each helper just swapped their shares, i.e. H1 now holds
-                                // H3 shares, H2 holds H1 shares, etc.
-                                shares
-                            },
-                        )
-                        .await
-                        .reconstruct();
-
-                    assert_eq!(input, output);
-                });
-            },
-            1000,
-        );
-    }
-
-    #[test]
-    fn send_receive_parallel() {
-        shuttle::check_random(
-            || {
-                shuttle::future::block_on(async {
-                    let world = TestWorld::new().await;
-                    let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
-
-                    let output = world
-                        .semi_honest(
-                            input.clone(),
-                            |ctx: SemiHonestContext<'_, Fp32BitPrime>, shares| async move {
-                                let (left_ctx, right_ctx) =
-                                    (ctx.narrow("left"), ctx.narrow("right"));
-                                let left_channel = left_ctx.mesh();
-                                let right_channel = right_ctx.mesh();
-                                let left_peer = ctx.role().peer(Direction::Left);
-                                let right_peer = ctx.role().peer(Direction::Right);
-
-                                // send all shares to the right peer in parallel
-                                let mut futures = Vec::with_capacity(shares.len());
-                                for (i, share) in shares.iter().enumerate() {
-                                    let record_id = RecordId::from(i);
-                                    futures.push(left_channel.send(
-                                        right_peer,
-                                        record_id,
-                                        share.left(),
-                                    ));
-                                    futures.push(right_channel.send(
-                                        right_peer,
-                                        record_id,
-                                        share.right(),
-                                    ));
-                                }
-                                try_join_all(futures)
+                            // send all shares to the right peer
+                            for (i, share) in shares.iter().enumerate() {
+                                let record_id = RecordId::from(i);
+                                left_channel
+                                    .send(right_peer, record_id, share.left())
                                     .await
-                                    .unwrap()
-                                    .into_iter()
-                                    .for_each(drop);
+                                    .unwrap();
+                                right_channel
+                                    .send(right_peer, record_id, share.right())
+                                    .await
+                                    .unwrap();
+                            }
 
-                                // receive all shares from the left peer in parallel
-                                let mut futures = Vec::with_capacity(shares.len());
-                                for i in 0..shares.len() {
-                                    let record_id = RecordId::from(i);
-                                    futures.push(try_join(
-                                        left_channel.receive::<Fp32BitPrime>(left_peer, record_id),
-                                        right_channel.receive::<Fp32BitPrime>(left_peer, record_id),
-                                    ));
-                                }
+                            // receive all shares from the left peer
+                            for (i, share) in shares.iter_mut().enumerate() {
+                                let record_id = RecordId::from(i);
+                                let left: Fp32BitPrime =
+                                    left_channel.receive(left_peer, record_id).await.unwrap();
+                                let right: Fp32BitPrime =
+                                    right_channel.receive(left_peer, record_id).await.unwrap();
 
-                                let result = try_join_all(futures).await.unwrap();
+                                *share = Replicated::new(left, right);
+                            }
 
-                                result.into_iter().map(Replicated::from).collect::<Vec<_>>()
-                            },
-                        )
-                        .await
-                        .reconstruct();
+                            // each helper just swapped their shares, i.e. H1 now holds
+                            // H3 shares, H2 holds H1 shares, etc.
+                            shares
+                        },
+                    )
+                    .await
+                    .reconstruct();
 
-                    assert_eq!(input, output);
-                });
-            },
-            1000,
-        );
-    }
+                assert_eq!(input, output);
+            })
+        },
+        1000,
+    );
+}
+
+#[test]
+fn send_receive_parallel() {
+    shuttle::check_random(
+        || {
+            shuttle::future::block_on(async {
+                let world = TestWorld::new().await;
+                let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
+
+                let output = world
+                    .semi_honest(
+                        input.clone(),
+                        |ctx: SemiHonestContext<'_, Fp32BitPrime>, shares| async move {
+                            let (left_ctx, right_ctx) = (ctx.narrow("left"), ctx.narrow("right"));
+                            let left_channel = left_ctx.mesh();
+                            let right_channel = right_ctx.mesh();
+                            let left_peer = ctx.role().peer(Direction::Left);
+                            let right_peer = ctx.role().peer(Direction::Right);
+
+                            // send all shares to the right peer in parallel
+                            let mut futures = Vec::with_capacity(shares.len());
+                            for (i, share) in shares.iter().enumerate() {
+                                let record_id = RecordId::from(i);
+                                futures.push(left_channel.send(
+                                    right_peer,
+                                    record_id,
+                                    share.left(),
+                                ));
+                                futures.push(right_channel.send(
+                                    right_peer,
+                                    record_id,
+                                    share.right(),
+                                ));
+                            }
+                            try_join_all(futures)
+                                .await
+                                .unwrap()
+                                .into_iter()
+                                .for_each(drop);
+
+                            // receive all shares from the left peer in parallel
+                            let mut futures = Vec::with_capacity(shares.len());
+                            for i in 0..shares.len() {
+                                let record_id = RecordId::from(i);
+                                futures.push(try_join(
+                                    left_channel.receive::<Fp32BitPrime>(left_peer, record_id),
+                                    right_channel.receive::<Fp32BitPrime>(left_peer, record_id),
+                                ));
+                            }
+
+                            let result = try_join_all(futures).await.unwrap();
+
+                            result.into_iter().map(Replicated::from).collect::<Vec<_>>()
+                        },
+                    )
+                    .await
+                    .reconstruct();
+
+                assert_eq!(input, output);
+            })
+        },
+        1000,
+    );
 }

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -60,7 +60,7 @@ fn send_receive_sequential() {
                     .reconstruct();
 
                 assert_eq!(input, output);
-            })
+            });
         },
         1000,
     );
@@ -124,7 +124,7 @@ fn send_receive_parallel() {
                     .reconstruct();
 
                 assert_eq!(input, output);
-            })
+            });
         },
         1000,
     );

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -15,7 +15,7 @@ mod randomized {
             || {
                 shuttle::future::block_on(async {
                     let world = TestWorld::new().await;
-                    let input = (0u32..100).map(Fp32BitPrime::from).collect::<Vec<_>>();
+                    let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
 
                     let output = world
                         .semi_honest(
@@ -73,7 +73,7 @@ mod randomized {
             || {
                 shuttle::future::block_on(async {
                     let world = TestWorld::new().await;
-                    let input = (0u32..10).map(Fp32BitPrime::from).collect::<Vec<_>>();
+                    let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
 
                     let output = world
                         .semi_honest(
@@ -98,7 +98,7 @@ mod randomized {
                                     futures.push(right_channel.send(
                                         right_peer,
                                         record_id,
-                                        share.left(),
+                                        share.right(),
                                     ));
                                 }
                                 try_join_all(futures)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod infra;
+mod protocol;

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -40,7 +40,7 @@ fn semi_honest_ipa() {
                     .reconstruct();
 
                 assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
-            })
+            });
         },
         10,
     );

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -10,11 +10,11 @@ fn semi_honest_ipa() {
     shuttle::check_random(
         || {
             shuttle::future::block_on(async {
-                const BATCHSIZE: usize = 20;
+                const BATCHSIZE: usize = 5;
                 const PER_USER_CAP: u32 = 10;
                 const MAX_BREAKDOWN_KEY: u128 = 8;
                 const MAX_TRIGGER_VALUE: u128 = 5;
-                let max_match_key: u64 = BATCHSIZE as u64 / 10;
+                let max_match_key: u64 = 3;
 
                 let world = TestWorld::new().await;
                 let mut rng = thread_rng();
@@ -42,6 +42,6 @@ fn semi_honest_ipa() {
                 assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
             })
         },
-        2,
+        10,
     );
 }

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -1,0 +1,54 @@
+#[cfg(all(feature = "shuttle", test))]
+mod randomized {
+    use crate::ff::Fp32BitPrime;
+    use crate::protocol::ipa::ipa;
+    use crate::rand::thread_rng;
+    use crate::test_fixture::{IPAInputTestRow, Reconstruct, Runner, TestWorld};
+
+    #[test]
+    fn semi_honest_ipa() {
+        shuttle::check_random(
+            || {
+                shuttle::future::block_on(async {
+                    const BATCHSIZE: usize = 20;
+                    const PER_USER_CAP: u32 = 10;
+                    const MAX_BREAKDOWN_KEY: u128 = 8;
+                    const MAX_TRIGGER_VALUE: u128 = 5;
+                    let max_match_key: u64 = BATCHSIZE as u64 / 10;
+
+                    let world = TestWorld::new().await;
+                    let mut rng = thread_rng();
+
+                    let records = (0..BATCHSIZE)
+                        .map(|_| {
+                            IPAInputTestRow::random(
+                                &mut rng,
+                                max_match_key,
+                                MAX_BREAKDOWN_KEY,
+                                MAX_TRIGGER_VALUE,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+
+                    let result = world
+                        .semi_honest(records, |ctx, input_rows| async move {
+                            ipa::<Fp32BitPrime>(
+                                ctx,
+                                &input_rows,
+                                20,
+                                PER_USER_CAP,
+                                MAX_BREAKDOWN_KEY,
+                            )
+                            .await
+                            .unwrap()
+                        })
+                        .await
+                        .reconstruct();
+
+                    assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
+                });
+            },
+            2,
+        );
+    }
+}

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -1,54 +1,47 @@
-#[cfg(all(feature = "shuttle", test))]
-mod randomized {
-    use crate::ff::Fp32BitPrime;
-    use crate::protocol::ipa::ipa;
-    use crate::rand::thread_rng;
-    use crate::test_fixture::{IPAInputTestRow, Reconstruct, Runner, TestWorld};
+#![cfg(all(feature = "shuttle", test))]
 
-    #[test]
-    fn semi_honest_ipa() {
-        shuttle::check_random(
-            || {
-                shuttle::future::block_on(async {
-                    const BATCHSIZE: usize = 20;
-                    const PER_USER_CAP: u32 = 10;
-                    const MAX_BREAKDOWN_KEY: u128 = 8;
-                    const MAX_TRIGGER_VALUE: u128 = 5;
-                    let max_match_key: u64 = BATCHSIZE as u64 / 10;
+use crate::ff::Fp32BitPrime;
+use crate::protocol::ipa::ipa;
+use crate::rand::thread_rng;
+use crate::test_fixture::{IPAInputTestRow, Reconstruct, Runner, TestWorld};
 
-                    let world = TestWorld::new().await;
-                    let mut rng = thread_rng();
+#[test]
+fn semi_honest_ipa() {
+    shuttle::check_random(
+        || {
+            shuttle::future::block_on(async {
+                const BATCHSIZE: usize = 20;
+                const PER_USER_CAP: u32 = 10;
+                const MAX_BREAKDOWN_KEY: u128 = 8;
+                const MAX_TRIGGER_VALUE: u128 = 5;
+                let max_match_key: u64 = BATCHSIZE as u64 / 10;
 
-                    let records = (0..BATCHSIZE)
-                        .map(|_| {
-                            IPAInputTestRow::random(
-                                &mut rng,
-                                max_match_key,
-                                MAX_BREAKDOWN_KEY,
-                                MAX_TRIGGER_VALUE,
-                            )
-                        })
-                        .collect::<Vec<_>>();
+                let world = TestWorld::new().await;
+                let mut rng = thread_rng();
 
-                    let result = world
-                        .semi_honest(records, |ctx, input_rows| async move {
-                            ipa::<Fp32BitPrime>(
-                                ctx,
-                                &input_rows,
-                                20,
-                                PER_USER_CAP,
-                                MAX_BREAKDOWN_KEY,
-                            )
+                let records = (0..BATCHSIZE)
+                    .map(|_| {
+                        IPAInputTestRow::random(
+                            &mut rng,
+                            max_match_key,
+                            MAX_BREAKDOWN_KEY,
+                            MAX_TRIGGER_VALUE,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                let result = world
+                    .semi_honest(records, |ctx, input_rows| async move {
+                        ipa::<Fp32BitPrime>(ctx, &input_rows, 20, PER_USER_CAP, MAX_BREAKDOWN_KEY)
                             .await
                             .unwrap()
-                        })
-                        .await
-                        .reconstruct();
+                    })
+                    .await
+                    .reconstruct();
 
-                    assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
-                });
-            },
-            2,
-        );
-    }
+                assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
+            })
+        },
+        2,
+    );
 }


### PR DESCRIPTION
I finally found the bug that was blocking shuttle tests. The issue outlined in #256 was fixed in
#363 but there was another bug inside the concurrency test itself. This change fixes it and enables concurrency testing as part of PR workflow approval.

It also adds a test for semi-honest IPA but given that it is incredibly slow, it only runs it for 2 iterations. Once we improve the IPA latency, number of iterations can be increased. 