### PR TITLE
Reverting #379

### DIFF
--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -60,7 +60,8 @@ impl AsRef<str> for Step {
 pub async fn sum_of_products<F>(
     ctx: MaliciousContext<'_, F>,
     record_id: RecordId,
-    pairs: &[(&MaliciousReplicated<F>, &MaliciousReplicated<F>)],
+    a: &[&MaliciousReplicated<F>],
+    b: &[&MaliciousReplicated<F>],
 ) -> Result<MaliciousReplicated<F>, Error>
 where
     F: Field,
@@ -68,28 +69,27 @@ where
     use crate::protocol::context::SpecialAccessToMaliciousContext;
     use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 
+    assert_eq!(a.len(), b.len());
+
     let duplicate_multiply_ctx = ctx.narrow(&Step::DuplicateSop);
     let random_constant_ctx = ctx.narrow(&Step::RandomnessForValidation);
-    let semi_honest_pairs = pairs
+    let ax = a
         .iter()
-        .map(|pair| {
-            (
-                pair.0.x().access_without_downgrade(),
-                pair.1.x().access_without_downgrade(),
-            )
-        })
+        .map(|a| a.x().access_without_downgrade())
         .collect::<Vec<_>>();
-    let r_pairs = pairs
+    let arx = a.iter().map(|a| a.rx()).collect::<Vec<_>>();
+
+    let bx = b
         .iter()
-        .map(|pair| (pair.0.rx(), pair.1.x().access_without_downgrade()))
+        .map(|b| b.x().access_without_downgrade())
         .collect::<Vec<_>>();
 
     let (ab, rab) = try_join(
         ctx.semi_honest_context()
-            .sum_of_products(record_id, semi_honest_pairs.as_slice()),
+            .sum_of_products(record_id, ax.as_slice(), bx.as_slice()),
         duplicate_multiply_ctx
             .semi_honest_context()
-            .sum_of_products(record_id, r_pairs.as_slice()),
+            .sum_of_products(record_id, arx.as_slice(), bx.as_slice()),
     )
     .await?;
 
@@ -128,11 +128,9 @@ mod test {
 
         let res = world
             .malicious((av, bv), |ctx, (a_share, b_share)| async move {
-                let mut pairs = Vec::with_capacity(BATCHSIZE);
-                for i in 0..a_share.len() {
-                    pairs.push((&a_share[i], &b_share[i]));
-                }
-                ctx.sum_of_products(RecordId::from(0), pairs.as_slice())
+                let a_refs = a_share.iter().collect::<Vec<_>>();
+                let b_refs = b_share.iter().collect::<Vec<_>>();
+                ctx.sum_of_products(RecordId::from(0), a_refs.as_slice(), b_refs.as_slice())
                     .await
                     .unwrap()
             })

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -20,7 +20,8 @@ pub trait SecureSop<F: ArithmeticShare>: Sized {
     async fn sum_of_products(
         self,
         record_id: RecordId,
-        pairs: &[(&Self::Share, &Self::Share)],
+        a: &[&Self::Share],
+        b: &[&Self::Share],
     ) -> Result<Self::Share, Error>;
 }
 
@@ -32,9 +33,10 @@ impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
     async fn sum_of_products(
         self,
         record_id: RecordId,
-        pairs: &[(&Self::Share, &Self::Share)],
+        a: &[&Self::Share],
+        b: &[&Self::Share],
     ) -> Result<Self::Share, Error> {
-        semi_honest::sum_of_products(self, record_id, pairs).await
+        semi_honest::sum_of_products(self, record_id, a, b).await
     }
 }
 
@@ -46,8 +48,9 @@ impl<F: Field> SecureSop<F> for MaliciousContext<'_, F> {
     async fn sum_of_products(
         self,
         record_id: RecordId,
-        pairs: &[(&Self::Share, &Self::Share)],
+        a: &[&Self::Share],
+        b: &[&Self::Share],
     ) -> Result<Self::Share, Error> {
-        malicious::sum_of_products(self, record_id, pairs).await
+        malicious::sum_of_products(self, record_id, a, b).await
     }
 }


### PR DESCRIPTION
As it turns out, the only time we ever compute the dot-product of two vectors, we independently have them in memory as two vectors. So it's better to just use them as-is, rather than creating a new vector of pairs of them.