### PR TITLE
Split out some of the longer-running tasks

### DIFF
--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   rust-check:
-    name: Rust Checks
+    name: Additional Builds and Concurrency Tests
     env:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: -D warnings
@@ -27,20 +27,17 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        if: ${{ success() || failure() }}
-        run: cargo clippy --tests
-
-      - name: Clippy concurrency tests
-        if: ${{ success() || failure() }}
-        run: cargo clippy --tests --features shuttle
-
       - name: Build
-        if: ${{ success() || failure() }}
         run: cargo build --tests
 
-      - name: Run Tests
-        run: cargo test
+      - name: Release Build
+        run: cargo build --release
+
+      - name: Build benchmarks
+        run: cargo build --benches --features enable-benches
+
+      - name: Build concurrency tests
+        run: cargo build --features shuttle
+
+      - name: Run concurrency tests
+        run: cargo test --features shuttle

--- a/.github/workflows/extra.yml
+++ b/.github/workflows/extra.yml
@@ -27,9 +27,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Build
-        run: cargo build --tests
-
       - name: Release Build
         run: cargo build --release
 


### PR DESCRIPTION
An additional workflow can run in parallel.  This increases overall work, but it might allow us to reduce the overall time to getting a positive answer.