### PR TITLE
Revert cargo audit change

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -8,9 +8,6 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-  schedule:
-    - cron: '0 0 * * *'
-
 jobs:
   audit:
     name: Security audit
@@ -22,8 +19,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/audit-check@v1
         with:
-          components: cargo-audit
-      - name: cargo audit
-        run: cargo audit
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-daily.yml
+++ b/.github/workflows/audit-daily.yml
@@ -1,0 +1,15 @@
+name: Daily security audit against advisory DB
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,11 +1,13 @@
 name: Check dependencies against Advisory DB
 on:
   push:
-    paths: &PATHS
+    paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
-    paths: *PATHS
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
It does not seem to work. I agree that we need to get rid of `actions-rs` but for now want to unblock main
https://github.com/akoshelev/raw-ipa/actions/runs/4067659251/jobs/7005327980

```bash
Run rustup toolchain install stable --component cargo-audit --profile minimal --no-self-update
  rustup toolchain install stable --component cargo-audit --profile minimal --no-self-update
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CARGO_TERM_COLOR: always
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
warning: Signature verification failed for 'https://static.rust-lang.org/dist/channel-rust-stable.toml'
info: latest update on 2023-01-26, rust version 1.67.0 (fc594f156 2023-01-24)
error: component 'cargo-audit' for target 'x86_64-unknown-linux-gnu' is unavailable for download for channel 'stable'
If you don't need the component, you could try a minimal installation with:
```