### PR TITLE
Remove bit padding

### DIFF
--- a/src/bits/bit_array.rs
+++ b/src/bits/bit_array.rs
@@ -94,7 +94,7 @@ macro_rules! bit_array_impl {
                 /// be at most `Self::BITS` long. That is, the integer value must be less than
                 /// or equal to `2^Self::BITS`, or it will return an error.
                 fn try_from(v: u128) -> Result<Self, Self::Error> {
-                    if 128 - v.leading_zeros() <= Self::BITS {
+                    if u128::BITS - v.leading_zeros() <= Self::BITS {
                         Ok(Self::truncate_from(v))
                     } else {
                         Err(format!(
@@ -177,7 +177,7 @@ macro_rules! bit_array_impl {
                 use bitvec::prelude::*;
                 use rand::{thread_rng, Rng};
 
-                const MASK: u128 = u128::MAX >> (128 - $name::BITS);
+                const MASK: u128 = u128::MAX >> (u128::BITS - $name::BITS);
 
                 #[test]
                 pub fn basic() {

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -2,7 +2,7 @@ use super::bitwise_less_than_prime::BitwiseLessThanPrime;
 use super::dumb_bitwise_sum::bitwise_sum;
 use super::random_bits_generator::RandomBitsGenerator;
 use crate::error::Error;
-use crate::ff::{Field, Int};
+use crate::ff::Field;
 use crate::protocol::boolean::local_secret_shared_bits;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
@@ -61,15 +61,19 @@ impl BitDecomposition {
         .await?;
 
         // Step 7. a bitwise scalar value `f_B = bits(2^l - p)`
-        let l = F::Integer::BITS;
+        let l = u128::BITS - F::PRIME.into().leading_zeros();
         let x = 2_u128.pow(l) - F::PRIME.into();
         let f_b = (0..l).map(|i| F::from(x >> i & 1));
 
         // Step 8, 9. [g_i] = [q] * f_i
-        let g_b = f_b
+        let mut g_b = f_b
             .into_iter()
             .map(|f_bit| q_p.clone() * f_bit)
             .collect::<Vec<_>>();
+
+        // Since bitwise-sum will return +1 bit from the carry, d_b.len() is 1 bit longer
+        // than g_b. Append ZERO to make them the same size.
+        g_b.push(S::ZERO);
 
         // Step 10. [h]_B = [d + g]_B, where [h]_B = ([h]_0,...[h]_(l+1))
         //
@@ -109,7 +113,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitDecomposition;
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime, Int},
+        ff::{Field, Fp31, Fp32BitPrime},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -142,10 +146,11 @@ mod tests {
             })
             .await;
 
-        // bit-decomposed values must have the same bit length of the target field
-        assert_eq!(F::Integer::BITS as usize, result[0].len());
-        assert_eq!(F::Integer::BITS as usize, result[1].len());
-        assert_eq!(F::Integer::BITS as usize, result[2].len());
+        // bit-decomposed values generate valid number of bits to fit the target field values
+        let l = u128::BITS - F::PRIME.into().leading_zeros();
+        assert_eq!(usize::try_from(l).unwrap(), result[0].len());
+        assert_eq!(usize::try_from(l).unwrap(), result[1].len());
+        assert_eq!(usize::try_from(l).unwrap(), result[2].len());
 
         result.reconstruct()
     }

--- a/src/protocol/boolean/dumb_bitwise_sum.rs
+++ b/src/protocol/boolean/dumb_bitwise_sum.rs
@@ -1,4 +1,3 @@
-use super::align_bit_lengths;
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::boolean::or::or;
@@ -59,9 +58,10 @@ where
     C: Context<F, Share = S>,
     S: ArithmeticSecretSharing<F>,
 {
-    let (a, b) = align_bit_lengths(a, b); // TODO: remove
+    debug_assert_eq!(a.len(), b.len());
+
     let both_bits_one =
-        multiply_all_the_bits(&a, &b, ctx.narrow(&Step::MultiplyAllTheBits), record_id).await?;
+        multiply_all_the_bits(a, b, ctx.narrow(&Step::MultiplyAllTheBits), record_id).await?;
     let mut xored_bits = Vec::with_capacity(a.len());
     for i in 0..a.len() {
         xored_bits.push(-(both_bits_one[i].clone() * F::from(2)) + &a[i] + &b[i]);

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -1,7 +1,7 @@
 use futures::future::try_join_all;
 
 use crate::error::Error;
-use crate::ff::{Field, Int};
+use crate::ff::Field;
 use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
 use std::iter::repeat;
 
@@ -34,7 +34,7 @@ where
     C: Context<F, Share = S>,
     S: SecretSharing<F>,
 {
-    (0..F::Integer::BITS)
+    (0..(u128::BITS - F::PRIME.into().leading_zeros()))
         .map(|i| {
             if ((x >> i) & 1) == 1 {
                 ctx.share_of_one()
@@ -43,29 +43,6 @@ where
             }
         })
         .collect::<Vec<_>>()
-}
-
-/// Aligns the bits by padding extra zeros at the end (assuming the bits are in
-/// little-endian format).
-/// TODO: this needs to be removed; where it is used there are better optimizations.
-fn align_bit_lengths<F, S>(a: &[S], b: &[S]) -> (Vec<S>, Vec<S>)
-where
-    F: Field,
-    S: SecretSharing<F>,
-{
-    let mut a = a.to_vec();
-    let mut b = b.to_vec();
-
-    if a.len() == b.len() {
-        return (a, b);
-    }
-
-    let pad_a = b.len().saturating_sub(a.len());
-    let pad_b = a.len().saturating_sub(b.len());
-    a.append(&mut repeat(S::ZERO).take(pad_a).collect::<Vec<_>>());
-    b.append(&mut repeat(S::ZERO).take(pad_b).collect::<Vec<_>>());
-
-    (a, b)
 }
 
 /// We can minimize circuit depth by doing this in a binary-tree like fashion, where pairs of shares are multiplied together

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -11,7 +11,7 @@ use std::iter::zip;
 
 /// Deconstructs a value into N values, one for each bit.
 pub fn into_bits<F: Field>(x: F) -> Vec<F> {
-    (0..(128 - F::PRIME.into().leading_zeros()))
+    (0..(u128::BITS - F::PRIME.into().leading_zeros()))
         .map(|i| F::from((x.as_u128() >> i) & 1))
         .collect::<Vec<_>>()
 }


### PR DESCRIPTION
When I first implemented bitwise protocols, I used `F::Integer::BITS` to determine a bit length of a value into bits for the bit decomposition. Instead, we can computer the exact number of bits needed to fit a value by counting the number of leading zeros of the targeted field's prime number.