### PR TITLE
Experimental `Serialize` trait backed by GenericArray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ criterion = { version = "0.4.0", optional = true, default-features = false, feat
 embed-doc-image = "0.1.4"
 futures = "0.3.24"
 futures-util = "0.3.24"
+generic-array = "0.14.6"
 hex = { version = "0.4", optional = true, features = ["serde"] }
 hkdf = "0.12.3"
 hyper = { version = "0.14.20", optional = true, features = ["client", "h2"] }
@@ -60,6 +61,7 @@ tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+typenum = "1.16.0"
 x25519-dalek = "2.0.0-pre.1"
 
 [dev-dependencies]

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -2,6 +2,8 @@ use super::BitArray;
 use crate::bits::Serializable;
 use crate::secret_sharing::SharedValue;
 use bitvec::prelude::{BitArr, Lsb0};
+use sha2::digest::generic_array::GenericArray;
+use sha2::digest::typenum::Unsigned;
 
 /// Bit store type definition. Five `u8` blocks.
 type U8_5 = BitArr!(for 40, in u8, Lsb0);
@@ -9,7 +11,7 @@ type U8_5 = BitArr!(for 40, in u8, Lsb0);
 type U8_8 = BitArr!(for 64, in u8, Lsb0);
 
 macro_rules! bit_array_impl {
-    ( $modname:ident, $name:ident, $store:ty, $bits:expr ) => {
+    ( $modname:ident, $name:ident, $store:ty, $bits:expr, $arraylen:ty ) => {
         mod $modname {
             use super::*;
 
@@ -28,11 +30,8 @@ macro_rules! bit_array_impl {
 
             impl BitArray for $name {
                 fn truncate_from<T: Into<u128>>(v: T) -> Self {
-                    Self(<$store>::new(
-                        v.into().to_le_bytes()[0..<Self as Serializable>::SIZE_IN_BYTES]
-                            .try_into()
-                            .unwrap(),
-                    ))
+                    let v = &v.into().to_le_bytes()[..<Self as Serializable>::Size::to_usize()];
+                    Self(<$store>::new(v.try_into().unwrap()))
                 }
             }
 
@@ -160,43 +159,14 @@ macro_rules! bit_array_impl {
             }
 
             impl Serializable for $name {
-                const SIZE_IN_BYTES: usize = Self::BITS as usize / 8;
+                type Size = $arraylen;
 
-                fn serialize(self, buf: &mut [u8]) -> std::io::Result<()> {
-                    let req = <Self as Serializable>::SIZE_IN_BYTES;
-
-                    if buf.len() >= req {
-                        buf[..req].copy_from_slice(self.0.as_raw_slice());
-                        Ok(())
-                    } else {
-                        let error_text = format!(
-                            "Buffer with total capacity {} cannot hold the value {:?} because \
-                             it required at least {req} bytes available",
-                            buf.len(),
-                            self,
-                        );
-
-                        Err(std::io::Error::new(
-                            std::io::ErrorKind::WriteZero,
-                            error_text,
-                        ))
-                    }
+                fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
+                    buf.copy_from_slice(self.0.as_raw_slice());
                 }
 
-                fn deserialize(buf: &[u8]) -> std::io::Result<Self> {
-                    let sz = <Self as Serializable>::SIZE_IN_BYTES;
-                    if sz <= buf.len() {
-                        Ok(Self(<$store>::new(buf.try_into().unwrap())))
-                    } else {
-                        let error_text = format!(
-                            "Buffer is too small to read values of the type {}. Required at least {sz} bytes,\
-                             got {}", std::any::type_name::<Self>(), buf.len()
-                        );
-                        Err(std::io::Error::new(
-                            std::io::ErrorKind::UnexpectedEof,
-                            error_text,
-                        ))
-                    }
+                fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self {
+                    Self(<$store>::new(buf.into()))
                 }
             }
 
@@ -291,10 +261,10 @@ macro_rules! bit_array_impl {
                     let a = rng.gen::<u128>() & MASK;
                     let a = $name::truncate_from(a);
 
-                    let mut buf = vec![0_u8; $name::SIZE_IN_BYTES];
-                    a.clone().serialize(&mut buf).unwrap();
+                    let mut buf = GenericArray::default();
+                    a.clone().serialize(&mut buf);
 
-                    assert_eq!(a, $name::deserialize(&buf).unwrap());
+                    assert_eq!(a, $name::deserialize(buf));
                 }
             }
         }
@@ -303,5 +273,6 @@ macro_rules! bit_array_impl {
     };
 }
 
-bit_array_impl!(bit_array_64, BitArray64, U8_8, 64);
-bit_array_impl!(bit_array_40, BitArray40, U8_5, 40);
+use sha2::digest::typenum::{U5, U8};
+bit_array_impl!(bit_array_64, BitArray64, U8_8, 64, U8);
+bit_array_impl!(bit_array_40, BitArray40, U8_5, 40, U5);

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -2,8 +2,8 @@ use super::BitArray;
 use crate::bits::Serializable;
 use crate::secret_sharing::SharedValue;
 use bitvec::prelude::{BitArr, Lsb0};
-use sha2::digest::generic_array::GenericArray;
-use sha2::digest::typenum::Unsigned;
+use generic_array::GenericArray;
+use typenum::Unsigned;
 
 /// Bit store type definition. Five `u8` blocks.
 type U8_5 = BitArr!(for 40, in u8, Lsb0);
@@ -273,6 +273,6 @@ macro_rules! bit_array_impl {
     };
 }
 
-use sha2::digest::typenum::{U5, U8};
+use typenum::{U5, U8};
 bit_array_impl!(bit_array_64, BitArray64, U8_8, 64, U8);
 bit_array_impl!(bit_array_40, BitArray40, U8_5, 40, U5);

--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -3,7 +3,7 @@ use crate::bits::Serializable;
 use crate::secret_sharing::SharedValue;
 use bitvec::prelude::{BitArr, Lsb0};
 use generic_array::GenericArray;
-use typenum::Unsigned;
+use typenum::{Unsigned, U5, U8};
 
 /// Bit store type definition. Five `u8` blocks.
 type U8_5 = BitArr!(for 40, in u8, Lsb0);
@@ -273,6 +273,5 @@ macro_rules! bit_array_impl {
     };
 }
 
-use typenum::{U5, U8};
 bit_array_impl!(bit_array_64, BitArray64, U8_8, 64, U8);
 bit_array_impl!(bit_array_40, BitArray40, U8_5, 40, U5);

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,6 +1,6 @@
 use crate::secret_sharing::BooleanShare;
 
-use sha2::digest::generic_array::{ArrayLength, GenericArray};
+use generic_array::{ArrayLength, GenericArray};
 
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
 

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -62,11 +62,14 @@ pub trait Serializable: Sized {
     /// Required number of bytes to store this message on disk/network
     type Size: ArrayLength<u8>;
 
-    /// Serialize this message to a mutable slice. Implementations need to ensure `buf` has enough
-    /// capacity to store this message.
-    ///
+    /// Serialize this message to a mutable slice. It is enforced at compile time or on the caller
+    /// side that this slice is sized to fit this instance. Implementations do not need to check
+    /// the buffer size.
     fn serialize(self, buf: &mut GenericArray<u8, Self::Size>);
 
-    /// Deserialize message from a sequence of bytes.
+    /// Deserialize message from a sequence of bytes. Similar to [`serialize`], it is enforced that
+    /// buffer has enough capacity to fit instances of this trait.
+    ///
+    /// [`serialize`]: Self::serialize
     fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self;
 }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -65,14 +65,8 @@ pub trait Serializable: Sized {
     /// Serialize this message to a mutable slice. Implementations need to ensure `buf` has enough
     /// capacity to store this message.
     ///
-    /// ## Errors
-    /// Returns an error if `buf` does not have enough capacity to store at least `SIZE_IN_BYTES` more
-    /// data.
     fn serialize(self, buf: &mut GenericArray<u8, Self::Size>);
 
     /// Deserialize message from a sequence of bytes.
-    ///
-    /// ## Errors
-    /// Returns an error if the provided buffer does not have enough bytes to read (EOF).
     fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self;
 }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -1,5 +1,7 @@
 use crate::secret_sharing::BooleanShare;
-use std::io;
+
+use sha2::digest::generic_array::{ArrayLength, GenericArray};
+
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
 
 mod bit_array;
@@ -58,7 +60,7 @@ impl<T> BooleanRefOps for T where
 /// Trait for items that have fixed-byte length representation.
 pub trait Serializable: Sized {
     /// Required number of bytes to store this message on disk/network
-    const SIZE_IN_BYTES: usize;
+    type Size: ArrayLength<u8>;
 
     /// Serialize this message to a mutable slice. Implementations need to ensure `buf` has enough
     /// capacity to store this message.
@@ -66,11 +68,11 @@ pub trait Serializable: Sized {
     /// ## Errors
     /// Returns an error if `buf` does not have enough capacity to store at least `SIZE_IN_BYTES` more
     /// data.
-    fn serialize(self, buf: &mut [u8]) -> io::Result<()>;
+    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>);
 
     /// Deserialize message from a sequence of bytes.
     ///
     /// ## Errors
     /// Returns an error if the provided buffer does not have enough bytes to read (EOF).
-    fn deserialize(buf: &[u8]) -> io::Result<Self>;
+    fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self;
 }

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,5 +1,5 @@
-use sha2::digest::generic_array::ArrayLength;
-use sha2::digest::generic_array::GenericArray;
+use generic_array::ArrayLength;
+use generic_array::GenericArray;
 
 use std::fmt::Debug;
 

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,7 +1,7 @@
-use std::any::type_name;
+use sha2::digest::generic_array::ArrayLength;
+use sha2::digest::generic_array::GenericArray;
+
 use std::fmt::Debug;
-use std::io;
-use std::io::ErrorKind;
 
 use crate::bits::Serializable;
 use crate::secret_sharing::ArithmeticShare;
@@ -21,6 +21,7 @@ impl Int for u32 {
 
 pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
     type Integer: Int;
+    type Size: ArrayLength<u8>;
 
     const PRIME: Self::Integer;
     /// Multiplicative identity element
@@ -35,56 +36,17 @@ pub trait Field: ArithmeticShare + From<u128> + Into<Self::Integer> {
 }
 
 impl<F: Field> Serializable for F {
-    const SIZE_IN_BYTES: usize = F::BITS as usize / 8;
+    type Size = <F as Field>::Size;
 
-    /// Generic implementation to serialize fields into a buffer. Callers need to make sure
-    /// there is enough capacity to store the value of this field.
-    /// It is less efficient because it operates with generic representation of fields as 16 byte
-    /// integers, so consider overriding it for actual field implementations
-    ///
-    /// ## Errors
-    /// Returns an error if buffer did not have enough capacity to store this field value
-    fn serialize(self, buf: &mut [u8]) -> io::Result<()> {
-        let raw_value = &self.as_u128().to_le_bytes()[..<Self as Serializable>::SIZE_IN_BYTES];
-
-        if buf.len() >= raw_value.len() {
-            buf[..<Self as Serializable>::SIZE_IN_BYTES].copy_from_slice(raw_value);
-            Ok(())
-        } else {
-            let error_text = format!(
-                "Buffer with total capacity {} cannot hold field value {:?} because \
-                 it required at least {} bytes available",
-                buf.len(),
-                self,
-                <Self as Serializable>::SIZE_IN_BYTES
-            );
-
-            Err(io::Error::new(ErrorKind::WriteZero, error_text))
-        }
+    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
+        let raw = &self.as_u128().to_le_bytes()[..buf.len()];
+        buf.copy_from_slice(raw);
     }
 
-    /// Generic implementation to deserialize fields from buffer.
-    /// It is less efficient because it allocates 16 bytes on the stack to accommodate for all
-    /// possible field implementations, so consider overriding it for actual field implementations
-    ///
-    /// In the bright future when we have const generic expressions, this can be changed to provide
-    /// zero-cost generic implementation
-    ///
-    /// ## Errors
-    /// Returns an error if buffer did not have enough capacity left to read the field value.
-    fn deserialize(buf_from: &[u8]) -> io::Result<Self> {
-        let sz = <Self as Serializable>::SIZE_IN_BYTES;
-        if sz <= buf_from.len() {
-            let mut buf_to = [0; 16]; // one day...
-            buf_to[..sz].copy_from_slice(&buf_from[..sz]);
+    fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self {
+        let mut buf_to = [0u8; 16];
+        buf_to[..buf.len()].copy_from_slice(&buf);
 
-            Ok(Self::from(u128::from_le_bytes(buf_to)))
-        } else {
-            let error_text = format!(
-                "Buffer is too small to read values of the field type {}. Required at least {sz} bytes,\
-                 got {}", type_name::<Self>(), buf_from.len()
-            );
-            Err(io::Error::new(ErrorKind::UnexpectedEof, error_text))
-        }
+        Self::from(u128::from_le_bytes(buf_to))
     }
 }

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -134,8 +134,8 @@ macro_rules! field_impl {
         mod common_tests {
             use super::*;
             use crate::bits::Serializable;
+            use generic_array::GenericArray;
             use proptest::proptest;
-            use sha2::digest::generic_array::GenericArray;
 
             #[test]
             fn zero() {
@@ -163,7 +163,7 @@ macro_rules! field_impl {
 }
 
 mod fp31 {
-    use sha2::digest::typenum::U1;
+    use typenum::U1;
     field_impl! { Fp31, u8, 31, U1 }
 
     #[cfg(all(test, not(feature = "shuttle")))]
@@ -187,7 +187,7 @@ mod fp31 {
 }
 
 mod fp32bit {
-    use sha2::digest::typenum::U5;
+    use typenum::U5;
     field_impl! { Fp32BitPrime, u32, 4_294_967_291, U5 }
 
     #[cfg(all(test, not(feature = "shuttle")))]

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -2,7 +2,7 @@ use super::Field;
 use crate::secret_sharing::SharedValue;
 
 macro_rules! field_impl {
-    ( $field:ident, $int:ty, $prime:expr ) => {
+    ( $field:ident, $int:ty, $prime:expr, $arraylen:ty ) => {
         use super::*;
 
         #[derive(Clone, Copy, PartialEq)]
@@ -10,6 +10,7 @@ macro_rules! field_impl {
 
         impl Field for $field {
             type Integer = $int;
+            type Size = $arraylen;
             const PRIME: Self::Integer = $prime;
             const ONE: Self = $field(1);
         }
@@ -132,8 +133,9 @@ macro_rules! field_impl {
         #[cfg(all(test, not(feature = "shuttle")))]
         mod common_tests {
             use super::*;
-            use proptest::proptest;
             use crate::bits::Serializable;
+            use proptest::proptest;
+            use sha2::digest::generic_array::GenericArray;
 
             #[test]
             fn zero() {
@@ -145,40 +147,15 @@ macro_rules! field_impl {
                 assert_eq!($field::ZERO, $field::ZERO * $field::ONE);
             }
 
-            #[test]
-            fn can_write_into_buf_larger_than_required() {
-                let mut buf = vec![0_u8; <$field as Serializable>::SIZE_IN_BYTES + 1];
-
-                // panic will show the error while assert will just tell us that something went wrong
-                $field::ONE.serialize(&mut buf).unwrap();
-            }
-
             proptest! {
-                #[test]
-                fn ser_not_enough_capacity(buf_capacity in 0..<$field as Serializable>::SIZE_IN_BYTES) {
-                    let mut buf = vec![0u8; buf_capacity];
-                    assert!(matches!(
-                        $field::ONE.serialize(&mut buf),
-                        Err(e) if e.kind() == std::io::ErrorKind::WriteZero
-                    ));
-                }
-
-                #[test]
-                fn de_buf_too_small(buf_capacity in 0..<$field as Serializable>::SIZE_IN_BYTES) {
-                    let buf = vec![0u8; buf_capacity];
-                    assert!(matches!(
-                                    $field::deserialize(&buf),
-                                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof));
-                }
-
 
                 #[test]
                 fn serde(v in 0..$field::PRIME) {
                     let field_v = $field(v);
-                    let mut buf = vec![0; <$field as Serializable>::SIZE_IN_BYTES];
-                    field_v.serialize(&mut buf).unwrap();
+                    let mut buf = GenericArray::default();
+                    field_v.serialize(&mut buf);
 
-                    assert_eq!(field_v, $field::deserialize(&buf).unwrap());
+                    assert_eq!(field_v, $field::deserialize(buf));
                 }
             }
         }
@@ -186,7 +163,8 @@ macro_rules! field_impl {
 }
 
 mod fp31 {
-    field_impl! { Fp31, u8, 31 }
+    use sha2::digest::typenum::U1;
+    field_impl! { Fp31, u8, 31, U1 }
 
     #[cfg(all(test, not(feature = "shuttle")))]
     mod specialized_tests {
@@ -209,7 +187,8 @@ mod fp31 {
 }
 
 mod fp32bit {
-    field_impl! { Fp32BitPrime, u32, 4_294_967_291 }
+    use sha2::digest::typenum::U5;
+    field_impl! { Fp32BitPrime, u32, 4_294_967_291, U5 }
 
     #[cfg(all(test, not(feature = "shuttle")))]
     mod specialized_tests {

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -3,8 +3,7 @@ use crate::bits::Serializable;
 use crate::helpers::{messaging::Message, Error};
 use bitvec::{bitvec, vec::BitVec};
 use futures::FutureExt;
-use sha2::digest::generic_array::GenericArray;
-use sha2::digest::typenum::Unsigned;
+use generic_array::GenericArray;
 use std::{
     num::NonZeroUsize,
     sync::{
@@ -19,6 +18,7 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     Notify,
 };
+use typenum::Unsigned;
 
 pub struct OrderingMpscReceiver<M: Message> {
     rx: Receiver<(usize, M)>,
@@ -231,9 +231,9 @@ mod fixture {
     };
     use async_trait::async_trait;
     use futures::future::join_all;
-    use sha2::digest::typenum::Unsigned;
     use std::num::NonZeroUsize;
     use tokio::sync::mpsc::{channel, Receiver};
+    use typenum::Unsigned;
 
     pub const FP32BIT_SIZE: usize = <Fp32BitPrime as Serializable>::Size::USIZE;
 
@@ -314,7 +314,7 @@ mod unit {
         },
     };
     use futures::{future::join, FutureExt};
-    use sha2::digest::generic_array::GenericArray;
+    use generic_array::GenericArray;
     use std::{mem, num::NonZeroUsize};
 
     /// Test that a single value can be sent and received successfully.

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code)]
+use crate::bits::Serializable;
 use crate::helpers::{messaging::Message, Error};
 use bitvec::{bitvec, vec::BitVec};
 use futures::FutureExt;
+use sha2::digest::generic_array::GenericArray;
+use sha2::digest::typenum::Unsigned;
 use std::{
     num::NonZeroUsize,
     sync::{
@@ -55,7 +58,7 @@ pub fn ordering_mpsc<M: Message, S: AsRef<str>>(
         },
         OrderingMpscReceiver {
             rx,
-            buf: vec![0_u8; capacity.get() * M::SIZE_IN_BYTES],
+            buf: vec![0_u8; capacity.get() * <M as Serializable>::Size::USIZE],
             added: bitvec![0; capacity.get()],
             capacity,
             end,
@@ -92,8 +95,8 @@ impl<M: Message> OrderingMpscReceiver<M> {
         }
         // Translate from an absolute index into a relative one.
         let i = index % self.capacity.get();
-        let start = i * M::SIZE_IN_BYTES;
-        let offset = start..start + M::SIZE_IN_BYTES;
+        let start = i * M::Size::USIZE;
+        let offset = start..start + M::Size::USIZE;
 
         #[cfg_attr(not(debug_assertions), allow(unused_variables))]
         let overwritten = self.added.replace(i, true);
@@ -103,7 +106,7 @@ impl<M: Message> OrderingMpscReceiver<M> {
             "Duplicate send for index {index} on channel \"{}\"",
             self.name,
         );
-        msg.serialize(&mut self.buf[offset]).unwrap();
+        msg.serialize(GenericArray::from_mut_slice(&mut self.buf[offset]));
     }
 
     /// Takes a block of elements from the beginning of the vector, or `None` if
@@ -131,12 +134,12 @@ impl<M: Message> OrderingMpscReceiver<M> {
         self.added[i..(i + tail)].fill(false);
         if wrap > 0 {
             self.added[..wrap].fill(false);
-            let mut buf = Vec::with_capacity((tail + wrap) * M::SIZE_IN_BYTES);
-            buf.extend_from_slice(&self.buf[(i * M::SIZE_IN_BYTES)..]);
-            buf.extend_from_slice(&self.buf[..(wrap * M::SIZE_IN_BYTES)]);
+            let mut buf = Vec::with_capacity((tail + wrap) * M::Size::USIZE);
+            buf.extend_from_slice(&self.buf[(i * M::Size::USIZE)..]);
+            buf.extend_from_slice(&self.buf[..(wrap * M::Size::USIZE)]);
             Some(buf)
         } else {
-            Some(self.buf[(i * M::SIZE_IN_BYTES)..((i + tail) * M::SIZE_IN_BYTES)].to_owned())
+            Some(self.buf[(i * M::Size::USIZE)..((i + tail) * M::Size::USIZE)].to_owned())
         }
     }
 
@@ -228,10 +231,11 @@ mod fixture {
     };
     use async_trait::async_trait;
     use futures::future::join_all;
+    use sha2::digest::typenum::Unsigned;
     use std::num::NonZeroUsize;
     use tokio::sync::mpsc::{channel, Receiver};
 
-    pub const FP32BIT_SIZE: usize = <Fp32BitPrime as Serializable>::SIZE_IN_BYTES;
+    pub const FP32BIT_SIZE: usize = <Fp32BitPrime as Serializable>::Size::USIZE;
 
     #[async_trait]
     pub trait TestSender {
@@ -310,6 +314,7 @@ mod unit {
         },
     };
     use futures::{future::join, FutureExt};
+    use sha2::digest::generic_array::GenericArray;
     use std::{mem, num::NonZeroUsize};
 
     /// Test that a single value can be sent and received successfully.
@@ -322,7 +327,10 @@ mod unit {
             tx_a.send(0, input).await.unwrap();
         };
         let (_, output) = join(send, rx.next(1)).await;
-        assert_eq!(input, Fp31::deserialize(output.as_ref().unwrap()).unwrap());
+        assert_eq!(
+            input,
+            Fp31::deserialize(GenericArray::clone_from_slice(output.as_ref().unwrap()))
+        );
     }
 
     /// If the sender is dropped, then the receiver will report that it is done.

--- a/src/helpers/http/prss_exchange_protocol.rs
+++ b/src/helpers/http/prss_exchange_protocol.rs
@@ -4,7 +4,7 @@ use crate::{
     protocol::{RecordId, Substep},
 };
 
-use sha2::digest::generic_array::GenericArray;
+use generic_array::GenericArray;
 
 use tinyvec::ArrayVec;
 use x25519_dalek::PublicKey;
@@ -110,8 +110,8 @@ impl PublicKeyBytesBuilder {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::*;
+    use generic_array::GenericArray;
     use rand::thread_rng;
-    use sha2::digest::generic_array::GenericArray;
     use x25519_dalek::EphemeralSecret;
 
     #[test]

--- a/src/helpers/http/prss_exchange_protocol.rs
+++ b/src/helpers/http/prss_exchange_protocol.rs
@@ -3,7 +3,9 @@ use crate::{
     helpers::{messaging::Message, MESSAGE_PAYLOAD_SIZE_BYTES},
     protocol::{RecordId, Substep},
 };
-use std::io::ErrorKind;
+
+use sha2::digest::generic_array::GenericArray;
+
 use tinyvec::ArrayVec;
 use x25519_dalek::PublicKey;
 
@@ -58,39 +60,17 @@ impl PublicKeyChunk {
     }
 }
 
-impl Serializable for PublicKeyChunk {
-    const SIZE_IN_BYTES: usize = MESSAGE_PAYLOAD_SIZE_BYTES;
+use crate::helpers::MessagePayloadArrayLen;
 
-    fn serialize(self, buf: &mut [u8]) -> std::io::Result<()> {
-        if buf.len() >= self.0.len() {
-            buf[..Self::SIZE_IN_BYTES].copy_from_slice(&self.0);
-            Ok(())
-        } else {
-            Err(std::io::Error::new(
-                ErrorKind::WriteZero,
-                format!(
-                    "expected buffer to be at least {} bytes, but was only {} bytes",
-                    Self::SIZE_IN_BYTES,
-                    buf.len()
-                ),
-            ))
-        }
+impl Serializable for PublicKeyChunk {
+    type Size = MessagePayloadArrayLen;
+
+    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
+        buf.copy_from_slice(&self.0);
     }
-    fn deserialize(buf: &[u8]) -> std::io::Result<Self> {
-        if Self::SIZE_IN_BYTES <= buf.len() {
-            let mut chunk = [0; Self::SIZE_IN_BYTES];
-            chunk.copy_from_slice(&buf[..Self::SIZE_IN_BYTES]);
-            Ok(PublicKeyChunk(chunk))
-        } else {
-            Err(std::io::Error::new(
-                ErrorKind::UnexpectedEof,
-                format!(
-                    "expected buffer of size {}, but it was of size {}",
-                    Self::SIZE_IN_BYTES,
-                    buf.len()
-                ),
-            ))
-        }
+
+    fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self {
+        Self(buf.into())
     }
 }
 
@@ -131,18 +111,19 @@ impl PublicKeyBytesBuilder {
 mod tests {
     use super::*;
     use rand::thread_rng;
+    use sha2::digest::generic_array::GenericArray;
     use x25519_dalek::EphemeralSecret;
 
     #[test]
     fn chunk_ser_de() {
-        let chunk_bytes = [1, 2, 3, 4, 5, 6, 7, 8];
-        let chunk = PublicKeyChunk(chunk_bytes);
+        let chunk_bytes = GenericArray::from_slice(&[1u8, 2, 3, 4, 5, 6, 7, 8]);
+        let chunk = PublicKeyChunk(chunk_bytes.as_slice().try_into().unwrap());
 
-        let mut serialized = [0u8; 8];
-        chunk.serialize(&mut serialized).unwrap();
-        assert_eq!(chunk_bytes, serialized);
+        let mut serialized = GenericArray::default();
+        chunk.serialize(&mut serialized);
+        assert_eq!(chunk_bytes, &serialized);
 
-        let deserialized = PublicKeyChunk::deserialize(&serialized).unwrap();
+        let deserialized = PublicKeyChunk::deserialize(serialized);
         assert_eq!(chunk, deserialized);
     }
 

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -30,6 +30,9 @@ use crate::helpers::time::Timer;
 use crate::helpers::transport::Transport;
 use ::tokio::sync::{mpsc, oneshot};
 use futures_util::stream::FuturesUnordered;
+use sha2::digest::generic_array::GenericArray;
+use sha2::digest::typenum::Unsigned;
+
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;
 
@@ -129,7 +132,7 @@ impl Mesh<'_, '_> {
         record_id: RecordId,
         msg: T,
     ) -> Result<(), Error> {
-        if T::SIZE_IN_BYTES > MESSAGE_PAYLOAD_SIZE_BYTES {
+        if T::Size::USIZE > MESSAGE_PAYLOAD_SIZE_BYTES {
             Err(Error::serialization_error::<String>(record_id,
                                                      self.step,
                                                      format!("Message {msg:?} exceeds the maximum size allowed: {MESSAGE_PAYLOAD_SIZE_BYTES}"))
@@ -147,8 +150,9 @@ impl Mesh<'_, '_> {
         }
 
         let mut payload = array_vec![0; MESSAGE_PAYLOAD_SIZE_BYTES];
-        msg.serialize(&mut payload)
-            .map_err(|e| Error::serialization_error(record_id, self.step, e))?;
+        let mut data = GenericArray::default();
+        msg.serialize(&mut data);
+        payload[..data.len()].copy_from_slice(&data);
 
         let envelope = MessageEnvelope { record_id, payload };
 
@@ -180,8 +184,8 @@ impl Mesh<'_, '_> {
             .receive(ChannelId::new(source, self.step.clone()), record_id)
             .await?;
 
-        let obj = T::deserialize(&payload)
-            .map_err(|e| Error::serialization_error(record_id, self.step, e))?;
+        let g = GenericArray::clone_from_slice(&payload[..T::Size::USIZE]);
+        let obj = T::deserialize(g);
 
         Ok(obj)
     }

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -30,8 +30,8 @@ use crate::helpers::time::Timer;
 use crate::helpers::transport::Transport;
 use ::tokio::sync::{mpsc, oneshot};
 use futures_util::stream::FuturesUnordered;
-use sha2::digest::generic_array::GenericArray;
-use sha2::digest::typenum::Unsigned;
+use generic_array::GenericArray;
+use typenum::Unsigned;
 
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -21,10 +21,13 @@ use crate::helpers::{
     Direction::{Left, Right},
     Role::{H1, H2, H3},
 };
+use sha2::digest::typenum::{Unsigned, U8};
 use std::ops::{Index, IndexMut};
 use tinyvec::ArrayVec;
 
-pub const MESSAGE_PAYLOAD_SIZE_BYTES: usize = 8;
+// TODO work with ArrayLength only
+pub type MessagePayloadArrayLen = U8;
+pub const MESSAGE_PAYLOAD_SIZE_BYTES: usize = MessagePayloadArrayLen::USIZE;
 type MessagePayload = ArrayVec<[u8; MESSAGE_PAYLOAD_SIZE_BYTES]>;
 
 /// Represents an opaque identifier of the helper instance. Compare with a [`Role`], which

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -21,9 +21,9 @@ use crate::helpers::{
     Direction::{Left, Right},
     Role::{H1, H2, H3},
 };
-use sha2::digest::typenum::{Unsigned, U8};
 use std::ops::{Index, IndexMut};
 use tinyvec::ArrayVec;
+use typenum::{Unsigned, U8};
 
 // TODO work with ArrayLength only
 pub type MessagePayloadArrayLen = U8;

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -2,8 +2,8 @@ use crate::bits::Serializable;
 use crate::secret_sharing::{Boolean as BooleanSecretSharing, BooleanShare, SecretSharing};
 use aes::cipher::generic_array::GenericArray;
 
-use sha2::digest::generic_array::ArrayLength;
-use sha2::digest::typenum::Unsigned;
+use generic_array::ArrayLength;
+use typenum::Unsigned;
 
 use std::ops::Add;
 use std::{
@@ -104,7 +104,7 @@ mod tests {
     use super::XorShare;
     use crate::bits::{BitArray40, Serializable};
 
-    use sha2::digest::generic_array::GenericArray;
+    use generic_array::GenericArray;
 
     fn secret_share(
         a: u128,

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -83,6 +83,7 @@ where
     V::Size: Add<V::Size>,
     <V::Size as Add<V::Size>>::Output: ArrayLength<u8>,
 {
+    /// This constraint means that the serialized size must be `V::SIZE` + `V::SIZE`, i.e. `2 * V::SIZE`
     type Size = <V::Size as Add<V::Size>>::Output;
 
     fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -1,8 +1,13 @@
 use crate::bits::Serializable;
 use crate::secret_sharing::{Boolean as BooleanSecretSharing, BooleanShare, SecretSharing};
+use aes::cipher::generic_array::GenericArray;
+
+use sha2::digest::generic_array::ArrayLength;
+use sha2::digest::typenum::Unsigned;
+
+use std::ops::Add;
 use std::{
     fmt::{Debug, Formatter},
-    io,
     ops::{BitXor, BitXorAssign},
 };
 
@@ -73,36 +78,24 @@ impl<V: BooleanShare> BitXorAssign<&Self> for XorShare<V> {
     }
 }
 
-impl<V: BooleanShare> Serializable for XorShare<V> {
-    const SIZE_IN_BYTES: usize = 2 * V::SIZE_IN_BYTES;
+impl<V: BooleanShare> Serializable for XorShare<V>
+where
+    V::Size: Add<V::Size>,
+    <V::Size as Add<V::Size>>::Output: ArrayLength<u8>,
+{
+    type Size = <V::Size as Add<V::Size>>::Output;
 
-    fn serialize(self, buf: &mut [u8]) -> io::Result<()> {
-        if buf.len() < Self::SIZE_IN_BYTES {
-            Err(io::Error::new(
-                io::ErrorKind::WriteZero,
-                "not enough buffer capacity",
-            ))
-        } else {
-            let (left, right) = (self.left(), self.right());
-            left.serialize(&mut buf[..V::SIZE_IN_BYTES])?;
-            right.serialize(&mut buf[V::SIZE_IN_BYTES..2 * V::SIZE_IN_BYTES])?;
-
-            Ok(())
-        }
+    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
+        let (left, right) = buf.split_at_mut(V::Size::USIZE);
+        self.left().serialize(GenericArray::from_mut_slice(left));
+        self.right().serialize(GenericArray::from_mut_slice(right));
     }
 
-    fn deserialize(buf: &[u8]) -> io::Result<Self> {
-        if buf.len() < Self::SIZE_IN_BYTES {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "not enough buffer capacity",
-            ))
-        } else {
-            let left = V::deserialize(&buf[..V::SIZE_IN_BYTES])?;
-            let right = V::deserialize(&buf[V::SIZE_IN_BYTES..2 * V::SIZE_IN_BYTES])?;
+    fn deserialize(buf: GenericArray<u8, Self::Size>) -> Self {
+        let left = V::deserialize(GenericArray::clone_from_slice(&buf[..V::Size::USIZE]));
+        let right = V::deserialize(GenericArray::clone_from_slice(&buf[V::Size::USIZE..]));
 
-            Ok(Self::new(left, right))
-        }
+        Self::new(left, right)
     }
 }
 
@@ -110,10 +103,8 @@ impl<V: BooleanShare> Serializable for XorShare<V> {
 mod tests {
     use super::XorShare;
     use crate::bits::{BitArray40, Serializable};
-    use proptest::proptest;
-    use rand::rngs::StdRng;
-    use rand::Rng;
-    use rand_core::SeedableRng;
+
+    use sha2::digest::generic_array::GenericArray;
 
     fn secret_share(
         a: u128,
@@ -198,34 +189,16 @@ mod tests {
         xor_test_case((163, 202, 92), (172, 21, 199), 75);
     }
 
-    type XorReplicated = XorShare<BitArray40>;
+    #[test]
+    fn serde() {
+        let share = XorShare::new(
+            BitArray40::try_from(1u128 << 25).unwrap(),
+            BitArray40::try_from(1u128 << 15).unwrap(),
+        );
 
-    proptest! {
-        #[test]
-        fn serde_success(buf_len in XorReplicated::SIZE_IN_BYTES..100 * XorReplicated::SIZE_IN_BYTES, a in 0..1u64 << 39, b in 0..1u64 << 39) {
-            let mut buf = vec![0u8; buf_len];
-            let share = XorShare::new(BitArray40::try_from(u128::from(a)).unwrap(), BitArray40::try_from(u128::from(b)).unwrap());
-            share.clone().serialize(&mut buf).unwrap();
+        let mut buf = GenericArray::default();
+        share.clone().serialize(&mut buf);
 
-            assert_eq!(share, XorShare::deserialize(&buf).unwrap());
-        }
-
-        #[test]
-        fn serde_ser_small_buf(buf_len in 0..XorReplicated::SIZE_IN_BYTES, a in 0..1u64 << 39, b in 0..1u64 << 39) {
-            let mut buf = vec![0u8; buf_len];
-            let share = XorShare::new(BitArray40::try_from(u128::from(a)).unwrap(), BitArray40::try_from(u128::from(b)).unwrap());
-            assert!(matches!(share.serialize(&mut buf), Err(std::io::Error { .. })));
-        }
-
-        #[test]
-        fn serde_de_small_buf(seed: [u8; 32], buf_len in XorReplicated::SIZE_IN_BYTES..100 * XorReplicated::SIZE_IN_BYTES, a in 0..1u64 << 39, b in 0..1u64 << 39) {
-            let mut rng = StdRng::from_seed(seed);
-            let max = rng.gen_range(0..BitArray40::SIZE_IN_BYTES);
-            let mut buf = vec![0u8; buf_len];
-            let share = XorShare::new(BitArray40::try_from(u128::from(a)).unwrap(), BitArray40::try_from(u128::from(b)).unwrap());
-            share.serialize(&mut buf).unwrap();
-
-            assert!(matches!(XorShare::<BitArray40>::deserialize(&buf[..max]), Err(std::io::Error { .. })));
-        }
+        assert_eq!(share, XorShare::deserialize(buf));
     }
 }


### PR DESCRIPTION
`serialize`/`deserialize` now work with fixed-size arrays. Unfortunately it does not eliminate all the runtime checks because in some places I had to use `GenericArray::from_slice`.

The benefit of this approach is that `Serialize` implementors do not need to check the size of the buffer, it is guaranteed to be set correctly.

this is still rough (I want to fix import and add some doc tests) but should demonstrate the idea. 