### PR TITLE
More efficient multi-bit permutation generation

### DIFF
--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -145,12 +145,8 @@ fn check_equality_to<F: Field, S: SecretSharing<F>>(
 ) -> S {
     if bit_number == 0 {
         if sign == 1_i8 {
-            println!("checking if value is equal to: {}", value);
-            println!("Return index: {}, sign: {}", idx, sign);
             return precomputed_combinations[idx].clone();
         }
-        println!("checking if value is equal to: {}", value);
-        println!("Return index: {}, sign: {}", idx, sign);
         return -precomputed_combinations[idx].clone();
     }
     let bit = (value >> (bit_number - 1)) & 1;
@@ -236,7 +232,6 @@ mod tests {
             })
             .await;
         let reconstructs: Vec<Vec<Fp31>> = result.reconstruct();
-        println!("{:#?}", reconstructs);
         for (rec, row) in reconstructs.iter().enumerate() {
             for (j, check) in row.iter().enumerate() {
                 if EXPECTED_NUMS[rec] == j {

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -280,13 +280,13 @@ fn get_big_endian_bits(value: usize, num_bits: usize) -> Vec<i8> {
 fn check_equality_to<F: Field, S: SecretSharing<F>>(
     value: usize,
     num_bits: usize,
-    tree: &[S],
+    precomputed_combinations: &[S],
 ) -> S {
     debug_assert!(num_bits <= 4, "Lookup table only supports up to 4 bits");
     let coefficients = &COEFFICIENT_LOOK_UP_TABLE[value];
     coefficients
         .iter()
-        .zip(tree)
+        .zip(precomputed_combinations)
         .fold(S::ZERO, |acc, (coef, value)| {
             if *coef == P {
                 acc + value

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -110,7 +110,7 @@ where
     // <https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle#/media/File:Multigrade_operator_AND.svg>
     //
     // Martin Thomson found that the sign of the coefficients follows the following pattern:
-    // 1. Take the row and column and bitwise AND them: $(i & j)$
+    // 1. Take the row and column and bitwise AND them: $(!i & j)$
     // 2. Count the number of non-zero bits in the result
     // 3. If the result is an odd number, the coefficient is negative. If the result is even, the coefficient is positive.
     let side_length = 1 << num_bits;
@@ -120,11 +120,10 @@ where
         for (j, combination) in precomputed_combinations.iter().enumerate() {
             let bit: i8 = i8::from((i & j) == i);
             if bit > 0 {
-                let sign = 1 - 2 * i8::try_from((!i & j).count_ones() & 1).unwrap();
-                if sign > 0 {
-                    check += combination;
-                } else {
+                if (!i & j).count_ones() & 1 == 1 {
                     check -= combination;
+                } else {
+                    check += combination;
                 }
             }
         }
@@ -201,12 +200,12 @@ where
 mod tests {
     use futures::future::try_join_all;
 
+    use super::multi_bit_permutation;
     use crate::{
         ff::{Field, Fp31},
-        test_fixture::{Reconstruct, Runner, TestWorld},
         secret_sharing::SharedValue,
+        test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use super::multi_bit_permutation;
 
     use super::check_everything;
 

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -9,6 +9,193 @@ use crate::{
 
 use futures::future::try_join_all;
 
+// indicies reference elements in this array:
+// [
+//   1,
+//   x_1,
+// ]
+const COEFFICIENT_LOOK_UP_TABLE_ONE_BIT: &[&[i8]] = &[
+    // 1 - x_1
+    &[0, -1],
+    // x_1
+    &[1],
+];
+
+// indicies reference elements in this array:
+// [
+//   1,
+//   x_1,
+//   x_2, x_1*x_2,
+// ]
+const COEFFICIENT_LOOK_UP_TABLE_TWO_BITS: &[&[i8]] = &[
+    // 1 - x_2 - x_1 + x_1*x_2
+    &[0, -2, -1, 3],
+    // x_1 - x_1*x_2
+    &[1, -3],
+    // x_2 - x_1*x_2
+    &[2, -3],
+    // x_1*x_2
+    &[3],
+];
+
+// indicies reference elements in this array:
+// [
+//   1,
+//   x_1,
+//   x_2, x_1*x_2,
+//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
+// ]
+const COEFFICIENT_LOOK_UP_TABLE_THREE_BITS: &[&[i8]] = &[
+    // 1 - x_3 - x_2 + x_2*x_3 - x_1 + x_1*x_3 + x_1*x_2 - x_1*x_2*x_3
+    &[0, -4, -2, 6, -1, 5, 3, -7],
+    // x_1 - x_1*x_3 - x_1*x_2 + x_1*x_2*x_3
+    &[1, -5, -3, 7],
+    // x_2 - x_2*x_3 - x_1*x_2 + x_1*x_2*x_3
+    &[2, -6, -3, 7],
+    // x_1*x_2 - x_1*x_2*x_3
+    &[3, -7],
+    // x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3
+    &[4, -6, -5, 7],
+    // x_1*x_3 - x_1*x_2*x_3
+    &[5, -7],
+    // x_2*x_3 - x_1*x_2*x_3
+    &[6, -7],
+    // x_1*x_2*x_3
+    &[7],
+];
+
+// indicies reference elements in this array:
+// [
+//   1,
+//   x_1,
+//   x_2, x_1*x_2,
+//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
+//   x_4, x_1*x_4, x_2*x_4, x_1*x_2*x_4, x_3*x_4, x_1*x_3*x_4, x_2*x_3*x_4, x_1*x_2*x_3*x_4
+// ]
+const COEFFICIENT_LOOK_UP_TABLE_FOUR_BITS: &[&[i8]] = &[
+    // 1 - x_4 - x_3 + x_3*x_4 - x_2 + x_2*x_4 + x_2*x_3 - x_2*x_3*x_4 - x_1 + x_1*x_4 + x_1*x_3 - x_1*x_3*x_4 + x_1*x_2 - x_1*x_2*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
+    &[0, -8, -4, 12, -2, 10, 6, -14, -1, 9, 5, -13, 3, -11, -7, 15],
+    // x_1 - x_1*x_4 - x_1*x_3 + x_1*x_3*x_4 - x_1*x_2 + x_1*x_2*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
+    &[1, -9, -5, 13, -3, 11, 7, -15],
+    // x_2 - x_2*x_4 - x_2*x_3 + x_2*x_3*x_4 - x_1*x_2 + x_1*x_2*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
+    &[2, -10, -6, 14, -3, 11, 7, -15],
+    // x_1*x_2 - x_1*x_2*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
+    &[3, -11, -7, 15],
+    // x_3 - x_3*x_4 - x_2*x_3 + x_2*x_3*x_4 - x_1*x_3 + x_1*x_3*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
+    &[4, -12, -6, 14, -5, 13, 7, -15],
+    // x_1*x_3 - x_1*x_3*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
+    &[5, -13, -7, 15],
+    // x_2*x_3 - x_2*x_3*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
+    &[6, -14, -7, 15],
+    // x_1*x_2*x_3 - x_1*x_2*x_3*x_4
+    &[7, -15],
+    // x_4 - x_3*x_4 - x_2*x_4 + x_2*x_3*x_4 - x_1*x_4 + x_1*x_3*x_4 + x_1*x_2*x_4 - x_1*x_2*x_3*x_4
+    &[8, -12, -10, 14, -9, 13, 11, -15],
+    // x_1*x_4 - x_1*x_3*x_4 - x_1*x_2*x_4 + x_1*x_2*x_3*x_4
+    &[9, -13, -11, 15],
+    // x_2*x_4 - x_2*x_3*x_4 - x_1*x_2*x_4 + x_1*x_2*x_3*x_4
+    &[10, -14, -11, 15],
+    // x_1*x_2*x_4 - x_1*x_2*x_3*x_4
+    &[11, -15],
+    // x_3*x_4 - x_2*x_3*x_4 - x_1*x_3*x_4 + x_1*x_2*x_3*x_4
+    &[12, -14, -13, 15],
+    // x_1*x_3*x_4 - x_1*x_2*x_3*x_4
+    &[13, -15],
+    // x_2*x_3*x_4 - x_1*x_2*x_3*x_4
+    &[14, -15],
+    // x_1*x_2*x_3*x_4
+    &[15],
+];
+
+// indicies reference elements in this array:
+// [
+//   1,
+//   x_1,
+//   x_2, x_1*x_2,
+//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
+//   x_4, x_1*x_4, x_2*x_4, x_1*x_2*x_4, x_3*x_4, x_1*x_3*x_4, x_2*x_3*x_4, x_1*x_2*x_3*x_4
+//   x_5, x_1*x_5, x_2*x_5, x_1*x_2*x_5, x_3*x_5, x_1*x_3*x_5, x_2*x_3*x_5, x_1*x_2*x_3*x_5, x_4*x_5, x_1*x_4*x_5, x_2*x_4*x_5, x_1*x_2*x_4*x_5, x_3*x_4*x_5, x_1*x_3*x_4*x_5, x_2*x_3*x_4*x_5, x_1*x_2*x_3*x_4*x_5
+// ]
+const COEFFICIENT_LOOK_UP_TABLE_FIVE_BITS: &[&[i8]] = &[
+    // 1 - x_5 - x_4 + x_4*x_5 - x_3 + x_3*x_5 + x_3*x_4 - x_3*x_4*x_5 - x_2 + x_2*x_5 + x_2*x_4 - x_2*x_4*x_5 + x_2*x_3 - x_2*x_3*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1 + x_1*x_5 + x_1*x_4 - x_1*x_4*x_5 + x_1*x_3 - x_1*x_3*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 + x_1*x_2 - x_1*x_2*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[
+        0, -16, -8, 24, -4, 20, 12, -28, -2, 18, 10, -26, 6, -22, -14, 30, -1, 17, 9, -25, 5, -21,
+        -13, 29, 3, -19, -11, 27, -7, 23, 15, -31,
+    ],
+    // x_1 - x_1*x_5 - x_1*x_4 + x_1*x_4*x_5 - x_1*x_3 + x_1*x_3*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 - x_1*x_2 + x_1*x_2*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[
+        1, -17, -9, 25, -5, 21, 13, -29, -3, 19, 11, -27, 7, -23, -15, 31,
+    ],
+    // x_2 - x_2*x_5 - x_2*x_4 + x_2*x_4*x_5 - x_2*x_3 + x_2*x_3*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_2 + x_1*x_2*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[
+        2, -18, -10, 26, -6, 22, 14, -30, -3, 19, 11, -27, 7, -23, -15, 31,
+    ],
+    // x_1*x_2 - x_1*x_2*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[3, -19, -11, 27, -7, 23, 15, -31],
+    // x_3 - x_3*x_5 - x_3*x_4 + x_3*x_4*x_5 - x_2*x_3 + x_2*x_3*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_3 + x_1*x_3*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[
+        4, -20, -12, 28, -6, 22, 14, -30, -5, 21, 13, -29, 7, -23, -15, 31,
+    ],
+    // x_1*x_3 - x_1*x_3*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[5, -21, -13, 29, -7, 23, 15, -31],
+    // x_2*x_3 - x_2*x_3*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[6, -22, -14, 30, -7, 23, 15, -31],
+    // x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[7, -23, -15, 31],
+    // x_4 - x_4*x_5 - x_3*x_4 + x_3*x_4*x_5 - x_2*x_4 + x_2*x_4*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_4 + x_1*x_4*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[
+        8, -24, -12, 28, -10, 26, 14, -30, -9, 25, 13, -29, 11, -27, -15, 31,
+    ],
+    // x_1*x_4 - x_1*x_4*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[9, -25, -13, 29, -11, 27, 15, -31],
+    // x_2*x_4 - x_2*x_4*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[10, -26, -14, 30, -11, 27, 15, -31],
+    // x_1*x_2*x_4 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[11, -27, -15, 31],
+    // x_3*x_4 - x_3*x_4*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[12, -28, -14, 30, -13, 29, 15, -31],
+    // x_1*x_3*x_4 - x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[13, -29, -15, 31],
+    // x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
+    &[14, -30, -15, 31],
+    // x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
+    &[15, -31],
+    // x_5 - x_4*x_5 - x_3*x_5 + x_3*x_4*x_5 - x_2*x_5 + x_2*x_4*x_5 + x_2*x_3*x_5 - x_2*x_3*x_4*x_5 - x_1*x_5 + x_1*x_4*x_5 + x_1*x_3*x_5 - x_1*x_3*x_4*x_5 + x_1*x_2*x_5 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[
+        16, -24, -20, 28, -18, 26, 22, -30, -17, 25, 21, -29, 19, -27, -23, 31,
+    ],
+    // x_1*x_5 - x_1*x_4*x_5 - x_1*x_3*x_5 + x_1*x_3*x_4*x_5 - x_1*x_2*x_5 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[17, -25, -21, 29, -19, 27, 23, -31],
+    // x_2*x_5 - x_2*x_4*x_5 - x_2*x_3*x_5 + x_2*x_3*x_4*x_5 - x_1*x_2*x_5 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[18, -26, -22, 30, -19, 27, 23, -31],
+    // x_1*x_2*x_5 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[19, -27, -23, 31],
+    // x_3*x_5 - x_3*x_4*x_5 - x_2*x_3*x_5 + x_2*x_3*x_4*x_5 - x_1*x_3*x_5 + x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[20, -28, -22, 30, -21, 29, 23, -31],
+    // x_1*x_3*x_5 - x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[21, -29, -23, 31],
+    // x_2*x_3*x_5 - x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[22, -30, -23, 31],
+    // x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[23, -31],
+    // x_4*x_5 - x_3*x_4*x_5 - x_2*x_4*x_5 + x_2*x_3*x_4*x_5 - x_1*x_4*x_5 + x_1*x_3*x_4*x_5 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[24, -28, -26, 30, -25, 29, 27, -31],
+    // x_1*x_4*x_5 - x_1*x_3*x_4*x_5 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[25, -29, -27, 31],
+    // x_2*x_4*x_5 - x_2*x_3*x_4*x_5 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[26, -30, -27, 31],
+    // x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[27, -31],
+    // x_3*x_4*x_5 - x_2*x_3*x_4*x_5 - x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
+    &[28, -30, -29, 31],
+    // x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[29, -31],
+    // x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
+    &[30, -31],
+    // x_1*x_2*x_3*x_4*x_5
+    &[31],
+];
+
 /// This is an implementation of `GenMultiBitSort` (Algorithm 11) described in:
 /// "An Efficient Secure Three-Party Sorting Protocol with an Honest Majority"
 /// by K. Chida, K. Hamada, D. Ikarashi, R. Kikuchi, N. Kiribuchi, and B. Pinkas
@@ -83,6 +270,12 @@ pub async fn multi_bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context
     Ok(one_off_permutation)
 }
 
+///
+/// This function accepts a sequence of N secret-shared bits.
+/// When considered as a bitwise representation of an N-bit unsigned number, it's clear that there are exactly
+/// `2^N` possible values this could have.
+/// This function checks all of these possible values, and returns a vector of secret-shared results.
+/// Only one result will be a secret-sharing of one, all of the others will be secret-sharings of zero.
 async fn check_everything<F, C, S>(
     ctx: C,
     record_idx: usize,
@@ -95,6 +288,25 @@ where
 {
     let record_id = RecordId::from(record_idx);
     let num_bits = input.len();
+    //
+    // Every equality check can be computed as a linear combination of coefficients.
+    // For example, if we are given a 3-bit number `[x_3, x_2, x_1]`,
+    // we can check if it is equal to 4, by computing:
+    // `x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3`
+    //
+    // Since we need to check all possible values, it makes sense to pre-compute all
+    // of the coefficients that are used across all of these equality checks. In this way,
+    // we can minimize the total number of multiplications needed.
+    //
+    // We must pre-compute all combinations of bit values. The following loop does so.
+    // It does so by starting with the array `[1]`.
+    // The next step is to multiply this by `x_1` and append it to the end of the array.
+    // Now the array is `[1, x_1]`.
+    // The next step is to mulitply all of these values by `x_2` and append them to the end of the array.
+    // Now the array is `[1, x_1, x_2, x_1*x_2]`
+    // The next step is to mulitply all of these values of `x_3` and append them to the end of the array.
+    // Now the array is `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
+    // This process continues for as many steps as there are bits of input.
     let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
     precomputed_combinations.push(ctx.share_of_one());
     #[allow(clippy::needless_range_loop)]
@@ -120,38 +332,134 @@ where
         precomputed_combinations.append(&mut multiplication_results);
     }
 
+    // This loop just iterates over all the possible values this N-bit input could potentially represent
+    // and checks if the bits are equal to this value. It does so my computing a linear combination of the
+    // pre-computed coefficients.
     let mut equality_checks = Vec::with_capacity(1 << num_bits);
     for i in 0..(1 << num_bits) {
         equality_checks.push(check_equality_to(
             i,
             num_bits,
             precomputed_combinations.as_slice(),
-            0,
-            0,
         ));
     }
     Ok(equality_checks)
 }
 
-fn check_equality_to<F: Field, S: SecretSharing<F>>(
+///
+/// This function is used to generate the look-up tables saved as constants at the top of this file.
+///
+/// This function appears to be "unused" because it is only used to generate the constants.
+#[allow(dead_code)]
+fn generate_lookup_table(num_bits: usize) -> Vec<Vec<i8>> {
+    let num_possible_values = 1 << num_bits;
+    (0..num_possible_values)
+        .map(|value| collect_coefficients_recursive(value, num_bits, 0, 0_i8))
+        .collect()
+}
+
+///
+/// Each row of the look-up tables saved as constants at the top of this file was generated via a call to this function.
+/// Each row indicates which coefficients must be added / subtracted to check equality of an N-bit sequence to a specific value.
+///
+/// Let's work through an example:
+/// To check if a 3-bit value is equal to `4`, we would logically compute:
+/// `(x_3)(1 - x_2)(1 - x_1)`
+/// This function basically just "multiplies that all out", distributing terms.
+///
+/// It starts with the least significant bit, `x_1`. If the value is equal to `4`, then the least significant bit should be equal to `0`
+/// That is why the last term is `(1 - x_1)`.
+/// Since there are two parts of this term, we need to distribute both of them, multiplying each element of the rest of the equation by each.
+/// To do this, we recurse. We compute the rest of the equation times `1`, and subtract the rest of the equation times `x_1`.
+/// Recall how the array of pre-computed linear-combinations is ordered:
+/// `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
+/// It is ordered that way because we constructed it by:
+/// ...iterating through the bits from least significant to most significant
+/// ...and multiplying all values in the array by the next bit
+/// ...thereby doubling the length of the array at each bit.
+///
+/// Think of this like a "tree". We start at the root node, (index 0). We begin with a value of `1`.
+/// At depth=1 in the tree, we either multiply by `1`, or by `x_1`. Multiplication by `1` is easy, we just stay at the current index.
+/// Multiplication by `x_1` is achieved by moving to the right by 1.
+///
+/// Then we go to the next bit, `x_2`. If the value is equal to `4`, then this bit should be equal to `0` as well.
+/// That is why the second to last term is `(1 - x_2)`.
+/// Once again, there are two parts of this term, and we need to distribute them both, multiplying each element of the rest of the equation by each.
+/// To do this, we recurse yet again. We compute the rest of the equation times `1`, and subtract the rest of the equation times `x_2`.
+/// Just like before, for each element, multiplying by "1" is achieved by just remaining that the current index in the pre-computed linear coefficients.
+/// Now that we are at depth=2 in the tree, to find the value multiplied by `x_2` we must move to the index 2 to the right.
+/// That's because there were only 2 elements in the array, and we multiplied each by `x_2`, resulting in an array of length 4.
+///
+/// Finally, we come to the most significant bit, `x_3`. If the value is equal to `4`, then this bit should be equal to `1`.
+/// That is why we multiply by the term `(x_3)`.
+/// There is only one component of this term, so we only need to recurse one time.
+/// Now that we are at depth=3 in the tree, finding the value multiplied by `x_3` can be achieved by looking at the index 4 to the right in the array of pre-computed linear combinations.
+/// That's because we took an array of length 4, and multiplied each value by `x_3`, appending the results to the end, resulting in an array of length 8.
+fn collect_coefficients_recursive(
     value: u32,
     num_bits: usize,
-    tree: &[S],
     bit_idx: usize,
-    idx: usize,
-) -> S {
+    current_coefficient_idx: i8,
+) -> Vec<i8> {
     if bit_idx == num_bits {
-        return tree[idx].clone();
+        return vec![current_coefficient_idx];
     }
     let bit = (value >> bit_idx) & 1;
     let step = 1 << bit_idx;
     let next_bit_idx = bit_idx + 1;
-    let times_bit = check_equality_to(value, num_bits, tree, next_bit_idx, idx + step);
+    let times_x_coefficients = collect_coefficients_recursive(
+        value,
+        num_bits,
+        next_bit_idx,
+        current_coefficient_idx + step,
+    );
     if bit == 0 {
-        let times_one = check_equality_to(value, num_bits, tree, next_bit_idx, idx);
-        return times_one - &times_bit;
+        let times_one_coefficients =
+            collect_coefficients_recursive(value, num_bits, next_bit_idx, current_coefficient_idx);
+        return [
+            times_one_coefficients,
+            times_x_coefficients.iter().map(|x| -x).collect(),
+        ]
+        .concat();
     }
-    times_bit
+    times_x_coefficients
+}
+
+///
+/// This function checks to see if a sequence of bits is a representation of a specific value.
+/// It does so by computing a linear-combination of coefficients.
+/// For example, to check if a 4-bit value is equal to 8, we would logically compute:
+/// `(x_4)(1 - x_3)(1 - x_2)(1 - x_1)`
+/// If you multiply this all out, that's equivalent to:
+/// `x_4 - x_3*x_4 - x_2*x_4 + x_2*x_3*x_4 - x_1*x_4 + x_1*x_3*x_4 + x_1*x_2*x_4 - x_1*x_2*x_3*x_4`
+/// /// All of these coefficients have been pre-computed and are stored in an array.
+/// This function just looks up which coefficients are needed. In this case it would retrieve:
+/// `[8, -12, -10, 14, -9, 13, 11, -15]`
+/// The sign of each element indicates if that coefficient should be added or subtracted,
+/// while the absolute value of the elements indicates the position in the array of pre-computed coefficients.
+fn check_equality_to<F: Field, S: SecretSharing<F>>(
+    value: usize,
+    num_bits: usize,
+    tree: &[S],
+) -> S {
+    let look_up_table = match num_bits {
+        1 => COEFFICIENT_LOOK_UP_TABLE_ONE_BIT,
+        2 => COEFFICIENT_LOOK_UP_TABLE_TWO_BITS,
+        3 => COEFFICIENT_LOOK_UP_TABLE_THREE_BITS,
+        4 => COEFFICIENT_LOOK_UP_TABLE_FOUR_BITS,
+        5 => COEFFICIENT_LOOK_UP_TABLE_FIVE_BITS,
+        _ => panic!("No lookup table has been generated for {num_bits} bits."),
+    };
+    let coefficients = look_up_table[value];
+    coefficients.iter().fold(S::ZERO, |acc, x| {
+        let x_abs = usize::try_from(x.abs()).unwrap();
+        let next_value = &tree[x_abs];
+        if *x < 0 {
+            acc - next_value
+        } else {
+            acc + next_value
+        }
+    })
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
@@ -165,7 +473,7 @@ mod tests {
     };
     use super::multi_bit_permutation;
 
-    use super::check_everything;
+    use super::{check_everything, generate_lookup_table};
     const INPUT: [&[u128]; 3] = [
         &[0, 0, 1, 0, 1, 0],
         &[0, 1, 1, 0, 0, 0],
@@ -224,5 +532,67 @@ mod tests {
                 }
             }
         }
+    }
+
+    const COMMENT_KEY: [&str; 32] = [
+        "1",
+        "x_1",
+        "x_2",
+        "x_1*x_2",
+        "x_3",
+        "x_1*x_3",
+        "x_2*x_3",
+        "x_1*x_2*x_3",
+        "x_4",
+        "x_1*x_4",
+        "x_2*x_4",
+        "x_1*x_2*x_4",
+        "x_3*x_4",
+        "x_1*x_3*x_4",
+        "x_2*x_3*x_4",
+        "x_1*x_2*x_3*x_4",
+        "x_5",
+        "x_1*x_5",
+        "x_2*x_5",
+        "x_1*x_2*x_5",
+        "x_3*x_5",
+        "x_1*x_3*x_5",
+        "x_2*x_3*x_5",
+        "x_1*x_2*x_3*x_5",
+        "x_4*x_5",
+        "x_1*x_4*x_5",
+        "x_2*x_4*x_5",
+        "x_1*x_2*x_4*x_5",
+        "x_3*x_4*x_5",
+        "x_1*x_3*x_4*x_5",
+        "x_2*x_3*x_4*x_5",
+        "x_1*x_2*x_3*x_4*x_5",
+    ];
+
+    // This is used to generate the lookup tables of constants at the top of this file.
+    #[ignore]
+    #[test]
+    pub fn generate_lookup_table_constants() {
+        for i in 1..6 {
+            let look_up_table = generate_lookup_table(i);
+            println!("Lookup table for {i} bits: ");
+            for row in look_up_table {
+                let mut comment: String = "// ".to_owned();
+                row.iter().enumerate().for_each(|(idx, x)| {
+                    if idx > 0 {
+                        if *x < 0 {
+                            comment.push_str(" - ");
+                        } else {
+                            comment.push_str(" + ");
+                        }
+                    }
+                    let index: usize = usize::try_from(x.abs()).unwrap();
+                    comment.push_str(COMMENT_KEY[index]);
+                });
+                println!("    {comment}");
+                println!("    &{row:?},");
+            }
+        }
+        panic!();
     }
 }

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -3,197 +3,31 @@ use std::iter::repeat;
 use crate::{
     error::Error,
     ff::Field,
-    protocol::{context::Context, sort::bit_permutation::bit_permutation, BitOpStep, RecordId},
+    protocol::{context::Context, BitOpStep, RecordId},
     secret_sharing::SecretSharing,
 };
 
 use futures::future::try_join_all;
 
-// indicies reference elements in this array:
-// [
-//   1,
-//   x_1,
-// ]
-const COEFFICIENT_LOOK_UP_TABLE_ONE_BIT: &[&[i8]] = &[
-    // 1 - x_1
-    &[0, -1],
-    // x_1
-    &[1],
-];
-
-// indicies reference elements in this array:
-// [
-//   1,
-//   x_1,
-//   x_2, x_1*x_2,
-// ]
-const COEFFICIENT_LOOK_UP_TABLE_TWO_BITS: &[&[i8]] = &[
-    // 1 - x_2 - x_1 + x_1*x_2
-    &[0, -2, -1, 3],
-    // x_1 - x_1*x_2
-    &[1, -3],
-    // x_2 - x_1*x_2
-    &[2, -3],
-    // x_1*x_2
-    &[3],
-];
-
-// indicies reference elements in this array:
-// [
-//   1,
-//   x_1,
-//   x_2, x_1*x_2,
-//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
-// ]
-const COEFFICIENT_LOOK_UP_TABLE_THREE_BITS: &[&[i8]] = &[
-    // 1 - x_3 - x_2 + x_2*x_3 - x_1 + x_1*x_3 + x_1*x_2 - x_1*x_2*x_3
-    &[0, -4, -2, 6, -1, 5, 3, -7],
-    // x_1 - x_1*x_3 - x_1*x_2 + x_1*x_2*x_3
-    &[1, -5, -3, 7],
-    // x_2 - x_2*x_3 - x_1*x_2 + x_1*x_2*x_3
-    &[2, -6, -3, 7],
-    // x_1*x_2 - x_1*x_2*x_3
-    &[3, -7],
-    // x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3
-    &[4, -6, -5, 7],
-    // x_1*x_3 - x_1*x_2*x_3
-    &[5, -7],
-    // x_2*x_3 - x_1*x_2*x_3
-    &[6, -7],
-    // x_1*x_2*x_3
-    &[7],
-];
-
-// indicies reference elements in this array:
-// [
-//   1,
-//   x_1,
-//   x_2, x_1*x_2,
-//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
-//   x_4, x_1*x_4, x_2*x_4, x_1*x_2*x_4, x_3*x_4, x_1*x_3*x_4, x_2*x_3*x_4, x_1*x_2*x_3*x_4
-// ]
-const COEFFICIENT_LOOK_UP_TABLE_FOUR_BITS: &[&[i8]] = &[
-    // 1 - x_4 - x_3 + x_3*x_4 - x_2 + x_2*x_4 + x_2*x_3 - x_2*x_3*x_4 - x_1 + x_1*x_4 + x_1*x_3 - x_1*x_3*x_4 + x_1*x_2 - x_1*x_2*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
-    &[0, -8, -4, 12, -2, 10, 6, -14, -1, 9, 5, -13, 3, -11, -7, 15],
-    // x_1 - x_1*x_4 - x_1*x_3 + x_1*x_3*x_4 - x_1*x_2 + x_1*x_2*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
-    &[1, -9, -5, 13, -3, 11, 7, -15],
-    // x_2 - x_2*x_4 - x_2*x_3 + x_2*x_3*x_4 - x_1*x_2 + x_1*x_2*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
-    &[2, -10, -6, 14, -3, 11, 7, -15],
-    // x_1*x_2 - x_1*x_2*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
-    &[3, -11, -7, 15],
-    // x_3 - x_3*x_4 - x_2*x_3 + x_2*x_3*x_4 - x_1*x_3 + x_1*x_3*x_4 + x_1*x_2*x_3 - x_1*x_2*x_3*x_4
-    &[4, -12, -6, 14, -5, 13, 7, -15],
-    // x_1*x_3 - x_1*x_3*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
-    &[5, -13, -7, 15],
-    // x_2*x_3 - x_2*x_3*x_4 - x_1*x_2*x_3 + x_1*x_2*x_3*x_4
-    &[6, -14, -7, 15],
-    // x_1*x_2*x_3 - x_1*x_2*x_3*x_4
-    &[7, -15],
-    // x_4 - x_3*x_4 - x_2*x_4 + x_2*x_3*x_4 - x_1*x_4 + x_1*x_3*x_4 + x_1*x_2*x_4 - x_1*x_2*x_3*x_4
-    &[8, -12, -10, 14, -9, 13, 11, -15],
-    // x_1*x_4 - x_1*x_3*x_4 - x_1*x_2*x_4 + x_1*x_2*x_3*x_4
-    &[9, -13, -11, 15],
-    // x_2*x_4 - x_2*x_3*x_4 - x_1*x_2*x_4 + x_1*x_2*x_3*x_4
-    &[10, -14, -11, 15],
-    // x_1*x_2*x_4 - x_1*x_2*x_3*x_4
-    &[11, -15],
-    // x_3*x_4 - x_2*x_3*x_4 - x_1*x_3*x_4 + x_1*x_2*x_3*x_4
-    &[12, -14, -13, 15],
-    // x_1*x_3*x_4 - x_1*x_2*x_3*x_4
-    &[13, -15],
-    // x_2*x_3*x_4 - x_1*x_2*x_3*x_4
-    &[14, -15],
-    // x_1*x_2*x_3*x_4
-    &[15],
-];
-
-// indicies reference elements in this array:
-// [
-//   1,
-//   x_1,
-//   x_2, x_1*x_2,
-//   x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3,
-//   x_4, x_1*x_4, x_2*x_4, x_1*x_2*x_4, x_3*x_4, x_1*x_3*x_4, x_2*x_3*x_4, x_1*x_2*x_3*x_4
-//   x_5, x_1*x_5, x_2*x_5, x_1*x_2*x_5, x_3*x_5, x_1*x_3*x_5, x_2*x_3*x_5, x_1*x_2*x_3*x_5, x_4*x_5, x_1*x_4*x_5, x_2*x_4*x_5, x_1*x_2*x_4*x_5, x_3*x_4*x_5, x_1*x_3*x_4*x_5, x_2*x_3*x_4*x_5, x_1*x_2*x_3*x_4*x_5
-// ]
-const COEFFICIENT_LOOK_UP_TABLE_FIVE_BITS: &[&[i8]] = &[
-    // 1 - x_5 - x_4 + x_4*x_5 - x_3 + x_3*x_5 + x_3*x_4 - x_3*x_4*x_5 - x_2 + x_2*x_5 + x_2*x_4 - x_2*x_4*x_5 + x_2*x_3 - x_2*x_3*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1 + x_1*x_5 + x_1*x_4 - x_1*x_4*x_5 + x_1*x_3 - x_1*x_3*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 + x_1*x_2 - x_1*x_2*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[
-        0, -16, -8, 24, -4, 20, 12, -28, -2, 18, 10, -26, 6, -22, -14, 30, -1, 17, 9, -25, 5, -21,
-        -13, 29, 3, -19, -11, 27, -7, 23, 15, -31,
-    ],
-    // x_1 - x_1*x_5 - x_1*x_4 + x_1*x_4*x_5 - x_1*x_3 + x_1*x_3*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 - x_1*x_2 + x_1*x_2*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[
-        1, -17, -9, 25, -5, 21, 13, -29, -3, 19, 11, -27, 7, -23, -15, 31,
-    ],
-    // x_2 - x_2*x_5 - x_2*x_4 + x_2*x_4*x_5 - x_2*x_3 + x_2*x_3*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_2 + x_1*x_2*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[
-        2, -18, -10, 26, -6, 22, 14, -30, -3, 19, 11, -27, 7, -23, -15, 31,
-    ],
-    // x_1*x_2 - x_1*x_2*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[3, -19, -11, 27, -7, 23, 15, -31],
-    // x_3 - x_3*x_5 - x_3*x_4 + x_3*x_4*x_5 - x_2*x_3 + x_2*x_3*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_3 + x_1*x_3*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 + x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[
-        4, -20, -12, 28, -6, 22, 14, -30, -5, 21, 13, -29, 7, -23, -15, 31,
-    ],
-    // x_1*x_3 - x_1*x_3*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[5, -21, -13, 29, -7, 23, 15, -31],
-    // x_2*x_3 - x_2*x_3*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_2*x_3 + x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[6, -22, -14, 30, -7, 23, 15, -31],
-    // x_1*x_2*x_3 - x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[7, -23, -15, 31],
-    // x_4 - x_4*x_5 - x_3*x_4 + x_3*x_4*x_5 - x_2*x_4 + x_2*x_4*x_5 + x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_4 + x_1*x_4*x_5 + x_1*x_3*x_4 - x_1*x_3*x_4*x_5 + x_1*x_2*x_4 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[
-        8, -24, -12, 28, -10, 26, 14, -30, -9, 25, 13, -29, 11, -27, -15, 31,
-    ],
-    // x_1*x_4 - x_1*x_4*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[9, -25, -13, 29, -11, 27, 15, -31],
-    // x_2*x_4 - x_2*x_4*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_2*x_4 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[10, -26, -14, 30, -11, 27, 15, -31],
-    // x_1*x_2*x_4 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[11, -27, -15, 31],
-    // x_3*x_4 - x_3*x_4*x_5 - x_2*x_3*x_4 + x_2*x_3*x_4*x_5 - x_1*x_3*x_4 + x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[12, -28, -14, 30, -13, 29, 15, -31],
-    // x_1*x_3*x_4 - x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[13, -29, -15, 31],
-    // x_2*x_3*x_4 - x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_4 + x_1*x_2*x_3*x_4*x_5
-    &[14, -30, -15, 31],
-    // x_1*x_2*x_3*x_4 - x_1*x_2*x_3*x_4*x_5
-    &[15, -31],
-    // x_5 - x_4*x_5 - x_3*x_5 + x_3*x_4*x_5 - x_2*x_5 + x_2*x_4*x_5 + x_2*x_3*x_5 - x_2*x_3*x_4*x_5 - x_1*x_5 + x_1*x_4*x_5 + x_1*x_3*x_5 - x_1*x_3*x_4*x_5 + x_1*x_2*x_5 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[
-        16, -24, -20, 28, -18, 26, 22, -30, -17, 25, 21, -29, 19, -27, -23, 31,
-    ],
-    // x_1*x_5 - x_1*x_4*x_5 - x_1*x_3*x_5 + x_1*x_3*x_4*x_5 - x_1*x_2*x_5 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[17, -25, -21, 29, -19, 27, 23, -31],
-    // x_2*x_5 - x_2*x_4*x_5 - x_2*x_3*x_5 + x_2*x_3*x_4*x_5 - x_1*x_2*x_5 + x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[18, -26, -22, 30, -19, 27, 23, -31],
-    // x_1*x_2*x_5 - x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[19, -27, -23, 31],
-    // x_3*x_5 - x_3*x_4*x_5 - x_2*x_3*x_5 + x_2*x_3*x_4*x_5 - x_1*x_3*x_5 + x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[20, -28, -22, 30, -21, 29, 23, -31],
-    // x_1*x_3*x_5 - x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[21, -29, -23, 31],
-    // x_2*x_3*x_5 - x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[22, -30, -23, 31],
-    // x_1*x_2*x_3*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[23, -31],
-    // x_4*x_5 - x_3*x_4*x_5 - x_2*x_4*x_5 + x_2*x_3*x_4*x_5 - x_1*x_4*x_5 + x_1*x_3*x_4*x_5 + x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[24, -28, -26, 30, -25, 29, 27, -31],
-    // x_1*x_4*x_5 - x_1*x_3*x_4*x_5 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[25, -29, -27, 31],
-    // x_2*x_4*x_5 - x_2*x_3*x_4*x_5 - x_1*x_2*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[26, -30, -27, 31],
-    // x_1*x_2*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[27, -31],
-    // x_3*x_4*x_5 - x_2*x_3*x_4*x_5 - x_1*x_3*x_4*x_5 + x_1*x_2*x_3*x_4*x_5
-    &[28, -30, -29, 31],
-    // x_1*x_3*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[29, -31],
-    // x_2*x_3*x_4*x_5 - x_1*x_2*x_3*x_4*x_5
-    &[30, -31],
-    // x_1*x_2*x_3*x_4*x_5
-    &[31],
+const P: i8 = 1;
+const N: i8 = -1;
+const COEFFICIENT_LOOK_UP_TABLE: [[i8; 16]; 16] = [
+    [P, N, N, P, N, P, P, N, N, P, P, N, P, N, N, P],
+    [0, P, 0, N, 0, N, 0, P, 0, N, 0, P, 0, P, 0, N],
+    [0, 0, P, N, 0, 0, N, P, 0, 0, N, P, 0, 0, P, N],
+    [0, 0, 0, P, 0, 0, 0, N, 0, 0, 0, N, 0, 0, 0, P],
+    [0, 0, 0, 0, P, N, N, P, 0, 0, 0, 0, N, P, P, N],
+    [0, 0, 0, 0, 0, P, 0, N, 0, 0, 0, 0, 0, N, 0, P],
+    [0, 0, 0, 0, 0, 0, P, N, 0, 0, 0, 0, 0, 0, N, P],
+    [0, 0, 0, 0, 0, 0, 0, P, 0, 0, 0, 0, 0, 0, 0, N],
+    [0, 0, 0, 0, 0, 0, 0, 0, P, N, N, P, N, P, P, N],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, P, 0, N, 0, N, 0, P],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P, N, 0, 0, N, P],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P, 0, 0, 0, N],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P, N, N, P],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P, 0, N],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P, N],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, P],
 ];
 
 /// This is an implementation of `GenMultiBitSort` (Algorithm 11) described in:
