### PR TITLE
free send and receive buffer resources when no longer needed

### DIFF
--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -112,6 +112,11 @@ impl<const N: usize> FixedSizeByteVec<N> {
             Some(self.data[(i * N)..((i + tail) * N)].to_owned())
         }
     }
+
+    /// Returns `true` if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.added.not_any()
+    }
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]

--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -113,6 +113,11 @@ impl<const N: usize> FixedSizeByteVec<N> {
         }
     }
 
+    /// Returns total number of elements evicted from this buffer since the creation.
+    pub fn taken(&self) -> usize {
+        self.end - self.capacity.get()
+    }
+
     /// Returns `true` if the buffer is empty.
     pub fn is_empty(&self) -> bool {
         self.added.not_any()

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -131,6 +131,11 @@ impl ReceiveBuffer {
         }
     }
 
+    pub fn open_channels(&self) -> usize {
+        assert_eq!(self.inner.len(), self.record_ids.len());
+        self.inner.len()
+    }
+
     #[cfg(debug_assertions)]
     pub(in crate::helpers) fn waiting(&self) -> super::waiting::WaitingTasks {
         use super::waiting::WaitingTasks;

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -3,9 +3,9 @@ use crate::{
     helpers::messaging::TotalRecords,
     protocol::RecordId,
 };
-use std::{collections::hash_map::Entry, num::NonZeroUsize};
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 use std::fmt::Debug;
+use std::num::NonZeroUsize;
 use tokio::sync::oneshot;
 
 #[derive(Debug)]

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -52,8 +52,9 @@ impl ReceiveBuffer {
         channel_id: ChannelId,
         record_id: RecordId,
         sender: oneshot::Sender<MessagePayload>,
+        total_records: NonZeroUsize,
     ) {
-        let total_records = channel_id.total_records.expect("can't receive without a known total record count");
+        //let total_records = channel_id.total_records.expect("can't receive without a known total record count");
         let channel = self.inner.entry(channel_id.clone()).or_insert_with(|| {
             tracing::trace!("create rx channel for rx request {:?}", &channel_id);
             ReceiveChannel {
@@ -84,10 +85,10 @@ impl ReceiveBuffer {
     /// chunk will belong to range of records [0..chunk.len()), second chunk [chunk.len()..2*chunk.len())
     /// etc. It does not require all chunks to be of the same size, this assumption is baked in
     /// send buffers.
-    pub fn receive_messages(&mut self, channel_id: &ChannelId, messages: &[u8]) {
+    pub fn receive_messages(&mut self, channel_id: &ChannelId, messages: &[u8], total_records: NonZeroUsize) {
         // TODO: this is probably wrong. Need to maintain total count as
         // unknown until we see a receive request.
-        let total_records = channel_id.total_records.expect("can't receive without a known total record count");
+        //let total_records = channel_id.total_records.expect("can't receive without a known total record count");
 
         let offset = self
             .record_ids

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -1,5 +1,6 @@
 use crate::{
     helpers::{network::ChannelId, MessagePayload, MESSAGE_PAYLOAD_SIZE_BYTES},
+    helpers::messaging::TotalRecords,
     protocol::RecordId,
 };
 use std::{collections::hash_map::Entry, num::NonZeroUsize};
@@ -9,7 +10,7 @@ use tokio::sync::oneshot;
 
 #[derive(Debug)]
 struct ReceiveChannel {
-    total_records: NonZeroUsize,
+    total_records: TotalRecords,
     received_records: usize,
     items: HashMap<RecordId, ReceiveBufItem>,
 }
@@ -38,7 +39,12 @@ impl ReceiveBuffer {
     fn update_record_count(&mut self, channel_id: ChannelId) {
         let channel = self.inner.get_mut(&channel_id).expect("update_record_count called for invalid channel");
         channel.received_records += 1;
-        if NonZeroUsize::new(channel.received_records) == Some(channel.total_records) {
+        let total_records = if let TotalRecords::Specified(value) = channel.total_records {
+            value
+        } else {
+            return;
+        };
+        if NonZeroUsize::new(channel.received_records) == Some(total_records) {
             assert!(channel.items.is_empty());
             tracing::trace!("close rx {:?}", &channel_id);
             self.inner.remove(&channel_id);
@@ -58,7 +64,7 @@ impl ReceiveBuffer {
         let channel = self.inner.entry(channel_id.clone()).or_insert_with(|| {
             tracing::trace!("create rx channel for rx request {:?}", &channel_id);
             ReceiveChannel {
-                total_records,
+                total_records: TotalRecords::Specified(total_records),
                 received_records: 0,
                 items: Default::default(),
             }
@@ -85,7 +91,7 @@ impl ReceiveBuffer {
     /// chunk will belong to range of records [0..chunk.len()), second chunk [chunk.len()..2*chunk.len())
     /// etc. It does not require all chunks to be of the same size, this assumption is baked in
     /// send buffers.
-    pub fn receive_messages(&mut self, channel_id: &ChannelId, messages: &[u8], total_records: NonZeroUsize) {
+    pub fn receive_messages(&mut self, channel_id: &ChannelId, messages: &[u8]) {
         // TODO: this is probably wrong. Need to maintain total count as
         // unknown until we see a receive request.
         //let total_records = channel_id.total_records.expect("can't receive without a known total record count");
@@ -107,7 +113,7 @@ impl ReceiveBuffer {
                 .or_insert_with(|| {
                     tracing::trace!("create rx channel for rx msg {:?}", &channel_id);
                     ReceiveChannel {
-                        total_records,
+                        total_records: TotalRecords::Unspecified,
                         received_records: 0,
                         items: Default::default(),
                     }

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -102,6 +102,10 @@ impl SendBuffer {
         Ok(res.map(|b| (b, close)))
     }
 
+    pub fn open_channels(&self) -> usize {
+        self.inner.len()
+    }
+
     #[cfg(debug_assertions)]
     pub(in crate::helpers) fn waiting(&self) -> super::waiting::WaitingTasks {
         use super::waiting::WaitingTasks;

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -60,12 +60,12 @@ impl SendBuffer {
         &mut self,
         channel_id: &ChannelId,
         msg: &MessageEnvelope,
+        total_records: NonZeroUsize,
     ) -> Result<Option<(Vec<u8>, bool)>, PushError> {
         debug_assert!(
             msg.payload.len() <= ByteBuf::ELEMENT_SIZE_BYTES,
             "Message payload exceeds the maximum allowed size"
         );
-        let total_records = channel_id.total_records.expect("can't send without a known total record count");
 
         let channel = if let Some(channel) = self.inner.get_mut(channel_id) {
             channel

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -62,7 +62,7 @@ impl SendBuffer {
         channel_id: &ChannelId,
         msg: &MessageEnvelope,
         total_records: NonZeroUsize,
-    ) -> Option<(Vec<u8>, bool)> {
+    ) -> Option<Vec<u8>> {
         debug_assert!(
             msg.payload.len() <= ByteBuf::ELEMENT_SIZE_BYTES,
             "Message payload exceeds the maximum allowed size"
@@ -92,15 +92,12 @@ impl SendBuffer {
             assert!(vec.len() % ByteBuf::ELEMENT_SIZE_BYTES == 0);
             channel.sent_records += vec.len() / ByteBuf::ELEMENT_SIZE_BYTES;
         }
-        let close = if NonZeroUsize::new(channel.sent_records) == Some(channel.total_records.try_into().unwrap()) {
+        if NonZeroUsize::new(channel.sent_records) == Some(channel.total_records.try_into().unwrap()) {
             assert!(NonZeroUsize::new(channel.buf.taken()) == Some(channel.total_records.try_into().unwrap()));
             assert!(channel.buf.is_empty());
             self.inner.remove(&channel_id);
-            true
-        } else {
-            false
-        };
-        res.map(|res| (res, close))
+        }
+        res
     }
 
     pub fn open_channels(&self) -> usize {

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -21,7 +21,7 @@ use prss_exchange_protocol::{
     PrssExchangeStep, PublicKeyBytesBuilder, PublicKeyChunk, PUBLIC_KEY_CHUNK_COUNT,
 };
 use rand_core::{CryptoRng, RngCore};
-use std::{iter::zip, num::NonZeroUsize};
+use std::iter::zip;
 use std::net::SocketAddr;
 
 pub struct HttpHelper<'p> {

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -21,7 +21,7 @@ use prss_exchange_protocol::{
     PrssExchangeStep, PublicKeyBytesBuilder, PublicKeyChunk, PUBLIC_KEY_CHUNK_COUNT,
 };
 use rand_core::{CryptoRng, RngCore};
-use std::iter::zip;
+use std::{iter::zip, num::NonZeroUsize};
 use std::net::SocketAddr;
 
 pub struct HttpHelper<'p> {

--- a/src/helpers/http/mod.rs
+++ b/src/helpers/http/mod.rs
@@ -5,7 +5,10 @@ pub use network::HttpNetwork;
 
 use crate::{
     ff::Field,
-    helpers::{messaging::Gateway, Direction, Error, GatewayConfig, Role},
+    helpers::{
+        messaging::{Gateway, TotalRecords},
+        Direction, Error, GatewayConfig, Role,
+    },
     net::{
         discovery::{peer, PeerDiscovery},
         BindTarget, MessageSendMap, MpcHelperServer,
@@ -18,8 +21,8 @@ use prss_exchange_protocol::{
     PrssExchangeStep, PublicKeyBytesBuilder, PublicKeyChunk, PUBLIC_KEY_CHUNK_COUNT,
 };
 use rand_core::{CryptoRng, RngCore};
+use std::iter::zip;
 use std::net::SocketAddr;
-use std::{iter::zip, num::NonZeroUsize};
 
 pub struct HttpHelper<'p> {
     role: Role,
@@ -84,7 +87,7 @@ impl<'p> HttpHelper<'p> {
     ) -> Result<prss::Endpoint, Error> {
         // setup protocol to exchange prss public keys
         let step = step.narrow(&PrssExchangeStep);
-        let channel = gateway.mesh(&step, NonZeroUsize::new(PUBLIC_KEY_CHUNK_COUNT));
+        let channel = gateway.mesh(&step, TotalRecords::from(PUBLIC_KEY_CHUNK_COUNT));
         let left_peer = self.role.peer(Direction::Left);
         let right_peer = self.role.peer(Direction::Right);
 

--- a/src/helpers/http/network.rs
+++ b/src/helpers/http/network.rs
@@ -166,7 +166,7 @@ mod tests {
 
         // consume request on server-side
         let spawned = tokio::spawn({
-            let expected_channel_id = ChannelId::new(self_role, step.clone(), None);
+            let expected_channel_id = ChannelId::new(self_role, step.clone());
             let expected_body = body.to_vec();
             async move {
                 for _ in 0..num_reqs {
@@ -179,7 +179,7 @@ mod tests {
 
         // send request on client-side
         for _ in 0..num_reqs {
-            sink.send((ChannelId::new(target_role, step.clone(), None), body.to_vec()))
+            sink.send((ChannelId::new(target_role, step.clone()), body.to_vec()))
                 .await
                 .expect("send should succeed");
         }

--- a/src/helpers/http/network.rs
+++ b/src/helpers/http/network.rs
@@ -166,7 +166,7 @@ mod tests {
 
         // consume request on server-side
         let spawned = tokio::spawn({
-            let expected_channel_id = ChannelId::new(self_role, step.clone());
+            let expected_channel_id = ChannelId::new(self_role, step.clone(), None);
             let expected_body = body.to_vec();
             async move {
                 for _ in 0..num_reqs {
@@ -179,7 +179,7 @@ mod tests {
 
         // send request on client-side
         for _ in 0..num_reqs {
-            sink.send((ChannelId::new(target_role, step.clone()), body.to_vec()))
+            sink.send((ChannelId::new(target_role, step.clone(), None), body.to_vec()))
                 .await
                 .expect("send should succeed");
         }

--- a/src/helpers/http/prss_exchange_protocol.rs
+++ b/src/helpers/http/prss_exchange_protocol.rs
@@ -28,11 +28,13 @@ impl AsRef<str> for PrssExchangeStep {
 
 impl Substep for PrssExchangeStep {}
 
+pub const PUBLIC_KEY_CHUNK_COUNT: usize = 4;
+
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
 pub struct PublicKeyChunk([u8; 8]);
 
 impl PublicKeyChunk {
-    pub fn chunks(pk: PublicKey) -> [PublicKeyChunk; 4] {
+    pub fn chunks(pk: PublicKey) -> [PublicKeyChunk; PUBLIC_KEY_CHUNK_COUNT] {
         let pk_bytes = pk.to_bytes();
 
         // These assumptions are necessary for ser/de to work
@@ -46,7 +48,7 @@ impl PublicKeyChunk {
                 chunk_bytes.copy_from_slice(chunk);
                 PublicKeyChunk(chunk_bytes)
             })
-            .collect::<ArrayVec<[PublicKeyChunk; 4]>>()
+            .collect::<ArrayVec<[PublicKeyChunk; PUBLIC_KEY_CHUNK_COUNT]>>()
             .into_inner()
     }
 
@@ -100,7 +102,8 @@ pub struct PublicKeyBytesBuilder {
 }
 
 impl PublicKeyBytesBuilder {
-    const FULL_COUNT: u8 = 4;
+    #[allow(clippy::cast_possible_truncation)]
+    const FULL_COUNT: u8 = PUBLIC_KEY_CHUNK_COUNT as u8;
 
     pub fn empty() -> Self {
         PublicKeyBytesBuilder {

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -422,14 +422,13 @@ fn print_state(role: Role, send_buf: &SendBuffer, receive_buf: &ReceiveBuffer) {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use std::num::NonZeroUsize;
-
     use crate::ff::Fp31;
     use crate::helpers::messaging::TotalRecords;
     use crate::helpers::Role;
     use crate::protocol::context::Context;
     use crate::protocol::{RecordId, Step};
     use crate::test_fixture::{TestWorld, TestWorldConfig};
+    use std::num::NonZeroUsize;
 
     #[tokio::test]
     pub async fn handles_reordering() {

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -13,7 +13,7 @@ use crate::{
         network::ChannelId,
         Error, MessagePayload, Role, MESSAGE_PAYLOAD_SIZE_BYTES,
     },
-    protocol::{RecordId, Step},
+    protocol::{context::TotalRecords, RecordId, Step},
     task::JoinHandle,
     telemetry::{labels::STEP, metrics::RECORDS_SENT},
 };
@@ -180,7 +180,7 @@ impl Mesh<'_, '_> {
         let envelope = MessageEnvelope { record_id, payload };
 
         self.gateway
-            .send(ChannelId::new(dest, self.step.clone()), envelope)
+            .send(ChannelId::new(dest, self.step.clone(), self.total_records), envelope)
             .await
     }
 
@@ -204,7 +204,7 @@ impl Mesh<'_, '_> {
 
         let payload = self
             .gateway
-            .receive(ChannelId::new(source, self.step.clone()), record_id)
+            .receive(ChannelId::new(source, self.step.clone(), self.total_records), record_id)
             .await?;
 
         let obj = T::deserialize(&payload)
@@ -256,14 +256,23 @@ impl Gateway {
                     Some((channel_id, envelope)) = send_rx.recv(), if pending_sends.is_empty() => {
                         tracing::trace!("new SendRequest({:?})", (&channel_id, &envelope));
                         metrics::increment_counter!(RECORDS_SENT, STEP => channel_id.step.as_ref().to_string());
-                        if let Some(buf_to_send) = send_buf.push(&channel_id, &envelope) {
-                            tracing::trace!("sending {} bytes to {:?}", buf_to_send.len(), &channel_id);
-                            pending_sends.push(async { network
-                                .send((channel_id, buf_to_send))
-                                .await
-                                .expect("Failed to send data to the network");
-                            });
-                        }
+                        match buf.push(&channel_id, &msg) {
+                            Ok(Some((buf_to_send, close))) => {
+                                tracing::trace!("sending {} bytes to {:?}", buf_to_send.len(), &channel_id);
+                                pending_sends.push(async { network
+                                    .send((channel_id, buf_to_send))
+                                    .await
+                                    .expect("Failed to send data to the network");
+                                });
+                                if close {
+                                    tracing::trace!("close {:?}", &channel_id);
+                                    // TODO: need to update this post rebase
+                                    sink.close().await.expect("Failed to close channel");
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(err) => panic!("failed to send to the {channel_id:?}: {err}"),
+                        };
                     }
                     Some(_) = &mut pending_sends.next() => {
                         pending_sends.clear();
@@ -382,6 +391,8 @@ fn print_state(role: Role, send_buf: &SendBuffer, receive_buf: &ReceiveBuffer) {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use crate::ff::Fp31;
     use crate::helpers::messaging::TotalRecords;
     use crate::helpers::Role;

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -29,10 +29,7 @@ pub struct ChannelId {
 impl ChannelId {
     #[must_use]
     pub fn new(role: Role, step: Step) -> Self {
-        Self {
-            role,
-            step,
-        }
+        Self { role, step }
     }
 }
 

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -8,7 +8,7 @@ use crate::{
         transport::{SubscriptionType, Transport, TransportCommand},
         Error, Role,
     },
-    protocol::{QueryId, Step},
+    protocol::{context::TotalRecords, QueryId, RecordId, Step},
 };
 use futures::{Stream, StreamExt};
 use std::fmt::{Debug, Formatter};
@@ -25,12 +25,17 @@ pub struct MessageEnvelope {
 pub struct ChannelId {
     pub role: Role,
     pub step: Step,
+    pub total_records: TotalRecords,
 }
 
 impl ChannelId {
     #[must_use]
-    pub fn new(role: Role, step: Step) -> Self {
-        Self { role, step }
+    pub fn new(role: Role, step: Step, total_records: TotalRecords) -> Self {
+        Self {
+            role,
+            step,
+            total_records,
+        }
     }
 }
 

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -25,16 +25,14 @@ pub struct MessageEnvelope {
 pub struct ChannelId {
     pub role: Role,
     pub step: Step,
-    pub total_records: TotalRecords,
 }
 
 impl ChannelId {
     #[must_use]
-    pub fn new(role: Role, step: Step, total_records: TotalRecords) -> Self {
+    pub fn new(role: Role, step: Step) -> Self {
         Self {
             role,
             step,
-            total_records,
         }
     }
 }

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -2,13 +2,12 @@
 
 use crate::helpers::transport::CommandOrigin;
 use crate::helpers::{MessagePayload, RoleAssignment};
-use crate::protocol::RecordId;
 use crate::{
     helpers::{
         transport::{SubscriptionType, Transport, TransportCommand},
         Error, Role,
     },
-    protocol::{context::TotalRecords, QueryId, RecordId, Step},
+    protocol::{QueryId, RecordId, Step},
 };
 use futures::{Stream, StreamExt};
 use std::fmt::{Debug, Formatter};

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -162,7 +162,7 @@ mod tests {
             .await
             .expect("send should succeed");
 
-        let channel_id = ChannelId { role, step, total_records: None };
+        let channel_id = ChannelId { role, step };
         let server_recvd = rx_stream.next().await.unwrap(); // should already have been received
         assert_eq!(server_recvd, (channel_id, body.to_vec()));
     }

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -162,7 +162,7 @@ mod tests {
             .await
             .expect("send should succeed");
 
-        let channel_id = ChannelId { role, step };
+        let channel_id = ChannelId { role, step, total_records: None };
         let server_recvd = rx_stream.next().await.unwrap(); // should already have been received
         assert_eq!(server_recvd, (channel_id, body.to_vec()));
     }

--- a/src/net/server/handlers/query.rs
+++ b/src/net/server/handlers/query.rs
@@ -82,7 +82,7 @@ pub async fn obtain_permit_mw<B: Send>(
 
     // PANIC if messages arrive out of order; pretty print the error
     // TODO (ts): remove this when streaming solution is complete
-    let channel_id = ChannelId::new(role, step);
+    let channel_id = ChannelId::new(role, step, None);
     last_seen_messages.ensure_ordering(&channel_id, record_headers.offset);
 
     // get sender to correct network
@@ -229,6 +229,7 @@ mod tests {
             let channel_id = ChannelId {
                 role: target_helper,
                 step: step.clone(),
+                total_records: None,
             };
 
             assert_eq!(status, StatusCode::OK, "{resp_body_str}");

--- a/src/net/server/handlers/query.rs
+++ b/src/net/server/handlers/query.rs
@@ -82,7 +82,7 @@ pub async fn obtain_permit_mw<B: Send>(
 
     // PANIC if messages arrive out of order; pretty print the error
     // TODO (ts): remove this when streaming solution is complete
-    let channel_id = ChannelId::new(role, step, None);
+    let channel_id = ChannelId::new(role, step);
     last_seen_messages.ensure_ordering(&channel_id, record_headers.offset);
 
     // get sender to correct network
@@ -229,7 +229,6 @@ mod tests {
             let channel_id = ChannelId {
                 role: target_helper,
                 step: step.clone(),
-                total_records: None,
             };
 
             assert_eq!(status, StatusCode::OK, "{resp_body_str}");

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -83,6 +83,7 @@ pub async fn accumulate_credit<F: Field>(
     input: &[AttributionInputRow<F>],
 ) -> Result<Vec<AccumulateCreditOutputRow<F>>, Error> {
     let num_rows = input.len();
+    let ctx = ctx.set_total_records(num_rows);
 
     // 1. Create stop_bit vector.
     // These vector is updated in each iteration to help accumulate values
@@ -321,12 +322,15 @@ pub(crate) mod tests {
     use crate::{
         ff::{Field, Fp31},
         helpers::Role,
-        protocol::attribution::{
-            accumulate_credit::accumulate_credit,
-            tests::{BD, H, S, T},
-            AttributionInputRow,
+        protocol::{
+            attribution::{
+                accumulate_credit::accumulate_credit,
+                tests::{BD, H, S, T},
+                AttributionInputRow,
+            },
+            context::Context,
+            RecordId,
         },
-        protocol::RecordId,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
 
@@ -414,7 +418,10 @@ pub(crate) mod tests {
                 .semi_honest(
                     AttributionTestInput(secret),
                     |ctx, share: AttributionInputRow<Fp31>| async move {
-                        share.reshare(ctx, RecordId::from(0), role).await.unwrap()
+                        share
+                            .reshare(ctx.set_total_records(1), RecordId::from(0), role)
+                            .await
+                            .unwrap()
                     },
                 )
                 .await;

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -309,7 +309,6 @@ enum Step {
     ApplyPermutationOnBreakdownKey,
     GeneratePermutationByAttributionBit,
     ApplyPermutationOnAttributionBit,
-    GenerateRandomBits,
 }
 
 impl Substep for Step {}
@@ -330,7 +329,6 @@ impl AsRef<str> for Step {
             Self::ApplyPermutationOnBreakdownKey => "apply_permutation_by_breakdown_key",
             Self::GeneratePermutationByAttributionBit => "generate_permutation_by_attribution_bit",
             Self::ApplyPermutationOnAttributionBit => "apply_permutation_on_attribution_bit",
-            Self::GenerateRandomBits => "generate_random_bits",
         }
     }
 }

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -309,6 +309,7 @@ enum Step {
     ApplyPermutationOnBreakdownKey,
     GeneratePermutationByAttributionBit,
     ApplyPermutationOnAttributionBit,
+    GenerateRandomBits,
 }
 
 impl Substep for Step {}
@@ -329,6 +330,7 @@ impl AsRef<str> for Step {
             Self::ApplyPermutationOnBreakdownKey => "apply_permutation_by_breakdown_key",
             Self::GeneratePermutationByAttributionBit => "generate_permutation_by_attribution_bit",
             Self::ApplyPermutationOnAttributionBit => "apply_permutation_on_attribution_bit",
+            Self::GenerateRandomBits => "generate_random_bits",
         }
     }
 }

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -104,7 +104,9 @@ pub async fn aggregate_credit<F: Field>(
         .enumerate()
     {
         let end = num_rows - step_size;
-        let c = ctx.narrow(&InteractionPatternStep::from(depth));
+        let c = ctx
+            .narrow(&InteractionPatternStep::from(depth))
+            .set_total_records(end);
         let mut futures = Vec::with_capacity(end);
 
         for i in 0..end {
@@ -229,7 +231,7 @@ async fn bit_decompose_breakdown_key<F: Field>(
     try_join_all(
         input
             .iter()
-            .zip(repeat(ctx))
+            .zip(repeat(ctx.set_total_records(input.len())))
             .enumerate()
             .map(|(i, (x, c))| async move {
                 BitDecomposition::execute(c, RecordId::from(i), rbg, &x.breakdown_key).await

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -294,6 +294,7 @@ enum Step {
     IfCurrentExceedsCapOrElse,
     IfNextExceedsCapOrElse,
     IfNextEventHasSameMatchKeyOrElse,
+    GenerateRandomBits,
 }
 
 impl Substep for Step {}
@@ -313,6 +314,7 @@ impl AsRef<str> for Step {
             Self::IfCurrentExceedsCapOrElse => "if_current_exceeds_cap_or_else",
             Self::IfNextExceedsCapOrElse => "if_next_exceeds_cap_or_else",
             Self::IfNextEventHasSameMatchKeyOrElse => "if_next_event_has_same_match_key_or_else",
+            Self::GenerateRandomBits => "generate_random_bits",
         }
     }
 }

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -294,7 +294,6 @@ enum Step {
     IfCurrentExceedsCapOrElse,
     IfNextExceedsCapOrElse,
     IfNextEventHasSameMatchKeyOrElse,
-    GenerateRandomBits,
 }
 
 impl Substep for Step {}
@@ -314,7 +313,6 @@ impl AsRef<str> for Step {
             Self::IfCurrentExceedsCapOrElse => "if_current_exceeds_cap_or_else",
             Self::IfNextExceedsCapOrElse => "if_next_exceeds_cap_or_else",
             Self::IfNextEventHasSameMatchKeyOrElse => "if_next_event_has_same_match_key_or_else",
-            Self::GenerateRandomBits => "generate_random_bits",
         }
     }
 }

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -87,7 +87,7 @@ mod tests {
     #[tokio::test]
     async fn basic() -> Result<(), Error> {
         let world = TestWorld::new().await;
-        let context = world.contexts::<Fp31>();
+        let context = world.contexts::<Fp31>().map(|ctx| ctx.set_total_records(1));
         let mut rng = thread_rng();
         let mut counter = 0_u32;
 

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -100,7 +100,7 @@ where
 mod test {
     use crate::{
         ff::Fp31,
-        protocol::{basics::SecureMul, RecordId},
+        protocol::{basics::SecureMul, context::Context, RecordId},
         rand::{thread_rng, Rng},
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
@@ -115,7 +115,10 @@ mod test {
 
         let res = world
             .malicious((a, b), |ctx, (a, b)| async move {
-                ctx.multiply(RecordId::from(0), &a, &b).await.unwrap()
+                ctx.set_total_records(1)
+                    .multiply(RecordId::from(0), &a, &b)
+                    .await
+                    .unwrap()
             })
             .await;
 

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -79,7 +79,7 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod test {
     use crate::ff::{Field, Fp31};
-    use crate::protocol::{basics::SecureMul, RecordId};
+    use crate::protocol::{basics::SecureMul, context::Context, RecordId};
     use crate::rand::{thread_rng, Rng};
     use crate::test_fixture::{Reconstruct, Runner, TestWorld};
     use futures::future::try_join_all;
@@ -109,7 +109,10 @@ mod test {
 
         let res = world
             .semi_honest((a, b), |ctx, (a, b)| async move {
-                ctx.multiply(RecordId::from(0), &a, &b).await.unwrap()
+                ctx.set_total_records(1)
+                    .multiply(RecordId::from(0), &a, &b)
+                    .await
+                    .unwrap()
             })
             .await;
 
@@ -131,11 +134,16 @@ mod test {
         let expected: Vec<_> = zip(a.iter(), b.iter()).map(|(&a, &b)| a * b).collect();
         let results = world
             .semi_honest((a, b), |ctx, (a_shares, b_shares)| async move {
-                try_join_all(zip(repeat(ctx), zip(a_shares, b_shares)).enumerate().map(
-                    |(i, (ctx, (a_share, b_share)))| async move {
+                try_join_all(
+                    zip(
+                        repeat(ctx.set_total_records(COUNT)),
+                        zip(a_shares, b_shares),
+                    )
+                    .enumerate()
+                    .map(|(i, (ctx, (a_share, b_share)))| async move {
                         ctx.multiply(RecordId::from(i), &a_share, &b_share).await
-                    },
-                ))
+                    }),
+                )
                 .await
                 .unwrap()
             })
@@ -154,7 +162,8 @@ mod test {
 
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
-                ctx.multiply(RecordId::from(0), &a_share, &b_share)
+                ctx.set_total_records(1)
+                    .multiply(RecordId::from(0), &a_share, &b_share)
                     .await
                     .unwrap()
             })

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -193,6 +193,7 @@ pub(in crate::protocol) mod test {
         },
         protocol::{
             basics::{mul::sparse::MultiplyWork, MultiplyZeroPositions, SecureMul, ZeroPositions},
+            context::Context,
             malicious::MaliciousValidator,
             BitOpStep, RECORD_0,
         },
@@ -379,7 +380,8 @@ pub(in crate::protocol) mod test {
                 let v2 = SparseField::new(rng.gen::<Fp31>(), b);
                 let result = world
                     .semi_honest((v1, v2), |ctx, (v_a, v_b)| async move {
-                        ctx.multiply_sparse(RECORD_0, &v_a, &v_b, (a, b))
+                        ctx.set_total_records(1)
+                            .multiply_sparse(RECORD_0, &v_a, &v_b, (a, b))
                             .await
                             .unwrap()
                     })
@@ -406,7 +408,7 @@ pub(in crate::protocol) mod test {
                 let result = world
                     .semi_honest((v1, v2), |ctx, (v_a, v_b)| async move {
                         let v = MaliciousValidator::new(ctx);
-                        let m_ctx = v.context();
+                        let m_ctx = v.context().set_total_records(1);
                         let (m_a, m_b) = try_join(
                             m_ctx.upgrade_with_sparse(&BitOpStep::from(0), v_a, a),
                             m_ctx.upgrade_with_sparse(&BitOpStep::from(1), v_b, b),

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -153,6 +153,7 @@ mod tests {
                 let shares = world
                     .semi_honest(secret, |ctx, share| async move {
                         let record_id = RecordId::from(0);
+                        let ctx = ctx.set_total_records(1);
 
                         // run reshare protocol for all helpers except the one that does not know the input
                         if ctx.role() == target {
@@ -185,7 +186,10 @@ mod tests {
                 let secret = thread_rng().gen::<Fp32BitPrime>();
                 let new_shares = world
                     .semi_honest(secret, |ctx, share| async move {
-                        ctx.reshare(&share, RecordId::from(0), role).await.unwrap()
+                        ctx.set_total_records(1)
+                            .reshare(&share, RecordId::from(0), role)
+                            .await
+                            .unwrap()
                     })
                     .await;
 
@@ -227,7 +231,10 @@ mod tests {
                 let secret = thread_rng().gen::<Fp32BitPrime>();
                 let new_shares = world
                     .malicious(secret, |ctx, share| async move {
-                        ctx.reshare(&share, RecordId::from(0), role).await.unwrap()
+                        ctx.set_total_records(1)
+                            .reshare(&share, RecordId::from(0), role)
+                            .await
+                            .unwrap()
                     })
                     .await;
 
@@ -324,13 +331,14 @@ mod tests {
                 world
                     .semi_honest(a, |ctx, a| async move {
                         let v = MaliciousValidator::new(ctx);
+                        let m_ctx = v.context().set_total_records(1);
                         let record_id = RecordId::from(0);
                         let m_a = v.context().upgrade(a).await.unwrap();
 
-                        let m_reshared_a = if v.context().role() == *malicious_actor {
+                        let m_reshared_a = if m_ctx.role() == *malicious_actor {
                             // This role is spoiling the value.
                             reshare_malicious_with_additive_attack(
-                                v.context(),
+                                m_ctx,
                                 &m_a,
                                 record_id,
                                 to_helper,
@@ -339,10 +347,7 @@ mod tests {
                             .await
                             .unwrap()
                         } else {
-                            v.context()
-                                .reshare(&m_a, record_id, to_helper)
-                                .await
-                                .unwrap()
+                            m_ctx.reshare(&m_a, record_id, to_helper).await.unwrap()
                         };
                         match v.validate(m_reshared_a).await {
                             Ok(result) => panic!("Got a result {result:?}"),

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -127,7 +127,7 @@ where
 mod test {
     use crate::{
         ff::Fp31,
-        protocol::{basics::sum_of_product::SecureSop, RecordId},
+        protocol::{basics::sum_of_product::SecureSop, context::Context, RecordId},
         rand::{thread_rng, Rng},
         secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
@@ -152,7 +152,8 @@ mod test {
 
         let res = world
             .malicious((av, bv), |ctx, (a, b)| async move {
-                ctx.sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
+                ctx.set_total_records(1)
+                    .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
             })

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -74,6 +74,7 @@ mod test {
 
     use crate::ff::{Field, Fp31};
     use crate::protocol::basics::sum_of_product::SecureSop;
+    use crate::protocol::context::Context;
     use crate::protocol::RecordId;
     use crate::secret_sharing::SharedValue;
     use crate::test_fixture::{Reconstruct, Runner, TestWorld};
@@ -117,7 +118,8 @@ mod test {
 
         let res = world
             .semi_honest((av, bv), |ctx, (a, b)| async move {
-                ctx.sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
+                ctx.set_total_records(1)
+                    .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
             })
@@ -136,7 +138,8 @@ mod test {
 
         let result = world
             .semi_honest((a, b), |ctx, (a, b)| async move {
-                ctx.sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
+                ctx.set_total_records(1)
+                    .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
             })

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -107,7 +107,7 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::{BitDecomposition, Step};
+    use super::BitDecomposition;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Int},
         protocol::{

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -107,7 +107,7 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use super::BitDecomposition;
+    use super::{BitDecomposition, Step};
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Int},
         protocol::{

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -136,7 +136,7 @@ mod tests {
             .semi_honest(a, |ctx, a_p| async move {
                 let rbg = RandomBitsGenerator::new(ctx.narrow(&GenerateRandomBits));
 
-                BitDecomposition::execute(ctx, RecordId::from(0), &rbg, &a_p)
+                BitDecomposition::execute(ctx.set_total_records(1), RecordId::from(0), &rbg, &a_p)
                     .await
                     .unwrap()
             })

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -64,7 +64,7 @@ mod tests {
     use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
-        protocol::RecordId,
+        protocol::{context::Context, RecordId},
         test_fixture::{get_bits, Reconstruct, TestWorld},
     };
 
@@ -102,9 +102,14 @@ mod tests {
 
         let answer_fp31 = world
             .semi_honest((a_fp31, b_fp31), |ctx, (a_bits, b_bits)| async move {
-                bitwise_equal(ctx, RecordId::from(0), &a_bits, &b_bits)
-                    .await
-                    .unwrap()
+                bitwise_equal(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_bits,
+                    &b_bits,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
@@ -116,9 +121,14 @@ mod tests {
             .semi_honest(
                 (a_fp32_bit_prime, b_fp32_bit_prime),
                 |ctx, (a_bits, b_bits)| async move {
-                    bitwise_equal(ctx, RecordId::from(0), &a_bits, &b_bits)
-                        .await
-                        .unwrap()
+                    bitwise_equal(
+                        ctx.set_total_records(1),
+                        RecordId::from(0),
+                        &a_bits,
+                        &b_bits,
+                    )
+                    .await
+                    .unwrap()
                 },
             )
             .await

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -209,7 +209,7 @@ mod tests {
     use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
-        protocol::RecordId,
+        protocol::{context::Context, RecordId},
         test_fixture::{get_bits, Reconstruct, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};
@@ -296,18 +296,26 @@ mod tests {
         let bits = get_bits::<F>(a, num_bits);
         let result = world
             .semi_honest(bits.clone(), |ctx, x_share| async move {
-                BitwiseLessThanPrime::less_than_prime(ctx, RecordId::from(0), &x_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThanPrime::less_than_prime(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &x_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
 
         let m_result = world
             .malicious(bits, |ctx, x_share| async move {
-                BitwiseLessThanPrime::less_than_prime(ctx, RecordId::from(0), &x_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThanPrime::less_than_prime(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &x_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();

--- a/src/protocol/boolean/dumb_bitwise_lt.rs
+++ b/src/protocol/boolean/dumb_bitwise_lt.rs
@@ -170,6 +170,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::BitwiseLessThan;
+    use crate::protocol::context::Context;
     use crate::rand::thread_rng;
     use crate::secret_sharing::SharedValue;
     use crate::test_fixture::{get_bits, Runner};
@@ -189,18 +190,28 @@ mod tests {
         let input = (into_bits(a), into_bits(b));
         let result = world
             .semi_honest(input.clone(), |ctx, (a_share, b_share)| async move {
-                BitwiseLessThan::execute(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThan::execute(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
 
         let m_result = world
             .malicious(input, |ctx, (a_share, b_share)| async move {
-                BitwiseLessThan::execute(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThan::execute(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
@@ -266,18 +277,28 @@ mod tests {
         );
         let result = world
             .semi_honest(input.clone(), |ctx, (a_share, b_share)| async move {
-                BitwiseLessThan::execute(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThan::execute(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
 
         let m_result = world
             .malicious(input, |ctx, (a_share, b_share)| async move {
-                BitwiseLessThan::execute(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                BitwiseLessThan::execute(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -21,7 +21,7 @@ mod tests {
     use super::or;
     use crate::{
         ff::{Field, Fp31},
-        protocol::RecordId,
+        protocol::{context::Context, RecordId},
         secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
@@ -34,17 +34,27 @@ mod tests {
     {
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
-                or(ctx, RecordId::from(0_u32), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                or(
+                    ctx.set_total_records(1),
+                    RecordId::from(0_u32),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
         let m_result = world
             .malicious((a, b), |ctx, (a_share, b_share)| async move {
-                or(ctx, RecordId::from(0_u32), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                or(
+                    ctx.set_total_records(1),
+                    RecordId::from(0_u32),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -31,6 +31,7 @@ where
 {
     #[must_use]
     pub fn new(ctx: C) -> Self {
+        debug_assert!(!ctx.is_total_records_known());
         Self {
             ctx,
             record_id: AtomicU32::new(0),

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -1,9 +1,9 @@
 use super::solved_bits::{solved_bits, RandomBitsShare};
-use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
 use crate::secret_sharing::SecretSharing;
+use crate::{error::Error, helpers::messaging::TotalRecords};
 use std::{
     marker::PhantomData,
     sync::atomic::{AtomicU32, AtomicUsize, Ordering},
@@ -30,10 +30,11 @@ where
     C: Context<F, Share = S>,
 {
     #[must_use]
+    #[allow(clippy::needless_pass_by_value)] // TODO: pending resolution of TotalRecords::Indeterminate
     pub fn new(ctx: C) -> Self {
-        debug_assert!(!ctx.is_total_records_known());
+        debug_assert!(ctx.is_total_records_unspecified());
         Self {
-            ctx,
+            ctx: ctx.set_total_records(TotalRecords::Indeterminate),
             record_id: AtomicU32::new(0),
             abort_count: AtomicUsize::new(0),
             _marker: PhantomData::default(),

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -45,6 +45,7 @@ mod tests {
         protocol::{
             basics::{mul::sparse::test::SparseField, MultiplyZeroPositions, ZeroPositions},
             boolean::xor_sparse,
+            context::Context,
             RecordId,
         },
         secret_sharing::SharedValue,
@@ -59,18 +60,28 @@ mod tests {
     {
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
-                xor(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                xor(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
 
         let m_result = world
             .malicious((a, b), |ctx, (a_share, b_share)| async move {
-                xor(ctx, RecordId::from(0), &a_share, &b_share)
-                    .await
-                    .unwrap()
+                xor(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
@@ -101,18 +112,30 @@ mod tests {
         let b = SparseField::<F>::new(F::from(u128::from(b)), zeros.1);
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
-                xor_sparse(ctx, RecordId::from(0), &a_share, &b_share, zeros)
-                    .await
-                    .unwrap()
+                xor_sparse(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                    zeros,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();
 
         let m_result = world
             .malicious((a, b), |ctx, (a_share, b_share)| async move {
-                xor_sparse(ctx, RecordId::from(0), &a_share, &b_share, zeros)
-                    .await
-                    .unwrap()
+                xor_sparse(
+                    ctx.set_total_records(1),
+                    RecordId::from(0),
+                    &a_share,
+                    &b_share,
+                    zeros,
+                )
+                .await
+                .unwrap()
             })
             .await
             .reconstruct();

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -103,6 +103,8 @@ mod tests {
         assert_eq!(F::ONE, run(&world, F::ONE, F::ZERO).await);
         assert_eq!(F::ONE, run(&world, F::ZERO, F::ONE).await);
         assert_eq!(F::ZERO, run(&world, F::ONE, F::ONE).await);
+
+        world.join().await;
     }
 
     async fn run_sparse(world: &TestWorld, a: bool, b: bool, zeros: MultiplyZeroPositions) -> bool {

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,7 +1,5 @@
 use async_trait::async_trait;
-use futures::future::{try_join_all};
-use std::iter::{repeat, zip};
-use std::num::NonZeroUsize;
+use futures::future::{try_join, try_join_all};
 
 use crate::error::Error;
 use crate::ff::Field;

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -20,8 +20,6 @@ use crate::secret_sharing::replicated::{
 };
 use crate::sync::Arc;
 
-use super::TotalRecords;
-
 /// Represents protocol context in malicious setting, i.e. secure against one active adversary
 /// in 3 party MPC ring.
 #[derive(Clone, Debug)]

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use futures::future::{try_join, try_join_all};
+use futures::future::{try_join_all};
+use std::iter::{repeat, zip};
+use std::num::NonZeroUsize;
 
 use crate::error::Error;
 use crate::ff::Field;
@@ -19,6 +21,8 @@ use crate::secret_sharing::replicated::{
     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
 };
 use crate::sync::Arc;
+
+use super::TotalRecords;
 
 /// Represents protocol context in malicious setting, i.e. secure against one active adversary
 /// in 3 party MPC ring.

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
+use std::num::NonZeroUsize;
 
 use crate::error::Error;
 use crate::ff::Field;
@@ -28,6 +29,7 @@ pub struct MaliciousContext<'a, F: Field> {
     /// may operate with raw references and be more efficient
     inner: Arc<ContextInner<'a, F>>,
     step: Step,
+    total_records: Option<NonZeroUsize>,
 }
 
 pub trait SpecialAccessToMaliciousContext<'a, F: Field> {
@@ -46,6 +48,7 @@ impl<'a, F: Field> MaliciousContext<'a, F> {
         Self {
             inner: ContextInner::new(upgrade_ctx, acc, r_share),
             step: source.step().narrow(malicious_step),
+            total_records: None,
         }
     }
 
@@ -107,6 +110,23 @@ impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
         Self {
             inner: Arc::clone(&self.inner),
             step: self.step.narrow(step),
+            total_records: self.total_records,
+        }
+    }
+
+    fn is_total_records_known(&self) -> bool {
+        self.total_records.is_some()
+    }
+
+    fn set_total_records(&self, total_records: usize) -> Self {
+        debug_assert!(
+            !self.is_total_records_known(),
+            "attempt to set total_records more than once"
+        );
+        Self {
+            inner: Arc::clone(&self.inner),
+            step: self.step.clone(),
+            total_records: Some(total_records.try_into().unwrap()),
         }
     }
 
@@ -130,7 +150,7 @@ impl<'a, F: Field> Context<F> for MaliciousContext<'a, F> {
     }
 
     fn mesh(&self) -> Mesh<'_, '_> {
-        self.inner.gateway.mesh(self.step())
+        self.inner.gateway.mesh(self.step(), self.total_records)
     }
 
     fn share_of_one(&self) -> <Self as Context<F>>::Share {
@@ -160,7 +180,12 @@ impl<'a, F: Field> SpecialAccessToMaliciousContext<'a, F> for MaliciousContext<'
         // is not
         // For the same reason, it is not possible to implement Context<F, Share = Replicated<F>>
         // for `MaliciousContext`. Deep clone is the only option
-        let mut ctx = SemiHonestContext::new(self.inner.role, self.inner.prss, self.inner.gateway);
+        let mut ctx = SemiHonestContext::new_with_total_records(
+            self.inner.role,
+            self.inner.prss,
+            self.inner.gateway,
+            self.total_records,
+        );
         ctx.step = self.step;
 
         ctx
@@ -340,7 +365,7 @@ impl<'a, F: Field> UpgradeContext<'a, F, NoRecord> {
     ) -> Result<MaliciousReplicated<F>, Error> {
         self.inner
             .upgrade_one(
-                self.upgrade_ctx, /*.set_total_records(1)*/
+                self.upgrade_ctx.set_total_records(1),
                 RecordId::from(0u32),
                 input,
                 zeros_at,
@@ -423,7 +448,7 @@ where
         self,
         input: Vec<Replicated<F>>,
     ) -> Result<Vec<MaliciousReplicated<F>>, Error> {
-        let ctx = self.upgrade_ctx/*.set_total_records(input.len())*/;
+        let ctx = self.upgrade_ctx.set_total_records(input.len());
         let ctx_ref = &ctx;
         try_join_all(input.into_iter().enumerate().map(|(i, share)| async move {
             self.inner
@@ -468,7 +493,7 @@ where
 {
     async fn upgrade(self, input: T) -> Result<M, Error> {
         UpgradeContext {
-            upgrade_ctx: self.upgrade_ctx, /*.set_total_records(1)*/
+            upgrade_ctx: self.upgrade_ctx.set_total_records(1),
             inner: self.inner,
             record_binding: RECORD_0,
         }

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,4 +1,4 @@
-use crate::helpers::messaging::Mesh;
+use crate::helpers::messaging::{Mesh, TotalRecords};
 use crate::helpers::Role;
 use crate::protocol::basics::{Reveal, SecureMul};
 
@@ -45,13 +45,14 @@ pub trait Context<V: ArithmeticShare>:
     #[must_use]
     fn narrow<S: Substep + ?Sized>(&self, step: &S) -> Self;
 
-    /// Returns true if the context has a known total number of records.
-    fn is_total_records_known(&self) -> bool;
+    /// Returns true if the context does not have a total record count set (regardless
+    /// of whether that total is known or indeterminate).
+    fn is_total_records_unspecified(&self) -> bool;
 
     /// Sets the context's total number of records field. Communication channels are
     /// closed based on sending the expected total number of records.
     #[must_use]
-    fn set_total_records(&self, total_records: usize) -> Self;
+    fn set_total_records<T: Into<TotalRecords>>(&self, total_records: T) -> Self;
 
     /// Get the indexed PRSS instance for this step.  It is safe to call this function
     /// multiple times.

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,4 +1,7 @@
 use crate::helpers::messaging::{Mesh, TotalRecords};
+use std::num::NonZeroUsize;
+
+use crate::helpers::messaging::Mesh;
 use crate::helpers::Role;
 use crate::protocol::basics::{Reveal, SecureMul};
 
@@ -17,6 +20,8 @@ pub use semi_honest::SemiHonestContext;
 use super::basics::sum_of_product::SecureSop;
 use super::basics::Reshare;
 use super::boolean::RandomBits;
+
+pub type TotalRecords = Option<NonZeroUsize>;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
 /// generator and communication channel.

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,7 +1,4 @@
 use crate::helpers::messaging::{Mesh, TotalRecords};
-use std::num::NonZeroUsize;
-
-use crate::helpers::messaging::Mesh;
 use crate::helpers::Role;
 use crate::protocol::basics::{Reveal, SecureMul};
 
@@ -20,8 +17,6 @@ pub use semi_honest::SemiHonestContext;
 use super::basics::sum_of_product::SecureSop;
 use super::basics::Reshare;
 use super::boolean::RandomBits;
-
-pub type TotalRecords = Option<NonZeroUsize>;
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
 /// generator and communication channel.

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -12,6 +12,7 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 
 /// Context for protocol executions suitable for semi-honest security model, i.e. secure against
 /// honest-but-curious adversary parties.
@@ -21,14 +22,25 @@ pub struct SemiHonestContext<'a, F: Field> {
     /// may operate with raw references and be more efficient
     pub(super) inner: Arc<ContextInner<'a>>,
     pub(super) step: Step,
+    pub(super) total_records: Option<NonZeroUsize>,
     _marker: PhantomData<F>,
 }
 
 impl<'a, F: Field> SemiHonestContext<'a, F> {
     pub fn new(role: Role, participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
+        Self::new_with_total_records(role, participant, gateway, None)
+    }
+
+    pub fn new_with_total_records(
+        role: Role,
+        participant: &'a PrssEndpoint,
+        gateway: &'a Gateway,
+        total_records: Option<NonZeroUsize>,
+    ) -> Self {
         Self {
             inner: ContextInner::new(role, participant, gateway),
             step: Step::default(),
+            total_records,
             _marker: PhantomData::default(),
         }
     }
@@ -66,6 +78,24 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
         Self {
             inner: Arc::clone(&self.inner),
             step: self.step.narrow(step),
+            total_records: self.total_records,
+            _marker: PhantomData::default(),
+        }
+    }
+
+    fn is_total_records_known(&self) -> bool {
+        self.total_records.is_some()
+    }
+
+    fn set_total_records(&self, total_records: usize) -> Self {
+        debug_assert!(
+            !self.is_total_records_known(),
+            "attempt to set total_records more than once"
+        );
+        Self {
+            inner: Arc::clone(&self.inner),
+            step: self.step.clone(),
+            total_records: NonZeroUsize::new(total_records),
             _marker: PhantomData::default(),
         }
     }
@@ -90,7 +120,7 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
     }
 
     fn mesh(&self) -> Mesh<'_, '_> {
-        self.inner.gateway.mesh(self.step())
+        self.inner.gateway.mesh(self.step(), self.total_records)
     }
 
     fn share_of_one(&self) -> <Self as Context<F>>::Share {

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -12,6 +12,9 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+
+use super::TotalRecords;
 
 /// Context for protocol executions suitable for semi-honest security model, i.e. secure against
 /// honest-but-curious adversary parties.

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -1,5 +1,5 @@
 use crate::ff::Field;
-use crate::helpers::messaging::{Gateway, Mesh};
+use crate::helpers::messaging::{Gateway, Mesh, TotalRecords};
 use crate::helpers::Role;
 use crate::protocol::context::{
     Context, InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness,
@@ -12,7 +12,6 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
-use std::num::NonZeroUsize;
 
 /// Context for protocol executions suitable for semi-honest security model, i.e. secure against
 /// honest-but-curious adversary parties.
@@ -22,20 +21,20 @@ pub struct SemiHonestContext<'a, F: Field> {
     /// may operate with raw references and be more efficient
     pub(super) inner: Arc<ContextInner<'a>>,
     pub(super) step: Step,
-    pub(super) total_records: Option<NonZeroUsize>,
+    pub(super) total_records: TotalRecords,
     _marker: PhantomData<F>,
 }
 
 impl<'a, F: Field> SemiHonestContext<'a, F> {
     pub fn new(role: Role, participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
-        Self::new_with_total_records(role, participant, gateway, None)
+        Self::new_with_total_records(role, participant, gateway, TotalRecords::Unspecified)
     }
 
     pub fn new_with_total_records(
         role: Role,
         participant: &'a PrssEndpoint,
         gateway: &'a Gateway,
-        total_records: Option<NonZeroUsize>,
+        total_records: TotalRecords,
     ) -> Self {
         Self {
             inner: ContextInner::new(role, participant, gateway),
@@ -83,19 +82,19 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
         }
     }
 
-    fn is_total_records_known(&self) -> bool {
-        self.total_records.is_some()
+    fn is_total_records_unspecified(&self) -> bool {
+        self.total_records.is_unspecified()
     }
 
-    fn set_total_records(&self, total_records: usize) -> Self {
+    fn set_total_records<T: Into<TotalRecords>>(&self, total_records: T) -> Self {
         debug_assert!(
-            !self.is_total_records_known(),
+            self.is_total_records_unspecified(),
             "attempt to set total_records more than once"
         );
         Self {
             inner: Arc::clone(&self.inner),
             step: self.step.clone(),
-            total_records: NonZeroUsize::new(total_records),
+            total_records: total_records.into(),
             _marker: PhantomData::default(),
         }
     }

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -12,7 +12,6 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use crate::sync::Arc;
 
 use std::marker::PhantomData;
-use std::num::NonZeroUsize;
 
 use super::TotalRecords;
 

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -13,8 +13,6 @@ use crate::sync::Arc;
 
 use std::marker::PhantomData;
 
-use super::TotalRecords;
-
 /// Context for protocol executions suitable for semi-honest security model, i.e. secure against
 /// honest-but-curious adversary parties.
 #[derive(Clone, Debug)]

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -181,7 +181,10 @@ where
     .unwrap();
 
     let futures = zip(
-        repeat(ctx.narrow(&Step::ComputeHelperBits)),
+        repeat(
+            ctx.narrow(&Step::ComputeHelperBits)
+                .set_total_records(sorted_rows.len() - 1),
+        ),
         sorted_rows.iter(),
     )
     .zip(sorted_rows.iter().skip(1))

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -203,11 +203,17 @@ impl<'a, F: Field> MaliciousValidator<'a, F> {
         let (u_share, w_share) = self.propagate_u_and_w().await?;
 
         // This should probably be done in parallel with the futures above
-        let narrow_ctx = self.validate_ctx.narrow(&ValidateStep::RevealR);
+        let narrow_ctx = self
+            .validate_ctx
+            .narrow(&ValidateStep::RevealR)
+            .set_total_records(1);
         let r = narrow_ctx.reveal(RECORD_0, &self.r_share).await?;
         let t = u_share - &(w_share * r);
 
-        let check_zero_ctx = self.validate_ctx.narrow(&ValidateStep::CheckZero);
+        let check_zero_ctx = self
+            .validate_ctx
+            .narrow(&ValidateStep::CheckZero)
+            .set_total_records(1);
         let is_valid = check_zero(check_zero_ctx, RECORD_0, &t).await?;
 
         if is_valid {
@@ -221,7 +227,10 @@ impl<'a, F: Field> MaliciousValidator<'a, F> {
 
     /// Turns out local values for `u` and `w` into proper replicated shares.
     async fn propagate_u_and_w(&self) -> Result<(Replicated<F>, Replicated<F>), Error> {
-        let propagate_ctx = self.validate_ctx.narrow(&ValidateStep::PropagateUW);
+        let propagate_ctx = self
+            .validate_ctx
+            .narrow(&ValidateStep::PropagateUW)
+            .set_total_records(2);
         let channel = propagate_ctx.mesh();
         let helper_right = propagate_ctx.role().peer(Direction::Right);
         let helper_left = propagate_ctx.role().peer(Direction::Left);
@@ -293,12 +302,13 @@ mod tests {
         let futures =
             zip(context, zip(a_shares, b_shares)).map(|(ctx, (a_share, b_share))| async move {
                 let v = MaliciousValidator::new(ctx);
+                let m_ctx = v.context();
 
                 let (a_malicious, b_malicious) =
                     v.context().upgrade((a_share, b_share)).await.unwrap();
 
-                let m_result = v
-                    .context()
+                let m_result = m_ctx
+                    .set_total_records(1)
                     .multiply(RecordId::from(0), &a_malicious, &b_malicious)
                     .await?;
 
@@ -392,12 +402,13 @@ mod tests {
     /// There is a small chance of failure which is `2 / |F|`, where `|F|` is the cardinality of the prime field.
     #[tokio::test]
     async fn complex_circuit() -> Result<(), Error> {
+        const COUNT: usize = 100;
         let world = TestWorld::new().await;
         let context = world.contexts::<Fp31>();
         let mut rng = thread_rng();
 
-        let mut original_inputs = Vec::with_capacity(100);
-        for _ in 0..100 {
+        let mut original_inputs = Vec::with_capacity(COUNT);
+        for _ in 0..COUNT {
             let x = rng.gen::<Fp31>();
             original_inputs.push(x);
         }
@@ -420,7 +431,7 @@ mod tests {
 
                 let m_results = try_join_all(
                     zip(
-                        repeat(m_ctx).enumerate(),
+                        repeat(m_ctx.set_total_records(COUNT - 1)).enumerate(),
                         zip(m_input.iter(), m_input.iter().skip(1)),
                     )
                     .map(|((i, ctx), (a_malicious, b_malicious))| async move {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::hash::Hash;
 use std::ops::AddAssign;
+use std::ops::Sub;
 
 /// Defines a unique step of the IPA protocol at a given level of implementation.
 ///
@@ -283,5 +284,13 @@ impl From<RecordId> for usize {
 impl AddAssign<usize> for RecordId {
     fn add_assign(&mut self, rhs: usize) {
         self.0 += u32::try_from(rhs).unwrap();
+    }
+}
+
+impl Sub<usize> for RecordId {
+    type Output = RecordId;
+
+    fn sub(self, rhs: usize) -> RecordId {
+        RecordId::from(self.0 - u32::try_from(rhs).unwrap())
     }
 }

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -147,7 +147,8 @@ where
         .enumerate()
         .map(|(bit_num, one_column)| {
             convert_bit_list(
-                ctx.narrow(&ModulusConversion(bit_num.try_into().unwrap())),
+                ctx.narrow(&ModulusConversion(bit_num.try_into().unwrap()))
+                    .set_total_records(one_column.len()),
                 one_column,
             )
         })
@@ -207,7 +208,9 @@ mod tests {
         let result: [Replicated<Fp31>; 3] = world
             .semi_honest(match_key, |ctx, mk_share| async move {
                 let triple = convert_bit_local::<Fp31>(ctx.role(), BITNUM, &mk_share);
-                convert_bit(ctx, RecordId::from(0), &triple).await.unwrap()
+                convert_bit(ctx.set_total_records(1usize), RecordId::from(0), &triple)
+                    .await
+                    .unwrap()
             })
             .await;
         assert_eq!(Fp31::from(match_key.bit(BITNUM)), result.reconstruct());
@@ -225,7 +228,7 @@ mod tests {
                 let triple = convert_bit_local::<Fp31>(ctx.role(), BITNUM, &mk_share);
 
                 let v = MaliciousValidator::new(ctx);
-                let m_ctx = v.context();
+                let m_ctx = v.context().set_total_records(1);
                 let m_triple = m_ctx.upgrade(triple).await.unwrap();
                 let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)
                     .await
@@ -284,7 +287,7 @@ mod tests {
                     let tweaked = tweak.flip_bit(ctx.role(), triple);
 
                     let v = MaliciousValidator::new(ctx);
-                    let m_ctx = v.context();
+                    let m_ctx = v.context().set_total_records(1);
                     let m_triple = m_ctx.upgrade(tweaked).await.unwrap();
                     let m_bit = convert_bit(m_ctx, RecordId::from(0), &m_triple)
                         .await

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -214,6 +214,7 @@ mod tests {
             })
             .await;
         assert_eq!(Fp31::from(match_key.bit(BITNUM)), result.reconstruct());
+        world.join().await;
     }
 
     #[tokio::test]

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -72,6 +72,7 @@ where
     S: SecretSharing<F>,
     T: Resharable<F, Share = S>,
 {
+    let ctx = ctx.set_total_records(input.len());
     let reshares = zip(repeat(ctx), input)
         .enumerate()
         .map(|(index, (ctx, input))| async move {

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -36,6 +36,7 @@ pub async fn bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context<F, Sh
     ctx: C,
     input: &[S],
 ) -> Result<Vec<S>, Error> {
+    let ctx = ctx.set_total_records(2 * input.len());
     let share_of_one = ctx.share_of_one();
 
     let mult_input = zip(repeat(share_of_one.clone()), input)

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -6,8 +6,7 @@ use crate::{
         context::{Context, MaliciousContext},
         malicious::MaliciousValidator,
         sort::SortStep::{
-            ApplyInv, BitPermutationStep, ComposeStep, MaliciousUpgradeContext,
-            ShuffleRevealPermutation, SortKeys,
+            ApplyInv, BitPermutationStep, ComposeStep, ShuffleRevealPermutation, SortKeys,
         },
         sort::{
             bit_permutation::bit_permutation,
@@ -154,14 +153,15 @@ where
 
     let bit_0_permutation =
         bit_permutation(ctx_0.narrow(&BitPermutationStep), &sort_keys[0]).await?;
-    let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more that 1B rows
+    let input_len = sort_keys[0].len();
 
     let mut composed_less_significant_bits_permutation = bit_0_permutation;
     for bit_num in 1..num_bits {
         let ctx_bit = ctx.narrow(&Sort(bit_num));
+
         let revealed_and_random_permutations = shuffle_and_reveal_permutation(
             ctx_bit.narrow(&ShuffleRevealPermutation),
-            input_len,
+            input_len.try_into().unwrap(), // safe, we don't sort more than 1B rows
             composed_less_significant_bits_permutation,
         )
         .await?;
@@ -222,10 +222,13 @@ pub async fn generate_permutation_and_reveal_shuffled<F: Field>(
     sort_keys: &[Vec<Replicated<F>>],
     num_bits: u32,
 ) -> Result<RevealedAndRandomPermutations, Error> {
+    // The input is transposed, so this really is the number of sort keys,
+    // not the length of each sort key.
+    let key_count = sort_keys[0].len();
     let sort_permutation = generate_permutation(ctx.narrow(&SortKeys), sort_keys, num_bits).await?;
     shuffle_and_reveal_permutation(
         ctx.narrow(&ShuffleRevealPermutation),
-        u32::try_from(sort_keys[0].len()).unwrap(),
+        u32::try_from(key_count).unwrap(),
         sort_permutation,
     )
     .await
@@ -268,19 +271,17 @@ pub async fn malicious_generate_permutation<'a, F>(
 where
     F: Field,
 {
-    let mut malicious_validator = MaliciousValidator::new(sh_ctx.narrow(&MaliciousUpgradeContext));
-    let mut m_ctx = malicious_validator.context();
-    let m_ctx_0 = m_ctx.narrow(&Sort(0));
+    let mut malicious_validator = MaliciousValidator::new(sh_ctx.narrow(&Sort(0)));
+    let mut m_ctx_bit = malicious_validator.context();
     assert_eq!(sort_keys.len(), num_bits as usize);
 
-    let upgraded_sort_keys = m_ctx.upgrade(sort_keys[0].clone()).await?;
+    let upgraded_sort_keys = m_ctx_bit.upgrade(sort_keys[0].clone()).await?;
     let bit_0_permutation =
-        bit_permutation(m_ctx_0.narrow(&BitPermutationStep), &upgraded_sort_keys).await?;
-    let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more that 1B rows
+        bit_permutation(m_ctx_bit.narrow(&BitPermutationStep), &upgraded_sort_keys).await?;
+    let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more than 1B rows
 
     let mut composed_less_significant_bits_permutation = bit_0_permutation;
     for bit_num in 1..num_bits {
-        let mut m_ctx_bit = m_ctx.narrow(&Sort(bit_num));
         let revealed_and_random_permutations = malicious_shuffle_and_reveal_permutation(
             m_ctx_bit.narrow(&ShuffleRevealPermutation),
             input_len,
@@ -334,7 +335,6 @@ where
         )
         .await?;
         composed_less_significant_bits_permutation = composed_i_permutation;
-        m_ctx = m_ctx_bit;
     }
     Ok((
         malicious_validator,

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -21,8 +21,6 @@ pub enum SortStep {
     ShuffleRevealPermutation,
     SortKeys,
     MultiApplyInv(u32),
-    //malicious features
-    MaliciousUpgradeContext,
 }
 
 impl Substep for SortStep {}
@@ -37,8 +35,6 @@ impl AsRef<str> for SortStep {
             Self::ShuffleRevealPermutation => "shuffle_reveal_permutation",
             Self::SortKeys => "sort_keys",
             Self::MultiApplyInv(i) => MULTI_APPLY_INV[usize::try_from(*i).unwrap()],
-            //malicious features
-            Self::MaliciousUpgradeContext => "malicious_upgrade_context",
         }
     }
 }

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -42,7 +42,7 @@ pub async fn multi_bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context
     // Equality bit checker: this checks if each secret shared record is equal to any of numbers between 0 and num_possible_bit_values
     let equality_checks = try_join_all(
         (0..num_records)
-            .zip(repeat(ctx.clone()))
+            .zip(repeat(ctx.set_total_records(num_records)))
             .map(|(i, ctx)| check_everything(ctx, i, input)),
     )
     .await?;
@@ -65,7 +65,7 @@ pub async fn multi_bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context
         equality_checks
             .into_iter()
             .zip(prefix_sum.into_iter())
-            .zip(repeat(ctx))
+            .zip(repeat(ctx.set_total_records(num_records)))
             .enumerate()
             .map(|(i, ((eq_checks, prefix_sums), ctx))| async move {
                 ctx.sum_of_products(
@@ -226,6 +226,7 @@ mod tests {
     use super::multi_bit_permutation;
     use crate::{
         ff::{Field, Fp31},
+        protocol::context::Context,
         secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
@@ -274,7 +275,7 @@ mod tests {
             .semi_honest(input, |ctx, m_shares| async move {
                 let mut equality_check_futures = Vec::with_capacity(num_records);
                 for i in 0..num_records {
-                    let ctx = ctx.clone();
+                    let ctx = ctx.set_total_records(num_records);
                     equality_check_futures.push(check_everything(ctx, i, m_shares.as_slice()));
                 }
                 try_join_all(equality_check_futures).await.unwrap()

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -115,6 +115,8 @@ pub async fn shuffle_shares<F: Field, S: SecretSharing<F>, C: Context<F, Share =
     random_permutations: (&[u32], &[u32]),
     ctx: C,
 ) -> Result<Vec<S>, Error> {
+    let ctx = ctx.set_total_records(input.len());
+
     let input = shuffle_or_unshuffle_once(
         input,
         random_permutations,
@@ -150,6 +152,8 @@ pub async fn unshuffle_shares<F: Field, S: SecretSharing<F>, C: Context<F, Share
     random_permutations: (&[u32], &[u32]),
     ctx: C,
 ) -> Result<Vec<S>, Error> {
+    let ctx = ctx.set_total_records(input.len());
+
     let input = shuffle_or_unshuffle_once(
         input,
         random_permutations,

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -52,6 +52,12 @@ where
 }
 
 // TODO: make a macro so we can use arbitrary-sized tuples
+impl IntoShares<()> for () {
+    fn share_with<R: Rng>(self, _rng: &mut R) -> [(); 3] {
+        [(), (), ()]
+    }
+}
+
 impl<T, U, V, W> IntoShares<(T, U)> for (V, W)
 where
     T: Sized,

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -21,6 +21,7 @@ fn send_receive_sequential() {
                     .semi_honest(
                         input.clone(),
                         |ctx: SemiHonestContext<'_, Fp32BitPrime>, mut shares| async move {
+                            let ctx = ctx.set_total_records(shares.len());
                             let (left_ctx, right_ctx) = (ctx.narrow("left"), ctx.narrow("right"));
                             let left_channel = left_ctx.mesh();
                             let right_channel = right_ctx.mesh();
@@ -78,6 +79,7 @@ fn send_receive_parallel() {
                     .semi_honest(
                         input.clone(),
                         |ctx: SemiHonestContext<'_, Fp32BitPrime>, shares| async move {
+                            let ctx = ctx.set_total_records(shares.len());
                             let (left_ctx, right_ctx) = (ctx.narrow("left"), ctx.narrow("right"));
                             let left_channel = left_ctx.mesh();
                             let right_channel = right_ctx.mesh();


### PR DESCRIPTION
This is still pretty rough but it works for tests that don't use RandomBitsGenerator.

There is a check for channels not cleaned up, but the check is only effective if the test calls `world.join`, which most don't.

This is on top of the total-records PR. For a diff with only the latest changes, see https://github.com/andyleiserson/ipa/compare/total-records-3...andyleiserson:ipa:total-records-2a?diff=split