### PR TITLE
Refactor of sort to take multi bits per record

### DIFF
--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -30,17 +30,22 @@ async fn main() -> Result<(), Error> {
 
     let converted_shares = world
         .semi_honest(match_keys.clone(), |ctx, match_key| async move {
-            convert_all_bits(&ctx, &convert_all_bits_local(ctx.role(), &match_key))
-                .await
-                .unwrap()
+            convert_all_bits(
+                &ctx,
+                &convert_all_bits_local(ctx.role(), &match_key, BitArray40::BITS),
+                BitArray40::BITS,
+                NUM_MULTI_BITS,
+            )
+            .await
+            .unwrap()
         })
         .await;
 
     let start = Instant::now();
     let result = join3(
-        generate_permutation_opt(ctx0, &converted_shares[0], BitArray40::BITS, NUM_MULTI_BITS),
-        generate_permutation_opt(ctx1, &converted_shares[1], BitArray40::BITS, NUM_MULTI_BITS),
-        generate_permutation_opt(ctx2, &converted_shares[2], BitArray40::BITS, NUM_MULTI_BITS),
+        generate_permutation_opt(ctx0, &converted_shares[0]),
+        generate_permutation_opt(ctx1, &converted_shares[1]),
+        generate_permutation_opt(ctx2, &converted_shares[2]),
     )
     .await;
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -11,7 +11,7 @@ use crate::protocol::attribution::AttributionResharableStep::{
 use crate::protocol::basics::SecureMul;
 use crate::protocol::boolean::{random_bits_generator::RandomBitsGenerator, BitDecomposition};
 use crate::protocol::context::{Context, SemiHonestContext};
-use crate::protocol::modulus_conversion::transpose;
+use crate::protocol::modulus_conversion::split_into_multi_bit_slices;
 use crate::protocol::sort::apply_sort::apply_sort_permutation;
 use crate::protocol::sort::apply_sort::shuffle::Resharable;
 use crate::protocol::sort::generate_permutation::generate_permutation_and_reveal_shuffled;
@@ -169,12 +169,9 @@ pub async fn aggregate_credit<F: Field>(
     //
     // 4. Sort by `aggregation_bit`
     //
-    let sorted_output = sort_by_aggregation_bit(
-        ctx.narrow(&Step::SortByAttributionBit),
-        &aggregated_credits,
-        num_multi_bits,
-    )
-    .await?;
+    let sorted_output =
+        sort_by_aggregation_bit(ctx.narrow(&Step::SortByAttributionBit), &aggregated_credits)
+            .await?;
 
     // Take the first k elements, where k is the amount of breakdown keys.
     let result = sorted_output
@@ -253,19 +250,20 @@ async fn sort_by_breakdown_key<F: Field>(
     num_multi_bits: u32,
 ) -> Result<Vec<CappedCreditsWithAggregationBit<F>>, Error> {
     // TODO: Change breakdown_keys to use XorReplicated to avoid bit-decomposition calls
-    let breakdown_keys = transpose(
-        &bit_decompose_breakdown_key(ctx.narrow(&Step::BitDecomposeBreakdownKey), input).await?,
-    );
 
     // We only need to run a radix sort on the bits used by all possible
     // breakdown key values.
     let valid_bits_count = u128::BITS - (max_breakdown_key - 1).leading_zeros();
 
-    let sort_permutation = generate_permutation_and_reveal_shuffled(
-        ctx.narrow(&Step::GeneratePermutationByBreakdownKey),
-        &breakdown_keys[..valid_bits_count as usize],
+    let breakdown_keys = split_into_multi_bit_slices(
+        &bit_decompose_breakdown_key(ctx.narrow(&Step::BitDecomposeBreakdownKey), input).await?,
         valid_bits_count,
         num_multi_bits,
+    );
+
+    let sort_permutation = generate_permutation_and_reveal_shuffled(
+        ctx.narrow(&Step::GeneratePermutationByBreakdownKey),
+        &breakdown_keys,
     )
     .await?;
 
@@ -280,20 +278,17 @@ async fn sort_by_breakdown_key<F: Field>(
 async fn sort_by_aggregation_bit<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     input: &[CappedCreditsWithAggregationBit<F>],
-    num_multi_bits: u32,
 ) -> Result<Vec<CappedCreditsWithAggregationBit<F>>, Error> {
     // Since aggregation_bit is a 1-bit share of 1 or 0, we'll just extract the
     // field and wrap it in another vector.
-    let aggregation_bits = &[input
+    let aggregation_bits = vec![input
         .iter()
-        .map(|x| x.aggregation_bit.clone())
+        .map(|x| vec![x.aggregation_bit.clone()])
         .collect::<Vec<_>>()];
 
     let sort_permutation = generate_permutation_and_reveal_shuffled(
         ctx.narrow(&Step::GeneratePermutationByAttributionBit),
-        aggregation_bits,
-        1,
-        num_multi_bits,
+        aggregation_bits.as_slice(),
     )
     .await?;
 

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -38,12 +38,12 @@ pub fn split_into_multi_bit_slices<F: Field>(
     let total_records = input.len();
     (0..num_bits)
         .step_by(num_multi_bits as usize)
-        .map(move |bit_num| {
+        .map(move |chunk_number| {
             (0..total_records)
                 .map(|record_idx| {
-                    let last_bit_num = std::cmp::min(bit_num + num_multi_bits, num_bits) as usize;
-                    let one_slice = &input[record_idx][bit_num as usize..last_bit_num];
-                    one_slice.to_vec()
+                    let last_bit = std::cmp::min(chunk_number + num_multi_bits, num_bits) as usize;
+                    let next_few_bits = &input[record_idx][chunk_number as usize..last_bit];
+                    next_few_bits.to_vec()
                 })
                 .collect::<Vec<_>>()
         })

--- a/src/protocol/modulus_conversion/mod.rs
+++ b/src/protocol/modulus_conversion/mod.rs
@@ -7,7 +7,7 @@ pub use convert_shares::{
 
 use crate::{ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated};
 
-/// Transpose rows of bits into bits of rows
+/// Split rows of bits into bits of rows such that each 2D vector can be processed as a set
 ///
 /// input:
 /// `[`
@@ -16,17 +16,69 @@ use crate::{ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as
 ///     ...
 ///     `[ row[n].bit0, row[n].bit1, ..., row[n].bit31 ]`,
 ///  `]`
+/// `num_multi_bits`: L
+///
+/// output:
+///     `[ row[0].bit0, row[0].bit1, ..., row[0].bitL ], [ row[1].bit0, row[1].bit1, ..., row[1].bitL ], .. [ row[n].bit0, row[n].bit1, ..., row[n].bitL ]`,
+///     `[ row[0].bitL+1, ..., row[0].bit2L ], [ row[1].bitL+1, ..., row[1].bit2L ], .. [ row[n].bitL+1, ..., row[n].bit2L ], `,
+///     ...
+///     `[ row[0].bitmL,  ..., row[0].bit31 ], [ row[1].bitmL, ..., row[n].bit31 ], .. [ row[n].bitmL, ..., row[n].bit31 ]`,
+/// `]`
+///     `[ row[0].bit0, row[0].bit1, ..., row[0].bitL ], [ row[1].bit0, row[1].bit1, ..., row[1].bitL ], .. [ row[n].bit0, row[n].bit1, ..., row[n].bitL ]`,
+///     `[ row[0].bitL+1, ..., row[0].bit2L ], [ row[1].bitL+1, ..., row[1].bit2L ], .. [ row[n].bitL+1, ..., row[n].bit2L ], `,
+///     ...
+///     `[ row[0].bitmL,  ..., row[0].bit31 ], [ row[1].bitmL, ..., row[n].bit31 ], .. [ row[n].bitmL, ..., row[n].bit31 ]`,
+/// `]`
+#[must_use]
+pub fn split_into_multi_bit_slices<F: Field>(
+    input: &[Vec<Replicated<F>>],
+    num_bits: u32,
+    num_multi_bits: u32,
+) -> Vec<Vec<Vec<Replicated<F>>>> {
+    let total_records = input.len();
+    (0..num_bits)
+        .step_by(num_multi_bits as usize)
+        .map(move |bit_num| {
+            (0..total_records)
+                .map(|record_idx| {
+                    let last_bit_num = std::cmp::min(bit_num + num_multi_bits, num_bits) as usize;
+                    let one_slice = &input[record_idx][bit_num as usize..last_bit_num];
+                    one_slice.to_vec()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Combine 3D vectors to get 2D vectors
+///
+/// input:
+/// `[`
+///     `[ row[0].bit0, row[0].bit1, ..., row[0].bitL ], [ row[1].bit0, row[1].bit1, ..., row[1].bitL ], .. [ row[n].bit0, row[n].bit1, ..., row[n].bitL ]`,
+///     `[ row[0].bitL+1, ..., row[0].bit2L ], [ row[1].bitL+1, ..., row[1].bit2L ], .. [ row[n].bitL+1, ..., row[n].bit2L ], `,
+///     ...
+///     `[ row[0].bitmL,  ..., row[0].bit31 ], [ row[1].bitmL, ..., row[n].bit31 ], .. [ row[n].bitmL, ..., row[n].bit31 ]`,
+/// `]`
+/// `num_multi_bits`: L
 ///
 /// output:
 /// `[`
-///     `[ row[0].bit0, row[1].bit0, ..., row[n].bit0 ]`,
-///     `[ row[0].bit1, row[1].bit1, ..., row[n].bit1 ]`,
+///     `[ row[0].bit0, row[0].bit1, ..., row[0].bit31 ]`,
+///     `[ row[1].bit0, row[1].bit1, ..., row[1].bit31 ]`,
 ///     ...
-///     `[ row[0].bit31, row[1].bit31, ..., row[n].bit31 ]`,
-/// `]`
-#[must_use]
-pub fn transpose<F: Field>(input: &[Vec<Replicated<F>>]) -> Vec<Vec<Replicated<F>>> {
-    (0..input[0].len())
-        .map(|i| input.iter().map(|b| b[i].clone()).collect::<Vec<_>>())
-        .collect::<Vec<_>>()
+///     `[ row[n].bit0, row[n].bit1, ..., row[n].bit31 ]`,
+///  `]`
+pub fn combine_slices<F: Field>(
+    input: &[Vec<Vec<Replicated<F>>>],
+    num_bits: u32,
+) -> impl Iterator<Item = Vec<Replicated<F>>> + '_ {
+    let record_count = input[0].len();
+    let mut output = Vec::with_capacity(record_count);
+    output.resize_with(record_count, || Vec::with_capacity(num_bits as usize));
+    for slice in input.iter() {
+        slice.iter().enumerate().for_each(|(idx, record)| {
+            output[idx].append(&mut record.clone());
+        });
+    }
+    output.into_iter()
 }

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -80,16 +80,19 @@ mod tests {
             .semi_honest(
                 (match_keys, sidecar),
                 |ctx, (mk_shares, secret)| async move {
-                    let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
-                    let converted_shares =
-                        convert_all_bits(&ctx.narrow("convert_all_bits"), &local_lists)
-                            .await
-                            .unwrap();
+                    let local_lists =
+                        convert_all_bits_local(ctx.role(), &mk_shares, MaskedMatchKey::BITS);
+                    let converted_shares = convert_all_bits(
+                        &ctx.narrow("convert_all_bits"),
+                        &local_lists,
+                        MaskedMatchKey::BITS,
+                        NUM_MULTI_BITS,
+                    )
+                    .await
+                    .unwrap();
                     let sort_permutation = generate_permutation_and_reveal_shuffled(
                         ctx.narrow(&SortPreAccumulation),
                         &converted_shares,
-                        MaskedMatchKey::BITS,
-                        NUM_MULTI_BITS,
                     )
                     .await
                     .unwrap();

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -220,16 +220,10 @@ where
 /// If unable to convert sort keys length to u32
 pub async fn generate_permutation_and_reveal_shuffled<F: Field>(
     ctx: SemiHonestContext<'_, F>,
-    sort_keys: &[Vec<Replicated<F>>],
-    num_bits: u32,
-    num_multi_bits: u32,
+    sort_keys: &[Vec<Vec<Replicated<F>>>],
 ) -> Result<RevealedAndRandomPermutations, Error> {
-    // The input is transposed, so this really is the number of sort keys,
-    // not the length of each sort key.
     let key_count = sort_keys[0].len();
-    let sort_permutation =
-        generate_permutation_opt(ctx.narrow(&SortKeys), sort_keys, num_bits, num_multi_bits)
-            .await?;
+    let sort_permutation = generate_permutation_opt(ctx.narrow(&SortKeys), sort_keys).await?;
     shuffle_and_reveal_permutation(
         ctx.narrow(&ShuffleRevealPermutation),
         u32::try_from(key_count).unwrap(),
@@ -350,28 +344,26 @@ where
 mod tests {
     use std::iter::zip;
 
+    use rand::seq::SliceRandom;
+
     use crate::bits::BitArray;
     use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
-    use crate::protocol::sort::generate_permutation::malicious_generate_permutation;
+    use crate::protocol::sort::generate_permutation_opt::generate_permutation_opt;
     use crate::rand::{thread_rng, Rng};
-    use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
     use crate::secret_sharing::SharedValue;
-    use rand::seq::SliceRandom;
 
     use crate::protocol::context::{Context, SemiHonestContext};
     use crate::test_fixture::{join3, MaskedMatchKey, Runner};
     use crate::{
         ff::{Field, Fp31},
-        protocol::sort::generate_permutation::{
-            generate_permutation, shuffle_and_reveal_permutation,
-        },
+        protocol::sort::generate_permutation::shuffle_and_reveal_permutation,
         test_fixture::{generate_shares, Reconstruct, TestWorld},
     };
 
     #[tokio::test]
     pub async fn semi_honest() {
         const COUNT: usize = 5;
-
+        const NUM_MULTI_BITS: u32 = 3;
         let world = TestWorld::new().await;
         let mut rng = thread_rng();
 
@@ -385,15 +377,15 @@ mod tests {
             .semi_honest(
                 match_keys.clone(),
                 |ctx: SemiHonestContext<Fp31>, mk_shares| async move {
-                    let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
-                    let converted_shares = convert_all_bits(&ctx, &local_lists).await.unwrap();
-                    generate_permutation(
-                        ctx.narrow("sort"),
-                        &converted_shares,
-                        MaskedMatchKey::BITS,
-                    )
-                    .await
-                    .unwrap()
+                    let local_lists =
+                        convert_all_bits_local(ctx.role(), &mk_shares, MaskedMatchKey::BITS);
+                    let converted_shares =
+                        convert_all_bits(&ctx, &local_lists, MaskedMatchKey::BITS, NUM_MULTI_BITS)
+                            .await
+                            .unwrap();
+                    generate_permutation_opt(ctx.narrow("sort"), &converted_shares)
+                        .await
+                        .unwrap()
                 },
             )
             .await;
@@ -445,47 +437,5 @@ mod tests {
             perms_and_randoms[2].randoms_for_shuffle.0,
             perms_and_randoms[1].randoms_for_shuffle.1
         );
-    }
-
-    #[tokio::test]
-    pub async fn malicious_sort_in_semi_honest() {
-        const COUNT: usize = 5;
-
-        let world = TestWorld::new().await;
-        let mut rng = thread_rng();
-
-        let mut match_keys = Vec::with_capacity(COUNT);
-        match_keys.resize_with(COUNT, || rng.gen::<MaskedMatchKey>());
-
-        let mut expected = match_keys.iter().map(|mk| mk.as_u128()).collect::<Vec<_>>();
-        expected.sort_unstable();
-
-        let [(v0, result0), (v1, result1), (v2, result2)] = world
-            .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
-                let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
-                let converted_shares: Vec<Vec<Replicated<Fp31>>> =
-                    convert_all_bits(&ctx, &local_lists).await.unwrap();
-                malicious_generate_permutation(
-                    ctx.narrow("sort"),
-                    &converted_shares,
-                    MaskedMatchKey::BITS,
-                )
-                .await
-                .unwrap()
-            })
-            .await;
-
-        let result = join3(
-            v0.validate(result0),
-            v1.validate(result1),
-            v2.validate(result2),
-        )
-        .await;
-        let mut mpc_sorted_list = (0..u128::try_from(COUNT).unwrap()).collect::<Vec<_>>();
-        for (match_key, index) in zip(match_keys, result.reconstruct()) {
-            mpc_sorted_list[index.as_u128() as usize] = match_key.as_u128();
-        }
-
-        assert_eq!(expected, mpc_sorted_list);
     }
 }

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -3,7 +3,10 @@ use crate::{
     ff::Field,
     protocol::{
         context::Context,
-        sort::generate_permutation::shuffle_and_reveal_permutation,
+        sort::{
+            generate_permutation::shuffle_and_reveal_permutation,
+            secureapplyinv::secureapplyinv_multi,
+        },
         sort::{
             multi_bit_permutation::multi_bit_permutation,
             SortStep::{BitPermutationStep, ComposeStep, MultiApplyInv, ShuffleRevealPermutation},
@@ -12,11 +15,9 @@ use crate::{
     },
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use std::iter::repeat;
 
-use super::{compose::compose, secureapplyinv::secureapplyinv};
+use super::compose::compose;
 use crate::protocol::context::SemiHonestContext;
-use futures::future::try_join_all;
 
 /// This is an implementation of `OptGenPerm` (Algorithm 12) described in:
 /// "An Efficient Secure Three-Party Sorting Protocol with an Honest Majority"
@@ -43,29 +44,22 @@ use futures::future::try_join_all;
 
 pub async fn generate_permutation_opt<F>(
     ctx: SemiHonestContext<'_, F>,
-    sort_keys: &[Vec<Replicated<F>>],
-    num_bits: u32,
-    num_multi_bits: u32,
+    sort_keys: &[Vec<Vec<Replicated<F>>>],
 ) -> Result<Vec<Replicated<F>>, Error>
 where
     F: Field,
 {
+    assert_ne!(sort_keys.len(), 0);
     let ctx_0 = ctx.narrow(&Sort(0));
-    assert_eq!(sort_keys.len(), num_bits as usize);
 
-    let last_bit_num = std::cmp::min(num_multi_bits, num_bits);
-
-    let lsb_permutation = multi_bit_permutation(
-        ctx_0.narrow(&BitPermutationStep),
-        &sort_keys[0..last_bit_num.try_into().unwrap()],
-    )
-    .await?;
+    let lsb_permutation =
+        multi_bit_permutation(ctx_0.narrow(&BitPermutationStep), &sort_keys[0]).await?;
 
     let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more that 1B rows
 
     let mut composed_less_significant_bits_permutation = lsb_permutation;
-    for bit_num in (num_multi_bits..num_bits).step_by(num_multi_bits.try_into().unwrap()) {
-        let ctx_bit = ctx.narrow(&Sort(bit_num));
+    for (bit_num, one_slice) in sort_keys.iter().enumerate().skip(1) {
+        let ctx_bit = ctx.narrow(&Sort(bit_num.try_into().unwrap()));
         let revealed_and_random_permutations = shuffle_and_reveal_permutation(
             ctx_bit.narrow(&ShuffleRevealPermutation),
             input_len,
@@ -85,21 +79,13 @@ where
             revealed_and_random_permutations.revealed.as_slice(),
         );
 
-        let last_bit_num = std::cmp::min(bit_num + num_multi_bits, num_bits);
-
-        let futures =
-            (bit_num..last_bit_num)
-                .zip(repeat(ctx_bit.clone()))
-                .map(|(idx, ctx_bit)| async move {
-                    secureapplyinv(
-                        ctx_bit.narrow(&MultiApplyInv(idx)),
-                        sort_keys[idx as usize].clone(),
-                        (randoms_for_shuffle0, randoms_for_shuffle1),
-                        revealed,
-                    )
-                    .await
-                });
-        let next_few_bits_sorted_by_less_significant_bits = try_join_all(futures).await?;
+        let next_few_bits_sorted_by_less_significant_bits = secureapplyinv_multi(
+            ctx_bit.narrow(&MultiApplyInv(bit_num.try_into().unwrap())),
+            one_slice.clone(),
+            (randoms_for_shuffle0, randoms_for_shuffle1),
+            revealed,
+        )
+        .await?;
 
         let next_few_bits_permutation = multi_bit_permutation(
             ctx_bit.narrow(&BitPermutationStep),
@@ -131,7 +117,7 @@ where
 mod tests {
     use std::iter::zip;
 
-    use crate::bits::BitArray;
+    use crate::bits::{BitArray, BitArray40};
     use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
     use crate::rand::{thread_rng, Rng};
 
@@ -162,16 +148,16 @@ mod tests {
             .semi_honest(
                 match_keys.clone(),
                 |ctx: SemiHonestContext<Fp31>, mk_shares| async move {
-                    let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
-                    let converted_shares = convert_all_bits(&ctx, &local_lists).await.unwrap();
-                    generate_permutation_opt(
-                        ctx.narrow("sort"),
-                        &converted_shares,
-                        MaskedMatchKey::BITS,
-                        NUM_MULTI_BITS,
-                    )
-                    .await
-                    .unwrap()
+                    let local_lists =
+                        convert_all_bits_local(ctx.role(), &mk_shares, BitArray40::BITS);
+                    let converted_shares =
+                        convert_all_bits(&ctx, &local_lists, BitArray40::BITS, NUM_MULTI_BITS)
+                            .await
+                            .unwrap();
+
+                    generate_permutation_opt(ctx.narrow("sort"), &converted_shares)
+                        .await
+                        .unwrap()
                 },
             )
             .await;

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -47,9 +47,11 @@ pub async fn multi_bit_permutation<
 
     // Equality bit checker: this checks if each secret shared record is equal to any of numbers between 0 and num_possible_bit_values
     let equality_checks = try_join_all(
-        (0..num_records)
+        input
+            .iter()
             .zip(repeat(ctx.set_total_records(num_records)))
-            .map(|(i, ctx)| check_everything(ctx, i, input[i].as_slice())),
+            .enumerate()
+            .map(|(idx, (record, ctx))| check_everything(ctx, idx, record)),
     )
     .await?;
 

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -35,9 +35,12 @@ pub async fn multi_bit_permutation<
     ctx: C,
     input: &[Vec<S>],
 ) -> Result<Vec<S>, Error> {
-    let num_multi_bits = input.len();
+    let num_records = input.len();
+    assert!(num_records > 0);
+
+    let num_multi_bits = (input[0]).len();
     assert!(num_multi_bits > 0);
-    let num_records = input[0].len();
+
     let num_possible_bit_values = 2 << (num_multi_bits - 1);
 
     let share_of_one = ctx.share_of_one();
@@ -46,7 +49,7 @@ pub async fn multi_bit_permutation<
     let equality_checks = try_join_all(
         (0..num_records)
             .zip(repeat(ctx.set_total_records(num_records)))
-            .map(|(i, ctx)| check_everything(ctx, i, input)),
+            .map(|(i, ctx)| check_everything(ctx, i, input[i].as_slice())),
     )
     .await?;
 
@@ -94,20 +97,15 @@ pub async fn multi_bit_permutation<
 /// `2^N` possible values this could have.
 /// This function checks all of these possible values, and returns a vector of secret-shared results.
 /// Only one result will be a secret-sharing of one, all of the others will be secret-sharings of zero.
-async fn check_everything<F, C, S>(
-    ctx: C,
-    record_idx: usize,
-    input: &[Vec<S>],
-) -> Result<Vec<S>, Error>
+async fn check_everything<F, C, S>(ctx: C, record_idx: usize, record: &[S]) -> Result<Vec<S>, Error>
 where
     F: Field,
     C: Context<F, Share = S>,
     S: ArithmeticSecretSharing<F>,
 {
-    let num_bits = input.len();
-
+    let num_bits = record.len();
     let precomputed_combinations =
-        pregenerate_all_combinations(ctx, record_idx, input, num_bits).await?;
+        pregenerate_all_combinations(ctx, record_idx, record, num_bits).await?;
 
     // This loop just iterates over all the possible values this N-bit input could potentially represent
     // and checks if the bits are equal to this value. It does so my computing a linear combination of the
@@ -190,7 +188,7 @@ where
 async fn pregenerate_all_combinations<F, C, S>(
     ctx: C,
     record_idx: usize,
-    input: &[Vec<S>],
+    input: &[S],
     num_bits: usize,
 ) -> Result<Vec<S>, Error>
 where
@@ -201,8 +199,7 @@ where
     let record_id = RecordId::from(record_idx);
     let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
     precomputed_combinations.push(ctx.share_of_one());
-    for (bit_idx, column) in input.iter().enumerate() {
-        let bit = &column[record_idx];
+    for (bit_idx, bit) in input.iter().enumerate() {
         let step = 1 << bit_idx;
         let mut multiplication_results =
             try_join_all(precomputed_combinations.iter().skip(1).enumerate().map(
@@ -236,11 +233,15 @@ mod tests {
 
     use super::check_everything;
 
-    const INPUT: [&[u128]; 3] = [
-        &[0, 0, 1, 0, 1, 0],
-        &[0, 1, 1, 0, 0, 0],
-        &[1, 0, 1, 0, 1, 0],
+    const INPUT: [[u128; 3]; 6] = [
+        [0, 0, 1],
+        [0, 1, 0],
+        [1, 1, 1],
+        [0, 0, 0],
+        [1, 0, 1],
+        [0, 0, 0],
     ];
+
     const EXPECTED: &[u128] = &[3, 2, 5, 0, 4, 1]; //100 010 111 000 101 000
     const EXPECTED_NUMS: &[usize] = &[4, 2, 7, 0, 5, 0];
 
@@ -254,9 +255,7 @@ mod tests {
             .collect();
         let result = world
             .semi_honest(input, |ctx, m_shares| async move {
-                multi_bit_permutation(ctx, m_shares.as_slice())
-                    .await
-                    .unwrap()
+                multi_bit_permutation(ctx, &m_shares).await.unwrap()
             })
             .await;
 
@@ -272,14 +271,14 @@ mod tests {
             .map(|v| v.iter().map(|x| Fp31::from(*x)).collect())
             .collect();
 
-        let num_records = INPUT[0].len();
+        let num_records = INPUT.len();
 
         let result = world
             .semi_honest(input, |ctx, m_shares| async move {
                 let mut equality_check_futures = Vec::with_capacity(num_records);
-                for i in 0..num_records {
+                for (i, record) in m_shares.iter().enumerate() {
                     let ctx = ctx.set_total_records(num_records);
-                    equality_check_futures.push(check_everything(ctx, i, m_shares.as_slice()));
+                    equality_check_futures.push(check_everything(ctx, i, record));
                 }
                 try_join_all(equality_check_futures).await.unwrap()
             })


### PR DESCRIPTION
Now, convert_all_bits returns vector of 2D vectors where each 2D vector is of size [ record_count ; num_multi_bits].
This helps in code clarity and is also required for malicious sort to do upgrade