### PR TITLE
Remove input_len argument from shuffle_and_reveal_permutation

### DIFF
--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -83,7 +83,6 @@ mod tests {
                 |ctx, (m_sigma_shares, m_rho_shares)| async move {
                     let sigma_and_randoms = shuffle_and_reveal_permutation(
                         ctx.narrow("shuffle_reveal"),
-                        BATCHSIZE,
                         m_sigma_shares,
                     )
                     .await

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -54,11 +54,10 @@ pub(super) async fn shuffle_and_reveal_permutation<
     C: Context<F, Share = S>,
 >(
     ctx: C,
-    input_len: u32,
     input_permutation: Vec<S>,
 ) -> Result<RevealedAndRandomPermutations, Error> {
     let random_permutations_for_shuffle = get_two_of_three_random_permutations(
-        input_len,
+        u32::try_from(input_permutation.len()).expect("Input size fits into u32"),
         ctx.narrow(&GeneratePermutation).prss_rng(),
     );
 
@@ -154,7 +153,6 @@ where
 
     let bit_0_permutation =
         bit_permutation(ctx_0.narrow(&BitPermutationStep), &sort_keys[0]).await?;
-    let input_len = sort_keys[0].len();
 
     let mut composed_less_significant_bits_permutation = bit_0_permutation;
     for bit_num in 1..num_bits {
@@ -162,7 +160,6 @@ where
 
         let revealed_and_random_permutations = shuffle_and_reveal_permutation(
             ctx_bit.narrow(&ShuffleRevealPermutation),
-            input_len.try_into().unwrap(), // safe, we don't sort more than 1B rows
             composed_less_significant_bits_permutation,
         )
         .await?;
@@ -222,14 +219,8 @@ pub async fn generate_permutation_and_reveal_shuffled<F: Field>(
     ctx: SemiHonestContext<'_, F>,
     sort_keys: &[Vec<Vec<Replicated<F>>>],
 ) -> Result<RevealedAndRandomPermutations, Error> {
-    let key_count = sort_keys[0].len();
     let sort_permutation = generate_permutation_opt(ctx.narrow(&SortKeys), sort_keys).await?;
-    shuffle_and_reveal_permutation(
-        ctx.narrow(&ShuffleRevealPermutation),
-        u32::try_from(key_count).unwrap(),
-        sort_permutation,
-    )
-    .await
+    shuffle_and_reveal_permutation(ctx.narrow(&ShuffleRevealPermutation), sort_permutation).await
 }
 
 /// This function takes in a semihonest context and sort keys, generates a sort permutation, shuffles and reveals it and
@@ -440,12 +431,9 @@ mod tests {
 
         let [perm0, perm1, perm2] = generate_shares::<Fp31>(&permutation);
 
-        let h0_future =
-            shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), BATCHSIZE, perm0);
-        let h1_future =
-            shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), BATCHSIZE, perm1);
-        let h2_future =
-            shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), BATCHSIZE, perm2);
+        let h0_future = shuffle_and_reveal_permutation(ctx0.narrow("shuffle_reveal"), perm0);
+        let h1_future = shuffle_and_reveal_permutation(ctx1.narrow("shuffle_reveal"), perm1);
+        let h2_future = shuffle_and_reveal_permutation(ctx2.narrow("shuffle_reveal"), perm2);
 
         let perms_and_randoms = join3(h0_future, h1_future, h2_future).await;
 

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -60,14 +60,11 @@ where
     let lsb_permutation =
         multi_bit_permutation(ctx_0.narrow(&BitPermutationStep), &sort_keys[0]).await?;
 
-    let input_len = u32::try_from(sort_keys[0].len()).unwrap(); // safe, we don't sort more that 1B rows
-
     let mut composed_less_significant_bits_permutation = lsb_permutation;
     for (bit_num, one_slice) in sort_keys.iter().enumerate().skip(1) {
         let ctx_bit = ctx.narrow(&Sort(bit_num));
         let revealed_and_random_permutations = shuffle_and_reveal_permutation(
             ctx_bit.narrow(&ShuffleRevealPermutation),
-            input_len,
             composed_less_significant_bits_permutation,
         )
         .await?;

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -115,13 +115,10 @@ mod tests {
                 .semi_honest(
                     (input, permutation_iter),
                     |ctx, (m_shares, m_perms)| async move {
-                        let perm_and_randoms = shuffle_and_reveal_permutation(
-                            ctx.narrow("shuffle_reveal"),
-                            BATCHSIZE,
-                            m_perms,
-                        )
-                        .await
-                        .unwrap();
+                        let perm_and_randoms =
+                            shuffle_and_reveal_permutation(ctx.narrow("shuffle_reveal"), m_perms)
+                                .await
+                                .unwrap();
                         secureapplyinv(
                             ctx,
                             m_shares,
@@ -168,13 +165,10 @@ mod tests {
                 .semi_honest(
                     (input, permutation_iter),
                     |ctx, (m_shares, m_perms)| async move {
-                        let perm_and_randoms = shuffle_and_reveal_permutation(
-                            ctx.narrow("shuffle_reveal"),
-                            BATCHSIZE,
-                            m_perms,
-                        )
-                        .await
-                        .unwrap();
+                        let perm_and_randoms =
+                            shuffle_and_reveal_permutation(ctx.narrow("shuffle_reveal"), m_perms)
+                                .await
+                                .unwrap();
                         secureapplyinv_multi(
                             ctx,
                             m_shares,


### PR DESCRIPTION
Our code asserts that input_len == input_permutation.len() in apply/applyinv so there is no reason to have this argument as it is implied to be equal to input_permutation.len()