### PR TITLE
Sanitize features in cargo.toml and update benches readme

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,7 +46,7 @@ jobs:
         run: cargo build --release
 
       - name: Build benchmarks
-        run: cargo build --benches --all-features
+        run: cargo build --benches --features enable-benches
 
       - name: Build concurrency tests
         run: cargo build --features shuttle

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,18 @@ rust-version = "1.64.0"
 edition = "2021"
 
 [features]
-default = ["debug", "cli"]
-cli = ["comfy-table", "clap", "enable-serde", "metrics-tracing-context", "metrics-util", "tracing-subscriber", "web-app"]
-debug = []
+# by default remove all TRACE, DEBUG spans from release builds
+default = ["web-app", "tracing/max_level_trace", "tracing/release_max_level_info"]
+cli = ["comfy-table", "clap"]
 enable-serde = ["serde", "serde_json"]
-web-app = ["tokio", "tokio-stream", "tokio-util", "axum", "axum-server", "hyper", "hyper-tls", "tower", "tower-http"]
+# TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
+# TODO Consider moving out benches as well
+web-app = ["axum", "axum-server", "enable-serde", "hex", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
 test-fixture = []
 shuttle = ["shuttle-crate", "test-fixture"]
+debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
+enable-benches = ["cli", "test-fixture", "criterion", "iai"]
 
 [dependencies]
 aes = "0.8"
@@ -23,16 +27,18 @@ bitvec = "1.0.1"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }
 config = "0.13.2"
