### PR TITLE
rework upgrades for malicious protocol

### DIFF
--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -408,8 +408,8 @@ pub(in crate::protocol) mod test {
                         let v = MaliciousValidator::new(ctx);
                         let m_ctx = v.context();
                         let (m_a, m_b) = try_join(
-                            m_ctx.upgrade_with_sparse(&BitOpStep::from(0), RECORD_0, v_a, a),
-                            m_ctx.upgrade_with_sparse(&BitOpStep::from(1), RECORD_0, v_b, b),
+                            m_ctx.upgrade_with_sparse(&BitOpStep::from(0), v_a, a),
+                            m_ctx.upgrade_with_sparse(&BitOpStep::from(1), v_b, b),
                         )
                         .await
                         .unwrap();

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -325,7 +325,7 @@ mod tests {
                     .semi_honest(a, |ctx, a| async move {
                         let v = MaliciousValidator::new(ctx);
                         let record_id = RecordId::from(0);
-                        let m_a = v.context().upgrade(RecordId::from(0), a).await.unwrap();
+                        let m_a = v.context().upgrade(a).await.unwrap();
 
                         let m_reshared_a = if v.context().role() == *malicious_actor {
                             // This role is spoiling the value.

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -172,7 +172,7 @@ mod tests {
 
         let m_shares = join3v(
             zip(v.iter(), input.share_with(&mut rng))
-                .map(|(v, share)| async { v.context().upgrade(record_id, share).await }),
+                .map(|(v, share)| async { v.context().upgrade(share).await }),
         )
         .await;
 
@@ -201,7 +201,7 @@ mod tests {
 
         let m_shares = join3v(
             zip(v.iter(), input.share_with(&mut rng))
-                .map(|(v, share)| async { v.context().upgrade(record_id, share).await }),
+                .map(|(v, share)| async { v.context().upgrade(share).await }),
         )
         .await;
         let result = try_join3(

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -20,7 +20,7 @@ impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
         let ctx = &c;
         let malicious_triples =
             try_join_all(triples.into_iter().enumerate().map(|(i, t)| async move {
-                ctx.upgrade_bit_triple(&BitOpStep::from(i), record_id, t)
+                ctx.upgrade_for_record_with(&BitOpStep::from(i), record_id, t)
                     .await
             }))
             .await?;

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -286,7 +286,9 @@ impl<'a, F: Field> ContextInner<'a, F> {
 /// ```no_run
 /// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
 /// use raw_ipa::ff::Fp31;
-/// use raw_ipa::secret_sharing::{MaliciousReplicated, Replicated};
+/// use raw_ipa::secret_sharing::replicated::{
+///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+/// };
 /// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<Replicated<Fp31>, _>>::upgrade;
 /// let _ = <UpgradeContext<Fp31, RecordId> as UpgradeToMalicious<Replicated<Fp31>, _>>::upgrade;
 /// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<(Replicated<Fp31>, Replicated<Fp31>), _>>::upgrade;
@@ -297,7 +299,9 @@ impl<'a, F: Field> ContextInner<'a, F> {
 /// ```compile_fail
 /// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
 /// use raw_ipa::ff::Fp31;
-/// use raw_ipa::secret_sharing::{MaliciousReplicated, Replicated};
+/// use raw_ipa::secret_sharing::replicated::{
+///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+/// };
 /// // This can't be upgraded with a record-bound context because the record ID
 /// // is used internally for vector indexing.
 /// let _ = <UpgradeContext<Fp31, RecordId> as UpgradeToMalicious<Vec<Replicated<Fp31>>, _>>::upgrade;
@@ -398,8 +402,7 @@ where
     U: Send + 'static,
     TM: Send + Sized,
     UM: Send + Sized,
-    for<'u> UpgradeContext<'u, F, NoRecord>: UpgradeToMalicious<T, TM>,
-    for<'u> UpgradeContext<'u, F, NoRecord>: UpgradeToMalicious<U, UM>,
+    for<'u> UpgradeContext<'u, F, NoRecord>: UpgradeToMalicious<T, TM> + UpgradeToMalicious<U, UM>,
 {
     async fn upgrade(self, input: (T, U)) -> Result<(TM, UM), Error> {
         try_join(

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,6 +1,5 @@
-use std::iter::{repeat, zip};
-
-use futures::future::try_join_all;
+use async_trait::async_trait;
+use futures::future::{try_join, try_join_all};
 
 use crate::error::Error;
 use crate::ff::Field;
@@ -15,7 +14,7 @@ use crate::protocol::context::{
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::modulus_conversion::BitConversionTriple;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
-use crate::protocol::{RecordId, Step, Substep};
+use crate::protocol::{BitOpStep, RecordId, Step, Substep, RECORD_0};
 use crate::secret_sharing::replicated::{
     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
 };
@@ -54,88 +53,42 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
     /// # Errors
     /// When the multiplication fails. This does not include additive attacks
     /// by other helpers.  These are caught later.
-    pub async fn upgrade(
-        &self,
-        record_id: RecordId,
-        input: Replicated<F>,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        self.upgrade_sparse(record_id, input, ZeroPositions::Pvvv)
-            .await
+    pub async fn upgrade<T, M>(&self, input: T) -> Result<M, Error>
+    where
+        for<'u> UpgradeContext<'u, F>: UpgradeToMalicious<T, M>,
+    {
+        self.inner.upgrade(input).await
     }
 
     /// Upgrade a sparse input using this context.
     /// # Errors
     /// When the multiplication fails. This does not include additive attacks
     /// by other helpers.  These are caught later.
-    pub async fn upgrade_sparse(
-        &self,
-        record_id: RecordId,
-        input: Replicated<F>,
-        zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        self.inner.upgrade(record_id, input, zeros_at).await
-    }
-
-    /// Upgrade an input vector using this context.
-    /// # Errors
-    /// When the multiplication fails. This does not include additive attacks
-    /// by other helpers.  These are caught later.
-    pub async fn upgrade_vector<SS: Substep>(
-        &self,
-        step: &SS,
-        input: Vec<Replicated<F>>,
-    ) -> Result<Vec<MaliciousReplicated<F>>, Error> {
-        try_join_all(
-            zip(repeat(self), input.into_iter().enumerate()).map(|(ctx, (i, share))| async move {
-                ctx.upgrade_with(step, RecordId::from(i), share).await
-            }),
-        )
-        .await
-    }
-
-    /// Upgrade an input for a specific bit index using this context.  Use this for
-    /// inputs that have multiple bit positions in place of `upgrade()`.
-    /// # Errors
-    /// When the multiplication fails. This does not include additive attacks
-    /// by other helpers.  These are caught later.
-    pub async fn upgrade_with<SS: Substep>(
-        &self,
-        step: &SS,
-        record_id: RecordId,
-        input: Replicated<F>,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        self.upgrade_with_sparse(step, record_id, input, ZeroPositions::Pvvv)
-            .await
-    }
-
-    /// Upgrade an input for a specific bit index using this context.  Use this for
-    /// inputs that have multiple bit positions in place of `upgrade()`.
-    /// # Errors
-    /// When the multiplication fails. This does not include additive attacks
-    /// by other helpers.  These are caught later.
     pub async fn upgrade_with_sparse<SS: Substep>(
         &self,
         step: &SS,
-        record_id: RecordId,
         input: Replicated<F>,
         zeros_at: ZeroPositions,
     ) -> Result<MaliciousReplicated<F>, Error> {
-        self.inner
-            .upgrade_with(step, record_id, input, zeros_at)
-            .await
+        self.inner.upgrade_with_sparse(step, input, zeros_at).await
     }
 
-    /// Upgrade an bit conversion triple for a specific bit.
+    /// Upgrade an input for a specific bit index and record using this context.
     /// # Errors
     /// When the multiplication fails. This does not include additive attacks
     /// by other helpers.  These are caught later.
-    pub async fn upgrade_bit_triple<SS: Substep>(
+    pub async fn upgrade_for_record_with<SS: Substep, T, M>(
         &self,
         step: &SS,
         record_id: RecordId,
-        triple: BitConversionTriple<Replicated<F>>,
-    ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
-        self.inner.upgrade_bit_triple(step, record_id, triple).await
+        input: T,
+    ) -> Result<M, Error>
+    where
+        for<'u> UpgradeContext<'u, F, RecordId>: UpgradeToMalicious<T, M>,
+    {
+        self.inner
+            .upgrade_for_record_with(step, record_id, input)
+            .await
     }
 }
 
@@ -281,52 +234,151 @@ impl<'a, F: Field> ContextInner<'a, F> {
         Ok(m)
     }
 
+    async fn upgrade<T, M>(&self, input: T) -> Result<M, Error>
+    where
+        for<'u> UpgradeContext<'u, F>: UpgradeToMalicious<T, M>,
+    {
+        UpgradeContext {
+            upgrade_ctx: self.upgrade_ctx.clone(),
+            inner: self,
+            record_binding: NoRecord,
+        }
+        .upgrade(input)
+        .await
+    }
+
+    async fn upgrade_with_sparse<SS: Substep>(
+        &self,
+        step: &SS,
+        input: Replicated<F>,
+        zeros_at: ZeroPositions,
+    ) -> Result<MaliciousReplicated<F>, Error> {
+        UpgradeContext {
+            upgrade_ctx: self.upgrade_ctx.narrow(step),
+            inner: self,
+            record_binding: NoRecord,
+        }
+        .upgrade_sparse(input, zeros_at)
+        .await
+    }
+
+    async fn upgrade_for_record_with<SS: Substep, T, M>(
+        &self,
+        step: &SS,
+        record_id: RecordId,
+        input: T,
+    ) -> Result<M, Error>
+    where
+        for<'u> UpgradeContext<'u, F, RecordId>: UpgradeToMalicious<T, M>,
+    {
+        UpgradeContext {
+            upgrade_ctx: self.upgrade_ctx.narrow(step),
+            inner: self,
+            record_binding: record_id,
+        }
+        .upgrade(input)
+        .await
+    }
+}
+
+/// Helper to prevent using the record ID multiple times to implement an upgrade.
+///
+/// ```no_run
+/// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
+/// use raw_ipa::ff::Fp31;
+/// use raw_ipa::secret_sharing::{MaliciousReplicated, Replicated};
+/// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<Replicated<Fp31>, _>>::upgrade;
+/// let _ = <UpgradeContext<Fp31, RecordId> as UpgradeToMalicious<Replicated<Fp31>, _>>::upgrade;
+/// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<(Replicated<Fp31>, Replicated<Fp31>), _>>::upgrade;
+/// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<Vec<Replicated<Fp31>>, _>>::upgrade;
+/// let _ = <UpgradeContext<Fp31, NoRecord> as UpgradeToMalicious<(Vec<Replicated<Fp31>>, Vec<Replicated<Fp31>>), _>>::upgrade;
+/// ```
+///
+/// ```compile_fail
+/// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
+/// use raw_ipa::ff::Fp31;
+/// use raw_ipa::secret_sharing::{MaliciousReplicated, Replicated};
+/// // This can't be upgraded with a record-bound context because the record ID
+/// // is used internally for vector indexing.
+/// let _ = <UpgradeContext<Fp31, RecordId> as UpgradeToMalicious<Vec<Replicated<Fp31>>, _>>::upgrade;
+/// ```
+pub trait RecordBinding: Copy + Send + Sync {}
+
+#[derive(Clone, Copy)]
+pub struct NoRecord;
+impl RecordBinding for NoRecord {}
+
+impl RecordBinding for RecordId {}
+
+pub struct UpgradeContext<'a, F: Field, B: RecordBinding = NoRecord> {
+    upgrade_ctx: SemiHonestContext<'a, F>,
+    inner: &'a ContextInner<'a, F>,
+    record_binding: B,
+}
+
+impl<'a, F: Field, B: RecordBinding> UpgradeContext<'a, F, B> {
+    fn narrow<SS: Substep>(&self, step: &SS) -> Self {
+        Self {
+            upgrade_ctx: self.upgrade_ctx.narrow(step),
+            inner: self.inner,
+            record_binding: self.record_binding,
+        }
+    }
+}
+
+// This could also work on a record-bound context, but it's only used in one place for tests where
+// that's not currently required.
+impl<'a, F: Field> UpgradeContext<'a, F, NoRecord> {
+    async fn upgrade_sparse(
+        self,
+        input: Replicated<F>,
+        zeros_at: ZeroPositions,
+    ) -> Result<MaliciousReplicated<F>, Error> {
+        self.inner
+            .upgrade_one(
+                self.upgrade_ctx, /*.set_total_records(1)*/
+                RecordId::from(0u32),
+                input,
+                zeros_at,
+            )
+            .await
+    }
+}
+
+#[async_trait]
+pub trait UpgradeToMalicious<T, M> {
+    async fn upgrade(self, input: T) -> Result<M, Error>;
+}
+
+#[async_trait]
+impl<'a, F: Field>
+    UpgradeToMalicious<
+        BitConversionTriple<Replicated<F>>,
+        BitConversionTriple<MaliciousReplicated<F>>,
+    > for UpgradeContext<'a, F, RecordId>
+{
     async fn upgrade(
-        &self,
-        record_id: RecordId,
-        x: Replicated<F>,
-        zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        self.upgrade_one(self.upgrade_ctx.clone(), record_id, x, zeros_at)
-            .await
-    }
-
-    async fn upgrade_with<SS: Substep>(
-        &self,
-        step: &SS,
-        record_id: RecordId,
-        x: Replicated<F>,
-        zeros_at: ZeroPositions,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        self.upgrade_one(self.upgrade_ctx.narrow(step), record_id, x, zeros_at)
-            .await
-    }
-
-    async fn upgrade_bit_triple<SS: Substep>(
-        &self,
-        step: &SS,
-        record_id: RecordId,
-        triple: BitConversionTriple<Replicated<F>>,
+        self,
+        input: BitConversionTriple<Replicated<F>>,
     ) -> Result<BitConversionTriple<MaliciousReplicated<F>>, Error> {
-        let [v0, v1, v2] = triple.0;
-        let c = self.upgrade_ctx.narrow(step);
+        let [v0, v1, v2] = input.0;
         Ok(BitConversionTriple(
             try_join_all([
-                self.upgrade_one(
-                    c.narrow(&UpgradeTripleStep::V0),
-                    record_id,
+                self.inner.upgrade_one(
+                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V0),
+                    self.record_binding,
                     v0,
                     ZeroPositions::Pvzz,
                 ),
-                self.upgrade_one(
-                    c.narrow(&UpgradeTripleStep::V1),
-                    record_id,
+                self.inner.upgrade_one(
+                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V1),
+                    self.record_binding,
                     v1,
                     ZeroPositions::Pzvz,
                 ),
-                self.upgrade_one(
-                    c.narrow(&UpgradeTripleStep::V2),
-                    record_id,
+                self.inner.upgrade_one(
+                    self.upgrade_ctx.narrow(&UpgradeTripleStep::V2),
+                    self.record_binding,
                     v2,
                     ZeroPositions::Pzzv,
                 ),
@@ -335,5 +387,89 @@ impl<'a, F: Field> ContextInner<'a, F> {
             .try_into()
             .unwrap(),
         ))
+    }
+}
+
+#[async_trait]
+impl<'a, F, T, TM, U, UM> UpgradeToMalicious<(T, U), (TM, UM)> for UpgradeContext<'a, F, NoRecord>
+where
+    F: Field,
+    T: Send + 'static,
+    U: Send + 'static,
+    TM: Send + Sized,
+    UM: Send + Sized,
+    for<'u> UpgradeContext<'u, F, NoRecord>: UpgradeToMalicious<T, TM>,
+    for<'u> UpgradeContext<'u, F, NoRecord>: UpgradeToMalicious<U, UM>,
+{
+    async fn upgrade(self, input: (T, U)) -> Result<(TM, UM), Error> {
+        try_join(
+            self.narrow(&BitOpStep::from(0)).upgrade(input.0),
+            self.narrow(&BitOpStep::from(1)).upgrade(input.1),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl<'a, F> UpgradeToMalicious<Vec<Replicated<F>>, Vec<MaliciousReplicated<F>>>
+    for UpgradeContext<'a, F, NoRecord>
+where
+    F: Field,
+{
+    async fn upgrade(
+        self,
+        input: Vec<Replicated<F>>,
+    ) -> Result<Vec<MaliciousReplicated<F>>, Error> {
+        let ctx = self.upgrade_ctx/*.set_total_records(input.len())*/;
+        let ctx_ref = &ctx;
+        try_join_all(input.into_iter().enumerate().map(|(i, share)| async move {
+            self.inner
+                .upgrade_one(
+                    ctx_ref.clone(),
+                    RecordId::from(i),
+                    share,
+                    ZeroPositions::Pvvv,
+                )
+                .await
+        }))
+        .await
+    }
+}
+
+#[async_trait]
+impl<'a, F> UpgradeToMalicious<Replicated<F>, MaliciousReplicated<F>>
+    for UpgradeContext<'a, F, RecordId>
+where
+    F: Field,
+{
+    async fn upgrade(self, input: Replicated<F>) -> Result<MaliciousReplicated<F>, Error> {
+        self.inner
+            .upgrade_one(
+                self.upgrade_ctx,
+                self.record_binding,
+                input,
+                ZeroPositions::Pvvv,
+            )
+            .await
+    }
+}
+
+// Impl for upgrading things that can be upgraded using a single record ID using a non-record-bound
+// context. This gets used e.g. when the protocol takes a single `Replicated<F>` input.
+#[async_trait]
+impl<'a, F, T, M> UpgradeToMalicious<T, M> for UpgradeContext<'a, F, NoRecord>
+where
+    F: Field,
+    T: Send + 'static,
+    for<'u> UpgradeContext<'u, F, RecordId>: UpgradeToMalicious<T, M>,
+{
+    async fn upgrade(self, input: T) -> Result<M, Error> {
+        UpgradeContext {
+            upgrade_ctx: self.upgrade_ctx, /*.set_total_records(1)*/
+            inner: self.inner,
+            record_binding: RECORD_0,
+        }
+        .upgrade(input)
+        .await
     }
 }

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -9,8 +9,8 @@ mod malicious;
 mod prss;
 mod semi_honest;
 
-pub use malicious::MaliciousContext;
 pub(super) use malicious::SpecialAccessToMaliciousContext;
+pub use malicious::{MaliciousContext, NoRecord, UpgradeContext, UpgradeToMalicious};
 pub use prss::{InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness};
 pub use semi_honest::SemiHonestContext;
 

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -184,7 +184,6 @@ mod tests {
     use crate::helpers::{Direction, Role};
     use crate::protocol::context::Context;
     use crate::protocol::malicious::MaliciousValidator;
-    use crate::protocol::BitOpStep;
     use crate::rand::thread_rng;
     use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
     use crate::{
@@ -227,10 +226,7 @@ mod tests {
 
                 let v = MaliciousValidator::new(ctx);
                 let m_ctx = v.context();
-                let m_triple = m_ctx
-                    .upgrade_bit_triple(&BitOpStep::from(0), RecordId::from(0), triple)
-                    .await
-                    .unwrap();
+                let m_triple = m_ctx.upgrade(triple).await.unwrap();
                 let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)
                     .await
                     .unwrap();
@@ -289,10 +285,7 @@ mod tests {
 
                     let v = MaliciousValidator::new(ctx);
                     let m_ctx = v.context();
-                    let m_triple = m_ctx
-                        .upgrade_bit_triple(&BitOpStep::from(0), RecordId::from(0), tweaked)
-                        .await
-                        .unwrap();
+                    let m_triple = m_ctx.upgrade(tweaked).await.unwrap();
                     let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)
                         .await
                         .unwrap();

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -7,7 +7,7 @@ use crate::{
         malicious::MaliciousValidator,
         sort::SortStep::{
             ApplyInv, BitPermutationStep, ComposeStep, MaliciousUpgradeContext,
-            MaliciousUpgradeInput, ShuffleRevealPermutation, SortKeys,
+            ShuffleRevealPermutation, SortKeys,
         },
         sort::{
             bit_permutation::bit_permutation,
@@ -273,9 +273,7 @@ where
     let m_ctx_0 = m_ctx.narrow(&Sort(0));
     assert_eq!(sort_keys.len(), num_bits as usize);
 
-    let upgraded_sort_keys = m_ctx
-        .upgrade_vector(&MaliciousUpgradeInput, sort_keys[0].clone())
-        .await?;
+    let upgraded_sort_keys = m_ctx.upgrade(sort_keys[0].clone()).await?;
     let bit_0_permutation =
         bit_permutation(m_ctx_0.narrow(&BitPermutationStep), &upgraded_sort_keys).await?;
     let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more that 1B rows
@@ -294,7 +292,7 @@ where
         malicious_validator = MaliciousValidator::new(sh_ctx.narrow(&Sort(bit_num)));
         m_ctx_bit = malicious_validator.context();
         let upgraded_sort_keys = m_ctx_bit
-            .upgrade_vector(&MaliciousUpgradeInput, sort_keys[bit_num as usize].clone())
+            .upgrade(sort_keys[bit_num as usize].clone())
             .await?;
         let bit_i_sorted_by_less_significant_bits = secureapplyinv(
             m_ctx_bit.narrow(&ApplyInv),

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -23,7 +23,6 @@ pub enum SortStep {
     MultiApplyInv(u32),
     //malicious features
     MaliciousUpgradeContext,
-    MaliciousUpgradeInput,
 }
 
 impl Substep for SortStep {}
@@ -40,7 +39,6 @@ impl AsRef<str> for SortStep {
             Self::MultiApplyInv(i) => MULTI_APPLY_INV[usize::try_from(*i).unwrap()],
             //malicious features
             Self::MaliciousUpgradeContext => "malicious_upgrade_context",
-            Self::MaliciousUpgradeInput => "malicious_upgrade_input",
         }
     }
 }


### PR DESCRIPTION
Split this off from #360.

The purpose of these changes is to allow managing total_records on the upgrade_ctx without exposing a
set_total_upgrades function on MaliciousContext.

This ended up being a bit more involved than I thought it would be originally. I could pretty easily change this to get rid of set_total_upgrades without the UpgradeContext stuff, by adding an upgrade_vector function on ContextInner and narrowing the IntoMalicious impl for IntoIter to be specific to vectors.

I do think it's possible we'll want UpgradeContext as an entity, either as part of the changes to have contexts own open channels, or as part of the changes to make context cloning more efficient (#380).