### PR TITLE
Rename `Replicated`

### DIFF
--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -32,12 +32,10 @@ pub struct BitArray64(U8_8);
 impl SharedValue for BitArray64 {
     const SIZE_IN_BYTES: usize = std::mem::size_of::<Self>();
     const BITS: u32 = 64;
+    const ZERO: Self = Self(U8_8::ZERO);
 }
 
 impl BitArray for BitArray64 {
-    #[allow(dead_code)]
-    const ZERO: Self = Self(U8_8::ZERO);
-
     fn truncate_from<T: Into<u128>>(v: T) -> Self {
         Self(U8_8::new(
             v.into().to_le_bytes()[0..<Self as SharedValue>::SIZE_IN_BYTES]

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -8,9 +8,6 @@ pub use bit_array::BitArray64;
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`
 pub trait BitArray: BooleanShare + TryFrom<u128> + Index<usize> {
-    /// A bit array with all its elements initialized to 0.
-    const ZERO: Self;
-
     /// Truncates the higher-order bits larger than `Self::BITS`, and converts
     /// into this data type. This conversion is lossy. Callers are encouraged
     /// to use `try_from` if the input is not known in advance.

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -1,6 +1,6 @@
 use crate::cli::playbook::InputSource;
 use crate::ff::Field;
-use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
+use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
 use std::fmt::Debug;
 
 /// Secure multiplication. Each input must be a valid tuple of field values.
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 #[allow(clippy::unused_async)] // soon it will be used
 pub async fn secure_mul<F>(input: InputSource) -> [Vec<impl Send + Debug>; 3]
 where
-    F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
+    F: Field + IntoShares<Replicated<F>>,
 {
     // TODO: inputs are ready, send them to helpers once query API is ready
     // for now, just print them to make sure sharing works

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -1,6 +1,6 @@
 use crate::cli::playbook::InputSource;
 use crate::ff::Field;
-use crate::secret_sharing::{IntoShares, Replicated};
+use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
 use std::fmt::Debug;
 
 /// Secure multiplication. Each input must be a valid tuple of field values.
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 #[allow(clippy::unused_async)] // soon it will be used
 pub async fn secure_mul<F>(input: InputSource) -> [Vec<impl Send + Debug>; 3]
 where
-    F: Field + IntoShares<Replicated<F>>,
+    F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
 {
     // TODO: inputs are ready, send them to helpers once query API is ready
     // for now, just print them to make sure sharing works

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -23,7 +23,6 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     type Integer: Int;
 
     const PRIME: Self::Integer;
-
     /// Multiplicative identity element
     const ONE: Self;
 

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -23,8 +23,7 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     type Integer: Int;
 
     const PRIME: Self::Integer;
-    /// Additive identity element
-    const ZERO: Self;
+
     /// Multiplicative identity element
     const ONE: Self;
 

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -11,13 +11,13 @@ macro_rules! field_impl {
         impl Field for $field {
             type Integer = $int;
             const PRIME: Self::Integer = $prime;
-            const ZERO: Self = $field(0);
             const ONE: Self = $field(1);
         }
 
         impl SharedValue for $field {
             const BITS: u32 = <Self as Field>::Integer::BITS;
             const SIZE_IN_BYTES: usize = (Self::BITS / 8) as usize;
+            const ZERO: Self = $field(0);
         }
 
         impl std::ops::Add for $field {

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -12,7 +12,7 @@ use crate::protocol::context::Context;
 use crate::protocol::context::SemiHonestContext;
 use crate::protocol::sort::apply_sort::shuffle::Resharable;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
 use std::iter::repeat;
@@ -40,7 +40,7 @@ impl AsRef<str> for Step {
 
 #[async_trait]
 impl<F: Field> Resharable<F> for AttributionInputRow<F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
@@ -182,11 +182,11 @@ pub async fn accumulate_credit<F: Field>(
 async fn compute_b_bit<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    current_stop_bit: &Replicated<F>,
-    sibling_helper_bit: &Replicated<F>,
-    sibling_is_trigger_bit: &Replicated<F>,
+    current_stop_bit: &ReplicatedAdditiveShares<F>,
+    sibling_helper_bit: &ReplicatedAdditiveShares<F>,
+    sibling_is_trigger_bit: &ReplicatedAdditiveShares<F>,
     first_iteration: bool,
-) -> Result<Replicated<F>, Error> {
+) -> Result<ReplicatedAdditiveShares<F>, Error> {
     // Compute `b = current_stop_bit * sibling_helper_bit * sibling_trigger_bit`.
     // Since `current_stop_bit` is initialized with 1, we only multiply it in
     // the second and later iterations.
@@ -209,7 +209,7 @@ async fn compute_b_bit<F: Field>(
 pub mod input {
     use crate::ff::{Field, Fp31};
     use crate::protocol::attribution::{AggregateCreditOutputRow, AttributionInputRow};
-    use crate::secret_sharing::{IntoShares, Replicated};
+    use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
     use crate::test_fixture::Reconstruct;
     use rand::distributions::{Distribution, Standard};
     use rand::Rng;
@@ -219,7 +219,7 @@ pub mod input {
 
     impl<F> IntoShares<AttributionInputRow<F>> for AttributionTestInput<F>
     where
-        F: Field + IntoShares<Replicated<F>>,
+        F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
         Standard: Distribution<F>,
     {
         fn share_with<R: Rng>(self, rng: &mut R) -> [AttributionInputRow<F>; 3] {

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -12,7 +12,7 @@ use crate::protocol::context::Context;
 use crate::protocol::context::SemiHonestContext;
 use crate::protocol::sort::apply_sort::shuffle::Resharable;
 use crate::protocol::RecordId;
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
 use std::iter::repeat;
@@ -40,7 +40,7 @@ impl AsRef<str> for Step {
 
 #[async_trait]
 impl<F: Field> Resharable<F> for AttributionInputRow<F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
@@ -182,11 +182,11 @@ pub async fn accumulate_credit<F: Field>(
 async fn compute_b_bit<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    current_stop_bit: &ReplicatedAdditiveShares<F>,
-    sibling_helper_bit: &ReplicatedAdditiveShares<F>,
-    sibling_is_trigger_bit: &ReplicatedAdditiveShares<F>,
+    current_stop_bit: &Replicated<F>,
+    sibling_helper_bit: &Replicated<F>,
+    sibling_is_trigger_bit: &Replicated<F>,
     first_iteration: bool,
-) -> Result<ReplicatedAdditiveShares<F>, Error> {
+) -> Result<Replicated<F>, Error> {
     // Compute `b = current_stop_bit * sibling_helper_bit * sibling_trigger_bit`.
     // Since `current_stop_bit` is initialized with 1, we only multiply it in
     // the second and later iterations.
@@ -209,7 +209,7 @@ async fn compute_b_bit<F: Field>(
 pub mod input {
     use crate::ff::{Field, Fp31};
     use crate::protocol::attribution::{AggregateCreditOutputRow, AttributionInputRow};
-    use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
+    use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
     use crate::test_fixture::Reconstruct;
     use rand::distributions::{Distribution, Standard};
     use rand::Rng;
@@ -219,7 +219,7 @@ pub mod input {
 
     impl<F> IntoShares<AttributionInputRow<F>> for AttributionTestInput<F>
     where
-        F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
+        F: Field + IntoShares<Replicated<F>>,
         Standard: Distribution<F>,
     {
         fn share_with<R: Rng>(self, rng: &mut R) -> [AttributionInputRow<F>; 3] {

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -16,14 +16,14 @@ use crate::protocol::sort::apply_sort::apply_sort_permutation;
 use crate::protocol::sort::apply_sort::shuffle::Resharable;
 use crate::protocol::sort::generate_permutation::generate_permutation_and_reveal_shuffled;
 use crate::protocol::{RecordId, Substep};
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
 use std::iter::repeat;
 
 #[async_trait]
 impl<F: Field + Sized> Resharable<F> for CappedCreditsWithAggregationBit<F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
@@ -187,7 +187,7 @@ fn add_aggregation_bits_and_breakdown_keys<F: Field>(
     capped_credits: &[CreditCappingOutputRow<F>],
     max_breakdown_key: u128,
 ) -> Vec<CappedCreditsWithAggregationBit<F>> {
-    let zero = ReplicatedAdditiveShares::ZERO;
+    let zero = Replicated::ZERO;
     let one = ctx.share_of_one();
 
     // Unique breakdown_key values with all other fields initialized with 0's.
@@ -198,7 +198,7 @@ fn add_aggregation_bits_and_breakdown_keys<F: Field>(
         .map(|i| CappedCreditsWithAggregationBit {
             helper_bit: zero.clone(),
             aggregation_bit: zero.clone(),
-            breakdown_key: ReplicatedAdditiveShares::from_scalar(ctx.role(), F::from(i)),
+            breakdown_key: Replicated::from_scalar(ctx.role(), F::from(i)),
             credit: zero.clone(),
         })
         .collect::<Vec<_>>();
@@ -222,7 +222,7 @@ fn add_aggregation_bits_and_breakdown_keys<F: Field>(
 async fn bit_decompose_breakdown_key<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CappedCreditsWithAggregationBit<F>],
-) -> Result<Vec<Vec<ReplicatedAdditiveShares<F>>>, Error> {
+) -> Result<Vec<Vec<Replicated<F>>>, Error> {
     let random_bits_generator =
         RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForBitDecomposition));
     let rbg = &random_bits_generator;
@@ -339,14 +339,16 @@ pub(crate) mod tests {
     use crate::protocol::attribution::accumulate_credit::input::AttributionTestInput;
     use crate::protocol::attribution::{CappedCreditsWithAggregationBit, CreditCappingOutputRow};
     use crate::rand::Rng;
-    use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares, SharedValue};
+    use crate::secret_sharing::{
+        replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SharedValue,
+    };
     use crate::test_fixture::{Reconstruct, Runner, TestWorld};
     use rand::{distributions::Standard, prelude::Distribution};
 
     // TODO: There are now too many xxxInputRow and yyyOutputRow. Combine them into one
     impl<F> IntoShares<CreditCappingOutputRow<F>> for AttributionTestInput<F>
     where
-        F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
+        F: Field + IntoShares<Replicated<F>>,
         Standard: Distribution<F>,
     {
         fn share_with<R: Rng>(self, rng: &mut R) -> [CreditCappingOutputRow<F>; 3] {
@@ -371,7 +373,7 @@ pub(crate) mod tests {
 
     impl<F> IntoShares<CappedCreditsWithAggregationBit<F>> for AttributionTestInput<F>
     where
-        F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
+        F: Field + IntoShares<Replicated<F>>,
         Standard: Distribution<F>,
     {
         fn share_with<R: Rng>(self, rng: &mut R) -> [CappedCreditsWithAggregationBit<F>; 3] {

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -9,7 +9,7 @@ use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
 use crate::protocol::boolean::{local_secret_shared_bits, BitDecomposition, BitwiseLessThan};
 use crate::protocol::context::{Context, SemiHonestContext};
 use crate::protocol::{RecordId, Substep};
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use futures::future::{try_join, try_join_all};
 use std::iter::{repeat, zip};
 
@@ -73,7 +73,7 @@ pub async fn credit_capping<F: Field>(
 async fn mask_source_credits<F: Field>(
     input: &[CreditCappingInputRow<F>],
     ctx: SemiHonestContext<'_, F>,
-) -> Result<Vec<Replicated<F>>, Error> {
+) -> Result<Vec<ReplicatedAdditiveShares<F>>, Error> {
     try_join_all(
         input
             .iter()
@@ -93,8 +93,8 @@ async fn mask_source_credits<F: Field>(
 async fn credit_prefix_sum<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CreditCappingInputRow<F>],
-    mut original_credits: Vec<Replicated<F>>,
-) -> Result<Vec<Replicated<F>>, Error> {
+    mut original_credits: Vec<ReplicatedAdditiveShares<F>>,
+) -> Result<Vec<ReplicatedAdditiveShares<F>>, Error> {
     let one = ctx.share_of_one();
     let mut stop_bits = repeat(one.clone()).take(input.len()).collect::<Vec<_>>();
 
@@ -164,9 +164,9 @@ async fn credit_prefix_sum<F: Field>(
 
 async fn is_credit_larger_than_cap<F: Field>(
     ctx: SemiHonestContext<'_, F>,
-    prefix_summed_credits: &[Replicated<F>],
+    prefix_summed_credits: &[ReplicatedAdditiveShares<F>],
     cap: u32,
-) -> Result<Vec<Replicated<F>>, Error> {
+) -> Result<Vec<ReplicatedAdditiveShares<F>>, Error> {
     //TODO: `cap` is publicly known value for each query. We can avoid creating shares every time.
     let cap = local_secret_shared_bits(&ctx, cap.into());
     let random_bits_generator =
@@ -208,13 +208,13 @@ async fn is_credit_larger_than_cap<F: Field>(
 async fn compute_final_credits<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CreditCappingInputRow<F>],
-    prefix_summed_credits: &[Replicated<F>],
-    exceeds_cap_bits: &[Replicated<F>],
-    original_credits: &[Replicated<F>],
+    prefix_summed_credits: &[ReplicatedAdditiveShares<F>],
+    exceeds_cap_bits: &[ReplicatedAdditiveShares<F>],
+    original_credits: &[ReplicatedAdditiveShares<F>],
     cap: u32,
-) -> Result<Vec<Replicated<F>>, Error> {
+) -> Result<Vec<ReplicatedAdditiveShares<F>>, Error> {
     let num_rows = input.len();
-    let cap = Replicated::from_scalar(ctx.role(), F::from(cap.into()));
+    let cap = ReplicatedAdditiveShares::from_scalar(ctx.role(), F::from(cap.into()));
     let mut final_credits = original_credits.to_vec();
 
     // This method implements the logic below:
@@ -250,7 +250,7 @@ async fn compute_final_credits<F: Field>(
                 ctx.narrow(&Step::IfNextExceedsCapOrElse),
                 record_id,
                 next_credit_exceeds_cap,
-                &Replicated::ZERO,
+                &ReplicatedAdditiveShares::ZERO,
                 &(cap.clone() - next_prefix_summed_credit),
             )
             .await?,

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId, Substep};
 use crate::repeat64str;
-use crate::secret_sharing::{ReplicatedAdditiveShares, SecretSharing};
+use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SecretSharing};
 
 pub(crate) mod accumulate_credit;
 pub mod aggregate_credit;
@@ -10,10 +10,10 @@ pub mod credit_capping;
 
 #[derive(Debug, Clone)]
 pub struct AttributionInputRow<F: Field> {
-    pub is_trigger_bit: ReplicatedAdditiveShares<F>,
-    pub helper_bit: ReplicatedAdditiveShares<F>,
-    pub breakdown_key: ReplicatedAdditiveShares<F>,
-    pub credit: ReplicatedAdditiveShares<F>,
+    pub is_trigger_bit: Replicated<F>,
+    pub helper_bit: Replicated<F>,
+    pub breakdown_key: Replicated<F>,
+    pub credit: Replicated<F>,
 }
 
 pub type AccumulateCreditOutputRow<F> = AttributionInputRow<F>;
@@ -21,23 +21,23 @@ pub type AccumulateCreditOutputRow<F> = AttributionInputRow<F>;
 pub type CreditCappingInputRow<F> = AccumulateCreditOutputRow<F>;
 
 pub struct CreditCappingOutputRow<F: Field> {
-    breakdown_key: ReplicatedAdditiveShares<F>,
-    credit: ReplicatedAdditiveShares<F>,
+    breakdown_key: Replicated<F>,
+    credit: Replicated<F>,
 }
 
 #[derive(Clone, Debug)]
 pub struct CappedCreditsWithAggregationBit<F: Field> {
-    helper_bit: ReplicatedAdditiveShares<F>,
-    aggregation_bit: ReplicatedAdditiveShares<F>,
-    breakdown_key: ReplicatedAdditiveShares<F>,
-    credit: ReplicatedAdditiveShares<F>,
+    helper_bit: Replicated<F>,
+    aggregation_bit: Replicated<F>,
+    breakdown_key: Replicated<F>,
+    credit: Replicated<F>,
 }
 
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct AggregateCreditOutputRow<F: Field> {
-    breakdown_key: ReplicatedAdditiveShares<F>,
-    credit: ReplicatedAdditiveShares<F>,
+    breakdown_key: Replicated<F>,
+    credit: Replicated<F>,
 }
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId, Substep};
 use crate::repeat64str;
-use crate::secret_sharing::{Replicated, SecretSharing};
+use crate::secret_sharing::{ReplicatedAdditiveShares, SecretSharing};
 
 pub(crate) mod accumulate_credit;
 pub mod aggregate_credit;
@@ -10,10 +10,10 @@ pub mod credit_capping;
 
 #[derive(Debug, Clone)]
 pub struct AttributionInputRow<F: Field> {
-    pub is_trigger_bit: Replicated<F>,
-    pub helper_bit: Replicated<F>,
-    pub breakdown_key: Replicated<F>,
-    pub credit: Replicated<F>,
+    pub is_trigger_bit: ReplicatedAdditiveShares<F>,
+    pub helper_bit: ReplicatedAdditiveShares<F>,
+    pub breakdown_key: ReplicatedAdditiveShares<F>,
+    pub credit: ReplicatedAdditiveShares<F>,
 }
 
 pub type AccumulateCreditOutputRow<F> = AttributionInputRow<F>;
@@ -21,23 +21,23 @@ pub type AccumulateCreditOutputRow<F> = AttributionInputRow<F>;
 pub type CreditCappingInputRow<F> = AccumulateCreditOutputRow<F>;
 
 pub struct CreditCappingOutputRow<F: Field> {
-    breakdown_key: Replicated<F>,
-    credit: Replicated<F>,
+    breakdown_key: ReplicatedAdditiveShares<F>,
+    credit: ReplicatedAdditiveShares<F>,
 }
 
 #[derive(Clone, Debug)]
 pub struct CappedCreditsWithAggregationBit<F: Field> {
-    helper_bit: Replicated<F>,
-    aggregation_bit: Replicated<F>,
-    breakdown_key: Replicated<F>,
-    credit: Replicated<F>,
+    helper_bit: ReplicatedAdditiveShares<F>,
+    aggregation_bit: ReplicatedAdditiveShares<F>,
+    breakdown_key: ReplicatedAdditiveShares<F>,
+    credit: ReplicatedAdditiveShares<F>,
 }
 
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct AggregateCreditOutputRow<F: Field> {
-    breakdown_key: Replicated<F>,
-    credit: Replicated<F>,
+    breakdown_key: ReplicatedAdditiveShares<F>,
+    credit: ReplicatedAdditiveShares<F>,
 }
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, RecordId},
-    secret_sharing::ReplicatedAdditiveShares,
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
 use serde::{Deserialize, Serialize};
 
@@ -64,7 +64,7 @@ impl AsRef<str> for Step {
 pub async fn check_zero<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    v: &ReplicatedAdditiveShares<F>,
+    v: &Replicated<F>,
 ) -> Result<bool, Error> {
     let r_sharing = ctx.prss().generate_replicated(record_id);
 

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, RecordId},
-    secret_sharing::Replicated,
+    secret_sharing::ReplicatedAdditiveShares,
 };
 use serde::{Deserialize, Serialize};
 
@@ -64,7 +64,7 @@ impl AsRef<str> for Step {
 pub async fn check_zero<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    v: &Replicated<F>,
+    v: &ReplicatedAdditiveShares<F>,
 ) -> Result<bool, Error> {
     let r_sharing = ctx.prss().generate_replicated(record_id);
 
@@ -87,7 +87,7 @@ mod tests {
     use crate::protocol::context::Context;
     use crate::protocol::{basics::check_zero, RecordId};
     use crate::rand::thread_rng;
-    use crate::secret_sharing::IntoShares;
+    use crate::secret_sharing::{IntoShares, SharedValue};
     use crate::test_fixture::TestWorld;
 
     #[tokio::test]

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
     context::{Context, MaliciousContext},
     RecordId,
 };
-use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -60,15 +60,15 @@ impl AsRef<str> for Step {
 pub async fn multiply<F>(
     ctx: MaliciousContext<'_, F>,
     record_id: RecordId,
-    a: &MaliciousReplicatedAdditiveShares<F>,
-    b: &MaliciousReplicatedAdditiveShares<F>,
+    a: &MaliciousReplicated<F>,
+    b: &MaliciousReplicated<F>,
     zeros_at: MultiplyZeroPositions,
-) -> Result<MaliciousReplicatedAdditiveShares<F>, Error>
+) -> Result<MaliciousReplicated<F>, Error>
 where
     F: Field,
 {
     use crate::protocol::context::SpecialAccessToMaliciousContext;
-    use crate::secret_sharing::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+    use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 
     let duplicate_multiply_ctx = ctx.narrow(&Step::DuplicateMultiply);
     let random_constant_ctx = ctx.narrow(&Step::RandomnessForValidation);
@@ -90,7 +90,7 @@ where
     )
     .await?;
 
-    let malicious_ab = MaliciousReplicatedAdditiveShares::new(ab, rab);
+    let malicious_ab = MaliciousReplicated::new(ab, rab);
     random_constant_ctx.accumulate_macs(record_id, &malicious_ab);
 
     Ok(malicious_ab)

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
     context::{Context, MaliciousContext},
     RecordId,
 };
-use crate::secret_sharing::MaliciousReplicated;
+use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -60,10 +60,10 @@ impl AsRef<str> for Step {
 pub async fn multiply<F>(
     ctx: MaliciousContext<'_, F>,
     record_id: RecordId,
-    a: &MaliciousReplicated<F>,
-    b: &MaliciousReplicated<F>,
+    a: &MaliciousReplicatedAdditiveShares<F>,
+    b: &MaliciousReplicatedAdditiveShares<F>,
     zeros_at: MultiplyZeroPositions,
-) -> Result<MaliciousReplicated<F>, Error>
+) -> Result<MaliciousReplicatedAdditiveShares<F>, Error>
 where
     F: Field,
 {
@@ -90,7 +90,7 @@ where
     )
     .await?;
 
-    let malicious_ab = MaliciousReplicated::new(ab, rab);
+    let malicious_ab = MaliciousReplicatedAdditiveShares::new(ab, rab);
     random_constant_ctx.accumulate_macs(record_id, &malicious_ab);
 
     Ok(malicious_ab)

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -2,7 +2,9 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::{ArithmeticShare, MaliciousReplicated, Replicated, SecretSharing};
+use crate::secret_sharing::{
+    ArithmeticShare, MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing,
+};
 use async_trait::async_trait;
 
 pub(crate) mod malicious;
@@ -47,7 +49,7 @@ use {malicious::multiply as malicious_mul, semi_honest::multiply as semi_honest_
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     async fn multiply_sparse(
         self,
@@ -63,7 +65,7 @@ impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureMul<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicated<F>;
+    type Share = MaliciousReplicatedAdditiveShares<F>;
 
     async fn multiply_sparse(
         self,

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -3,7 +3,8 @@ use crate::ff::Field;
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
 use crate::secret_sharing::{
-    ArithmeticShare, MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing,
+    replicated::malicious::AdditiveShare as MaliciousReplicated,
+    replicated::semi_honest::AdditiveShare as Replicated, ArithmeticShare, SecretSharing,
 };
 use async_trait::async_trait;
 
@@ -49,7 +50,7 @@ use {malicious::multiply as malicious_mul, semi_honest::multiply as semi_honest_
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     async fn multiply_sparse(
         self,
@@ -65,7 +66,7 @@ impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureMul<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicatedAdditiveShares<F>;
+    type Share = MaliciousReplicated<F>;
 
     async fn multiply_sparse(
         self,

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
     context::{Context, SemiHonestContext},
     RecordId,
 };
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 
 /// IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -25,10 +25,10 @@ use crate::secret_sharing::ReplicatedAdditiveShares;
 pub async fn multiply<F>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    a: &ReplicatedAdditiveShares<F>,
-    b: &ReplicatedAdditiveShares<F>,
+    a: &Replicated<F>,
+    b: &Replicated<F>,
     zeros: MultiplyZeroPositions,
-) -> Result<ReplicatedAdditiveShares<F>, Error>
+) -> Result<Replicated<F>, Error>
 where
     F: Field,
 {
@@ -73,7 +73,7 @@ where
         lhs += s0;
     }
 
-    Ok(ReplicatedAdditiveShares::new(lhs, rhs))
+    Ok(Replicated::new(lhs, rhs))
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -7,7 +7,7 @@ use crate::protocol::{
     context::{Context, SemiHonestContext},
     RecordId,
 };
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 
 /// IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -25,10 +25,10 @@ use crate::secret_sharing::Replicated;
 pub async fn multiply<F>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    a: &Replicated<F>,
-    b: &Replicated<F>,
+    a: &ReplicatedAdditiveShares<F>,
+    b: &ReplicatedAdditiveShares<F>,
     zeros: MultiplyZeroPositions,
-) -> Result<Replicated<F>, Error>
+) -> Result<ReplicatedAdditiveShares<F>, Error>
 where
     F: Field,
 {
@@ -73,7 +73,7 @@ where
         lhs += s0;
     }
 
-    Ok(Replicated::new(lhs, rhs))
+    Ok(ReplicatedAdditiveShares::new(lhs, rhs))
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -1,4 +1,4 @@
-use crate::{ff::Field, helpers::Role, secret_sharing::Replicated};
+use crate::{ff::Field, helpers::Role, secret_sharing::ReplicatedAdditiveShares};
 
 /// A description of a replicated secret sharing, with zero values at known positions.
 /// Convention here is to refer to the "left" share available at each helper, with
@@ -103,7 +103,7 @@ impl ZeroPositions {
     /// # Panics
     /// When the input value includes a non-zero value in a position marked as having a zero.
     #[cfg_attr(not(debug_assertions), allow(unused_variables))]
-    pub fn check<F: Field>(self, role: Role, which: &str, v: &Replicated<F>) {
+    pub fn check<F: Field>(self, role: Role, which: &str, v: &ReplicatedAdditiveShares<F>) {
         #[cfg(debug_assertions)]
         {
             use crate::helpers::Direction::Right;
@@ -195,7 +195,7 @@ pub(in crate::protocol) mod test {
             BitOpStep, RECORD_0,
         },
         rand::{thread_rng, Rng},
-        secret_sharing::Replicated,
+        secret_sharing::ReplicatedAdditiveShares,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use futures::future::try_join;
@@ -220,14 +220,14 @@ pub(in crate::protocol) mod test {
         }
     }
 
-    impl<F> IntoShares<Replicated<F>> for SparseField<F>
+    impl<F> IntoShares<ReplicatedAdditiveShares<F>> for SparseField<F>
     where
         F: Field,
         Standard: Distribution<F>,
     {
         // Create a sharing of `self.v` with zeros in positions determined by `self.z`.
         // This is a little inefficient, but it shouldn't be so bad in tests.
-        fn share_with<R: rand::Rng>(self, rng: &mut R) -> [Replicated<F>; 3] {
+        fn share_with<R: rand::Rng>(self, rng: &mut R) -> [ReplicatedAdditiveShares<F>; 3] {
             let zeros = <[bool; 3]>::from(self.z);
             // Generate one fewer random value than there are values.
             let mut randoms = zeros.iter().filter(|&x| !x).skip(1).map(|_| rng.gen::<F>());
@@ -247,9 +247,9 @@ pub(in crate::protocol) mod test {
                 .collect::<Vec<_>>();
 
             [
-                Replicated::new(values[0], values[1]),
-                Replicated::new(values[1], values[2]),
-                Replicated::new(values[2], values[0]),
+                ReplicatedAdditiveShares::new(values[0], values[1]),
+                ReplicatedAdditiveShares::new(values[1], values[2]),
+                ReplicatedAdditiveShares::new(values[2], values[0]),
             ]
         }
     }
@@ -352,7 +352,7 @@ pub(in crate::protocol) mod test {
     fn check_output_zeros<F, T>(v: &[T; 3], work: MultiplyZeroPositions)
     where
         F: Field,
-        T: Borrow<Replicated<F>>,
+        T: Borrow<ReplicatedAdditiveShares<F>>,
     {
         for (&role, expect_zero) in zip(Role::all(), <[bool; 3]>::from(work.output())) {
             if expect_zero {

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -2,7 +2,9 @@ use std::iter::{repeat, zip};
 
 use crate::ff::Field;
 use crate::protocol::context::{Context, MaliciousContext, SemiHonestContext};
-use crate::secret_sharing::{ArithmeticShare, MaliciousReplicated, Replicated, SecretSharing};
+use crate::secret_sharing::{
+    ArithmeticShare, MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing,
+};
 use crate::{error::Error, helpers::Direction, protocol::RecordId};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
@@ -35,7 +37,7 @@ pub trait Reveal<V: ArithmeticShare> {
 #[async_trait]
 #[embed_doc_image("reveal", "images/reveal.png")]
 impl<F: Field> Reveal<F> for SemiHonestContext<'_, F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     async fn reveal(self, record_id: RecordId, input: &Self::Share) -> Result<F, Error> {
         let (role, channel) = (self.role(), self.mesh());
@@ -60,7 +62,7 @@ impl<F: Field> Reveal<F> for SemiHonestContext<'_, F> {
 /// indeed match.
 #[async_trait]
 impl<F: Field> Reveal<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicated<F>;
+    type Share = MaliciousReplicatedAdditiveShares<F>;
 
     async fn reveal(self, record_id: RecordId, input: &Self::Share) -> Result<F, Error> {
         use crate::secret_sharing::ThisCodeIsAuthorizedToDowngradeFromMalicious;
@@ -131,7 +133,9 @@ mod tests {
             context::{Context, MaliciousContext},
             RecordId,
         },
-        secret_sharing::{MaliciousReplicated, ThisCodeIsAuthorizedToDowngradeFromMalicious},
+        secret_sharing::{
+            MaliciousReplicatedAdditiveShares, ThisCodeIsAuthorizedToDowngradeFromMalicious,
+        },
         test_fixture::{join3, join3v, TestWorld},
     };
 
@@ -221,7 +225,7 @@ mod tests {
     pub async fn reveal_with_additive_attack<F: Field>(
         ctx: MaliciousContext<'_, F>,
         record_id: RecordId,
-        input: &MaliciousReplicated<F>,
+        input: &MaliciousReplicatedAdditiveShares<F>,
         additive_error: F,
     ) -> Result<F, Error> {
         let channel = ctx.mesh();

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
     context::{Context, MaliciousContext},
     RecordId,
 };
-use crate::secret_sharing::MaliciousReplicated;
+use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -60,9 +60,9 @@ impl AsRef<str> for Step {
 pub async fn sum_of_products<F>(
     ctx: MaliciousContext<'_, F>,
     record_id: RecordId,
-    a: &[&MaliciousReplicated<F>],
-    b: &[&MaliciousReplicated<F>],
-) -> Result<MaliciousReplicated<F>, Error>
+    a: &[&MaliciousReplicatedAdditiveShares<F>],
+    b: &[&MaliciousReplicatedAdditiveShares<F>],
+) -> Result<MaliciousReplicatedAdditiveShares<F>, Error>
 where
     F: Field,
 {
@@ -93,7 +93,7 @@ where
     )
     .await?;
 
-    let malicious_ab = MaliciousReplicated::new(ab, rab);
+    let malicious_ab = MaliciousReplicatedAdditiveShares::new(ab, rab);
     random_constant_ctx.accumulate_macs(record_id, &malicious_ab);
 
     Ok(malicious_ab)
@@ -102,9 +102,10 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod test {
     use crate::{
-        ff::{Field, Fp31},
+        ff::Fp31,
         protocol::{basics::sum_of_product::SecureSop, RecordId},
         rand::{thread_rng, Rng},
+        secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
 

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -5,7 +5,7 @@ use crate::protocol::{
     context::{Context, MaliciousContext},
     RecordId,
 };
-use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -60,14 +60,14 @@ impl AsRef<str> for Step {
 pub async fn sum_of_products<F>(
     ctx: MaliciousContext<'_, F>,
     record_id: RecordId,
-    a: &[&MaliciousReplicatedAdditiveShares<F>],
-    b: &[&MaliciousReplicatedAdditiveShares<F>],
-) -> Result<MaliciousReplicatedAdditiveShares<F>, Error>
+    a: &[&MaliciousReplicated<F>],
+    b: &[&MaliciousReplicated<F>],
+) -> Result<MaliciousReplicated<F>, Error>
 where
     F: Field,
 {
     use crate::protocol::context::SpecialAccessToMaliciousContext;
-    use crate::secret_sharing::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+    use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 
     assert_eq!(a.len(), b.len());
 
@@ -93,7 +93,7 @@ where
     )
     .await?;
 
-    let malicious_ab = MaliciousReplicatedAdditiveShares::new(ab, rab);
+    let malicious_ab = MaliciousReplicated::new(ab, rab);
     random_constant_ctx.accumulate_macs(record_id, &malicious_ab);
 
     Ok(malicious_ab)

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -3,7 +3,8 @@ use crate::ff::Field;
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
 use crate::secret_sharing::{
-    MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing,
+    replicated::malicious::AdditiveShare as MaliciousReplicated,
+    replicated::semi_honest::AdditiveShare as Replicated, SecretSharing,
 };
 use async_trait::async_trait;
 
@@ -32,7 +33,7 @@ use {
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     async fn sum_of_products(
         self,
@@ -47,7 +48,7 @@ impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureSop<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicatedAdditiveShares<F>;
+    type Share = MaliciousReplicated<F>;
 
     async fn sum_of_products(
         self,

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -2,7 +2,9 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::{MaliciousContext, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::{MaliciousReplicated, Replicated, SecretSharing};
+use crate::secret_sharing::{
+    MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing,
+};
 use async_trait::async_trait;
 
 pub(crate) mod malicious;
@@ -30,7 +32,7 @@ use {
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     async fn sum_of_products(
         self,
@@ -45,7 +47,7 @@ impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
 impl<F: Field> SecureSop<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicated<F>;
+    type Share = MaliciousReplicatedAdditiveShares<F>;
 
     async fn sum_of_products(
         self,

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -6,7 +6,7 @@ use crate::protocol::{
     context::{Context, SemiHonestContext},
     RecordId,
 };
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 
 /// Sum of product protocol developed using IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -22,9 +22,9 @@ use crate::secret_sharing::ReplicatedAdditiveShares;
 pub async fn sum_of_products<F>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    a: &[&ReplicatedAdditiveShares<F>],
-    b: &[&ReplicatedAdditiveShares<F>],
-) -> Result<ReplicatedAdditiveShares<F>, Error>
+    a: &[&Replicated<F>],
+    b: &[&Replicated<F>],
+) -> Result<Replicated<F>, Error>
 where
     F: Field,
 {
@@ -63,7 +63,7 @@ where
         lhs += a[i].left() * b[i].left();
         rhs += a[i].right() * b[i].right();
     }
-    Ok(ReplicatedAdditiveShares::new(lhs, rhs))
+    Ok(Replicated::new(lhs, rhs))
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -6,7 +6,7 @@ use crate::protocol::{
     context::{Context, SemiHonestContext},
     RecordId,
 };
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 
 /// Sum of product protocol developed using IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -22,9 +22,9 @@ use crate::secret_sharing::Replicated;
 pub async fn sum_of_products<F>(
     ctx: SemiHonestContext<'_, F>,
     record_id: RecordId,
-    a: &[&Replicated<F>],
-    b: &[&Replicated<F>],
-) -> Result<Replicated<F>, Error>
+    a: &[&ReplicatedAdditiveShares<F>],
+    b: &[&ReplicatedAdditiveShares<F>],
+) -> Result<ReplicatedAdditiveShares<F>, Error>
 where
     F: Field,
 {
@@ -63,7 +63,7 @@ where
         lhs += a[i].left() * b[i].left();
         rhs += a[i].right() * b[i].right();
     }
-    Ok(Replicated::new(lhs, rhs))
+    Ok(ReplicatedAdditiveShares::new(lhs, rhs))
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
@@ -75,6 +75,7 @@ mod test {
     use crate::ff::{Field, Fp31};
     use crate::protocol::basics::sum_of_product::SecureSop;
     use crate::protocol::RecordId;
+    use crate::secret_sharing::SharedValue;
     use crate::test_fixture::{Reconstruct, Runner, TestWorld};
 
     #[tokio::test]

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -204,6 +204,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::BitwiseLessThanPrime;
+    use crate::secret_sharing::SharedValue;
     use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/boolean/dumb_bitwise_lt.rs
+++ b/src/protocol/boolean/dumb_bitwise_lt.rs
@@ -171,6 +171,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitwiseLessThan;
     use crate::rand::thread_rng;
+    use crate::secret_sharing::SharedValue;
     use crate::test_fixture::{get_bits, Runner};
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -3,13 +3,13 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::MaliciousContext;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::MaliciousReplicated;
+use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
 use async_trait::async_trait;
 use futures::future::try_join_all;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicated<F>;
+    type Share = MaliciousReplicatedAdditiveShares<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -3,13 +3,13 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::MaliciousContext;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::MaliciousReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
 use async_trait::async_trait;
 use futures::future::try_join_all;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
-    type Share = MaliciousReplicatedAdditiveShares<F>;
+    type Share = MaliciousReplicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -4,7 +4,8 @@ use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitCon
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
 use crate::secret_sharing::{
-    ArithmeticShare, ReplicatedAdditiveShares, SecretSharing, XorReplicated,
+    replicated::semi_honest::AdditiveShare as Replicated, ArithmeticShare, SecretSharing,
+    XorReplicated,
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;
@@ -23,7 +24,7 @@ pub trait RandomBits<V: ArithmeticShare> {
 fn random_bits_triples<F, C, S>(
     ctx: &C,
     record_id: RecordId,
-) -> Vec<BitConversionTriple<ReplicatedAdditiveShares<F>>>
+) -> Vec<BitConversionTriple<Replicated<F>>>
 where
     F: Field,
     C: Context<F, Share = S>,

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -3,7 +3,9 @@ use crate::ff::{Field, Int};
 use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple};
 use crate::protocol::prss::SharedRandomness;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{ArithmeticShare, Replicated, SecretSharing, XorReplicated};
+use crate::secret_sharing::{
+    ArithmeticShare, ReplicatedAdditiveShares, SecretSharing, XorReplicated,
+};
 use async_trait::async_trait;
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -21,7 +23,7 @@ pub trait RandomBits<V: ArithmeticShare> {
 fn random_bits_triples<F, C, S>(
     ctx: &C,
     record_id: RecordId,
-) -> Vec<BitConversionTriple<Replicated<F>>>
+) -> Vec<BitConversionTriple<ReplicatedAdditiveShares<F>>>
 where
     F: Field,
     C: Context<F, Share = S>,

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -3,12 +3,12 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::SemiHonestContext;
 use crate::protocol::{context::Context, RecordId};
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use async_trait::async_trait;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -3,12 +3,12 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::SemiHonestContext;
 use crate::protocol::{context::Context, RecordId};
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use async_trait::async_trait;
 
 #[async_trait]
 impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -22,6 +22,7 @@ mod tests {
     use crate::{
         ff::{Field, Fp31},
         protocol::RecordId,
+        secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use rand::distributions::{Distribution, Standard};

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -2,10 +2,10 @@ use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId};
-use crate::secret_sharing::{
-    DowngradeMalicious, MaliciousReplicatedAdditiveShares, SecretSharing,
-    UnauthorizedDowngradeWrapper,
+use crate::secret_sharing::replicated::malicious::{
+    AdditiveShare as MaliciousReplicated, DowngradeMalicious, UnauthorizedDowngradeWrapper,
 };
+use crate::secret_sharing::SecretSharing;
 use async_trait::async_trait;
 use std::marker::PhantomData;
 
@@ -21,14 +21,15 @@ where
 }
 
 #[async_trait]
-impl<F> DowngradeMalicious for RandomBitsShare<F, MaliciousReplicatedAdditiveShares<F>>
+impl<F> DowngradeMalicious for RandomBitsShare<F, MaliciousReplicated<F>>
 where
     F: Field,
 {
-    type Target = RandomBitsShare<F, crate::secret_sharing::ReplicatedAdditiveShares<F>>;
+    type Target =
+        RandomBitsShare<F, crate::secret_sharing::replicated::semi_honest::AdditiveShare<F>>;
 
     async fn downgrade(self) -> UnauthorizedDowngradeWrapper<Self::Target> {
-        use crate::secret_sharing::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+        use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 
         // Note that this clones the values rather than moving them.
         // This code is only used in test code, so that's probably OK.

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -3,7 +3,8 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId};
 use crate::secret_sharing::{
-    DowngradeMalicious, MaliciousReplicated, SecretSharing, UnauthorizedDowngradeWrapper,
+    DowngradeMalicious, MaliciousReplicatedAdditiveShares, SecretSharing,
+    UnauthorizedDowngradeWrapper,
 };
 use async_trait::async_trait;
 use std::marker::PhantomData;
@@ -20,11 +21,11 @@ where
 }
 
 #[async_trait]
-impl<F> DowngradeMalicious for RandomBitsShare<F, MaliciousReplicated<F>>
+impl<F> DowngradeMalicious for RandomBitsShare<F, MaliciousReplicatedAdditiveShares<F>>
 where
     F: Field,
 {
-    type Target = RandomBitsShare<F, crate::secret_sharing::Replicated<F>>;
+    type Target = RandomBitsShare<F, crate::secret_sharing::ReplicatedAdditiveShares<F>>;
 
     async fn downgrade(self) -> UnauthorizedDowngradeWrapper<Self::Target> {
         use crate::secret_sharing::ThisCodeIsAuthorizedToDowngradeFromMalicious;
@@ -145,6 +146,7 @@ impl AsRef<str> for Step {
 mod tests {
     use crate::protocol::boolean::solved_bits::solved_bits;
     use crate::protocol::context::SemiHonestContext;
+    use crate::secret_sharing::SharedValue;
     use crate::test_fixture::Runner;
     use crate::{
         error::Error,

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -47,6 +47,7 @@ mod tests {
             boolean::xor_sparse,
             RecordId,
         },
+        secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use rand::distributions::{Distribution, Standard};

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -16,7 +16,9 @@ use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::modulus_conversion::BitConversionTriple;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::{RecordId, Step, Substep};
-use crate::secret_sharing::{MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares};
+use crate::secret_sharing::replicated::{
+    malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+};
 use crate::sync::Arc;
 
 /// Represents protocol context in malicious setting, i.e. secure against one active adversary
@@ -30,7 +32,7 @@ pub struct MaliciousContext<'a, F: Field> {
 }
 
 pub trait SpecialAccessToMaliciousContext<'a, F: Field> {
-    fn accumulate_macs(self, record_id: RecordId, x: &MaliciousReplicatedAdditiveShares<F>);
+    fn accumulate_macs(self, record_id: RecordId, x: &MaliciousReplicated<F>);
     fn semi_honest_context(self) -> SemiHonestContext<'a, F>;
 }
 
@@ -40,7 +42,7 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
         malicious_step: &S,
         upgrade_ctx: SemiHonestContext<'a, F>,
         acc: MaliciousValidatorAccumulator<F>,
-        r_share: ReplicatedAdditiveShares<F>,
+        r_share: Replicated<F>,
     ) -> Self {
         Self {
             inner: ContextInner::new(upgrade_ctx, acc, r_share),
@@ -55,8 +57,8 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
     pub async fn upgrade(
         &self,
         record_id: RecordId,
-        input: ReplicatedAdditiveShares<F>,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+        input: Replicated<F>,
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.upgrade_sparse(record_id, input, ZeroPositions::Pvvv)
             .await
     }
@@ -68,9 +70,9 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
     pub async fn upgrade_sparse(
         &self,
         record_id: RecordId,
-        input: ReplicatedAdditiveShares<F>,
+        input: Replicated<F>,
         zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.inner.upgrade(record_id, input, zeros_at).await
     }
 
@@ -81,8 +83,8 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
     pub async fn upgrade_vector<SS: Substep>(
         &self,
         step: &SS,
-        input: Vec<ReplicatedAdditiveShares<F>>,
-    ) -> Result<Vec<MaliciousReplicatedAdditiveShares<F>>, Error> {
+        input: Vec<Replicated<F>>,
+    ) -> Result<Vec<MaliciousReplicated<F>>, Error> {
         try_join_all(
             zip(repeat(self), input.into_iter().enumerate()).map(|(ctx, (i, share))| async move {
                 ctx.upgrade_with(step, RecordId::from(i), share).await
@@ -100,8 +102,8 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
         &self,
         step: &SS,
         record_id: RecordId,
-        input: ReplicatedAdditiveShares<F>,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+        input: Replicated<F>,
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.upgrade_with_sparse(step, record_id, input, ZeroPositions::Pvvv)
             .await
     }
@@ -115,9 +117,9 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
         &self,
         step: &SS,
         record_id: RecordId,
-        input: ReplicatedAdditiveShares<F>,
+        input: Replicated<F>,
         zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.inner
             .upgrade_with(step, record_id, input, zeros_at)
             .await
@@ -131,14 +133,14 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
         &self,
         step: &SS,
         record_id: RecordId,
-        triple: BitConversionTriple<ReplicatedAdditiveShares<F>>,
-    ) -> Result<BitConversionTriple<MaliciousReplicatedAdditiveShares<F>>, Error> {
+        triple: BitConversionTriple<Replicated<F>>,
+    ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
         self.inner.upgrade_bit_triple(step, record_id, triple).await
     }
 }
 
 impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
-    type Share = MaliciousReplicatedAdditiveShares<F>;
+    type Share = MaliciousReplicated<F>;
 
     fn role(&self) -> Role {
         self.inner.role
@@ -179,7 +181,7 @@ impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
     }
 
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
-        MaliciousReplicatedAdditiveShares::one(self.role(), self.inner.r_share.clone())
+        MaliciousReplicated::one(self.role(), self.inner.r_share.clone())
     }
 }
 
@@ -188,7 +190,7 @@ impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
 /// `ProtocolContext<'a, S: SecretShare<F>, F: Field>` as the context. If that is not possible,
 /// this implementation makes it easier to reinterpret the context as semi-honest.
 impl<'a, F: Field> SpecialAccessToMaliciousContext<'a, F> for MaliciousContext<'a, F> {
-    fn accumulate_macs(self, record_id: RecordId, x: &MaliciousReplicatedAdditiveShares<F>) {
+    fn accumulate_macs(self, record_id: RecordId, x: &MaliciousReplicated<F>) {
         self.inner
             .accumulator
             .accumulate_macs(&self.prss(), record_id, x);
@@ -237,14 +239,14 @@ struct ContextInner<'a, F: Field> {
     gateway: &'a Gateway,
     upgrade_ctx: SemiHonestContext<'a, F>,
     accumulator: MaliciousValidatorAccumulator<F>,
-    r_share: ReplicatedAdditiveShares<F>,
+    r_share: Replicated<F>,
 }
 
 impl<'a, F: Field> ContextInner<'a, F> {
     fn new(
         upgrade_ctx: SemiHonestContext<'a, F>,
         accumulator: MaliciousValidatorAccumulator<F>,
-        r_share: ReplicatedAdditiveShares<F>,
+        r_share: Replicated<F>,
     ) -> Arc<Self> {
         Arc::new(ContextInner {
             role: upgrade_ctx.inner.role,
@@ -260,9 +262,9 @@ impl<'a, F: Field> ContextInner<'a, F> {
         &self,
         ctx: SemiHonestContext<'a, F>,
         record_id: RecordId,
-        x: ReplicatedAdditiveShares<F>,
+        x: Replicated<F>,
         zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         let rx = ctx
             .clone()
             .multiply_sparse(
@@ -272,7 +274,7 @@ impl<'a, F: Field> ContextInner<'a, F> {
                 (zeros_at, ZeroPositions::Pvvv),
             )
             .await?;
-        let m = MaliciousReplicatedAdditiveShares::new(x, rx);
+        let m = MaliciousReplicated::new(x, rx);
         let ctx = ctx.narrow(&RandomnessForValidation);
         let prss = ctx.prss();
         self.accumulator.accumulate_macs(&prss, record_id, &m);
@@ -282,9 +284,9 @@ impl<'a, F: Field> ContextInner<'a, F> {
     async fn upgrade(
         &self,
         record_id: RecordId,
-        x: ReplicatedAdditiveShares<F>,
+        x: Replicated<F>,
         zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.upgrade_one(self.upgrade_ctx.clone(), record_id, x, zeros_at)
             .await
     }
@@ -293,9 +295,9 @@ impl<'a, F: Field> ContextInner<'a, F> {
         &self,
         step: &SS,
         record_id: RecordId,
-        x: ReplicatedAdditiveShares<F>,
+        x: Replicated<F>,
         zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicatedAdditiveShares<F>, Error> {
+    ) -> Result<MaliciousReplicated<F>, Error> {
         self.upgrade_one(self.upgrade_ctx.narrow(step), record_id, x, zeros_at)
             .await
     }
@@ -304,8 +306,8 @@ impl<'a, F: Field> ContextInner<'a, F> {
         &self,
         step: &SS,
         record_id: RecordId,
-        triple: BitConversionTriple<ReplicatedAdditiveShares<F>>,
-    ) -> Result<BitConversionTriple<MaliciousReplicatedAdditiveShares<F>>, Error> {
+        triple: BitConversionTriple<Replicated<F>>,
+    ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
         let [v0, v1, v2] = triple.0;
         let c = self.upgrade_ctx.narrow(step);
         Ok(BitConversionTriple(

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -81,7 +81,7 @@ mod tests {
     use crate::protocol::malicious::Step::MaliciousProtocol;
     use crate::protocol::prss::SharedRandomness;
     use crate::protocol::RecordId;
-    use crate::secret_sharing::{MaliciousReplicated, Replicated};
+    use crate::secret_sharing::{MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares};
     use crate::telemetry::metrics::{
         INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED,
     };
@@ -99,13 +99,13 @@ mod tests {
         fn right(&self) -> F;
     }
 
-    impl<F: Field> AsReplicated<F> for Replicated<F> {
+    impl<F: Field> AsReplicated<F> for ReplicatedAdditiveShares<F> {
         fn left(&self) -> F {
-            (self as &Replicated<F>).left()
+            (self as &ReplicatedAdditiveShares<F>).left()
         }
 
         fn right(&self) -> F {
-            (self as &Replicated<F>).right()
+            (self as &ReplicatedAdditiveShares<F>).right()
         }
     }
 
@@ -113,18 +113,18 @@ mod tests {
     /// Malicious context intentionally disallows access to `x` without validating first and
     /// here it does not matter at all. It needs just some value to send (any value would do just
     /// fine)
-    impl<F: Field> AsReplicated<F> for MaliciousReplicated<F> {
+    impl<F: Field> AsReplicated<F> for MaliciousReplicatedAdditiveShares<F> {
         fn left(&self) -> F {
-            (self as &MaliciousReplicated<F>).rx().left()
+            (self as &MaliciousReplicatedAdditiveShares<F>).rx().left()
         }
 
         fn right(&self) -> F {
-            (self as &MaliciousReplicated<F>).rx().right()
+            (self as &MaliciousReplicatedAdditiveShares<F>).rx().right()
         }
     }
 
     /// Toy protocol to execute PRSS generation and send/receive logic
-    async fn toy_protocol<F, S, C>(ctx: C, index: usize, share: &S) -> Replicated<F>
+    async fn toy_protocol<F, S, C>(ctx: C, index: usize, share: &S) -> ReplicatedAdditiveShares<F>
     where
         F: Field,
         Standard: Distribution<F>,
@@ -152,7 +152,7 @@ mod tests {
         )
         .unwrap();
 
-        Replicated::new(share.left(), right_share + r + seq_r)
+        ReplicatedAdditiveShares::new(share.left(), right_share + r + seq_r)
     }
 
     #[tokio::test]

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -81,7 +81,9 @@ mod tests {
     use crate::protocol::malicious::Step::MaliciousProtocol;
     use crate::protocol::prss::SharedRandomness;
     use crate::protocol::RecordId;
-    use crate::secret_sharing::{MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares};
+    use crate::secret_sharing::replicated::{
+        malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+    };
     use crate::telemetry::metrics::{
         INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED,
     };
@@ -99,13 +101,13 @@ mod tests {
         fn right(&self) -> F;
     }
 
-    impl<F: Field> AsReplicated<F> for ReplicatedAdditiveShares<F> {
+    impl<F: Field> AsReplicated<F> for Replicated<F> {
         fn left(&self) -> F {
-            (self as &ReplicatedAdditiveShares<F>).left()
+            (self as &Replicated<F>).left()
         }
 
         fn right(&self) -> F {
-            (self as &ReplicatedAdditiveShares<F>).right()
+            (self as &Replicated<F>).right()
         }
     }
 
@@ -113,18 +115,18 @@ mod tests {
     /// Malicious context intentionally disallows access to `x` without validating first and
     /// here it does not matter at all. It needs just some value to send (any value would do just
     /// fine)
-    impl<F: Field> AsReplicated<F> for MaliciousReplicatedAdditiveShares<F> {
+    impl<F: Field> AsReplicated<F> for MaliciousReplicated<F> {
         fn left(&self) -> F {
-            (self as &MaliciousReplicatedAdditiveShares<F>).rx().left()
+            (self as &MaliciousReplicated<F>).rx().left()
         }
 
         fn right(&self) -> F {
-            (self as &MaliciousReplicatedAdditiveShares<F>).rx().right()
+            (self as &MaliciousReplicated<F>).rx().right()
         }
     }
 
     /// Toy protocol to execute PRSS generation and send/receive logic
-    async fn toy_protocol<F, S, C>(ctx: C, index: usize, share: &S) -> ReplicatedAdditiveShares<F>
+    async fn toy_protocol<F, S, C>(ctx: C, index: usize, share: &S) -> Replicated<F>
     where
         F: Field,
         Standard: Distribution<F>,
@@ -152,7 +154,7 @@ mod tests {
         )
         .unwrap();
 
-        ReplicatedAdditiveShares::new(share.left(), right_share + r + seq_r)
+        Replicated::new(share.left(), right_share + r + seq_r)
     }
 
     #[tokio::test]

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -8,7 +8,7 @@ use crate::protocol::context::{
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::{Step, Substep};
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
@@ -44,7 +44,7 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
         malicious_step: &S,
         upgrade_step: &S,
         accumulator: MaliciousValidatorAccumulator<F>,
-        r_share: Replicated<F>,
+        r_share: ReplicatedAdditiveShares<F>,
     ) -> MaliciousContext<'a, F> {
         let upgrade_ctx = self.narrow(upgrade_step);
         MaliciousContext::new(&self, malicious_step, upgrade_ctx, accumulator, r_share)
@@ -52,7 +52,7 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
 }
 
 impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     fn role(&self) -> Role {
         self.inner.role
@@ -94,7 +94,7 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
     }
 
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
-        Replicated::one(self.role())
+        ReplicatedAdditiveShares::one(self.role())
     }
 }
 

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -8,7 +8,7 @@ use crate::protocol::context::{
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::{Step, Substep};
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
@@ -36,7 +36,7 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
     /// Upgrade this context to malicious.
     /// `malicious_step` is the step that will be used for malicious protocol execution.
     /// `upgrade_step` is the step that will be used for upgrading inputs
-    /// from `Replicated` to `MaliciousReplicated`.
+    /// from `replicated::semi_honest::AdditiveShare` to `replicated::malicious::AdditiveShare`.
     /// `accumulator` and `r_share` come from a `MaliciousValidator`.
     #[must_use]
     pub fn upgrade<S: Substep + ?Sized>(
@@ -44,7 +44,7 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
         malicious_step: &S,
         upgrade_step: &S,
         accumulator: MaliciousValidatorAccumulator<F>,
-        r_share: ReplicatedAdditiveShares<F>,
+        r_share: Replicated<F>,
     ) -> MaliciousContext<'a, F> {
         let upgrade_ctx = self.narrow(upgrade_step);
         MaliciousContext::new(&self, malicious_step, upgrade_ctx, accumulator, r_share)
@@ -52,7 +52,7 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
 }
 
 impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     fn role(&self) -> Role {
         self.inner.role
@@ -94,7 +94,7 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
     }
 
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
-        ReplicatedAdditiveShares::one(self.role())
+        Replicated::one(self.role())
     }
 }
 

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         RecordId,
     },
-    secret_sharing::{ReplicatedAdditiveShares, XorReplicated},
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, XorReplicated},
 };
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
@@ -77,21 +77,21 @@ impl AsRef<str> for IPAInputRowResharableStep {
 
 pub struct IPAInputRow<F: Field> {
     pub mk_shares: XorReplicated,
-    pub is_trigger_bit: ReplicatedAdditiveShares<F>,
-    pub breakdown_key: ReplicatedAdditiveShares<F>,
-    pub trigger_value: ReplicatedAdditiveShares<F>,
+    pub is_trigger_bit: Replicated<F>,
+    pub breakdown_key: Replicated<F>,
+    pub trigger_value: Replicated<F>,
 }
 
 struct IPAModulusConvertedInputRow<F: Field> {
-    mk_shares: Vec<ReplicatedAdditiveShares<F>>,
-    is_trigger_bit: ReplicatedAdditiveShares<F>,
-    breakdown_key: ReplicatedAdditiveShares<F>,
-    trigger_value: ReplicatedAdditiveShares<F>,
+    mk_shares: Vec<Replicated<F>>,
+    is_trigger_bit: Replicated<F>,
+    breakdown_key: Replicated<F>,
+    trigger_value: Replicated<F>,
 }
 
 #[async_trait]
 impl<F: Field + Sized> Resharable<F> for IPAModulusConvertedInputRow<F> {
-    type Share = ReplicatedAdditiveShares<F>;
+    type Share = Replicated<F>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
@@ -190,7 +190,7 @@ where
         let record_id = RecordId::from(i);
         async move { bitwise_equal(ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
     });
-    let helper_bits = Some(ReplicatedAdditiveShares::ZERO)
+    let helper_bits = Some(Replicated::ZERO)
         .into_iter()
         .chain(try_join_all(futures).await?);
 

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         RecordId,
     },
-    secret_sharing::{Replicated, XorReplicated},
+    secret_sharing::{ReplicatedAdditiveShares, XorReplicated},
 };
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
@@ -77,21 +77,21 @@ impl AsRef<str> for IPAInputRowResharableStep {
 
 pub struct IPAInputRow<F: Field> {
     pub mk_shares: XorReplicated,
-    pub is_trigger_bit: Replicated<F>,
-    pub breakdown_key: Replicated<F>,
-    pub trigger_value: Replicated<F>,
+    pub is_trigger_bit: ReplicatedAdditiveShares<F>,
+    pub breakdown_key: ReplicatedAdditiveShares<F>,
+    pub trigger_value: ReplicatedAdditiveShares<F>,
 }
 
 struct IPAModulusConvertedInputRow<F: Field> {
-    mk_shares: Vec<Replicated<F>>,
-    is_trigger_bit: Replicated<F>,
-    breakdown_key: Replicated<F>,
-    trigger_value: Replicated<F>,
+    mk_shares: Vec<ReplicatedAdditiveShares<F>>,
+    is_trigger_bit: ReplicatedAdditiveShares<F>,
+    breakdown_key: ReplicatedAdditiveShares<F>,
+    trigger_value: ReplicatedAdditiveShares<F>,
 }
 
 #[async_trait]
 impl<F: Field + Sized> Resharable<F> for IPAModulusConvertedInputRow<F> {
-    type Share = Replicated<F>;
+    type Share = ReplicatedAdditiveShares<F>;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>
     where
@@ -190,7 +190,7 @@ where
         let record_id = RecordId::from(i);
         async move { bitwise_equal(ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
     });
-    let helper_bits = Some(Replicated::ZERO)
+    let helper_bits = Some(ReplicatedAdditiveShares::ZERO)
         .into_iter()
         .chain(try_join_all(futures).await?);
 

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -4,7 +4,7 @@ use crate::{
     ff::Field,
     helpers::Role,
     protocol::{basics::ZeroPositions, boolean::xor_sparse, context::Context, RecordId},
-    secret_sharing::{Replicated, SecretSharing, XorReplicated},
+    secret_sharing::{ReplicatedAdditiveShares, SecretSharing, XorReplicated},
 };
 use futures::future::try_join_all;
 use std::iter::{repeat, zip};
@@ -60,24 +60,24 @@ pub fn convert_bit_local<F: Field>(
     helper_role: Role,
     bit_index: u32,
     input: &XorReplicated,
-) -> BitConversionTriple<Replicated<F>> {
+) -> BitConversionTriple<ReplicatedAdditiveShares<F>> {
     let left = u128::from(input.left() >> bit_index) & 1;
     let right = u128::from(input.right() >> bit_index) & 1;
     BitConversionTriple(match helper_role {
         Role::H1 => [
-            Replicated::new(F::from(left), F::ZERO),
-            Replicated::new(F::ZERO, F::from(right)),
-            Replicated::new(F::ZERO, F::ZERO),
+            ReplicatedAdditiveShares::new(F::from(left), F::ZERO),
+            ReplicatedAdditiveShares::new(F::ZERO, F::from(right)),
+            ReplicatedAdditiveShares::new(F::ZERO, F::ZERO),
         ],
         Role::H2 => [
-            Replicated::new(F::ZERO, F::ZERO),
-            Replicated::new(F::from(left), F::ZERO),
-            Replicated::new(F::ZERO, F::from(right)),
+            ReplicatedAdditiveShares::new(F::ZERO, F::ZERO),
+            ReplicatedAdditiveShares::new(F::from(left), F::ZERO),
+            ReplicatedAdditiveShares::new(F::ZERO, F::from(right)),
         ],
         Role::H3 => [
-            Replicated::new(F::ZERO, F::from(right)),
-            Replicated::new(F::ZERO, F::ZERO),
-            Replicated::new(F::from(left), F::ZERO),
+            ReplicatedAdditiveShares::new(F::ZERO, F::from(right)),
+            ReplicatedAdditiveShares::new(F::ZERO, F::ZERO),
+            ReplicatedAdditiveShares::new(F::from(left), F::ZERO),
         ],
     })
 }
@@ -87,7 +87,7 @@ pub fn convert_all_bits_local<F: Field>(
     helper_role: Role,
     input: &[XorReplicated],
     num_bits: u32,
-) -> Vec<Vec<BitConversionTriple<Replicated<F>>>> {
+) -> Vec<Vec<BitConversionTriple<ReplicatedAdditiveShares<F>>>> {
     let mut total_list = Vec::new();
     for bit_index in 0..num_bits {
         let one_list = input
@@ -184,7 +184,7 @@ mod tests {
     use crate::protocol::malicious::MaliciousValidator;
     use crate::protocol::BitOpStep;
     use crate::rand::thread_rng;
-    use crate::secret_sharing::Replicated;
+    use crate::secret_sharing::ReplicatedAdditiveShares;
     use crate::{
         error::Error,
         ff::Fp31,
@@ -203,7 +203,7 @@ mod tests {
 
         let world = TestWorld::new().await;
         let match_key = MaskedMatchKey::mask(rng.gen());
-        let result: [Replicated<Fp31>; 3] = world
+        let result: [ReplicatedAdditiveShares<Fp31>; 3] = world
             .semi_honest(match_key, |ctx, mk_share| async move {
                 let triple = convert_bit_local::<Fp31>(ctx.role(), BITNUM, &mk_share);
                 convert_bit(ctx, RecordId::from(0), &triple).await.unwrap()
@@ -219,7 +219,7 @@ mod tests {
 
         let world = TestWorld::new().await;
         let match_key = MaskedMatchKey::mask(rng.gen());
-        let result: [Replicated<Fp31>; 3] = world
+        let result: [ReplicatedAdditiveShares<Fp31>; 3] = world
             .semi_honest(match_key, |ctx, mk_share| async move {
                 let triple = convert_bit_local::<Fp31>(ctx.role(), BITNUM, &mk_share);
 
@@ -249,15 +249,15 @@ mod tests {
             fn flip_bit<F: Field>(
                 &self,
                 role: Role,
-                mut triple: BitConversionTriple<Replicated<F>>,
-            ) -> BitConversionTriple<Replicated<F>> {
+                mut triple: BitConversionTriple<ReplicatedAdditiveShares<F>>,
+            ) -> BitConversionTriple<ReplicatedAdditiveShares<F>> {
                 if role != self.role {
                     return triple;
                 }
                 let v = &mut triple.0[self.index];
                 *v = match self.dir {
-                    Direction::Left => Replicated::new(F::ONE - v.left(), v.right()),
-                    Direction::Right => Replicated::new(v.left(), F::ONE - v.right()),
+                    Direction::Left => ReplicatedAdditiveShares::new(F::ONE - v.left(), v.right()),
+                    Direction::Right => ReplicatedAdditiveShares::new(v.left(), F::ONE - v.right()),
                 };
                 triple
             }

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -5,7 +5,7 @@ pub use convert_shares::{
     BitConversionTriple,
 };
 
-use crate::{ff::Field, secret_sharing::ReplicatedAdditiveShares};
+use crate::{ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated};
 
 /// Transpose rows of bits into bits of rows
 ///
@@ -25,9 +25,7 @@ use crate::{ff::Field, secret_sharing::ReplicatedAdditiveShares};
 ///     `[ row[0].bit31, row[1].bit31, ..., row[n].bit31 ]`,
 /// `]`
 #[must_use]
-pub fn transpose<F: Field>(
-    input: &[Vec<ReplicatedAdditiveShares<F>>],
-) -> Vec<Vec<ReplicatedAdditiveShares<F>>> {
+pub fn transpose<F: Field>(input: &[Vec<Replicated<F>>]) -> Vec<Vec<Replicated<F>>> {
     (0..input[0].len())
         .map(|i| input.iter().map(|b| b[i].clone()).collect::<Vec<_>>())
         .collect::<Vec<_>>()

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -5,7 +5,7 @@ pub use convert_shares::{
     BitConversionTriple,
 };
 
-use crate::{ff::Field, secret_sharing::Replicated};
+use crate::{ff::Field, secret_sharing::ReplicatedAdditiveShares};
 
 /// Transpose rows of bits into bits of rows
 ///
@@ -25,7 +25,9 @@ use crate::{ff::Field, secret_sharing::Replicated};
 ///     `[ row[0].bit31, row[1].bit31, ..., row[n].bit31 ]`,
 /// `]`
 #[must_use]
-pub fn transpose<F: Field>(input: &[Vec<Replicated<F>>]) -> Vec<Vec<Replicated<F>>> {
+pub fn transpose<F: Field>(
+    input: &[Vec<ReplicatedAdditiveShares<F>>],
+) -> Vec<Vec<ReplicatedAdditiveShares<F>>> {
     (0..input[0].len())
         .map(|i| input.iter().map(|b| b[i].clone()).collect::<Vec<_>>())
         .collect::<Vec<_>>()

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -1,7 +1,7 @@
 use super::Step;
 use crate::ff::Field;
 use crate::rand::{CryptoRng, RngCore};
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use crate::sync::{Arc, Mutex};
 
 use aes::{
@@ -85,9 +85,12 @@ pub trait SharedRandomness {
     /// <https://eprint.iacr.org/2018/387.pdf>
     ///
     #[must_use]
-    fn generate_replicated<F: Field, I: Into<u128>>(&self, index: I) -> Replicated<F> {
+    fn generate_replicated<F: Field, I: Into<u128>>(
+        &self,
+        index: I,
+    ) -> ReplicatedAdditiveShares<F> {
         let (l, r) = self.generate_fields(index);
-        Replicated::new(l, r)
+        ReplicatedAdditiveShares::new(l, r)
     }
 
     /// Generate an additive share of zero.

--- a/src/protocol/prss.rs
+++ b/src/protocol/prss.rs
@@ -1,7 +1,7 @@
 use super::Step;
 use crate::ff::Field;
 use crate::rand::{CryptoRng, RngCore};
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::{Arc, Mutex};
 
 use aes::{
@@ -85,12 +85,9 @@ pub trait SharedRandomness {
     /// <https://eprint.iacr.org/2018/387.pdf>
     ///
     #[must_use]
-    fn generate_replicated<F: Field, I: Into<u128>>(
-        &self,
-        index: I,
-    ) -> ReplicatedAdditiveShares<F> {
+    fn generate_replicated<F: Field, I: Into<u128>>(&self, index: I) -> Replicated<F> {
         let (l, r) = self.generate_fields(index);
-        ReplicatedAdditiveShares::new(l, r)
+        Replicated::new(l, r)
     }
 
     /// Generate an additive share of zero.

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,7 +1,7 @@
 use std::iter::{repeat, zip};
 
 use crate::repeat64str;
-use crate::secret_sharing::{ArithmeticShare, Replicated, SecretSharing};
+use crate::secret_sharing::{ArithmeticShare, ReplicatedAdditiveShares, SecretSharing};
 use crate::{
     error::Error,
     ff::Field,
@@ -45,8 +45,8 @@ impl From<usize> for InnerVectorElementStep {
 }
 
 #[async_trait]
-impl<F: Field> Resharable<F> for Vec<Replicated<F>> {
-    type Share = Replicated<F>;
+impl<F: Field> Resharable<F> for Vec<ReplicatedAdditiveShares<F>> {
+    type Share = ReplicatedAdditiveShares<F>;
 
     /// This is intended to be used for resharing vectors of bit-decomposed values.
     /// # Errors
@@ -171,7 +171,7 @@ mod tests {
         use crate::protocol::context::Context;
         use crate::protocol::sort::apply_sort::shuffle::shuffle_shares;
         use crate::protocol::sort::shuffle::get_two_of_three_random_permutations;
-        use crate::secret_sharing::Replicated;
+        use crate::secret_sharing::ReplicatedAdditiveShares;
         use crate::test_fixture::{bits_to_value, get_bits, Reconstruct, Runner, TestWorld};
         use std::collections::HashSet;
 
@@ -212,8 +212,8 @@ mod tests {
         }
 
         fn share_appears_anywhere(
-            x: &Replicated<Fp32BitPrime>,
-            inputs: &[Vec<Replicated<Fp32BitPrime>>],
+            x: &ReplicatedAdditiveShares<Fp32BitPrime>,
+            inputs: &[Vec<ReplicatedAdditiveShares<Fp32BitPrime>>],
         ) -> bool {
             inputs.iter().any(|row| {
                 row.iter()

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,7 +1,9 @@
 use std::iter::{repeat, zip};
 
 use crate::repeat64str;
-use crate::secret_sharing::{ArithmeticShare, ReplicatedAdditiveShares, SecretSharing};
+use crate::secret_sharing::{
+    replicated::semi_honest::AdditiveShare as Replicated, ArithmeticShare, SecretSharing,
+};
 use crate::{
     error::Error,
     ff::Field,
@@ -45,8 +47,8 @@ impl From<usize> for InnerVectorElementStep {
 }
 
 #[async_trait]
-impl<F: Field> Resharable<F> for Vec<ReplicatedAdditiveShares<F>> {
-    type Share = ReplicatedAdditiveShares<F>;
+impl<F: Field> Resharable<F> for Vec<Replicated<F>> {
+    type Share = Replicated<F>;
 
     /// This is intended to be used for resharing vectors of bit-decomposed values.
     /// # Errors
@@ -171,7 +173,7 @@ mod tests {
         use crate::protocol::context::Context;
         use crate::protocol::sort::apply_sort::shuffle::shuffle_shares;
         use crate::protocol::sort::shuffle::get_two_of_three_random_permutations;
-        use crate::secret_sharing::ReplicatedAdditiveShares;
+        use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
         use crate::test_fixture::{bits_to_value, get_bits, Reconstruct, Runner, TestWorld};
         use std::collections::HashSet;
 
@@ -212,8 +214,8 @@ mod tests {
         }
 
         fn share_appears_anywhere(
-            x: &ReplicatedAdditiveShares<Fp32BitPrime>,
-            inputs: &[Vec<ReplicatedAdditiveShares<Fp32BitPrime>>],
+            x: &Replicated<Fp32BitPrime>,
+            inputs: &[Vec<Replicated<Fp32BitPrime>>],
         ) -> bool {
             inputs.iter().any(|row| {
                 row.iter()

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         IpaProtocolStep::Sort,
     },
-    secret_sharing::{MaliciousReplicated, Replicated, SecretSharing},
+    secret_sharing::{MaliciousReplicatedAdditiveShares, ReplicatedAdditiveShares, SecretSharing},
 };
 
 use super::{
@@ -37,7 +37,7 @@ pub struct RevealedAndRandomPermutations {
 }
 
 pub struct ShuffledPermutationWrapper<'a, F: Field> {
-    pub perm: Vec<MaliciousReplicated<F>>,
+    pub perm: Vec<MaliciousReplicatedAdditiveShares<F>>,
     pub m_ctx: MaliciousContext<'a, F>,
 }
 
@@ -87,7 +87,7 @@ pub(super) async fn shuffle_and_reveal_permutation<
 pub(super) async fn malicious_shuffle_and_reveal_permutation<F: Field>(
     m_ctx: MaliciousContext<'_, F>,
     input_len: u32,
-    input_permutation: Vec<MaliciousReplicated<F>>,
+    input_permutation: Vec<MaliciousReplicatedAdditiveShares<F>>,
     malicious_validator: MaliciousValidator<'_, F>,
 ) -> Result<RevealedAndRandomPermutations, Error> {
     let random_permutations_for_shuffle = get_two_of_three_random_permutations(
@@ -140,9 +140,9 @@ pub(super) async fn malicious_shuffle_and_reveal_permutation<F: Field>(
 /// ![Generate sort permutation steps][semi_honest_sort]
 pub async fn generate_permutation<F>(
     ctx: SemiHonestContext<'_, F>,
-    sort_keys: &[Vec<Replicated<F>>],
+    sort_keys: &[Vec<ReplicatedAdditiveShares<F>>],
     num_bits: u32,
-) -> Result<Vec<Replicated<F>>, Error>
+) -> Result<Vec<ReplicatedAdditiveShares<F>>, Error>
 where
     F: Field,
 {
@@ -216,7 +216,7 @@ where
 /// If unable to convert sort keys length to u32
 pub async fn generate_permutation_and_reveal_shuffled<F: Field>(
     ctx: SemiHonestContext<'_, F>,
-    sort_keys: &[Vec<Replicated<F>>],
+    sort_keys: &[Vec<ReplicatedAdditiveShares<F>>],
     num_bits: u32,
 ) -> Result<RevealedAndRandomPermutations, Error> {
     let sort_permutation = generate_permutation(ctx.narrow(&SortKeys), sort_keys, num_bits).await?;
@@ -259,9 +259,15 @@ pub async fn generate_permutation_and_reveal_shuffled<F: Field>(
 /// # Errors
 pub async fn malicious_generate_permutation<'a, F>(
     sh_ctx: SemiHonestContext<'a, F>,
-    sort_keys: &[Vec<Replicated<F>>],
+    sort_keys: &[Vec<ReplicatedAdditiveShares<F>>],
     num_bits: u32,
-) -> Result<(MaliciousValidator<'a, F>, Vec<MaliciousReplicated<F>>), Error>
+) -> Result<
+    (
+        MaliciousValidator<'a, F>,
+        Vec<MaliciousReplicatedAdditiveShares<F>>,
+    ),
+    Error,
+>
 where
     F: Field,
 {
@@ -348,7 +354,7 @@ mod tests {
     use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
     use crate::protocol::sort::generate_permutation::malicious_generate_permutation;
     use crate::rand::{thread_rng, Rng};
-    use crate::secret_sharing::Replicated;
+    use crate::secret_sharing::ReplicatedAdditiveShares;
     use rand::seq::SliceRandom;
 
     use crate::protocol::context::{Context, SemiHonestContext};
@@ -464,7 +470,7 @@ mod tests {
             .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
                 let local_lists =
                     convert_all_bits_local(ctx.role(), &mk_shares, MaskedMatchKey::BITS);
-                let converted_shares: Vec<Vec<Replicated<Fp31>>> =
+                let converted_shares: Vec<Vec<ReplicatedAdditiveShares<Fp31>>> =
                     convert_all_bits(&ctx, &local_lists).await.unwrap();
                 malicious_generate_permutation(
                     ctx.narrow("sort"),

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -1,6 +1,6 @@
 use crate::ff::Field;
 use crate::rand::{thread_rng, Rng};
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use rand::distributions::{Distribution, Standard};
 
 pub trait IntoShares<T>: Sized {
@@ -10,20 +10,20 @@ pub trait IntoShares<T>: Sized {
     fn share_with<R: Rng>(self, rng: &mut R) -> [T; 3];
 }
 
-impl<F> IntoShares<Replicated<F>> for F
+impl<F> IntoShares<ReplicatedAdditiveShares<F>> for F
 where
     F: Field,
     Standard: Distribution<F>,
 {
-    fn share_with<R: Rng>(self, rng: &mut R) -> [Replicated<F>; 3] {
+    fn share_with<R: Rng>(self, rng: &mut R) -> [ReplicatedAdditiveShares<F>; 3] {
         let x1 = rng.gen::<F>();
         let x2 = rng.gen::<F>();
         let x3 = self - (x1 + x2);
 
         [
-            Replicated::new(x1, x2),
-            Replicated::new(x2, x3),
-            Replicated::new(x3, x1),
+            ReplicatedAdditiveShares::new(x1, x2),
+            ReplicatedAdditiveShares::new(x2, x3),
+            ReplicatedAdditiveShares::new(x3, x1),
         ]
     }
 }

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -1,6 +1,6 @@
 use crate::ff::Field;
 use crate::rand::{thread_rng, Rng};
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use rand::distributions::{Distribution, Standard};
 
 pub trait IntoShares<T>: Sized {
@@ -10,20 +10,20 @@ pub trait IntoShares<T>: Sized {
     fn share_with<R: Rng>(self, rng: &mut R) -> [T; 3];
 }
 
-impl<F> IntoShares<ReplicatedAdditiveShares<F>> for F
+impl<F> IntoShares<Replicated<F>> for F
 where
     F: Field,
     Standard: Distribution<F>,
 {
-    fn share_with<R: Rng>(self, rng: &mut R) -> [ReplicatedAdditiveShares<F>; 3] {
+    fn share_with<R: Rng>(self, rng: &mut R) -> [Replicated<F>; 3] {
         let x1 = rng.gen::<F>();
         let x2 = rng.gen::<F>();
         let x3 = self - (x1 + x2);
 
         [
-            ReplicatedAdditiveShares::new(x1, x2),
-            ReplicatedAdditiveShares::new(x2, x3),
-            ReplicatedAdditiveShares::new(x3, x1),
+            Replicated::new(x1, x2),
+            Replicated::new(x2, x3),
+            Replicated::new(x3, x1),
         ]
     }
 }

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -1,22 +1,17 @@
 mod into_shares;
-mod malicious_replicated;
-mod replicated;
+pub mod replicated;
 mod xor;
 #[cfg(any(feature = "test-fixture", feature = "cli"))]
 pub use into_shares::IntoShares;
 
 use crate::bits::BooleanOps;
-use crate::ff::{ArithmeticOps, Field};
-pub use malicious_replicated::{
-    Downgrade as DowngradeMalicious, MaliciousReplicatedAdditiveShares,
-};
-pub(crate) use malicious_replicated::{
-    ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
-};
-pub use replicated::ReplicatedAdditiveShares;
+use crate::ff::ArithmeticOps;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 pub use xor::XorReplicated;
+
+use self::replicated::malicious::AdditiveShare as MaliciousAdditiveShare;
+use self::replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare;
 
 pub trait SharedValue: Clone + Copy + PartialEq + Debug + Send + Sync + Sized + 'static {
     /// Number of bits stored in this data type.
@@ -54,9 +49,9 @@ pub trait SecretSharing<V: SharedValue>:
     const ZERO: Self;
 }
 
-impl<V: ArithmeticShare> SecretSharing<V> for ReplicatedAdditiveShares<V> {
-    const ZERO: Self = ReplicatedAdditiveShares::ZERO;
+impl<V: ArithmeticShare> SecretSharing<V> for SemiHonestAdditiveShare<V> {
+    const ZERO: Self = SemiHonestAdditiveShare::ZERO;
 }
-impl<F: Field> SecretSharing<F> for MaliciousReplicatedAdditiveShares<F> {
-    const ZERO: Self = MaliciousReplicatedAdditiveShares::ZERO;
+impl<V: ArithmeticShare> SecretSharing<V> for MaliciousAdditiveShare<V> {
+    const ZERO: Self = MaliciousAdditiveShare::ZERO;
 }

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -7,11 +7,13 @@ pub use into_shares::IntoShares;
 
 use crate::bits::BooleanOps;
 use crate::ff::{ArithmeticOps, Field};
-pub use malicious_replicated::{Downgrade as DowngradeMalicious, MaliciousReplicated};
+pub use malicious_replicated::{
+    Downgrade as DowngradeMalicious, MaliciousReplicatedAdditiveShares,
+};
 pub(crate) use malicious_replicated::{
     ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
 };
-pub use replicated::Replicated;
+pub use replicated::ReplicatedAdditiveShares;
 use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 pub use xor::XorReplicated;
@@ -23,6 +25,8 @@ pub trait SharedValue: Clone + Copy + PartialEq + Debug + Send + Sync + Sized + 
     /// Size of this data type in bytes. This is the size in memory allocated
     /// for this data type to store the number of bits specified by `BITS`.
     const SIZE_IN_BYTES: usize;
+
+    const ZERO: Self;
 }
 
 pub trait ArithmeticShare: SharedValue + ArithmeticOps {}
@@ -50,9 +54,9 @@ pub trait SecretSharing<V: SharedValue>:
     const ZERO: Self;
 }
 
-impl<F: Field> SecretSharing<F> for Replicated<F> {
-    const ZERO: Self = Replicated::ZERO;
+impl<V: ArithmeticShare> SecretSharing<V> for ReplicatedAdditiveShares<V> {
+    const ZERO: Self = ReplicatedAdditiveShares::ZERO;
 }
-impl<F: Field> SecretSharing<F> for MaliciousReplicated<F> {
-    const ZERO: Self = MaliciousReplicated::ZERO;
+impl<F: Field> SecretSharing<F> for MaliciousReplicatedAdditiveShares<F> {
+    const ZERO: Self = MaliciousReplicatedAdditiveShares::ZERO;
 }

--- a/src/secret_sharing/replicated.rs
+++ b/src/secret_sharing/replicated.rs
@@ -1,41 +1,47 @@
+use super::ArithmeticShare;
 use crate::ff::Field;
 use crate::helpers::Role;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct Replicated<F: Field>(F, F);
+pub struct ReplicatedAdditiveShares<V: ArithmeticShare>(V, V);
 
-impl<F: Field + Debug> Debug for Replicated<F> {
+impl<V: ArithmeticShare + Debug> Debug for ReplicatedAdditiveShares<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 
-impl<F: Field> Default for Replicated<F> {
+impl<V: ArithmeticShare> Default for ReplicatedAdditiveShares<V> {
     fn default() -> Self {
-        Replicated::new(F::ZERO, F::ZERO)
+        ReplicatedAdditiveShares::new(V::ZERO, V::ZERO)
     }
 }
 
-impl<F: Field> Replicated<F> {
+impl<V: ArithmeticShare> ReplicatedAdditiveShares<V> {
     #[must_use]
-    pub fn new(a: F, b: F) -> Self {
+    pub fn new(a: V, b: V) -> Self {
         Self(a, b)
     }
 
-    pub fn as_tuple(&self) -> (F, F) {
+    pub fn as_tuple(&self) -> (V, V) {
         (self.0, self.1)
     }
 
-    pub fn left(&self) -> F {
+    pub fn left(&self) -> V {
         self.0
     }
 
-    pub fn right(&self) -> F {
+    pub fn right(&self) -> V {
         self.1
     }
 
+    /// Replicated secret share where both left and right values are `F::ZERO`
+    pub const ZERO: ReplicatedAdditiveShares<V> = Self(V::ZERO, V::ZERO);
+}
+
+impl<F: Field> ReplicatedAdditiveShares<F> {
     /// Returns share of value one.
     #[must_use]
     pub fn one(helper_role: Role) -> Self {
@@ -50,20 +56,17 @@ impl<F: Field> Replicated<F> {
             Role::H3 => Self::new(F::ZERO, a),
         }
     }
-
-    /// Replicated secret share where both left and right values are `F::ZERO`
-    pub const ZERO: Replicated<F> = Self(F::ZERO, F::ZERO);
 }
 
-impl<F: Field> Add<Self> for &Replicated<F> {
-    type Output = Replicated<F>;
+impl<V: ArithmeticShare> Add<Self> for &ReplicatedAdditiveShares<V> {
+    type Output = ReplicatedAdditiveShares<V>;
 
     fn add(self, rhs: Self) -> Self::Output {
-        Replicated(self.0 + rhs.0, self.1 + rhs.1)
+        ReplicatedAdditiveShares(self.0 + rhs.0, self.1 + rhs.1)
     }
 }
 
-impl<F: Field> Add<&Self> for Replicated<F> {
+impl<V: ArithmeticShare> Add<&Self> for ReplicatedAdditiveShares<V> {
     type Output = Self;
 
     fn add(mut self, rhs: &Self) -> Self::Output {
@@ -72,14 +75,14 @@ impl<F: Field> Add<&Self> for Replicated<F> {
     }
 }
 
-impl<F: Field> AddAssign<&Self> for Replicated<F> {
+impl<V: ArithmeticShare> AddAssign<&Self> for ReplicatedAdditiveShares<V> {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += rhs.0;
         self.1 += rhs.1;
     }
 }
 
-impl<F: Field> Neg for Replicated<F> {
+impl<V: ArithmeticShare> Neg for ReplicatedAdditiveShares<V> {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
@@ -87,15 +90,15 @@ impl<F: Field> Neg for Replicated<F> {
     }
 }
 
-impl<F: Field> Sub<Self> for &Replicated<F> {
-    type Output = Replicated<F>;
+impl<V: ArithmeticShare> Sub<Self> for &ReplicatedAdditiveShares<V> {
+    type Output = ReplicatedAdditiveShares<V>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Replicated(self.0 - rhs.0, self.1 - rhs.1)
+        ReplicatedAdditiveShares(self.0 - rhs.0, self.1 - rhs.1)
     }
 }
 
-impl<F: Field> Sub<&Self> for Replicated<F> {
+impl<V: ArithmeticShare> Sub<&Self> for ReplicatedAdditiveShares<V> {
     type Output = Self;
 
     fn sub(mut self, rhs: &Self) -> Self::Output {
@@ -104,44 +107,52 @@ impl<F: Field> Sub<&Self> for Replicated<F> {
     }
 }
 
-impl<F: Field> SubAssign<&Self> for Replicated<F> {
+impl<V: ArithmeticShare> SubAssign<&Self> for ReplicatedAdditiveShares<V> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.0 -= rhs.0;
         self.1 -= rhs.1;
     }
 }
 
-impl<F: Field> Mul<F> for Replicated<F> {
+impl<V: ArithmeticShare> Mul<V> for ReplicatedAdditiveShares<V> {
     type Output = Self;
 
-    fn mul(self, rhs: F) -> Self::Output {
+    fn mul(self, rhs: V) -> Self::Output {
         Self(self.0 * rhs, self.1 * rhs)
     }
 }
 
-impl<F: Field> From<(F, F)> for Replicated<F> {
-    fn from(s: (F, F)) -> Self {
-        Replicated::new(s.0, s.1)
+impl<V: ArithmeticShare> From<(V, V)> for ReplicatedAdditiveShares<V> {
+    fn from(s: (V, V)) -> Self {
+        ReplicatedAdditiveShares::new(s.0, s.1)
     }
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::Replicated;
+    use super::ReplicatedAdditiveShares;
     use crate::ff::Fp31;
 
-    fn secret_share(a: u8, b: u8, c: u8) -> (Replicated<Fp31>, Replicated<Fp31>, Replicated<Fp31>) {
+    fn secret_share(
+        a: u8,
+        b: u8,
+        c: u8,
+    ) -> (
+        ReplicatedAdditiveShares<Fp31>,
+        ReplicatedAdditiveShares<Fp31>,
+        ReplicatedAdditiveShares<Fp31>,
+    ) {
         (
-            Replicated::new(Fp31::from(a), Fp31::from(b)),
-            Replicated::new(Fp31::from(b), Fp31::from(c)),
-            Replicated::new(Fp31::from(c), Fp31::from(a)),
+            ReplicatedAdditiveShares::new(Fp31::from(a), Fp31::from(b)),
+            ReplicatedAdditiveShares::new(Fp31::from(b), Fp31::from(c)),
+            ReplicatedAdditiveShares::new(Fp31::from(c), Fp31::from(a)),
         )
     }
 
     fn assert_valid_secret_sharing(
-        res1: &Replicated<Fp31>,
-        res2: &Replicated<Fp31>,
-        res3: &Replicated<Fp31>,
+        res1: &ReplicatedAdditiveShares<Fp31>,
+        res2: &ReplicatedAdditiveShares<Fp31>,
+        res3: &ReplicatedAdditiveShares<Fp31>,
     ) {
         assert_eq!(res1.1, res2.0);
         assert_eq!(res2.1, res3.0);
@@ -149,9 +160,9 @@ mod tests {
     }
 
     fn assert_secret_shared_value(
-        a1: &Replicated<Fp31>,
-        a2: &Replicated<Fp31>,
-        a3: &Replicated<Fp31>,
+        a1: &ReplicatedAdditiveShares<Fp31>,
+        a2: &ReplicatedAdditiveShares<Fp31>,
+        a3: &ReplicatedAdditiveShares<Fp31>,
         expected_value: u128,
     ) {
         assert_eq!(a1.0 + a2.0 + a3.0, Fp31::from(expected_value));

--- a/src/secret_sharing/replicated/malicious/mod.rs
+++ b/src/secret_sharing/replicated/malicious/mod.rs
@@ -1,0 +1,6 @@
+mod additive_share;
+
+pub use additive_share::{AdditiveShare, Downgrade as DowngradeMalicious};
+pub(crate) use additive_share::{
+    ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
+};

--- a/src/secret_sharing/replicated/mod.rs
+++ b/src/secret_sharing/replicated/mod.rs
@@ -1,0 +1,2 @@
+pub mod malicious;
+pub mod semi_honest;

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -1,25 +1,25 @@
-use super::ArithmeticShare;
 use crate::ff::Field;
 use crate::helpers::Role;
+use crate::secret_sharing::ArithmeticShare;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct ReplicatedAdditiveShares<V: ArithmeticShare>(V, V);
+pub struct AdditiveShare<V: ArithmeticShare>(V, V);
 
-impl<V: ArithmeticShare + Debug> Debug for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare + Debug> Debug for AdditiveShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "({:?}, {:?})", self.0, self.1)
     }
 }
 
-impl<V: ArithmeticShare> Default for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> Default for AdditiveShare<V> {
     fn default() -> Self {
-        ReplicatedAdditiveShares::new(V::ZERO, V::ZERO)
+        AdditiveShare::new(V::ZERO, V::ZERO)
     }
 }
 
-impl<V: ArithmeticShare> ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> AdditiveShare<V> {
     #[must_use]
     pub fn new(a: V, b: V) -> Self {
         Self(a, b)
@@ -38,10 +38,10 @@ impl<V: ArithmeticShare> ReplicatedAdditiveShares<V> {
     }
 
     /// Replicated secret share where both left and right values are `F::ZERO`
-    pub const ZERO: ReplicatedAdditiveShares<V> = Self(V::ZERO, V::ZERO);
+    pub const ZERO: AdditiveShare<V> = Self(V::ZERO, V::ZERO);
 }
 
-impl<F: Field> ReplicatedAdditiveShares<F> {
+impl<F: Field> AdditiveShare<F> {
     /// Returns share of value one.
     #[must_use]
     pub fn one(helper_role: Role) -> Self {
@@ -58,15 +58,15 @@ impl<F: Field> ReplicatedAdditiveShares<F> {
     }
 }
 
-impl<V: ArithmeticShare> Add<Self> for &ReplicatedAdditiveShares<V> {
-    type Output = ReplicatedAdditiveShares<V>;
+impl<V: ArithmeticShare> Add<Self> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
     fn add(self, rhs: Self) -> Self::Output {
-        ReplicatedAdditiveShares(self.0 + rhs.0, self.1 + rhs.1)
+        AdditiveShare(self.0 + rhs.0, self.1 + rhs.1)
     }
 }
 
-impl<V: ArithmeticShare> Add<&Self> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> Add<&Self> for AdditiveShare<V> {
     type Output = Self;
 
     fn add(mut self, rhs: &Self) -> Self::Output {
@@ -75,14 +75,14 @@ impl<V: ArithmeticShare> Add<&Self> for ReplicatedAdditiveShares<V> {
     }
 }
 
-impl<V: ArithmeticShare> AddAssign<&Self> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> AddAssign<&Self> for AdditiveShare<V> {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += rhs.0;
         self.1 += rhs.1;
     }
 }
 
-impl<V: ArithmeticShare> Neg for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> Neg for AdditiveShare<V> {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
@@ -90,15 +90,15 @@ impl<V: ArithmeticShare> Neg for ReplicatedAdditiveShares<V> {
     }
 }
 
-impl<V: ArithmeticShare> Sub<Self> for &ReplicatedAdditiveShares<V> {
-    type Output = ReplicatedAdditiveShares<V>;
+impl<V: ArithmeticShare> Sub<Self> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        ReplicatedAdditiveShares(self.0 - rhs.0, self.1 - rhs.1)
+        AdditiveShare(self.0 - rhs.0, self.1 - rhs.1)
     }
 }
 
-impl<V: ArithmeticShare> Sub<&Self> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> Sub<&Self> for AdditiveShare<V> {
     type Output = Self;
 
     fn sub(mut self, rhs: &Self) -> Self::Output {
@@ -107,14 +107,14 @@ impl<V: ArithmeticShare> Sub<&Self> for ReplicatedAdditiveShares<V> {
     }
 }
 
-impl<V: ArithmeticShare> SubAssign<&Self> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> SubAssign<&Self> for AdditiveShare<V> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.0 -= rhs.0;
         self.1 -= rhs.1;
     }
 }
 
-impl<V: ArithmeticShare> Mul<V> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> Mul<V> for AdditiveShare<V> {
     type Output = Self;
 
     fn mul(self, rhs: V) -> Self::Output {
@@ -122,15 +122,15 @@ impl<V: ArithmeticShare> Mul<V> for ReplicatedAdditiveShares<V> {
     }
 }
 
-impl<V: ArithmeticShare> From<(V, V)> for ReplicatedAdditiveShares<V> {
+impl<V: ArithmeticShare> From<(V, V)> for AdditiveShare<V> {
     fn from(s: (V, V)) -> Self {
-        ReplicatedAdditiveShares::new(s.0, s.1)
+        AdditiveShare::new(s.0, s.1)
     }
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::ReplicatedAdditiveShares;
+    use super::AdditiveShare;
     use crate::ff::Fp31;
 
     fn secret_share(
@@ -138,21 +138,21 @@ mod tests {
         b: u8,
         c: u8,
     ) -> (
-        ReplicatedAdditiveShares<Fp31>,
-        ReplicatedAdditiveShares<Fp31>,
-        ReplicatedAdditiveShares<Fp31>,
+        AdditiveShare<Fp31>,
+        AdditiveShare<Fp31>,
+        AdditiveShare<Fp31>,
     ) {
         (
-            ReplicatedAdditiveShares::new(Fp31::from(a), Fp31::from(b)),
-            ReplicatedAdditiveShares::new(Fp31::from(b), Fp31::from(c)),
-            ReplicatedAdditiveShares::new(Fp31::from(c), Fp31::from(a)),
+            AdditiveShare::new(Fp31::from(a), Fp31::from(b)),
+            AdditiveShare::new(Fp31::from(b), Fp31::from(c)),
+            AdditiveShare::new(Fp31::from(c), Fp31::from(a)),
         )
     }
 
     fn assert_valid_secret_sharing(
-        res1: &ReplicatedAdditiveShares<Fp31>,
-        res2: &ReplicatedAdditiveShares<Fp31>,
-        res3: &ReplicatedAdditiveShares<Fp31>,
+        res1: &AdditiveShare<Fp31>,
+        res2: &AdditiveShare<Fp31>,
+        res3: &AdditiveShare<Fp31>,
     ) {
         assert_eq!(res1.1, res2.0);
         assert_eq!(res2.1, res3.0);
@@ -160,9 +160,9 @@ mod tests {
     }
 
     fn assert_secret_shared_value(
-        a1: &ReplicatedAdditiveShares<Fp31>,
-        a2: &ReplicatedAdditiveShares<Fp31>,
-        a3: &ReplicatedAdditiveShares<Fp31>,
+        a1: &AdditiveShare<Fp31>,
+        a2: &AdditiveShare<Fp31>,
+        a3: &AdditiveShare<Fp31>,
         expected_value: u128,
     ) {
         assert_eq!(a1.0 + a2.0 + a3.0, Fp31::from(expected_value));

--- a/src/secret_sharing/replicated/semi_honest/mod.rs
+++ b/src/secret_sharing/replicated/semi_honest/mod.rs
@@ -1,0 +1,3 @@
+mod additive_share;
+
+pub use additive_share::AdditiveShare;

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -3,7 +3,7 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{IntoShares, Replicated};
+use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
 use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
 
@@ -29,7 +29,11 @@ pub async fn arithmetic<F: Field>(width: u32, depth: u8) {
     assert_eq!(sum, u128::from(width));
 }
 
-async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
+async fn circuit(
+    world: &TestWorld,
+    record_id: RecordId,
+    depth: u8,
+) -> [ReplicatedAdditiveShares<Fp31>; 3] {
     let top_ctx = world.contexts();
     let mut a = Fp31::ONE.share_with(&mut thread_rng());
 

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -3,7 +3,7 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares};
+use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
 use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
 
@@ -29,11 +29,7 @@ pub async fn arithmetic<F: Field>(width: u32, depth: u8) {
     assert_eq!(sum, u128::from(width));
 }
 
-async fn circuit(
-    world: &TestWorld,
-    record_id: RecordId,
-    depth: u8,
-) -> [ReplicatedAdditiveShares<Fp31>; 3] {
+async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicated<Fp31>; 3] {
     let top_ctx = world.contexts();
     let mut a = Fp31::ONE.share_with(&mut thread_rng());
 

--- a/src/test_fixture/ipa_input_row.rs
+++ b/src/test_fixture/ipa_input_row.rs
@@ -2,7 +2,8 @@ use rand::{distributions::Standard, prelude::Distribution};
 
 use crate::secret_sharing::IntoShares;
 use crate::{
-    ff::Field, protocol::ipa::IPAInputRow, rand::Rng, secret_sharing::ReplicatedAdditiveShares,
+    ff::Field, protocol::ipa::IPAInputRow, rand::Rng,
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
 
 use super::MaskedMatchKey;
@@ -37,7 +38,7 @@ impl IPAInputTestRow {
 
 impl<F> IntoShares<IPAInputRow<F>> for IPAInputTestRow
 where
-    F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
+    F: Field + IntoShares<Replicated<F>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [IPAInputRow<F>; 3] {

--- a/src/test_fixture/ipa_input_row.rs
+++ b/src/test_fixture/ipa_input_row.rs
@@ -1,7 +1,9 @@
 use rand::{distributions::Standard, prelude::Distribution};
 
 use crate::secret_sharing::IntoShares;
-use crate::{ff::Field, protocol::ipa::IPAInputRow, rand::Rng, secret_sharing::Replicated};
+use crate::{
+    ff::Field, protocol::ipa::IPAInputRow, rand::Rng, secret_sharing::ReplicatedAdditiveShares,
+};
 
 use super::MaskedMatchKey;
 
@@ -35,7 +37,7 @@ impl IPAInputTestRow {
 
 impl<F> IntoShares<IPAInputRow<F>> for IPAInputTestRow
 where
-    F: Field + IntoShares<Replicated<F>>,
+    F: Field + IntoShares<ReplicatedAdditiveShares<F>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [IPAInputRow<F>; 3] {

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -13,7 +13,7 @@ use crate::protocol::context::Context;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{IntoShares, Replicated, SecretSharing};
+use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares, SecretSharing};
 use futures::future::try_join_all;
 use futures::TryFuture;
 pub use ipa_input_row::IPAInputTestRow;
@@ -62,7 +62,7 @@ pub fn make_participants() -> [PrssEndpoint; 3] {
     [p1, p2, p3]
 }
 
-pub type ReplicatedShares<T> = [Vec<Replicated<T>>; 3];
+pub type ReplicatedShares<T> = [Vec<ReplicatedAdditiveShares<T>>; 3];
 
 // Generate vector shares from vector of inputs for three participant
 #[must_use]

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -13,7 +13,9 @@ use crate::protocol::context::Context;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{IntoShares, ReplicatedAdditiveShares, SecretSharing};
+use crate::secret_sharing::{
+    replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SecretSharing,
+};
 use futures::future::try_join_all;
 use futures::TryFuture;
 pub use ipa_input_row::IPAInputTestRow;
@@ -62,7 +64,7 @@ pub fn make_participants() -> [PrssEndpoint; 3] {
     [p1, p2, p3]
 }
 
-pub type ReplicatedShares<T> = [Vec<ReplicatedAdditiveShares<T>>; 3];
+pub type ReplicatedShares<T> = [Vec<Replicated<T>>; 3];
 
 // Generate vector shares from vector of inputs for three participant
 #[must_use]

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -16,7 +16,7 @@ use crate::{
         malicious::MaliciousValidator,
         prss::Endpoint as PrssEndpoint,
     },
-    secret_sharing::DowngradeMalicious,
+    secret_sharing::replicated::malicious::DowngradeMalicious,
     test_fixture::{logging, make_participants},
 };
 

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -4,7 +4,7 @@ use crate::ff::Fp32BitPrime;
 use crate::helpers::Direction;
 use crate::protocol::context::{Context, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::ReplicatedAdditiveShares;
+use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::test_fixture::Reconstruct;
 use crate::test_fixture::{Runner, TestWorld};
 use futures_util::future::{try_join, try_join_all};
@@ -48,7 +48,7 @@ fn send_receive_sequential() {
                                 let right: Fp32BitPrime =
                                     right_channel.receive(left_peer, record_id).await.unwrap();
 
-                                *share = ReplicatedAdditiveShares::new(left, right);
+                                *share = Replicated::new(left, right);
                             }
 
                             // each helper just swapped their shares, i.e. H1 now holds
@@ -117,10 +117,7 @@ fn send_receive_parallel() {
 
                             let result = try_join_all(futures).await.unwrap();
 
-                            result
-                                .into_iter()
-                                .map(ReplicatedAdditiveShares::from)
-                                .collect::<Vec<_>>()
+                            result.into_iter().map(Replicated::from).collect::<Vec<_>>()
                         },
                     )
                     .await

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -4,7 +4,7 @@ use crate::ff::Fp32BitPrime;
 use crate::helpers::Direction;
 use crate::protocol::context::{Context, SemiHonestContext};
 use crate::protocol::RecordId;
-use crate::secret_sharing::Replicated;
+use crate::secret_sharing::ReplicatedAdditiveShares;
 use crate::test_fixture::Reconstruct;
 use crate::test_fixture::{Runner, TestWorld};
 use futures_util::future::{try_join, try_join_all};
@@ -48,7 +48,7 @@ fn send_receive_sequential() {
                                 let right: Fp32BitPrime =
                                     right_channel.receive(left_peer, record_id).await.unwrap();
 
-                                *share = Replicated::new(left, right);
+                                *share = ReplicatedAdditiveShares::new(left, right);
                             }
 
                             // each helper just swapped their shares, i.e. H1 now holds
@@ -117,7 +117,10 @@ fn send_receive_parallel() {
 
                             let result = try_join_all(futures).await.unwrap();
 
-                            result.into_iter().map(Replicated::from).collect::<Vec<_>>()
+                            result
+                                .into_iter()
+                                .map(ReplicatedAdditiveShares::from)
+                                .collect::<Vec<_>>()
                         },
                     )
                     .await


### PR DESCRIPTION
Simple renamings of `Replicated` and `MaliciousReplicated` to `ReplicatedAdditiveShares` and `MaliciousReplicatedAdditiveShares`. Touches many files but no logic change is introduced by this diff.

Also moved the `const ZERO` to `SharedValue` as it's common to both arithmetic and boolean shares.