### PR TITLE
Add multiplicative identity const to SharedValue

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -23,8 +23,6 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     type Integer: Int;
 
     const PRIME: Self::Integer;
-    /// Multiplicative identity element
-    const ONE: Self;
 
     /// Blanket implementation to represent the instance of this trait as 16 byte integer.
     /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -11,12 +11,12 @@ macro_rules! field_impl {
         impl Field for $field {
             type Integer = $int;
             const PRIME: Self::Integer = $prime;
-            const ONE: Self = $field(1);
         }
 
         impl SharedValue for $field {
             const BITS: u32 = <Self as Field>::Integer::BITS;
             const ZERO: Self = $field(0);
+            const ONE: Self = $field(1);
         }
 
         impl std::ops::Add for $field {

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -213,7 +213,7 @@ mod tests {
         use crate::rand::{thread_rng, Rng};
         use crate::secret_sharing::{
             replicated::malicious::AdditiveShare as MaliciousReplicated,
-            replicated::semi_honest::AdditiveShare as Replicated,
+            replicated::semi_honest::AdditiveShare as Replicated, SharedValue,
         };
         use crate::test_fixture::{Reconstruct, Runner, TestWorld};
 

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -126,7 +126,7 @@ mod tests {
     use proptest::prelude::Rng;
     use std::iter::zip;
 
-    use crate::secret_sharing::IntoShares;
+    use crate::secret_sharing::{IntoShares, SharedValue};
     use crate::{
         error::Error,
         ff::{Field, Fp31},

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -259,7 +259,7 @@ mod tests {
     use std::iter::{repeat, zip};
 
     use crate::error::Error;
-    use crate::ff::{Field, Fp31, Fp32BitPrime};
+    use crate::ff::{Fp31, Fp32BitPrime};
     use crate::helpers::Role;
     use crate::protocol::basics::SecureMul;
     use crate::protocol::context::Context;
@@ -267,7 +267,7 @@ mod tests {
     use crate::rand::thread_rng;
     use crate::secret_sharing::{
         replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
-        replicated::semi_honest::AdditiveShare as Replicated, IntoShares,
+        replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SharedValue,
     };
     use crate::test_fixture::{join3v, Reconstruct, Runner, TestWorld};
     use futures::future::try_join_all;

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -228,7 +228,7 @@ mod tests {
 
     use super::multi_bit_permutation;
     use crate::{
-        ff::{Field, Fp31},
+        ff::Fp31,
         protocol::context::Context,
         secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -16,7 +16,11 @@ pub trait SharedValue:
     /// Number of bits stored in this data type.
     const BITS: u32;
 
+    /// Additive identity element.
     const ZERO: Self;
+
+    /// Multiplicative identity element
+    const ONE: Self;
 }
 
 pub trait ArithmeticShare: SharedValue + ArithmeticOps {}

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -230,11 +230,11 @@ impl<T> ThisCodeIsAuthorizedToDowngradeFromMalicious<T> for UnauthorizedDowngrad
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::{AdditiveShare, Downgrade, ThisCodeIsAuthorizedToDowngradeFromMalicious};
-    use crate::ff::{Field, Fp31};
+    use crate::ff::Fp31;
     use crate::helpers::Role;
     use crate::rand::thread_rng;
     use crate::secret_sharing::{
-        replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, IntoShares,
+        replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, IntoShares, SharedValue,
     };
     use crate::test_fixture::Reconstruct;
     use proptest::prelude::Rng;

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -3,7 +3,9 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
 use crate::rand::thread_rng;
-use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
+use crate::secret_sharing::{
+    replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SharedValue,
+};
 use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
 


### PR DESCRIPTION
Both boolean and arithmetic fields used in IPA make use of additive and multiplicative identity elements. This change removes the discrepancy between arithmetic and boolean field defitions by requiring `SharedValue` to define that constant (ONE) and implements it for bit arrays that are used to represent boolean field values