@@ -221,20 +55,18 @@ pub async fn multi_bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context
 ) -> Result<Vec<S>, Error> {
     let num_multi_bits = input.len();
     assert!(num_multi_bits > 0);
-    if num_multi_bits == 1 {
-        return bit_permutation(ctx, &input[0]).await;
-    }
     let num_records = input[0].len();
     let num_possible_bit_values = 2 << (num_multi_bits - 1);
 
     let share_of_one = ctx.share_of_one();
 
     // Equality bit checker: this checks if each secret shared record is equal to any of numbers between 0 and num_possible_bit_values
-    let mut equality_check_futures = Vec::with_capacity(num_records);
-    for i in 0..num_records {
-        equality_check_futures.push(check_everything(ctx.clone(), i, input));
-    }
-    let equality_checks = try_join_all(equality_check_futures).await?;
+    let equality_checks = try_join_all(
+        (0..num_records)
+            .zip(repeat(ctx.clone()))
+            .map(|(i, ctx)| check_everything(ctx, i, input)),
+    )
+    .await?;
 
     // Compute accumulated sum
     let mut prefix_sum = Vec::with_capacity(num_records);
@@ -286,51 +118,10 @@ where
     C: Context<F, Share = S>,
     S: SecretSharing<F>,
 {
-    let record_id = RecordId::from(record_idx);
     let num_bits = input.len();
-    //
-    // Every equality check can be computed as a linear combination of coefficients.
-    // For example, if we are given a 3-bit number `[x_3, x_2, x_1]`,
-    // we can check if it is equal to 4, by computing:
-    // `x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3`
-    //
-    // Since we need to check all possible values, it makes sense to pre-compute all
-    // of the coefficients that are used across all of these equality checks. In this way,
-    // we can minimize the total number of multiplications needed.
-    //
-    // We must pre-compute all combinations of bit values. The following loop does so.
-    // It does so by starting with the array `[1]`.
-    // The next step is to multiply this by `x_1` and append it to the end of the array.
-    // Now the array is `[1, x_1]`.
-    // The next step is to mulitply all of these values by `x_2` and append them to the end of the array.
-    // Now the array is `[1, x_1, x_2, x_1*x_2]`
-    // The next step is to mulitply all of these values of `x_3` and append them to the end of the array.
-    // Now the array is `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
-    // This process continues for as many steps as there are bits of input.
-    let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
-    precomputed_combinations.push(ctx.share_of_one());
-    #[allow(clippy::needless_range_loop)]
-    for bit_idx in 0..num_bits {
-        let bit = &input[bit_idx][record_idx];
-        let step = 1 << bit_idx;
-        let num_children_to_add = precomputed_combinations.len();
-        precomputed_combinations.push(bit.clone());
-        if bit_idx == 0 {
-            continue;
-        }
-        let mut multiplication_futures = Vec::with_capacity(num_children_to_add - 1);
-        #[allow(clippy::needless_range_loop)]
-        for j in 1..num_children_to_add {
-            let child_idx = j + step;
-            multiplication_futures.push(ctx.narrow(&BitOpStep::from(child_idx)).multiply(
-                record_id,
-                &precomputed_combinations[j],
-                bit,
-            ));
-        }
-        let mut multiplication_results = try_join_all(multiplication_futures).await?;
-        precomputed_combinations.append(&mut multiplication_results);
-    }
+
+    let precomputed_combinations =
+        pregenerate_all_combinations(ctx, record_idx, input, num_bits).await?;
 
     // This loop just iterates over all the possible values this N-bit input could potentially represent
     // and checks if the bits are equal to this value. It does so my computing a linear combination of the
@@ -346,83 +137,132 @@ where
     Ok(equality_checks)
 }
 
-///
-/// This function is used to generate the look-up tables saved as constants at the top of this file.
-///
-/// This function appears to be "unused" because it is only used to generate the constants.
-#[allow(dead_code)]
-fn generate_lookup_table(num_bits: usize) -> Vec<Vec<i8>> {
-    let num_possible_values = 1 << num_bits;
-    (0..num_possible_values)
-        .map(|value| collect_coefficients_recursive(value, num_bits, 0, 0_i8))
-        .collect()
+//
+// Every equality check can be computed as a linear combination of coefficients.
+// For example, if we are given a 3-bit number `[x_3, x_2, x_1]`,
+// we can check if it is equal to 4, by computing:
+// $x_3(1-x_2)(1-x_1)$,
+// which expands to:
+// $x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3$
+//
+// Since we need to check all possible values, it makes sense to pre-compute all
+// of the coefficients that are used across all of these equality checks. In this way,
+// we can minimize the total number of multiplications needed.
+//
+// We must pre-compute all combinations of bit values. The following loop does so.
+// It does so by starting with the array `[1]`.
+// The next step is to multiply this by `x_1` and append it to the end of the array.
+// Now the array is `[1, x_1]`.
+// The next step is to mulitply all of these values by `x_2` and append them to the end of the array.
+// Now the array is `[1, x_1, x_2, x_1*x_2]`
+// The next step is to mulitply all of these values of `x_3` and append them to the end of the array.
+// Now the array is `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
+// This process continues for as many steps as there are bits of input.
+async fn pregenerate_all_combinations<F, C, S>(
+    ctx: C,
+    record_idx: usize,
+    input: &[Vec<S>],
+    num_bits: usize,
+) -> Result<Vec<S>, Error>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: SecretSharing<F>,
+{
+    let record_id = RecordId::from(record_idx);
+    let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
+    precomputed_combinations.push(ctx.share_of_one());
+    for (bit_idx, column) in input.iter().enumerate() {
+        let bit = &column[record_idx];
+        let step = 1 << bit_idx;
+        let num_children_to_add = precomputed_combinations.len();
+        precomputed_combinations.push(bit.clone());
+        if bit_idx == 0 {
+            continue;
+        }
+        let mut multiplication_results = try_join_all(
+            precomputed_combinations
+                .iter()
+                .enumerate()
+                .skip(1)
+                .take(num_children_to_add - 1)
+                .map(|(j, precomputed_combination)| {
+                    let child_idx = j + step;
+                    ctx.narrow(&BitOpStep::from(child_idx)).multiply(
+                        record_id,
+                        precomputed_combination,
+                        bit,
+                    )
+                }),
+        )
+        .await?;
+        precomputed_combinations.append(&mut multiplication_results);
+    }
+    Ok(precomputed_combinations)
 }
 
 ///
-/// Each row of the look-up tables saved as constants at the top of this file was generated via a call to this function.
-/// Each row indicates which coefficients must be added / subtracted to check equality of an N-bit sequence to a specific value.
+/// This function is used to generate the look-up tables saved as constants at the top of this file.
+/// This function appears to be "unused" because it is only used to generate the constants.
 ///
-/// Let's work through an example:
-/// To check if a 3-bit value is equal to `4`, we would logically compute:
-/// `(x_3)(1 - x_2)(1 - x_1)`
-/// This function basically just "multiplies that all out", distributing terms.
+/// Observe that the coefficients necessary to compute a given equality check form a Sierpiński triangle
+/// <https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle#/media/File:Multigrade_operator_AND.svg>
+/// The Sierpiński triangle can be generated iteratively using the simple formula:
+/// $f(n+1) = f(n) XOR 2*f(n)$
+/// where $f(0) = 1$
 ///
-/// It starts with the least significant bit, `x_1`. If the value is equal to `4`, then the least significant bit should be equal to `0`
-/// That is why the last term is `(1 - x_1)`.
-/// Since there are two parts of this term, we need to distribute both of them, multiplying each element of the rest of the equation by each.
-/// To do this, we recurse. We compute the rest of the equation times `1`, and subtract the rest of the equation times `x_1`.
-/// Recall how the array of pre-computed linear-combinations is ordered:
-/// `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
-/// It is ordered that way because we constructed it by:
-/// ...iterating through the bits from least significant to most significant
-/// ...and multiplying all values in the array by the next bit
-/// ...thereby doubling the length of the array at each bit.
+/// This produces the following sequence:
+/// 1, 3, 5, 15, 17, 51, 85, 255, ...
+/// Considering these as binary numbers, you'll see they produce the Sierpiński triangle
+/// 00000001
+/// 00000011
+/// 00000101
+/// 00001111
+/// 00010001
+/// 00110011
+/// 01010101
+/// 11111111
 ///
-/// Think of this like a "tree". We start at the root node, (index 0). We begin with a value of `1`.
-/// At depth=1 in the tree, we either multiply by `1`, or by `x_1`. Multiplication by `1` is easy, we just stay at the current index.
-/// Multiplication by `x_1` is achieved by moving to the right by 1.
+/// In our case, we just have to reverse the order of the rows, so that the final one comes first,
+/// and represents the coefficients used to compute equality to zero.
 ///
-/// Then we go to the next bit, `x_2`. If the value is equal to `4`, then this bit should be equal to `0` as well.
-/// That is why the second to last term is `(1 - x_2)`.
-/// Once again, there are two parts of this term, and we need to distribute them both, multiplying each element of the rest of the equation by each.
-/// To do this, we recurse yet again. We compute the rest of the equation times `1`, and subtract the rest of the equation times `x_2`.
-/// Just like before, for each element, multiplying by "1" is achieved by just remaining that the current index in the pre-computed linear coefficients.
-/// Now that we are at depth=2 in the tree, to find the value multiplied by `x_2` we must move to the index 2 to the right.
-/// That's because there were only 2 elements in the array, and we multiplied each by `x_2`, resulting in an array of length 4.
+/// The signs of the coefficients are a bit more complex. Martin Thomson has observed that they follow
+/// the following pattern:
 ///
-/// Finally, we come to the most significant bit, `x_3`. If the value is equal to `4`, then this bit should be equal to `1`.
-/// That is why we multiply by the term `(x_3)`.
-/// There is only one component of this term, so we only need to recurse one time.
-/// Now that we are at depth=3 in the tree, finding the value multiplied by `x_3` can be achieved by looking at the index 4 to the right in the array of pre-computed linear combinations.
-/// That's because we took an array of length 4, and multiplied each value by `x_3`, appending the results to the end, resulting in an array of length 8.
-fn collect_coefficients_recursive(
-    value: u32,
-    num_bits: usize,
-    bit_idx: usize,
-    current_coefficient_idx: i8,
-) -> Vec<i8> {
-    if bit_idx == num_bits {
-        return vec![current_coefficient_idx];
+/// 1. Take the row and column and bitwise AND them: $(i & j)$
+/// 2. Count the number of non-zero bits in the result
+/// 3. If the result is an odd number, the coefficient is negative. If the result is even, the coefficient is positive.
+#[allow(dead_code)]
+fn generate_lookup_table(num_bits: usize) -> Vec<Vec<i8>> {
+    let side_length = 1 << num_bits;
+    let mut sterpinski_triangle = Vec::with_capacity(side_length);
+    for _ in 0..side_length {
+        sterpinski_triangle.push(Vec::with_capacity(side_length));
     }
-    let bit = (value >> bit_idx) & 1;
-    let step = 1 << bit_idx;
-    let next_bit_idx = bit_idx + 1;
-    let times_x_coefficients = collect_coefficients_recursive(
-        value,
-        num_bits,
-        next_bit_idx,
-        current_coefficient_idx + step,
-    );
-    if bit == 0 {
-        let times_one_coefficients =
-            collect_coefficients_recursive(value, num_bits, next_bit_idx, current_coefficient_idx);
-        return [
-            times_one_coefficients,
-            times_x_coefficients.iter().map(|x| -x).collect(),
-        ]
-        .concat();
+    let mut binary_representation = 1;
+    for i in 0..side_length {
+        if i > 0 {
+            binary_representation = binary_representation ^ (binary_representation << 1);
+        }
+        let bits = get_big_endian_bits(binary_representation, side_length);
+        for (j, bit) in bits.iter().enumerate() {
+            let rows_from_bottom = side_length - i - 1;
+            let sign = 1 - 2 * i8::try_from((j & i).count_ones() & 1).unwrap();
+
+            sterpinski_triangle[rows_from_bottom].push(bit * sign);
+        }
     }
-    times_x_coefficients
+    sterpinski_triangle
+}
+
+fn get_big_endian_bits(value: usize, num_bits: usize) -> Vec<i8> {
+    let mut output = Vec::with_capacity(num_bits);
+    for i in 0..num_bits {
+        let bit = (value >> i) & 1;
+        output.push(i8::from(bit != 0));
+    }
+    output.reverse();
+    output
 }
 
 ///
@@ -432,34 +272,30 @@ fn collect_coefficients_recursive(
 /// `(x_4)(1 - x_3)(1 - x_2)(1 - x_1)`
 /// If you multiply this all out, that's equivalent to:
 /// `x_4 - x_3*x_4 - x_2*x_4 + x_2*x_3*x_4 - x_1*x_4 + x_1*x_3*x_4 + x_1*x_2*x_4 - x_1*x_2*x_3*x_4`
-/// /// All of these coefficients have been pre-computed and are stored in an array.
+///
+/// All of these coefficients have been pre-computed and are stored in an array.
 /// This function just looks up which coefficients are needed. In this case it would retrieve:
-/// `[8, -12, -10, 14, -9, 13, 11, -15]`
-/// The sign of each element indicates if that coefficient should be added or subtracted,
-/// while the absolute value of the elements indicates the position in the array of pre-computed coefficients.
+/// `[0, 0, 0, 0, 0, 0, 0, 0, 1, -1, -1, 1, -1, 1, 1, -1],`
+/// The sign of each element indicates if that coefficient should be added or subtracted.
 fn check_equality_to<F: Field, S: SecretSharing<F>>(
     value: usize,
     num_bits: usize,
     tree: &[S],
 ) -> S {
-    let look_up_table = match num_bits {
-        1 => COEFFICIENT_LOOK_UP_TABLE_ONE_BIT,
-        2 => COEFFICIENT_LOOK_UP_TABLE_TWO_BITS,
-        3 => COEFFICIENT_LOOK_UP_TABLE_THREE_BITS,
-        4 => COEFFICIENT_LOOK_UP_TABLE_FOUR_BITS,
-        5 => COEFFICIENT_LOOK_UP_TABLE_FIVE_BITS,
-        _ => panic!("No lookup table has been generated for {num_bits} bits."),
-    };
-    let coefficients = look_up_table[value];
-    coefficients.iter().fold(S::ZERO, |acc, x| {
-        let x_abs = usize::try_from(x.abs()).unwrap();
-        let next_value = &tree[x_abs];
-        if *x < 0 {
-            acc - next_value
-        } else {
-            acc + next_value
-        }
-    })
+    debug_assert!(num_bits <= 4, "Lookup table only supports up to 4 bits");
+    let coefficients = &COEFFICIENT_LOOK_UP_TABLE[value];
+    coefficients
+        .iter()
+        .zip(tree)
+        .fold(S::ZERO, |acc, (coef, value)| {
+            if *coef == P {
+                acc + value
+            } else if *coef == N {
+                acc - value
+            } else {
+                acc
+            }
+        })
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
@@ -534,64 +370,25 @@ mod tests {
         }
     }
 
-    const COMMENT_KEY: [&str; 32] = [
-        "1",
-        "x_1",
-        "x_2",
-        "x_1*x_2",
-        "x_3",
-        "x_1*x_3",
-        "x_2*x_3",
-        "x_1*x_2*x_3",
-        "x_4",
-        "x_1*x_4",
-        "x_2*x_4",
-        "x_1*x_2*x_4",
-        "x_3*x_4",
-        "x_1*x_3*x_4",
-        "x_2*x_3*x_4",
-        "x_1*x_2*x_3*x_4",
-        "x_5",
-        "x_1*x_5",
-        "x_2*x_5",
-        "x_1*x_2*x_5",
-        "x_3*x_5",
-        "x_1*x_3*x_5",
-        "x_2*x_3*x_5",
-        "x_1*x_2*x_3*x_5",
-        "x_4*x_5",
-        "x_1*x_4*x_5",
-        "x_2*x_4*x_5",
-        "x_1*x_2*x_4*x_5",
-        "x_3*x_4*x_5",
-        "x_1*x_3*x_4*x_5",
-        "x_2*x_3*x_4*x_5",
-        "x_1*x_2*x_3*x_4*x_5",
-    ];
-
     // This is used to generate the lookup tables of constants at the top of this file.
     #[ignore]
     #[test]
     pub fn generate_lookup_table_constants() {
-        for i in 1..6 {
-            let look_up_table = generate_lookup_table(i);
-            println!("Lookup table for {i} bits: ");
-            for row in look_up_table {
-                let mut comment: String = "// ".to_owned();
-                row.iter().enumerate().for_each(|(idx, x)| {
-                    if idx > 0 {
-                        if *x < 0 {
-                            comment.push_str(" - ");
-                        } else {
-                            comment.push_str(" + ");
-                        }
-                    }
-                    let index: usize = usize::try_from(x.abs()).unwrap();
-                    comment.push_str(COMMENT_KEY[index]);
-                });
-                println!("    {comment}");
-                println!("    &{row:?},");
-            }
+        let look_up_table = generate_lookup_table(4);
+        for row in look_up_table {
+            println!(
+                "    [{}],",
+                row.iter()
+                    .map(|x| if *x == 1 {
+                        "P"
+                    } else if *x == -1 {
+                        "N"
+                    } else {
+                        "0"
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
         }
         panic!();
     }


### PR DESCRIPTION
tl;dr

Sorting 1000 rows:

= Old version =
(3-bit multi-sort) Total records sent: 1,950,000
(4-bit multi-sort) Total records sent: 3,129,000

= New version =
(3-bit multi-sort) Total records sent: 1,194,000
(4-bit multi-sort) Total records sent: 1,353,000

= Summary =
(3-bit multi-sort) 
- 756,000 fewer records sent
- 38.8% reduction

(4-bit multi-sort)
- 1,776,000 fewer records sent
- 56.7% reduction

For a 3-bit multi-bit-sort, here is what you do for each row:

- check if it's a bitwise representation of zero
- check if it's a bitwise representation of one
- check if it's a bitwise representation of two
- check if it's a bitwise representation of three
- check if it's a bitwise representation of four
- check if it's a bitwise representation of five
- check if it's a bitwise representation of six
- check if it's a bitwise representation of seven

So let's say that for a given row, you have three secret shares representing the three bits. Let's call it:

[ $b_0, b_1, b_2$ ]

Logically speaking, the way you check all 8 of these conditions is to compute the following:

- $(1-b_0) \times (1-b_1) \times (1 - b_2)$
- $(1-b_0) \times (1-b_1) \times b_2$
- $(1-b_0) \times b_1 \times (1 - b_2)$
- $(1-b_0) \times b_1 \times b_2$
- $b_0 \times (1-b_1) \times (1 - b_2)$
- $b_0 \times (1-b_1) \times b_2$
- $b_0 \times b_1 \times (1 - b_2)$
- $b_0 \times b_1 \times b_2$

Prior to this diff, that's exactly what we did. Very simple. Just two multiplications per equality check, so a total of 2 * 8 = 16 multiplications per row.

But you can expand these expressions out:
- $1 - b_0 - b_1 - b_2 + b_0 b_1 + b_0 b_2 + b_1 b_2$
- $b_2 - b_0 b_2 - b_1 b_2 + b_0 b_1 b_2$
- $b_1 - b_0 b_1 - b_1 b_2 + b_0 b_1 b_2$
- $b_1 b_2 - b_0 b_1 b_2$
- $b_0 - b_0 b_1 - b_0 b_2 + b_0 b_1 b_2$
- $b_0 b_2 - b_0 b_1 b_2$
- $b_0 b_1 - b_0 b_1 b_2$
- $b_0 b_1 b_2$

And as you can see, they are all just linear combinations of the same set of common terms! So we only need to pre-compute the following 4 things:

- $b_0 \times b_1$
- $b_0 \times b_2$
- $b_1 \times b_2$
- $b_0 \times b_1 \times b_2 $

...and then we can compute all 8 equality checks by just adding / subtracting those things in various combinations.

The tricky thing is determining *which* terms to use for each equality check, and what sign each should have.

I thought of it this way:
- The first term is either $b_0$ or $(1 - b_0)$. 
- Then we multiply by the second term, which is either $b_1$ or $(1 - b_1)$
- Then we multiply by the third term, which is either $b_2$ or $(1 - b_2)$

So I pre-compute these terms in that order:

First I add two elements:
$[1, b_0]$

Then, I multiply both of these by $b_1$ and append the results to the array:

$[1, b_0, b_1, b_0 b_1]$
(multiplying $1 * b_1$ clearly doesn't need a real multiplication - we can skip that one).

Then we multiply all four elements by $b_2$ and append the results to the array:

$[1, b_0, b_1, b_0 b_1, b_2, b_0 b_2, b_1 b_2, b_0 b_1 b_2]$
(multiplying $1 * b_2$ clearly doesn't need a real multiplication - we can skip that one too..)

If we were using more than 3 bits, we would just continue in this way.

Now this array of pre-computed values can be thought of like a *binary tree*. At each node in the tree, you can either go left (multiply by one), or go right (multiply by the next bit). To go "left" you just stay at the same index. To go "right" you just add the "step" which is 2^bit. 

Now, when we are trying to compute an equality check to a specific number, we can use this "binary tree" to help us. Let's say we are checking equality to "4". First, we compute the binary version of this number, 100. Then we use each bit to guide us. The first bit is a "1", so originally we go "right" (because we just multiply by $b_0$ in this case, not by $(1 - b_0)$. ). The next bit is a "0". This indicates that we need to multiply by $(1 - b_1)$. So now we have to go left AND right, and add the recursive results. Finally, the 3rd bit is also "0", indicating that we need to multiply by $(1 - b_2)$, so we need both of the branches from the last step to both go left AND right. In this way, we have re-derived that we need to compute $b_0 - b_0 b_1 - b_0 b_2 + b_0 b_1 b_2$, and we grabbed those four terms from out of our pre-computed array.
