### PR TITLE
Memoize b

### DIFF
--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -601,11 +601,11 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 3, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE: u64 = 10752;
+        /// empirical value as of Feb 4, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE: u64 = 10740;
 
-        /// empirical value as of Feb 3, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE: u64 = 26419;
+        /// empirical value as of Feb 4, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE: u64 = 26395;
 
         let world = TestWorld::new_with(*TestWorldConfig::default().enable_metrics()).await;
 


### PR DESCRIPTION
This takes us down BELOW the communication overhead of MP-SPDZ for attribution! Just 251 Mb of comms for 1 million rows (vs MP-SPDZ which uses 487). This is a huge drop compared to what we had before: 1354 Mb!!!

It was a really simple fix. We were just multiplying the same two numbers together over and over again every loop. I just memoized them so that we only do that mult once.