### PR TITLE
improve safety for indexed protocol steps

### DIFF
--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -410,8 +410,8 @@ pub(in crate::protocol) mod test {
                         let v = MaliciousValidator::new(ctx);
                         let m_ctx = v.context().set_total_records(1);
                         let (m_a, m_b) = try_join(
-                            m_ctx.upgrade_with_sparse(&BitOpStep::from(0), v_a, a),
-                            m_ctx.upgrade_with_sparse(&BitOpStep::from(1), v_b, b),
+                            m_ctx.upgrade_with_sparse(&BitOpStep::from(0u32), v_a, a),
+                            m_ctx.upgrade_with_sparse(&BitOpStep::from(1u32), v_b, b),
                         )
                         .await
                         .unwrap();

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -157,11 +157,11 @@ impl BitwiseLessThanPrime {
 
         let one = ctx.share_known_value(F::ONE);
         let least_significant_two_bits_both_one = ctx
-            .narrow(&BitOpStep::from(0))
+            .narrow(&BitOpStep::from(0u32))
             .multiply(record_id, &x[0], &x[1])
             .await?;
         let least_significant_bits_are_one_one_zero = ctx
-            .narrow(&BitOpStep::from(1))
+            .narrow(&BitOpStep::from(1u32))
             .multiply(
                 record_id,
                 &(one - &x[2]),

--- a/src/protocol/boolean/dumb_bitwise_add_constant.rs
+++ b/src/protocol/boolean/dumb_bitwise_add_constant.rs
@@ -136,7 +136,7 @@ where
     let mut output = Vec::with_capacity(a.len() + 1);
 
     let mut last_carry = ctx
-        .narrow(&BitOpStep::from(0))
+        .narrow(&BitOpStep::from(0u32))
         .multiply(record_id, &a[0], maybe)
         .await?;
     output.push(-last_carry.clone() * F::from(2) + &a[0] + maybe);

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -148,7 +148,7 @@ pub async fn generate_permutation<F>(
 where
     F: Field,
 {
-    let ctx_0 = ctx.narrow(&Sort(0));
+    let ctx_0 = ctx.narrow(&Sort(0u32.try_into().unwrap()));
     assert_eq!(sort_keys.len(), num_bits as usize);
 
     let bit_0_permutation =

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -59,7 +59,7 @@ where
 
     let mut composed_less_significant_bits_permutation = lsb_permutation;
     for (bit_num, one_slice) in sort_keys.iter().enumerate().skip(1) {
-        let ctx_bit = ctx.narrow(&Sort(bit_num));
+        let ctx_bit = ctx.narrow(&Sort(bit_num.try_into().unwrap()));
         let revealed_and_random_permutations = shuffle_and_reveal_permutation(
             ctx_bit.narrow(&ShuffleRevealPermutation),
             composed_less_significant_bits_permutation,
@@ -166,7 +166,8 @@ where
         )
         .await?;
 
-        malicious_validator = MaliciousValidator::new(sh_ctx.narrow(&Sort(chunk_num)));
+        malicious_validator =
+            MaliciousValidator::new(sh_ctx.narrow(&Sort(chunk_num.try_into().unwrap())));
         m_ctx_bit = malicious_validator.context();
 
         // TODO (richaj) it might even be more efficient to apply sort permutation to XorReplicated sharings,

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -9,7 +9,10 @@ mod multi_bit_permutation;
 mod secureapplyinv;
 mod shuffle;
 
-use crate::{protocol::Substep, repeat64str};
+use crate::{
+    protocol::{StepIndex64, Substep},
+    repeat64str,
+};
 use std::fmt::Debug;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -19,21 +22,21 @@ pub enum SortStep {
     ComposeStep,
     ShuffleRevealPermutation,
     SortKeys,
-    MultiApplyInv(u32),
+    MultiApplyInv(StepIndex64),
 }
 
 impl Substep for SortStep {}
 
 impl AsRef<str> for SortStep {
     fn as_ref(&self) -> &str {
-        const MULTI_APPLY_INV: [&str; 64] = repeat64str!["multi_apply_inv"];
+        const MULTI_APPLY_INV: [&str; StepIndex64::BOUND] = repeat64str!["multi_apply_inv"];
         match self {
             Self::BitPermutationStep => "bit_permute",
             Self::ApplyInv => "apply_inv",
             Self::ComposeStep => "compose",
             Self::ShuffleRevealPermutation => "shuffle_reveal_permutation",
             Self::SortKeys => "sort_keys",
-            Self::MultiApplyInv(i) => MULTI_APPLY_INV[usize::try_from(*i).unwrap()],
+            Self::MultiApplyInv(i) => MULTI_APPLY_INV[*i],
         }
     }
 }


### PR DESCRIPTION
This creates some guardrails around construction of indexed protocol steps.

I didn't convert `BitOpStep` from `from` to `try_from` since there are a number of places it needs to change, but I can do that if desired (after there's agreement on the general approach).