### PR TITLE
Enable debug assertions for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ x25519-dalek = "2.0.0-pre.1"
 permutation = "0.4.1"
 proptest = "1.0.0"
 
+[profile.bench]
+debug-assertions = true
+
 [lib]
 name = "raw_ipa"
 path = "src/lib.rs"


### PR DESCRIPTION
We're not quite ready to eliminate them, there are some missing features (channel backpressure) that we need to implement before we can ignore them in release builds.

In the meantime, it is better to give some clues why benchmark is stalled/failed even at the cost of adding more branches