### PR TITLE
Simplify logic in aggregation

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -57,10 +57,7 @@ where
     }))
     .await?;
 
-    let mut credits = input
-        .iter()
-        .map(|x| x.trigger_value.clone())
-        .collect::<Vec<_>>();
+    let credits = input.iter().map(|x| &x.trigger_value);
 
     // 2. Accumulate (up to 4 multiplications)
     //
@@ -77,7 +74,7 @@ where
     // of other elements, allowing the algorithm to be executed in parallel.
 
     // generate powers of 2 that fit into input len. If num_rows is 15, this will produce [1, 2, 4, 8]
-    do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
+    let credits = do_the_binary_tree_thing(ctx, &helper_bits, credits).await?;
 
     let output = input
         .iter()

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -1,5 +1,4 @@
 use super::{
-    compute_b_bit, compute_stop_bit,
     input::{
         MCAggregateCreditInputRow, MCAggregateCreditOutputRow, MCCappedCreditsWithAggregationBit,
     },
@@ -23,7 +22,7 @@ use crate::{
 };
 use crate::{ff::Field, protocol::basics::SecureMul};
 use futures::future::{try_join, try_join_all};
-use std::{iter::repeat, marker::PhantomData};
+use std::marker::PhantomData;
 
 /// Aggregation step for Oblivious Attribution protocol.
 /// # Panics
@@ -225,16 +224,31 @@ where
     //
     let num_rows = sorted_input.len();
 
-    let one = m_ctx.share_known_value(F::ONE);
+    let mut stop_bits = sorted_input
+        .iter()
+        .skip(1)
+        .map(|x| x.helper_bit.clone())
+        .collect::<Vec<_>>();
+    stop_bits.push(MaliciousReplicated::ZERO);
 
-    let mut stop_bits = repeat(one.clone()).take(num_rows).collect::<Vec<_>>();
+    let depth_0_ctx = m_ctx
+        .narrow(&Step::AggregateCreditBTimesSuccessorCredit)
+        .set_total_records(num_rows - 1);
+    let futures = sorted_input.iter().skip(1).enumerate().map(|(i, x)| {
+        let c = depth_0_ctx.clone();
+        let record_id = RecordId::from(i);
+        async move { c.multiply(record_id, &x.helper_bit, &x.credit).await }
+    });
 
+    let credit_updates = try_join_all(futures).await?;
     let mut credits = sorted_input
         .iter()
-        .map(|x| x.credit.clone())
+        .zip(credit_updates)
+        .map(|(x, update)| update + &x.credit)
         .collect::<Vec<_>>();
+    credits.push(sorted_input.last().unwrap().credit.clone());
 
-    for (depth, step_size) in std::iter::successors(Some(1_usize), |prev| prev.checked_mul(2))
+    for (depth, step_size) in std::iter::successors(Some(2_usize), |prev| prev.checked_mul(2))
         .take_while(|&v| v < num_rows)
         .enumerate()
     {
@@ -252,25 +266,16 @@ where
             let sibling_stop_bit = &stop_bits[i + step_size];
             let sibling_credit = &credits[i + step_size];
             futures.push(async move {
-                let b = compute_b_bit(
-                    c.narrow(&Step::ComputeBBit),
-                    record_id,
-                    current_stop_bit,
-                    sibling_helper_bit,
-                    depth == 0,
-                )
-                .await?;
+                let b = c
+                    .narrow(&Step::ComputeBBit)
+                    .multiply(record_id, current_stop_bit, sibling_helper_bit)
+                    .await?;
 
                 try_join(
                     c.narrow(&Step::AggregateCreditBTimesSuccessorCredit)
                         .multiply(record_id, &b, sibling_credit),
-                    compute_stop_bit(
-                        c.narrow(&Step::ComputeStopBit),
-                        record_id,
-                        &b,
-                        sibling_stop_bit,
-                        depth == 0,
-                    ),
+                    c.narrow(&Step::ComputeStopBit)
+                        .multiply(record_id, &b, sibling_stop_bit),
                 )
                 .await
             });

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -73,12 +73,9 @@ where
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
 
-    let mut credits = sorted_input
-        .iter()
-        .map(|x| x.credit.clone())
-        .collect::<Vec<_>>();
+    let credits = sorted_input.iter().map(|x| &x.credit);
 
-    do_the_binary_tree_thing(ctx.clone(), &helper_bits, &mut credits).await?;
+    let credits = do_the_binary_tree_thing(ctx.clone(), &helper_bits, credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input
@@ -170,12 +167,9 @@ where
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
 
-    let mut credits = sorted_input
-        .iter()
-        .map(|x| x.credit.clone())
-        .collect::<Vec<_>>();
+    let credits = sorted_input.iter().map(|x| &x.credit);
 
-    do_the_binary_tree_thing(m_ctx, &helper_bits, &mut credits).await?;
+    let credits = do_the_binary_tree_thing(m_ctx, &helper_bits, credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -100,7 +100,7 @@ where
     {
         let end = num_rows - step_size;
         let c = ctx
-            .narrow(&InteractionPatternStep::from(depth))
+            .narrow(&InteractionPatternStep::from(depth + 1))
             .set_total_records(end);
         let mut futures = Vec::with_capacity(end);
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -77,7 +77,7 @@ where
     stop_bits.push(ctx.share_known_value(F::ONE));
 
     let depth_0_ctx = ctx
-        .narrow(&Step::AggregateCreditBTimesSuccessorCredit)
+        .narrow(&InteractionPatternStep::from(0))
         .set_total_records(num_rows - 1);
     let credit_updates = try_join_all(sorted_input.iter().skip(1).enumerate().map(|(i, x)| {
         let c = depth_0_ctx.clone();
@@ -111,7 +111,7 @@ where
             let sibling_credit = &credits[i + step_size];
             futures.push(async move {
                 let b = c
-                    .narrow(&Step::ComputeBBit)
+                    .clone()
                     .multiply(record_id, sibling_helper_bit, current_stop_bit)
                     .await?;
 
@@ -231,7 +231,7 @@ where
     stop_bits.push(m_ctx.share_known_value(F::ONE));
 
     let depth_0_ctx = m_ctx
-        .narrow(&Step::AggregateCreditBTimesSuccessorCredit)
+        .narrow(&InteractionPatternStep::from(0))
         .set_total_records(num_rows - 1);
     let futures = sorted_input.iter().skip(1).enumerate().map(|(i, x)| {
         let c = depth_0_ctx.clone();
@@ -253,7 +253,7 @@ where
     {
         let end = num_rows - step_size;
         let c = m_ctx
-            .narrow(&InteractionPatternStep::from(depth))
+            .narrow(&InteractionPatternStep::from(depth + 1))
             .set_total_records(end);
         let mut futures = Vec::with_capacity(end);
 
@@ -266,7 +266,7 @@ where
             let sibling_credit = &credits[i + step_size];
             futures.push(async move {
                 let b = c
-                    .narrow(&Step::ComputeBBit)
+                    .clone()
                     .multiply(record_id, current_stop_bit, sibling_helper_bit)
                     .await?;
 
@@ -519,7 +519,6 @@ async fn malicious_sort_by_aggregation_bit<F: Field>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
-    ComputeBBit,
     ComputeStopBit,
     SortByBreakdownKey,
     SortByAttributionBit,
@@ -535,7 +534,6 @@ impl Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
-            Self::ComputeBBit => "compute_b_bit",
             Self::ComputeStopBit => "compute_stop_bit",
             Self::SortByBreakdownKey => "sort_by_breakdown_key",
             Self::SortByAttributionBit => "sort_by_attribution_bit",

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -1,7 +1,6 @@
 use super::{
     do_the_binary_tree_thing, if_else,
     input::{MCCreditCappingInputRow, MCCreditCappingOutputRow},
-    InteractionPatternStep,
 };
 use crate::ff::Field;
 use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
@@ -125,24 +124,6 @@ where
         .skip(1)
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
-
-    let num_rows = input.len();
-    let depth_0_ctx = ctx
-        .narrow(&InteractionPatternStep::from(0))
-        .set_total_records(num_rows - 1);
-    let credit_updates = try_join_all(helper_bits.iter().enumerate().map(|(i, helper_bit)| {
-        let c = depth_0_ctx.clone();
-        let record_id = RecordId::from(i);
-        let credit = &original_credits[i + 1];
-        async move { c.multiply(record_id, helper_bit, credit).await }
-    }))
-    .await?;
-    credit_updates
-        .into_iter()
-        .enumerate()
-        .for_each(|(i, credit)| {
-            original_credits[i] += &credit;
-        });
 
     do_the_binary_tree_thing(ctx, &helper_bits, &mut original_credits).await?;
 

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -1,3 +1,5 @@
+use futures::future::{try_join, try_join_all};
+
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId, Substep};
@@ -34,6 +36,98 @@ where
         + &ctx
             .multiply(record_id, condition, &(true_value.clone() - false_value))
             .await?)
+}
+
+///
+/// Computes `SUM(credits[i] through credits[i + n])` where `n` is the number of "matching rows", as indicated by the `helper_bits`
+/// This result is saved as credits[i].
+///
+/// Helper bits should be a sharing of either `1` or `0` for each row, indicating if that row "matches" the row preceeding it.
+/// Stop Bits should be initialized to a sharing of `1`
+///
+/// ## Errors
+/// Fails if the multiplication protocol fails.
+///
+pub async fn do_the_binary_tree_thing<F, C, S>(
+    ctx: C,
+    helper_bits: &[S],
+    credits: &mut [S],
+) -> Result<(), Error>
+where
+    F: Field,
+    C: Context<F, Share = S>,
+    S: ArithmeticSecretSharing<F>,
+{
+    // Create stop_bit vector.
+    // This vector is updated in each iteration to help accumulate values
+    // and determine when to stop accumulating.
+    let mut stop_bits = helper_bits.to_owned();
+    stop_bits.push(ctx.share_known_value(F::ONE));
+    let num_rows = stop_bits.len();
+
+    // Each loop the "step size" is doubled. This produces a "binary tree" like behavior
+    for (depth, step_size) in std::iter::successors(Some(2_usize), |prev| prev.checked_mul(2))
+        .take_while(|&v| v < num_rows)
+        .enumerate()
+    {
+        let end = num_rows - step_size;
+        let depth_i_ctx = ctx
+            .narrow(&InteractionPatternStep::from(depth + 1))
+            .set_total_records(end);
+        let b_times_sibling_credit_ctx = depth_i_ctx.narrow(&Step::BTimesSuccessorCredit);
+        let b_times_sibling_stop_bit_ctx = depth_i_ctx.narrow(&Step::BTimesSuccessorStopBit);
+        let mut futures = Vec::with_capacity(end);
+
+        for i in 0..end {
+            let c1 = depth_i_ctx.clone();
+            let c2 = b_times_sibling_credit_ctx.clone();
+            let c3 = b_times_sibling_stop_bit_ctx.clone();
+            let record_id = RecordId::from(i);
+            let sibling_helper_bit = &helper_bits[i + step_size - 1];
+            let current_stop_bit = &stop_bits[i];
+            let sibling_stop_bit = &stop_bits[i + step_size];
+            let sibling_credit = &credits[i + step_size];
+            futures.push(async move {
+                let b = c1
+                    .multiply(record_id, current_stop_bit, sibling_helper_bit)
+                    .await?;
+
+                try_join(
+                    c2.multiply(record_id, &b, sibling_credit),
+                    c3.multiply(record_id, &b, sibling_stop_bit),
+                )
+                .await
+            });
+        }
+
+        let results = try_join_all(futures).await?;
+
+        results
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, (credit, stop_bit))| {
+                credits[i] += &credit;
+                stop_bits[i] = stop_bit;
+            });
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Step {
+    BTimesSuccessorCredit,
+    BTimesSuccessorStopBit,
+}
+
+impl crate::protocol::Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::BTimesSuccessorCredit => "b_times_successor_credit",
+            Self::BTimesSuccessorStopBit => "b_times_successor_stop_bit",
+        }
+    }
 }
 
 struct InteractionPatternStep(usize);

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -82,6 +82,7 @@ where
         },
     ))
     .await?;
+    // This is crap and will resize the vector... it was too hard to fix...
     credits.push(last.unwrap());
 
     // Create stop_bit vector.

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, RecordId, Substep};
 use crate::repeat64str;
-use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
+use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
 
 pub(crate) mod accumulate_credit;
 pub mod aggregate_credit;
@@ -34,27 +34,6 @@ where
         + &ctx
             .multiply(record_id, condition, &(true_value.clone() - false_value))
             .await?)
-}
-
-async fn compute_stop_bit<F, C, S>(
-    ctx: C,
-    record_id: RecordId,
-    b_bit: &S,
-    sibling_stop_bit: &S,
-    first_iteration: bool,
-) -> Result<S, Error>
-where
-    F: Field,
-    C: Context<F, Share = S>,
-    S: SecretSharing<F>,
-{
-    // This method computes `b == 1 ? sibling_stop_bit : 0`.
-    // Since `sibling_stop_bit` is initialize with 1, we return `b` if this is
-    // the first iteration.
-    if first_iteration {
-        return Ok(b_bit.clone());
-    }
-    ctx.multiply(record_id, b_bit, sibling_stop_bit).await
 }
 
 struct InteractionPatternStep(usize);

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -57,30 +57,6 @@ where
     ctx.multiply(record_id, b_bit, sibling_stop_bit).await
 }
 
-async fn compute_b_bit<F, C, S>(
-    ctx: C,
-    record_id: RecordId,
-    current_stop_bit: &S,
-    sibling_helper_bit: &S,
-    first_iteration: bool,
-) -> Result<S, Error>
-where
-    F: Field,
-    C: Context<F, Share = S>,
-    S: SecretSharing<F>,
-{
-    // Compute `b = [this.stop_bit * sibling.helper_bit]`.
-    // Since `stop_bit` is initialized with all 1's, we only multiply in
-    // the second and later iterations.
-    let mut b = sibling_helper_bit.clone();
-    if !first_iteration {
-        b = ctx
-            .multiply(record_id, sibling_helper_bit, current_stop_bit)
-            .await?;
-    }
-    Ok(b)
-}
-
 struct InteractionPatternStep(usize);
 
 impl Substep for InteractionPatternStep {}


### PR DESCRIPTION
It bothered me that we were initializing a Vec with length num_records with all clones of ONE. Then we never even used them... just overwrote them.

It also bothered me that the functions to calculate "b" and "stop_bit" made it harder to see what was going on. Just inlining the first iteration allowed me to simplify the loop and make everything simpler.