### PR TITLE
Eliminate more calls to tokio::try_join!

### DIFF
--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -310,12 +310,11 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::super::tests::generate_shared_input;
     use crate::{
         ff::{Field, Fp32BitPrime},
         protocol::attribution::{
             credit_capping::credit_capping,
-            tests::{BD, H, S, T},
+            tests::{generate_shared_input, BD, H, S, T},
         },
         test_fixture::{Reconstruct, TestWorld},
     };


### PR DESCRIPTION
Apologies, missed more calls to `tokio::try_join!` :(

Verified that after this change there are no more calls to it

```bash
 grep -r "tokio::try_join" . --include \*.rs | wc -l
       0
```