+criterion = { version = "0.4.0", optional = true, default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
 embed-doc-image = "0.1.4"
 futures = "0.3.24"
 futures-util = "0.3.24"
-hex = { version = "0.4", features = ["serde"] }
+hex = { version = "0.4", optional = true, features = ["serde"] }
 hkdf = "0.12.3"
 hyper = { version = "0.14.20", optional = true, features = ["client", "h2"] }
 hyper-tls = { version = "0.5.0", optional = true }
+iai = { version = "0.1.1", optional = true }
 metrics = "0.20.1"
-metrics-tracing-context = { version = "0.12.0", optional = true }
-metrics-util = { version = "0.14.0", optional = true }
+metrics-tracing-context = "0.12.0"
+metrics-util = { version = "0.14.0" }
 once_cell = "1.16.0"
 pin-project = "1.0.12"
 rand = "0.8"
@@ -44,20 +50,17 @@ serde_json = { version = "1.0", optional = true }
 sha2 = "0.10.6"
 shuttle-crate = { package = "shuttle", version = "0.5", optional = true }
 thiserror = "1.0"
-tinyvec = { version = "1.6.0" }
-tokio = { version = "1.21.2", optional = true, features = ["rt", "rt-multi-thread", "macros"] }
-tokio-stream = { version = "0.1.10", optional = true }
-tokio-util = { version = "0.7.4", optional = true }
+tinyvec = "1.6.0"
+tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "macros"] }
+tokio-stream = "0.1.10"
+tokio-util = "0.7.4"
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
-# disable debug traces and below for release builds and keep everything for debug build
-tracing = { version = "0.1.37", features = ["max_level_trace", "release_max_level_info"] }
-tracing-subscriber = { version = "0.3.16", optional = true, features = ["env-filter"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]
-criterion = { version = "0.4.0", default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
-iai = "0.1.1"
 permutation = "0.4.1"
 proptest = "1.0.0"
 
@@ -68,13 +71,13 @@ bench = false
 
 [[bin]]
 name = "helper"
-required-features = ["cli"]
+required-features = ["cli", "web-app"]
 bench = false
 
 [[bin]]
 name = "ipa_bench"
 path = "src/bin/ipa_bench/ipa_bench.rs"
-required-features = ["cli"]
+required-features = ["cli", "enable-serde"]
 bench = false
 
 [[bin]]
@@ -82,35 +85,32 @@ name = "test_mpc"
 required-features = ["cli"]
 bench = false
 
-[profile.bench]
-debug = true
-
 [[bench]]
 name = "criterion_arithmetic"
 path = "benches/ct/arithmetic_circuit.rs"
 harness = false
-required-features = ["test-fixture"]
+required-features = ["enable-benches"]
 
 [[bench]]
 name = "iai_arithmetic"
 path = "benches/iai/arithmetic_circuit.rs"
 harness = false
-required-features = ["test-fixture"]
+required-features = ["enable-benches"]
 
 [[bench]]
 name = "oneshot_arithmetic"
 path = "benches/oneshot/arithmetic_circuit.rs"
 harness = false
-required-features = ["test-fixture"]
+required-features = ["enable-benches"]
 
 [[bench]]
 name = "oneshot_sort"
 path = "benches/oneshot/sort.rs"
 harness = false
-required-features = ["test-fixture"]
+required-features = ["enable-benches"]
 
 [[bench]]
 name = "oneshot_ipa"
 path = "benches/oneshot/ipa.rs"
 harness = false
-required-features = ["test-fixture"]
+required-features = ["enable-benches"]

--- a/benches/README.md
+++ b/benches/README.md
@@ -7,13 +7,13 @@ By convention, Criterion benchmarks have prefix `ct`, iai benchmark names start 
 To execute a benchmark, run
 
 ```bash
-cargo bench -F test-fixture --bench <benchmark_name>
+cargo bench -F enable-benches --bench <benchmark_name>
 ```
 
 Oneshot benchmarks are simply Rust programs that often share the benchmark logic with Criterion/iai benchmarks. They make it easier to produce and interpret flamegraphs. They may also read their input from stdin
 
 ```bash
-cargo flamegraph --root --bench oneshot_arithmetic --features="test-fixture" -- --depth=64 --width=1000000       
+CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --root --bench oneshot_arithmetic --features="enable-benches" -- --depth=64 --width=1000000       
 ```
 
 Note: make sure you've installed `cargo-flamegraph` by running 
@@ -21,3 +21,43 @@ Note: make sure you've installed `cargo-flamegraph` by running
 ```bash
 cargo add flamegraph
 ```
+
+### Enabling step-level metrics
+
+It is possible to print communication/crypto metrics with per-step breakdown. That requires default features to be turned
+off.
+
+
+Run the following command to print step-level metrics at the end of benchmarks. Note that debug traces impact program
+performance. It is not recommended to profile IPA in this mode. 
+
+Execute the following command to enable step-level metrics. It is possible to use different bench as long as it uses
+`TestWorld` to set up the environment.
+
+```bash
+RUST_LOG=raw_ipa=DEBUG cargo bench --bench oneshot_sort --no-default-features --features="enable-benches debug-trace"
+```
+
+The output would look similar to this:
+
+```
+benchmark complete after 0.7891756s
+Step,Records Sent,Indexed PRSS,Sequential PRSS
+protocol/run-0/mc0/xor1,100,300,0
+protocol/run-0/mc0/xor2,200,300,0
+protocol/run-0/mc1/xor1,100,300,0
+protocol/run-0/mc1/xor2,200,300,0
+protocol/run-0/mc10/xor1,100,300,0
+protocol/run-0/mc10/xor2,200,300,0
+protocol/run-0/mc11/xor1,100,300,0
+protocol/run-0/mc11/xor2,200,300,0
+```
+
+If the output is stored in a file, it is possible to derive additional metrics. For example, to compute total
+number of records sent between helpers:
+
+```bash
+cat -p /tmp/steps.log | cut -d',' -f2 | awk '{s+=$1}END{print s}'
+189900
+```
+

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -4,7 +4,6 @@ use raw_ipa::ff::{Field, Fp32BitPrime};
 use raw_ipa::protocol::context::Context;
 use raw_ipa::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
 use raw_ipa::protocol::sort::generate_permutation_opt::generate_permutation_opt;
-// use raw_ipa::protocol::sort::generate_permutation::generate_permutation;
 use raw_ipa::secret_sharing::XorReplicated;
 use raw_ipa::test_fixture::{join3, Reconstruct, TestWorld, TestWorldConfig};
 use std::num::NonZeroUsize;

--- a/pre-commit
+++ b/pre-commit
@@ -44,7 +44,7 @@ error() {
    exit 1
 }
 
-cargo build --benches --all-features || error "Benchmarks compilation errors"
+cargo build --benches --features "enable-benches" || error "Benchmarks compilation errors"
 
 cargo clippy --tests -- -D warnings || error "Clippy errors"
 

--- a/src/bin/ipa_bench/models.rs
+++ b/src/bin/ipa_bench/models.rs
@@ -304,7 +304,6 @@ struct TriggerFanoutQuery {
     value_range: Range<u32>,
 }
 
-#[cfg(feature = "debug")]
 impl Debug for TriggerFanoutQuery {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,9 +25,6 @@ pub enum Error {
     MaliciousSecurityCheckFailed,
     #[error("malicious reveal failed")]
     MaliciousRevealFailed,
-    #[error("failed to decode hex: {0}")]
-    #[cfg(feature = "cli")]
-    Hex(#[from] hex::FromHexError),
     #[error("problem during IO: {0}")]
     Io(#[from] std::io::Error),
     #[error("failed to parse json: {0}")]

--- a/src/helpers/error.rs
+++ b/src/helpers/error.rs
@@ -6,7 +6,6 @@ use crate::{
         network::{ChannelId, MessageChunks},
         HelperIdentity, Role,
     },
-    net::MpcHelperServerError,
     protocol::{RecordId, Step},
 };
 use thiserror::Error;
@@ -42,12 +41,14 @@ pub enum Error {
     },
     #[error("Encountered unknown identity {0:?}")]
     UnknownIdentity(HelperIdentity),
+    #[cfg(feature = "web-app")]
     #[error("identity had invalid format: {0}")]
     InvalidIdentity(#[from] hyper::http::uri::InvalidUri),
     #[error("Failed to send command on the transport: {0}")]
     TransportError(#[from] TransportError),
+    #[cfg(feature = "web-app")]
     #[error("server encountered an error: {0}")]
-    ServerError(#[from] MpcHelperServerError),
+    ServerError(#[from] crate::net::MpcHelperServerError),
 }
 
 impl Error {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "web-app")]
 pub mod http;
 pub mod messaging;
 pub mod network;
@@ -56,7 +57,8 @@ impl TryFrom<usize> for HelperIdentity {
 /// may be `H2` or `H3`.
 /// Each helper instance must be able to take any role, but once the role is assigned, it cannot
 /// be changed for the remainder of the query.
-#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq, clap::ValueEnum)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[cfg_attr(
     feature = "enable-serde",
     derive(serde::Deserialize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@
 
 pub mod bits;
 pub mod chunkscan;
+#[cfg(feature = "cli")]
 pub mod cli;
 pub mod error;
 pub mod ff;
 pub mod helpers;
+#[cfg(feature = "web-app")]
 pub mod net;
 pub mod protocol;
 pub mod secret_sharing;

--- a/src/net/server/handlers/echo.rs
+++ b/src/net/server/handlers/echo.rs
@@ -4,10 +4,10 @@ use axum::{
     Json,
 };
 use hyper::{Body, Request};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Payload {
     pub query_args: HashMap<String, String>,
     pub headers: HashMap<String, String>,

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -7,10 +7,7 @@ use crate::{
     helpers::{http::HttpNetwork, network::MessageChunks},
     net::LastSeenMessages,
     protocol::QueryId,
-    telemetry::metrics::{
-        web::RequestProtocolVersion,
-        REQUESTS_RECEIVED
-    }
+    telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
 };
 use ::tokio::sync::mpsc;
 use axum::{
@@ -419,7 +416,7 @@ mod e2e_tests {
         helpers::http::HttpNetwork,
         net::server::{handlers::EchoData, BindTarget, MessageSendMap, MpcHelperServer},
         protocol::QueryId,
-        telemetry::metrics::{RequestProtocolVersion, REQUESTS_RECEIVED},
+        telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
         test_fixture::metrics::MetricsHandle,
     };
     use hyper::{

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -7,7 +7,10 @@ use crate::{
     helpers::{http::HttpNetwork, network::MessageChunks},
     net::LastSeenMessages,
     protocol::QueryId,
-    telemetry::metrics::{RequestProtocolVersion, REQUESTS_RECEIVED},
+    telemetry::metrics::{
+        web::RequestProtocolVersion,
+        REQUESTS_RECEIVED
+    }
 };
 use ::tokio::sync::mpsc;
 use axum::{
@@ -50,6 +53,7 @@ pub enum MpcHelperServerError {
     MissingExtension(#[from] axum::extract::rejection::ExtensionRejection),
     #[error(transparent)]
     HyperError(#[from] hyper::Error),
+    #[cfg(feature = "enable-serde")]
     #[error("parse error: {0}")]
     SerdeError(#[from] serde_json::Error),
     #[error("could not forward messages: {0}")]

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -7,13 +7,6 @@ use crate::{
     protocol::{context::Context, RecordId},
     secret_sharing::Replicated,
 };
-use serde::{Deserialize, Serialize};
-
-/// A message sent by each helper when they've multiplied their own shares
-#[derive(Debug, Serialize, Deserialize, Default)]
-pub struct DValue<F> {
-    d: F,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -2,7 +2,7 @@ mod into_shares;
 mod malicious_replicated;
 mod replicated;
 mod xor;
-#[cfg(any(feature = "test-fixture", feature = "cli"))]
+#[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 pub use into_shares::IntoShares;
 
 use crate::bits::BooleanOps;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -9,40 +9,42 @@ pub mod labels {
 }
 
 pub mod metrics {
-    use axum::http::Version;
     use metrics::Unit;
-    use metrics::{describe_counter, KeyName};
+    use metrics::describe_counter;
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
     pub const RECORDS_SENT: &str = "records.sent";
     pub const INDEXED_PRSS_GENERATED: &str = "i.prss.gen";
     pub const SEQUENTIAL_PRSS_GENERATED: &str = "s.prss.gen";
 
-    /// Metric that records the version of HTTP protocol used for a particular request.
     #[cfg(feature = "web-app")]
-    pub struct RequestProtocolVersion(Version);
+    pub mod web {
+        use axum::http::Version;
+        use metrics::KeyName;
 
-    #[cfg(feature = "web-app")]
-    impl From<Version> for RequestProtocolVersion {
-        fn from(v: Version) -> Self {
-            RequestProtocolVersion(v)
+        /// Metric that records the version of HTTP protocol used for a particular request.
+        pub struct RequestProtocolVersion(Version);
+
+        impl From<Version> for RequestProtocolVersion {
+            fn from(v: Version) -> Self {
+                RequestProtocolVersion(v)
+            }
         }
-    }
 
-    #[cfg(feature = "web-app")]
-    impl From<RequestProtocolVersion> for KeyName {
-        fn from(v: RequestProtocolVersion) -> Self {
-            const HTTP11: &str = "request.protocol.HTTP/1.1";
-            const HTTP2: &str = "request.protocol.HTTP/2";
-            const HTTP3: &str = "request.protocol.HTTP/3";
-            const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
+        impl From<RequestProtocolVersion> for KeyName {
+            fn from(v: RequestProtocolVersion) -> Self {
+                const HTTP11: &str = "request.protocol.HTTP/1.1";
+                const HTTP2: &str = "request.protocol.HTTP/2";
+                const HTTP3: &str = "request.protocol.HTTP/3";
+                const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
 
-            KeyName::from_const_str(match v.0 {
-                Version::HTTP_11 => HTTP11,
-                Version::HTTP_2 => HTTP2,
-                Version::HTTP_3 => HTTP3,
-                _ => UNKNOWN,
-            })
+                KeyName::from_const_str(match v.0 {
+                    Version::HTTP_11 => HTTP11,
+                    Version::HTTP_2 => HTTP2,
+                    Version::HTTP_3 => HTTP3,
+                    _ => UNKNOWN,
+                })
+            }
         }
     }
 
@@ -62,17 +64,21 @@ pub mod metrics {
             "Total number of requests received by the web server"
         );
 
-        describe_counter!(
-            RequestProtocolVersion::from(Version::HTTP_11),
-            Unit::Count,
-            "Total number of HTTP/1.1 requests received"
-        );
+        #[cfg(feature = "web-app")]
+        {
+            use axum::http::Version;
+            describe_counter!(
+                web::RequestProtocolVersion::from(Version::HTTP_11),
+                Unit::Count,
+                "Total number of HTTP/1.1 requests received"
+            );
 
-        describe_counter!(
-            RequestProtocolVersion::from(Version::HTTP_2),
-            Unit::Count,
-            "Total number of HTTP/2 requests received"
-        );
+            describe_counter!(
+                web::RequestProtocolVersion::from(Version::HTTP_2),
+                Unit::Count,
+                "Total number of HTTP/2 requests received"
+            );
+        }
 
         describe_counter!(
             RECORDS_SENT,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -9,8 +9,8 @@ pub mod labels {
 }
 
 pub mod metrics {
-    use metrics::Unit;
     use metrics::describe_counter;
+    use metrics::Unit;
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
     pub const RECORDS_SENT: &str = "records.sent";

--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -2,9 +2,7 @@ use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-use std::io::Write;
 
-use comfy_table::Table;
 use metrics::{KeyName, Label, SharedString};
 
 use crate::helpers::Role;
@@ -131,8 +129,9 @@ impl Metrics {
     ///
     /// ## Errors
     /// returns an IO error if it fails to write to the provided writer.
-    pub fn print(&self, w: &mut impl Write) -> Result<(), std::io::Error> {
-        let mut metrics_table = Table::new();
+    #[cfg(feature = "cli")]
+    pub fn print(&self, w: &mut impl std::io::Write) -> Result<(), std::io::Error> {
+        let mut metrics_table = comfy_table::Table::new();
         metrics_table.set_header(vec!["metric", "description", "value", "dimensions"]);
 
         for (key_name, counter_stats) in &self.counters {

--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -2,7 +2,6 @@ use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-
 use metrics::{KeyName, Label, SharedString};
 
 use crate::helpers::Role;

--- a/src/test_fixture/net.rs
+++ b/src/test_fixture/net.rs
@@ -1,4 +1,3 @@
-
 /// Creates a new config for helpers configured to run on local machine using unique port.
 #[allow(clippy::missing_panics_doc)]
 #[cfg(feature = "web-app")]

--- a/src/test_fixture/net.rs
+++ b/src/test_fixture/net.rs
@@ -1,12 +1,13 @@
-use crate::net::discovery::conf::Conf;
-use std::fmt::Debug;
 
 /// Creates a new config for helpers configured to run on local machine using unique port.
 #[allow(clippy::missing_panics_doc)]
-pub fn localhost_config<P: TryInto<u16>>(ports: [P; 3]) -> Conf
+#[cfg(feature = "web-app")]
+pub fn localhost_config<P: TryInto<u16>>(ports: [P; 3]) -> crate::net::discovery::conf::Conf
 where
-    P::Error: Debug,
+    P::Error: std::fmt::Debug,
 {
+    use crate::net::discovery::conf::Conf;
+
     let ports = ports.map(|v| v.try_into().expect("Failed to parse the value into u16"));
     let config_str = format!(
         r#"


### PR DESCRIPTION
Initially I just wanted to update the readme file to show folks how to print per-step level metrics in benchmarks. After I started working on it, I realized it is not possible in the current cargo workspace configuration because debug spans are removed at compile time.

I thought I can just fix it with a one liner, but that turned into an exercise to clean up our existing code that does not protect imports behind feature gates. 

What I am proposing here is less than ideal, I would really want to move http related stuff into its own crate after looking at build timings

![Screenshot 2023-01-13 at 3 08 27 PM](https://user-images.githubusercontent.com/1110516/212435209-21e471fa-9fe8-4136-87f2-4eeb4d7e1931.png)
