### PR TITLE
Parametrize IPA benchmark with match key bits

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use rand::Rng;
 use raw_ipa::error::Error;
 use raw_ipa::ff::Fp32BitPrime;
@@ -5,11 +6,21 @@ use raw_ipa::ipa_test_input;
 use raw_ipa::protocol::ipa::ipa;
 // use raw_ipa::protocol::ipa::{ipa_wip_malicious};
 
-use raw_ipa::protocol::{BreakdownKey, MatchKey};
+use raw_ipa::protocol::{ipa, BreakdownKey, MatchKey};
+use raw_ipa::secret_sharing::SharedValue;
 use raw_ipa::test_fixture::input::GenericReportTestInput;
 use raw_ipa::test_fixture::{Runner, TestWorld, TestWorldConfig};
 use std::num::NonZeroUsize;
 use std::time::Instant;
+
+#[derive(Debug, Parser)]
+pub struct IpaBenchArgs {
+    #[arg(long, help = "bits of match key to use in IPA circuit.")]
+    pub match_key_bits: Option<u8>,
+
+    #[arg(short, long, help = "ignored")]
+    pub bench: bool,
+}
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), Error> {
@@ -17,7 +28,7 @@ async fn main() -> Result<(), Error> {
     const MAX_TRIGGER_VALUE: u128 = 5;
     const PER_USER_CAP: u32 = 3;
     const MAX_BREAKDOWN_KEY: u128 = 4;
-    const NUM_MULTI_BITS: u32 = 3;
+    let args = IpaBenchArgs::parse();
 
     let mut config = TestWorldConfig::default();
     config.gateway_config.send_buffer_config.items_in_batch = NonZeroUsize::new(1).unwrap();
@@ -26,9 +37,18 @@ async fn main() -> Result<(), Error> {
     let mut rng = rand::thread_rng();
 
     let max_match_key = u128::try_from(BATCHSIZE / 4).unwrap();
+    let match_key_bits = if let Some(bits) = args.match_key_bits {
+        bits
+    } else {
+        u8::try_from(MatchKey::BITS).unwrap()
+    };
 
-    let mut records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> =
-        Vec::with_capacity(BATCHSIZE);
+    assert!(
+        u32::from(match_key_bits) <= MatchKey::BITS,
+        "Requested to use more bits than available in match keys"
+    );
+
+    let mut records = Vec::with_capacity(BATCHSIZE);
 
     for _ in 0..BATCHSIZE {
         records.push(ipa_test_input!(
@@ -45,21 +65,17 @@ async fn main() -> Result<(), Error> {
     let start = Instant::now();
     let result = world
         .semi_honest(records, |ctx, input_rows| async move {
+            let query = ipa::Query::new(&input_rows, PER_USER_CAP, MAX_BREAKDOWN_KEY)
+                .with_match_key_bits(match_key_bits);
             // ipa_wip_malicious::<Fp32BitPrime, MatchKey, BreakdownKey>(
-            ipa::<Fp32BitPrime, MatchKey, BreakdownKey>(
-                ctx,
-                &input_rows,
-                PER_USER_CAP,
-                MAX_BREAKDOWN_KEY,
-                NUM_MULTI_BITS,
-            )
-            .await
-            .unwrap()
+            ipa(ctx, query).await.unwrap()
         })
         .await;
 
     let duration = start.elapsed();
-    println!("rows {BATCHSIZE} benchmark complete after {duration:?}");
+    println!(
+        "rows={BATCHSIZE}/match key bits={match_key_bits} benchmark complete after {duration:?}"
+    );
 
     assert_eq!(MAX_BREAKDOWN_KEY, result[0].len().try_into().unwrap());
     Ok(())

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -156,7 +156,8 @@ impl<F: Field + Sized, T: Arithmetic<F>> Resharable<F> for IPAModulusConvertedIn
     }
 }
 
-/// Describes a request to execute IPA protocol. Consists of computation inputs and query parameters
+/// Describes a request to execute IPA protocol. Consists of inputs for the computation
+/// and query parameters
 pub struct Query<'a, F: Field, MK: BitArray = MatchKey, BK: BitArray = BreakdownKey> {
     input: &'a [IPAInputRow<F, MK, BK>],
     /// Maximum contribution allowed per match key/user.
@@ -164,8 +165,7 @@ pub struct Query<'a, F: Field, MK: BitArray = MatchKey, BK: BitArray = Breakdown
     /// ?
     max_breakdown_key: u128,
     /// That many bits will be sorted at the same time. Setting it to 1 would mean IPA sorts
-    /// 1 bit at a time. Our experiments confirmed by research papers show that 3 is the optimal
-    /// value.
+    /// 1 bit at a time.
     num_multi_bits: u32,
     /// Indicates how many least significant bits of match keys are used inside the query. By default
     /// this value is set to `MK::BITS`, meaning all bits will be used.
@@ -173,6 +173,7 @@ pub struct Query<'a, F: Field, MK: BitArray = MatchKey, BK: BitArray = Breakdown
 }
 
 impl<'a, F: Field, MK: BitArray, BK: BitArray> Query<'a, F, MK, BK> {
+    /// Our experiments confirmed by research papers show that 3 is the optimal value.
     const DEFAULT_MULTI_BITS: u8 = 3;
 
     pub fn new(
@@ -190,6 +191,12 @@ impl<'a, F: Field, MK: BitArray, BK: BitArray> Query<'a, F, MK, BK> {
             num_multi_bits: u32::from(Self::DEFAULT_MULTI_BITS),
             match_key_bits,
         }
+    }
+
+    #[must_use]
+    pub fn with_match_key_bits(mut self, match_key_bits: u8) -> Self {
+        self.match_key_bits = match_key_bits;
+        self
     }
 }
 

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -136,6 +136,7 @@ where
 pub async fn convert_all_bits<F, C, S>(
     ctx: &C,
     locally_converted_bits: &[Vec<BitConversionTriple<S>>],
+    // TODO: u8 should be enough to represent bits
     num_bits: u32,
     num_multi_bits: u32,
 ) -> Result<Vec<Vec<Vec<S>>>, Error>


### PR DESCRIPTION
The goal is to allow more flexibility comparing MP-SPDZ and Rust implementation. This change does not make match key size dynamic as it is significantly more work, but rather instructs the IPA protocol (specifically modulus conversion) to ignore higher bits. 

## Testing

Using 20 bits from each match key

```bash
RUST_LOG=debug cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches debug-trace" -- --match-key-bits 20 | grep match_key_shares | cut -d'/' -f7 | cut -d',' -f1 | sed -e "s/elem//g" | sort -nr | uniq | head -n1
19
```

Omit `--match-key-bits` argument and IPA uses all 40 bits

```bash
RUST_LOG=debug cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches debug-trace" | grep match_key_shares | cut -d'/' -f7 | cut -d',' -f1 | sed -e "s/elem//g" | sort -nr | uniq | head -n1
39
```

