### PR TITLE
eliminate `Arc`s in contexts

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -152,7 +152,7 @@ mod tests {
         let result: [Vec<MCAccumulateCreditOutputRow<Fp32BitPrime, Replicated<Fp32BitPrime>>>; 3] = world
             .semi_honest(
                 input,
-                |ctx, input: Vec<AccumulateCreditInputRow<Fp32BitPrime, BreakdownKey>>| async move {
+                |ctx, input: Vec<AccumulateCreditInputRow<Fp32BitPrime, BreakdownKey>>| Box::pin(async move {
                     let bk_shares = input
                         .iter()
                         .map(|x| x.breakdown_key.clone())
@@ -181,7 +181,7 @@ mod tests {
                     accumulate_credit(ctx, &modulus_converted_shares)
                         .await
                         .unwrap()
-                },
+                }),
             )
             .await;
 
@@ -219,7 +219,7 @@ mod tests {
             let new_shares = world
                 .semi_honest(
                     secret,
-                    |ctx, share: AccumulateCreditInputRow<Fp31, BreakdownKey>| async move {
+                    |ctx, share: AccumulateCreditInputRow<Fp31, BreakdownKey>| Box::pin(async move {
                         let bk_shares = vec![share.breakdown_key];
                         let converted_bk_shares = convert_all_bits(
                             &ctx,
@@ -242,7 +242,7 @@ mod tests {
                             .reshare(ctx.set_total_records(1), RecordId::from(0), role)
                             .await
                             .unwrap()
-                    },
+                    }),
                 )
                 .await;
             assert_eq!(secret, new_shares.reconstruct());

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -333,7 +333,7 @@ mod tests {
         let result = world
             .semi_honest(
                 input,
-                |ctx, input: Vec<CreditCappingInputRow<Fp32BitPrime, BreakdownKey>>| async move {
+                |ctx, input: Vec<CreditCappingInputRow<Fp32BitPrime, BreakdownKey>>| Box::pin(async move {
                     let bk_shares = input
                         .iter()
                         .map(|x| x.breakdown_key.clone())
@@ -364,7 +364,7 @@ mod tests {
                     credit_capping(ctx, &modulus_converted_shares, CAP)
                         .await
                         .unwrap()
-                },
+                }),
             )
             .await;
 

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -55,7 +55,7 @@ impl AsRef<str> for Step {
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
 pub async fn check_zero<F: Field>(
-    ctx: SemiHonestContext<'_, F>,
+    ctx: SemiHonestContext<'_, '_, F>,
     record_id: RecordId,
     v: &Replicated<F>,
 ) -> Result<bool, Error> {
@@ -87,7 +87,7 @@ mod tests {
     #[tokio::test]
     async fn basic() -> Result<(), Error> {
         let world = TestWorld::new().await;
-        let context = world.contexts::<Fp31>().map(|ctx| ctx.set_total_records(1));
+        let contexts = world.contexts::<Fp31>();
         let mut rng = thread_rng();
         let mut counter = 0_u32;
 
@@ -101,9 +101,9 @@ mod tests {
                 counter += 1;
 
                 let protocol_output = try_join3(
-                    check_zero(context[0].narrow(&iteration), record_id, &v_shares[0]),
-                    check_zero(context[1].narrow(&iteration), record_id, &v_shares[1]),
-                    check_zero(context[2].narrow(&iteration), record_id, &v_shares[2]),
+                    check_zero(contexts[0].get_ref().narrow(&iteration).set_total_records(1), record_id, &v_shares[0]),
+                    check_zero(contexts[1].get_ref().narrow(&iteration).set_total_records(1), record_id, &v_shares[1]),
+                    check_zero(contexts[2].get_ref().narrow(&iteration).set_total_records(1), record_id, &v_shares[2]),
                 )
                 .await?;
 

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -58,7 +58,7 @@ impl AsRef<str> for Step {
 /// ## Panics
 /// Panics if the mutex is found to be poisoned
 pub async fn multiply<F>(
-    ctx: MaliciousContext<'_, F>,
+    ctx: MaliciousContext<'_, '_, F>,
     record_id: RecordId,
     a: &MaliciousReplicated<F>,
     b: &MaliciousReplicated<F>,
@@ -114,12 +114,12 @@ mod test {
         let b = rng.gen::<Fp31>();
 
         let res = world
-            .malicious((a, b), |ctx, (a, b)| async move {
+            .malicious((a, b), |ctx, (a, b)| Box::pin(async move {
                 ctx.set_total_records(1)
                     .multiply(RecordId::from(0), &a, &b)
                     .await
                     .unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(a * b, res.reconstruct());

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -49,7 +49,7 @@ use {malicious::multiply as malicious_mul, semi_honest::multiply as semi_honest_
 
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
-impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
+impl<F: Field> SecureMul<F> for SemiHonestContext<'_, '_, F> {
     type Share = Replicated<F>;
 
     async fn multiply_sparse(
@@ -65,7 +65,7 @@ impl<F: Field> SecureMul<F> for SemiHonestContext<'_, F> {
 
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
-impl<F: Field> SecureMul<F> for MaliciousContext<'_, F> {
+impl<F: Field> SecureMul<F> for MaliciousContext<'_, '_, F> {
     type Share = MaliciousReplicated<F>;
 
     async fn multiply_sparse(

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -379,12 +379,12 @@ pub(in crate::protocol) mod test {
                 let v1 = SparseField::new(rng.gen::<Fp31>(), a);
                 let v2 = SparseField::new(rng.gen::<Fp31>(), b);
                 let result = world
-                    .semi_honest((v1, v2), |ctx, (v_a, v_b)| async move {
+                    .semi_honest((v1, v2), |ctx, (v_a, v_b)| Box::pin(async move {
                         ctx.set_total_records(1)
                             .multiply_sparse(RECORD_0, &v_a, &v_b, (a, b))
                             .await
                             .unwrap()
-                    })
+                    }))
                     .await;
                 check_output_zeros(&result, (a, b));
                 assert_eq!(v1.value() * v2.value(), result.reconstruct());
@@ -406,7 +406,7 @@ pub(in crate::protocol) mod test {
                 let v1 = SparseField::new(rng.gen::<Fp31>(), a);
                 let v2 = SparseField::new(rng.gen::<Fp31>(), b);
                 let result = world
-                    .semi_honest((v1, v2), |ctx, (v_a, v_b)| async move {
+                    .semi_honest((v1, v2), |ctx, (v_a, v_b)| Box::pin(async move {
                         let v = MaliciousValidator::new(ctx);
                         let m_ctx = v.context().set_total_records(1);
                         let (m_a, m_b) = try_join(
@@ -422,7 +422,7 @@ pub(in crate::protocol) mod test {
                             .unwrap();
 
                         v.validate(m_ab).await.unwrap()
-                    })
+                    }))
                     .await;
                 check_output_zeros(&result, (a, b));
                 assert_eq!(v1.value() * v2.value(), result.reconstruct());

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -60,7 +60,7 @@ impl AsRef<str> for Step {
 /// ## Panics
 /// Panics if the mutex is found to be poisoned
 pub async fn sum_of_products<F>(
-    ctx: MaliciousContext<'_, F>,
+    ctx: MaliciousContext<'_, '_, F>,
     record_id: RecordId,
     a: &[MaliciousReplicated<F>],
     b: &[MaliciousReplicated<F>],
@@ -151,12 +151,12 @@ mod test {
         }
 
         let res = world
-            .malicious((av, bv), |ctx, (a, b)| async move {
+            .malicious((av, bv), |ctx, (a, b)| Box::pin(async move {
                 ctx.set_total_records(1)
                     .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(expected, res.reconstruct());

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -27,7 +27,7 @@ pub trait SecureSop<F: ArithmeticShare>: Sized {
 
 /// Implement secure multiplication for semi-honest contexts with replicated secret sharing.
 #[async_trait]
-impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
+impl<F: Field> SecureSop<F> for SemiHonestContext<'_, '_, F> {
     type Share = Replicated<F>;
 
     async fn sum_of_products(
@@ -42,7 +42,7 @@ impl<F: Field> SecureSop<F> for SemiHonestContext<'_, F> {
 
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
-impl<F: Field> SecureSop<F> for MaliciousContext<'_, F> {
+impl<F: Field> SecureSop<F> for MaliciousContext<'_, '_, F> {
     type Share = MaliciousReplicated<F>;
 
     async fn sum_of_products(

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -20,7 +20,7 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
 pub async fn sum_of_products<F>(
-    ctx: SemiHonestContext<'_, F>,
+    ctx: SemiHonestContext<'_, '_, F>,
     record_id: RecordId,
     a: &[Replicated<F>],
     b: &[Replicated<F>],
@@ -117,12 +117,12 @@ mod test {
         }
 
         let res = world
-            .semi_honest((av, bv), |ctx, (a, b)| async move {
+            .semi_honest((av, bv), |ctx, (a, b)| Box::pin(async move {
                 ctx.set_total_records(1)
                     .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(expected, res.reconstruct());
@@ -137,12 +137,12 @@ mod test {
         let b: Vec<_> = b.iter().map(|x| Fp31::from(*x)).collect();
 
         let result = world
-            .semi_honest((a, b), |ctx, (a, b)| async move {
+            .semi_honest((a, b), |ctx, (a, b)| Box::pin(async move {
                 ctx.set_total_records(1)
                     .sum_of_products(RecordId::from(0), a.as_slice(), b.as_slice())
                     .await
                     .unwrap()
-            })
+            }))
             .await;
 
         result.reconstruct().as_u128()

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -127,13 +127,13 @@ mod tests {
         Standard: Distribution<F>,
     {
         let result = world
-            .semi_honest(a, |ctx, a_p| async move {
+            .semi_honest(a, |ctx, a_p| Box::pin(async move {
                 let rbg = RandomBitsGenerator::new(ctx.narrow(&GenerateRandomBits));
 
                 BitDecomposition::execute(ctx.set_total_records(1), RecordId::from(0), &rbg, &a_p)
                     .await
                     .unwrap()
-            })
+            }))
             .await;
 
         // bit-decomposed values generate valid number of bits to fit the target field values

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -167,7 +167,7 @@ mod tests {
         let b_fp31 = get_bits::<Fp31>(b, num_bits);
 
         let answer_fp31 = world
-            .semi_honest((a_fp31, b_fp31), |ctx, (a_bits, b_bits)| async move {
+            .semi_honest((a_fp31, b_fp31), |ctx, (a_bits, b_bits)| Box::pin(async move {
                 bitwise_equal(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -176,7 +176,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
@@ -186,7 +186,7 @@ mod tests {
         let answer_fp32_bit_prime = world
             .semi_honest(
                 (a_fp32_bit_prime, b_fp32_bit_prime),
-                |ctx, (a_bits, b_bits)| async move {
+                |ctx, (a_bits, b_bits)| Box::pin(async move {
                     bitwise_equal(
                         ctx.set_total_records(1),
                         RecordId::from(0),
@@ -195,7 +195,7 @@ mod tests {
                     )
                     .await
                     .unwrap()
-                },
+                }),
             )
             .await
             .reconstruct();
@@ -211,22 +211,22 @@ mod tests {
         let a_fp31 = get_bits::<Fp31>(a, num_bits);
 
         let answer_fp31 = world
-            .semi_honest(a_fp31, |ctx, a_bits| async move {
+            .semi_honest(a_fp31, |ctx, a_bits| Box::pin(async move {
                 bitwise_equal_constant(ctx.set_total_records(1), RecordId::from(0), &a_bits, b)
                     .await
                     .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let a_fp32_bit_prime = get_bits::<Fp32BitPrime>(a, num_bits);
 
         let answer_fp32_bit_prime = world
-            .semi_honest(a_fp32_bit_prime, |ctx, a_bits| async move {
+            .semi_honest(a_fp32_bit_prime, |ctx, a_bits| Box::pin(async move {
                 bitwise_equal_constant(ctx.set_total_records(1), RecordId::from(0), &a_bits, b)
                     .await
                     .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/boolean/bitwise_gt_constant.rs
+++ b/src/protocol/boolean/bitwise_gt_constant.rs
@@ -139,7 +139,7 @@ mod tests {
         let input = into_bits(a);
 
         let result = world
-            .semi_honest(input.clone(), |ctx, a_share| async move {
+            .semi_honest(input.clone(), |ctx, a_share| Box::pin(async move {
                 bitwise_greater_than_constant(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -148,12 +148,12 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious(input.clone(), |ctx, a_share| async move {
+            .malicious(input.clone(), |ctx, a_share| Box::pin(async move {
                 bitwise_greater_than_constant(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -162,7 +162,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -291,7 +291,7 @@ mod tests {
         let world = TestWorld::new().await;
         let bits = get_bits::<F>(a, num_bits);
         let result = world
-            .semi_honest(bits.clone(), |ctx, x_share| async move {
+            .semi_honest(bits.clone(), |ctx, x_share| Box::pin(async move {
                 BitwiseLessThanPrime::less_than_prime(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -299,12 +299,12 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious(bits, |ctx, x_share| async move {
+            .malicious(bits, |ctx, x_share| Box::pin(async move {
                 BitwiseLessThanPrime::less_than_prime(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -312,7 +312,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/boolean/dumb_bitwise_add_constant.rs
+++ b/src/protocol/boolean/dumb_bitwise_add_constant.rs
@@ -209,20 +209,20 @@ mod tests {
     {
         let input = into_bits(a);
         let result = world
-            .semi_honest(input.clone(), |ctx, a_share| async move {
+            .semi_honest(input.clone(), |ctx, a_share| Box::pin(async move {
                 bitwise_add_constant(ctx.set_total_records(1), RecordId::from(0), &a_share, b)
                     .await
                     .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious(input, |ctx, a_share| async move {
+            .malicious(input, |ctx, a_share| Box::pin(async move {
                 bitwise_add_constant(ctx.set_total_records(1), RecordId::from(0), &a_share, b)
                     .await
                     .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
@@ -237,7 +237,7 @@ mod tests {
     {
         let input = (into_bits(a), maybe);
         let result = world
-            .semi_honest(input.clone(), |ctx, (a_share, maybe_share)| async move {
+            .semi_honest(input.clone(), |ctx, (a_share, maybe_share)| Box::pin(async move {
                 bitwise_add_constant_maybe(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -247,12 +247,12 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious(input, |ctx, (a_share, maybe_share)| async move {
+            .malicious(input, |ctx, (a_share, maybe_share)| Box::pin(async move {
                 bitwise_add_constant_maybe(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -262,7 +262,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -23,7 +23,7 @@ pub trait RandomBits<V: ArithmeticShare> {
 }
 
 fn random_bits_triples<F, C, S>(
-    ctx: &C,
+    ctx: C,
     record_id: RecordId,
 ) -> Vec<BitConversionTriple<Replicated<F>>>
 where
@@ -71,8 +71,8 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
+    GenerateRandom,
     ConvertShares,
-    UpgradeBitTriples,
 }
 
 impl crate::protocol::Substep for Step {}
@@ -80,8 +80,8 @@ impl crate::protocol::Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
+            Self::GenerateRandom => "generate_random",
             Self::ConvertShares => "convert_shares",
-            Self::UpgradeBitTriples => "upgrade_bit_triples",
         }
     }
 }

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -7,12 +7,12 @@ use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use async_trait::async_trait;
 
 #[async_trait]
-impl<F: Field> RandomBits<F> for SemiHonestContext<'_, F> {
+impl<F: Field> RandomBits<F> for SemiHonestContext<'_, '_, F> {
     type Share = Replicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.
     async fn generate_random_bits(self, record_id: RecordId) -> Result<Vec<Self::Share>, Error> {
-        let triples = random_bits_triples(&self, record_id);
+        let triples = random_bits_triples(self.narrow(&Step::GenerateRandom), record_id);
 
         convert_triples_to_shares(self.narrow(&Step::ConvertShares), record_id, &triples).await
     }

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -33,7 +33,7 @@ mod tests {
         Standard: Distribution<F>,
     {
         let result = world
-            .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
+            .semi_honest((a, b), |ctx, (a_share, b_share)| Box::pin(async move {
                 or(
                     ctx.set_total_records(1),
                     RecordId::from(0_u32),
@@ -42,11 +42,11 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
         let m_result = world
-            .malicious((a, b), |ctx, (a_share, b_share)| async move {
+            .malicious((a, b), |ctx, (a_share, b_share)| Box::pin(async move {
                 or(
                     ctx.set_total_records(1),
                     RecordId::from(0_u32),
@@ -55,7 +55,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -84,9 +84,9 @@ mod tests {
         let world = TestWorld::new().await;
         let [c0, c1, c2] = world.contexts::<Fp31>();
 
-        let rbg0 = RandomBitsGenerator::new(c0);
-        let rbg1 = RandomBitsGenerator::new(c1);
-        let rbg2 = RandomBitsGenerator::new(c2);
+        let rbg0 = RandomBitsGenerator::new(c0.get_ref());
+        let rbg1 = RandomBitsGenerator::new(c1.get_ref());
+        let rbg2 = RandomBitsGenerator::new(c2.get_ref());
 
         let result = join3(rbg0.generate(), rbg1.generate(), rbg2.generate()).await;
         assert_eq!(rbg0.aborts(), rbg1.aborts());
@@ -99,7 +99,7 @@ mod tests {
         let world = TestWorld::new().await;
         let contexts = world.contexts::<Fp31>();
 
-        let validators = contexts.map(MaliciousValidator::new);
+        let validators = contexts.iter().map(|ctx| MaliciousValidator::new(ctx.get_ref())).collect::<Vec<_>>();
         let rbg = validators
             .iter()
             .map(|v| RandomBitsGenerator::new(v.context()))

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -165,14 +165,14 @@ mod tests {
     {
         let world = TestWorld::new().await;
         let [rv0, rv1, rv2] = world
-            .semi_honest((), |ctx, ()| async move {
+            .semi_honest((), |ctx, ()| Box::pin(async move {
                 let mut outputs = Vec::with_capacity(COUNT);
                 let ctx = ctx.set_total_records(COUNT);
                 for i in 0..COUNT {
                     outputs.push(solved_bits(ctx.clone(), RecordId::from(i)).await.unwrap());
                 }
                 outputs
-            })
+            }))
             .await;
 
         let results = zip(rv0.into_iter(), zip(rv1.into_iter(), rv2.into_iter()))
@@ -236,7 +236,7 @@ mod tests {
 
         for _ in 0..4 {
             let results = world
-                .malicious(Fp32BitPrime::ZERO, |ctx, share_of_zero| async move {
+                .malicious(Fp32BitPrime::ZERO, |ctx, share_of_zero| Box::pin(async move {
                     let share_option = solved_bits(ctx.set_total_records(1), RecordId::from(0))
                         .await
                         .unwrap();
@@ -254,7 +254,7 @@ mod tests {
                         }
                         Some(share) => (share.b_p, share.b_b),
                     }
-                })
+                }))
                 .await;
 
             let [result0, result1, result2] = results;

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -59,7 +59,7 @@ mod tests {
         Standard: Distribution<F>,
     {
         let result = world
-            .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
+            .semi_honest((a, b), |ctx, (a_share, b_share)| Box::pin(async move {
                 xor(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -68,12 +68,12 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious((a, b), |ctx, (a_share, b_share)| async move {
+            .malicious((a, b), |ctx, (a_share, b_share)| Box::pin(async move {
                 xor(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -82,7 +82,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
@@ -111,7 +111,7 @@ mod tests {
         let a = SparseField::<F>::new(F::from(u128::from(a)), zeros.0);
         let b = SparseField::<F>::new(F::from(u128::from(b)), zeros.1);
         let result = world
-            .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
+            .semi_honest((a, b), |ctx, (a_share, b_share)| Box::pin(async move {
                 xor_sparse(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -121,12 +121,12 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 
         let m_result = world
-            .malicious((a, b), |ctx, (a_share, b_share)| async move {
+            .malicious((a, b), move |ctx, (a_share, b_share)| Box::pin(async move {
                 xor_sparse(
                     ctx.set_total_records(1),
                     RecordId::from(0),
@@ -136,7 +136,7 @@ mod tests {
                 )
                 .await
                 .unwrap()
-            })
+            }))
             .await
             .reconstruct();
 

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -1,44 +1,134 @@
+//! Context for protocol executions suitable for semi-honest security model, i.e. secure against
+//! honest-but-curious adversary parties.
+
 use crate::ff::Field;
 use crate::helpers::messaging::{Gateway, Mesh, TotalRecords};
 use crate::helpers::Role;
 use crate::protocol::context::{
     Context, InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness,
-    MaliciousContext,
+    MaliciousContext, MaliciousContextBuf,
 };
 use crate::protocol::malicious::MaliciousValidatorAccumulator;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::{Step, Substep};
 use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-use crate::sync::Arc;
 
+use once_cell::sync::OnceCell;
 use std::marker::PhantomData;
 
-/// Context for protocol executions suitable for semi-honest security model, i.e. secure against
-/// honest-but-curious adversary parties.
-#[derive(Clone, Debug)]
-pub struct SemiHonestContext<'a, F: Field> {
-    /// TODO (alex): Arc is required here because of the `TestWorld` structure. Real world
-    /// may operate with raw references and be more efficient
-    pub(super) inner: Arc<ContextInner<'a>>,
+#[derive(Debug)]
+pub struct ContextStore<'a> {
+    pub(super) static_data: ContextStatic<'a>,
+    // Ensure that the struct is invariant over 'a, because that may be required in the future.
+    pub(super) _dummy: PhantomData<OnceCell<&'a ()>>,
+}
+
+impl<'a> ContextStore<'a> {
+    fn new(prss: &'a PrssEndpoint, gateway: &'a Gateway) -> ContextStore<'a> {
+        ContextStore {
+            static_data: ContextStatic::new(prss, gateway),
+            _dummy: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SemiHonestContext<'c, 'a, F: Field> {
+    pub(super) store: &'c ContextStore<'a>,
     pub(super) step: Step,
     pub(super) total_records: TotalRecords,
+    // Ensure that the struct is invariant over 'a, because that may be required in the future.
+    _dummy: PhantomData<OnceCell<&'a ()>>,
     _marker: PhantomData<F>,
 }
 
-impl<'a, F: Field> SemiHonestContext<'a, F> {
-    pub fn new(participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
-        Self::new_with_total_records(participant, gateway, TotalRecords::Unspecified)
+#[derive(Debug)]
+pub struct SemiHonestContextBuf<'a, F: Field> {
+    pub(super) store: ContextStore<'a>,
+    pub(super) step: Step,
+    pub(super) total_records: TotalRecords,
+    // Ensure that the struct is invariant over 'a, because that may be required in the future.
+    _dummy: PhantomData<OnceCell<&'a ()>>,
+    _marker: PhantomData<F>,
+}
+
+impl<'c, 'a, F: Field> Clone for SemiHonestContext<'c, 'a, F> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            step: self.step.clone(),
+            total_records: self.total_records,
+            _dummy: PhantomData,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'c, 'a, F: Field> From<&'c SemiHonestContextBuf<'a, F>> for SemiHonestContext<'c, 'a, F> {
+    fn from(value: &'c SemiHonestContextBuf<'a, F>) -> Self {
+        SemiHonestContext {
+            store: &value.store,
+            step: value.step.clone(),
+            total_records: value.total_records,
+            _dummy: PhantomData,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, F: Field> SemiHonestContextBuf<'a, F> {
+    pub fn get_ref<'c>(&'c self) -> SemiHonestContext<'c, 'a, F>
+    {
+        SemiHonestContext::from(self)
+    }
+}
+
+impl<'a, T: Field> SemiHonestContextBuf<'a, T> {
+    pub fn update_with<F: for<'x> FnOnce(SemiHonestContext<'x, 'a, T>) -> SemiHonestContext<'x, 'a, T>>(self, f: F) -> Self {
+        let ctx = SemiHonestContext {
+            store: &self.store,
+            step: self.step,
+            total_records: self.total_records,
+            _dummy: PhantomData,
+            _marker: PhantomData,
+        };
+        let SemiHonestContext {
+            step,
+            total_records,
+            ..
+        } = f(ctx);
+        SemiHonestContextBuf {
+            store: self.store,
+            step,
+            total_records,
+            _dummy: PhantomData,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'c, 'a: 'c, F: Field> SemiHonestContext<'c, 'a, F> {
+    pub fn new(participant: &'a PrssEndpoint, gateway: &'a Gateway) -> SemiHonestContextBuf<'a, F> {
+        SemiHonestContextBuf {
+            store: ContextStore::new(participant, gateway),
+            step: Step::default(),
+            total_records: TotalRecords::Unspecified,
+            _dummy: PhantomData,
+            _marker: PhantomData,
+        }
     }
 
-    pub fn new_with_total_records(
-        participant: &'a PrssEndpoint,
-        gateway: &'a Gateway,
+    // Used by `impl SpecialAccessToMaliciousContext for MaliciousContext`.
+    pub(super) fn new_internal(
+        store: &'c ContextStore<'a>,
+        step: Step,
         total_records: TotalRecords,
-    ) -> Self {
-        Self {
-            inner: ContextInner::new(participant, gateway),
-            step: Step::default(),
+    ) -> SemiHonestContext<'c, 'a, F> {
+        SemiHonestContext {
+            store,
+            step,
             total_records,
+            _dummy: PhantomData,
             _marker: PhantomData,
         }
     }
@@ -55,17 +145,20 @@ impl<'a, F: Field> SemiHonestContext<'a, F> {
         upgrade_step: &S,
         accumulator: MaliciousValidatorAccumulator<F>,
         r_share: Replicated<F>,
-    ) -> MaliciousContext<'a, F> {
+    ) -> MaliciousContextBuf<'c, 'a, F> {
+        // Note: in SpecialAccessToMaliciousContext, we rely on the fact that
+        // upgrade_ctx uses the same store. That will need to be updated if
+        // something changes.
         let upgrade_ctx = self.narrow(upgrade_step);
         MaliciousContext::new(&self, malicious_step, upgrade_ctx, accumulator, r_share)
     }
 }
 
-impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
+impl<'c, 'a, F: Field> Context<F> for SemiHonestContext<'c, 'a, F> {
     type Share = Replicated<F>;
 
     fn role(&self) -> Role {
-        self.inner.gateway.role()
+        self.store.static_data.gateway.role()
     }
 
     fn step(&self) -> &Step {
@@ -74,10 +167,11 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
 
     fn narrow<S: Substep + ?Sized>(&self, step: &S) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
+            store: self.store.clone(),
             step: self.step.narrow(step),
             total_records: self.total_records,
             _marker: PhantomData,
+            _dummy: PhantomData,
         }
     }
 
@@ -91,15 +185,16 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
             "attempt to set total_records more than once"
         );
         Self {
-            inner: Arc::clone(&self.inner),
+            store: self.store.clone(),
             step: self.step.clone(),
             total_records: total_records.into(),
             _marker: PhantomData,
+            _dummy: PhantomData,
         }
     }
 
     fn prss(&self) -> InstrumentedIndexedSharedRandomness {
-        let prss = self.inner.prss.indexed(self.step());
+        let prss = self.store.static_data.prss.indexed(self.step());
 
         InstrumentedIndexedSharedRandomness::new(prss, &self.step, self.role())
     }
@@ -110,7 +205,7 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
         InstrumentedSequentialSharedRandomness<'_>,
         InstrumentedSequentialSharedRandomness<'_>,
     ) {
-        let (left, right) = self.inner.prss.sequential(self.step());
+        let (left, right) = self.store.static_data.prss.sequential(self.step());
         (
             InstrumentedSequentialSharedRandomness::new(left, self.step(), self.role()),
             InstrumentedSequentialSharedRandomness::new(right, self.step(), self.role()),
@@ -118,7 +213,7 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
     }
 
     fn mesh(&self) -> Mesh<'_, '_> {
-        self.inner.gateway.mesh(self.step(), self.total_records)
+        self.store.static_data.gateway.mesh(self.step(), self.total_records)
     }
 
     fn share_known_value(&self, scalar: F) -> <Self as Context<F>>::Share {
@@ -127,13 +222,16 @@ impl<'a, F: Field> Context<F> for SemiHonestContext<'a, F> {
 }
 
 #[derive(Debug)]
-pub(super) struct ContextInner<'a> {
+pub(super) struct ContextStatic<'a> {
     pub prss: &'a PrssEndpoint,
     pub gateway: &'a Gateway,
 }
 
-impl<'a> ContextInner<'a> {
-    fn new(prss: &'a PrssEndpoint, gateway: &'a Gateway) -> Arc<Self> {
-        Arc::new(Self { prss, gateway })
+impl<'a> ContextStatic<'a> {
+    fn new(prss: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
+        Self {
+            prss,
+            gateway,
+        }
     }
 }

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -223,12 +223,12 @@ mod tests {
         let world = TestWorld::new().await;
         let match_key = rng.gen::<MatchKey>();
         let result: [Replicated<Fp31>; 3] = world
-            .semi_honest(match_key, |ctx, mk_share| async move {
+            .semi_honest(match_key, |ctx, mk_share| Box::pin(async move {
                 let triple = convert_bit_local::<Fp31, MatchKey>(ctx.role(), BITNUM, &mk_share);
                 convert_bit(ctx.set_total_records(1usize), RecordId::from(0), &triple)
                     .await
                     .unwrap()
-            })
+            }))
             .await;
         assert_eq!(Fp31::from(match_key[BITNUM]), result.reconstruct());
     }
@@ -241,7 +241,7 @@ mod tests {
         let world = TestWorld::new().await;
         let match_key = rng.gen::<MatchKey>();
         let result: [Replicated<Fp31>; 3] = world
-            .semi_honest(match_key, |ctx, mk_share| async move {
+            .semi_honest(match_key, |ctx, mk_share| Box::pin(async move {
                 let triple = convert_bit_local::<Fp31, MatchKey>(ctx.role(), BITNUM, &mk_share);
 
                 let v = MaliciousValidator::new(ctx);
@@ -251,7 +251,7 @@ mod tests {
                     .await
                     .unwrap();
                 v.validate(m_bit).await.unwrap()
-            })
+            }))
             .await;
         assert_eq!(Fp31::from(match_key[BITNUM]), result.reconstruct());
     }
@@ -299,7 +299,7 @@ mod tests {
         for tweak in TWEAKS {
             let match_key = rng.gen::<MatchKey>();
             world
-                .semi_honest(match_key, |ctx, mk_share| async move {
+                .semi_honest(match_key, |ctx, mk_share| Box::pin(async move {
                     let triple =
                         convert_bit_local::<Fp32BitPrime, MatchKey>(ctx.role(), BITNUM, &mk_share);
                     let tweaked = tweak.flip_bit(ctx.role(), triple);
@@ -315,7 +315,7 @@ mod tests {
                         .await
                         .expect_err("This should fail validation");
                     assert!(matches!(err, Error::MaliciousSecurityCheckFailed));
-                })
+                }))
                 .await;
         }
     }

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -101,7 +101,7 @@ mod tests {
                  (mk_shares, secret): (
                     Vec<XorShare<MatchKey>>,
                     Vec<AccumulateCreditInputRow<Fp32BitPrime, BreakdownKey>>,
-                )| async move {
+                )| Box::pin(async move {
                     let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
                     let converted_shares = convert_all_bits(
                         &ctx.narrow("convert_all_bits"),
@@ -149,7 +149,7 @@ mod tests {
                     apply_sort_permutation(ctx, converted_secret, &sort_permutation)
                         .await
                         .unwrap()
-                },
+                }),
             )
             .await
             .reconstruct();

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -221,7 +221,7 @@ mod tests {
             let result: Vec<GenericReportTestInput<Fp31, MatchKey, BreakdownKey>> = world
                 .semi_honest(
                     input.clone(),
-                    |ctx, shares: Vec<AccumulateCreditInputRow<Fp31, BreakdownKey>>| async move {
+                    |ctx, shares: Vec<AccumulateCreditInputRow<Fp31, BreakdownKey>>| Box::pin(async move {
                         let perms =
                             get_two_of_three_random_permutations(BATCHSIZE.into(), ctx.prss_rng());
 
@@ -260,7 +260,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    }),
                 )
                 .await
                 .reconstruct();
@@ -311,7 +311,7 @@ mod tests {
             let result = world
                 .semi_honest(
                     some_numbers_as_bits,
-                    |ctx, vec_of_vec_of_shares| async move {
+                    |ctx, vec_of_vec_of_shares| Box::pin(async move {
                         let copy_of_input = vec_of_vec_of_shares.clone();
 
                         let perms = get_two_of_three_random_permutations(5, ctx.prss_rng());
@@ -328,7 +328,7 @@ mod tests {
                             .any(|x| share_appears_anywhere(x, &copy_of_input))));
 
                         shuffled_shares
-                    },
+                    }),
                 )
                 .await
                 .reconstruct();

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -93,9 +93,9 @@ mod tests {
 
         let input: Vec<_> = INPUT.iter().map(|x| Fp31::from(*x)).collect();
         let result = world
-            .semi_honest(input, |ctx, m_shares| async move {
+            .semi_honest(input, |ctx, m_shares| Box::pin(async move {
                 bit_permutation(ctx, &m_shares).await.unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(&result.reconstruct(), EXPECTED);
@@ -107,9 +107,9 @@ mod tests {
 
         let input: Vec<_> = INPUT.iter().map(|x| Fp31::from(*x)).collect();
         let result = world
-            .malicious(input, |ctx, m_shares| async move {
+            .malicious(input, |ctx, m_shares| Box::pin(async move {
                 bit_permutation(ctx, &m_shares).await.unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(&result.reconstruct(), EXPECTED);

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -80,7 +80,7 @@ mod tests {
                     sigma.into_iter().map(u128::from).map(Fp31::from),
                     rho.into_iter().map(Fp31::from),
                 ),
-                |ctx, (m_sigma_shares, m_rho_shares)| async move {
+                |ctx, (m_sigma_shares, m_rho_shares)| Box::pin(async move {
                     let sigma_and_randoms = shuffle_and_reveal_permutation(
                         ctx.narrow("shuffle_reveal"),
                         m_sigma_shares,
@@ -99,7 +99,7 @@ mod tests {
                     )
                     .await
                     .unwrap()
-                },
+                }),
             )
             .await;
 

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -255,9 +255,9 @@ mod tests {
             .map(|v| v.iter().map(|x| Fp31::from(*x)).collect())
             .collect();
         let result = world
-            .semi_honest(input, |ctx, m_shares| async move {
+            .semi_honest(input, |ctx, m_shares| Box::pin(async move {
                 multi_bit_permutation(ctx, &m_shares).await.unwrap()
-            })
+            }))
             .await;
 
         assert_eq!(&result.reconstruct(), EXPECTED);
@@ -275,14 +275,14 @@ mod tests {
         let num_records = INPUT.len();
 
         let result = world
-            .semi_honest(input, |ctx, m_shares| async move {
+            .semi_honest(input, |ctx, m_shares| Box::pin(async move {
                 let mut equality_check_futures = Vec::with_capacity(num_records);
                 for (i, record) in m_shares.iter().enumerate() {
                     let ctx = ctx.set_total_records(num_records);
                     equality_check_futures.push(check_everything(ctx, i, record));
                 }
                 try_join_all(equality_check_futures).await.unwrap()
-            })
+            }))
             .await;
         let reconstructs: Vec<Vec<Fp31>> = result.reconstruct();
         for (rec, row) in reconstructs.iter().enumerate() {

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -114,7 +114,7 @@ mod tests {
             let result = world
                 .semi_honest(
                     (input, permutation_iter),
-                    |ctx, (m_shares, m_perms)| async move {
+                    |ctx, (m_shares, m_perms)| Box::pin(async move {
                         let perm_and_randoms =
                             shuffle_and_reveal_permutation(ctx.narrow("shuffle_reveal"), m_perms)
                                 .await
@@ -130,7 +130,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    })
                 )
                 .await;
 
@@ -164,7 +164,7 @@ mod tests {
             let result = world
                 .semi_honest(
                     (input, permutation_iter),
-                    |ctx, (m_shares, m_perms)| async move {
+                    |ctx, (m_shares, m_perms)| Box::pin(async move {
                         let perm_and_randoms =
                             shuffle_and_reveal_permutation(ctx.narrow("shuffle_reveal"), m_perms)
                                 .await
@@ -180,7 +180,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    })
                 )
                 .await;
 

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -233,7 +233,7 @@ mod tests {
             let result = world
                 .semi_honest(
                     input.clone().into_iter().map(u128::from).map(Fp31::from),
-                    |ctx, m_shares| async move {
+                    |ctx, m_shares| Box::pin(async move {
                         let perms =
                             get_two_of_three_random_permutations(BATCHSIZE.into(), ctx.prss_rng());
                         shuffle_shares(
@@ -243,7 +243,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    }),
                 )
                 .await;
 
@@ -271,7 +271,7 @@ mod tests {
             let result = world
                 .semi_honest(
                     input.clone().into_iter().map(Fp31::from),
-                    |ctx, m_shares| async move {
+                    |ctx, m_shares| Box::pin(async move {
                         let perms = get_two_of_three_random_permutations(
                             BATCHSIZE.try_into().unwrap(),
                             ctx.prss_rng(),
@@ -291,7 +291,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    }),
                 )
                 .await;
 
@@ -321,7 +321,7 @@ mod tests {
             let result = world
                 .malicious(
                     input_u128.clone().into_iter().map(Fp31::from),
-                    |ctx, m_shares| async move {
+                    |ctx, m_shares| Box::pin(async move {
                         let perms =
                             get_two_of_three_random_permutations(BATCHSIZE.into(), ctx.prss_rng());
                         shuffle_shares(
@@ -331,7 +331,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    }),
                 )
                 .await;
 
@@ -359,7 +359,7 @@ mod tests {
             let result = world
                 .malicious(
                     input.clone().into_iter().map(Fp31::from),
-                    |ctx, m_shares| async move {
+                    |ctx, m_shares| Box::pin(async move {
                         let perms = get_two_of_three_random_permutations(
                             BATCHSIZE.try_into().unwrap(),
                             ctx.prss_rng(),
@@ -379,7 +379,7 @@ mod tests {
                         )
                         .await
                         .unwrap()
-                    },
+                    }),
                 )
                 .await;
 

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -242,7 +242,7 @@ where
 }
 
 #[async_trait]
-impl<'a, F: Field> Downgrade for ShuffledPermutationWrapper<'a, F> {
+impl<'a, F: Field> Downgrade for ShuffledPermutationWrapper<'_, 'a, F> {
     type Target = Vec<u32>;
     /// For ShuffledPermutationWrapper on downgrading, we return revealed permutation. This runs reveal on the malicious context
     async fn downgrade(self) -> UnauthorizedDowngradeWrapper<Self::Target> {

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -4,6 +4,7 @@ use crate::protocol::basics::SecureMul;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
 use crate::rand::thread_rng;
+use crate::secret_sharing::replicated::malicious::AdditiveShare;
 use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
 use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
 use futures_util::future::join_all;
@@ -36,7 +37,7 @@ async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicat
 
     for bit in 0..depth {
         let b = Fp31::ONE.share_with(&mut thread_rng());
-        let bit_ctx = narrow_contexts(&top_ctx, &format!("b{bit}"));
+        let bit_ctx = narrow_contexts::<Fp31, AdditiveShare<Fp31>>(&top_ctx, &format!("b{bit}"));
         a = async move {
             let mut coll = Vec::new();
             for (i, ctx) in bit_ctx.iter().enumerate() {

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -9,7 +9,7 @@ pub mod net;
 pub mod transport;
 
 use crate::ff::{Field, Fp31};
-use crate::protocol::context::Context;
+use crate::protocol::context::{Context, SemiHonestContext, SemiHonestContextBuf};
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::Substep;
 use crate::rand::thread_rng;
@@ -31,14 +31,14 @@ pub use world::{Runner, TestWorld, TestWorldConfig};
 /// # Panics
 /// Never, but then Rust doesn't know that; this is only needed because we don't have `each_ref()`.
 #[must_use]
-pub fn narrow_contexts<C: Debug + Context<F, Share = S>, F: Field, S: SecretSharing<F>>(
-    contexts: &[C; 3],
+pub fn narrow_contexts<'c, 'a, F: Field, S: SecretSharing<F>>(
+    contexts: &'a [SemiHonestContextBuf<'a, F>; 3],
     step: &impl Substep,
-) -> [C; 3] {
+) -> [SemiHonestContext<'c, 'a, F>; 3] {
     // This really wants <[_; N]>::each_ref()
     contexts
         .iter()
-        .map(|c| c.narrow(step))
+        .map(|c| c.get_ref().narrow(step))
         .collect::<Vec<_>>()
         .try_into()
         .unwrap()


### PR DESCRIPTION
This eliminates the `Arc`s in contexts, which has been raised as a performance concern (#380). However the larger reason I started down this road is to make it possible to use contexts to hold additional state, in particular, channel endpoints.

Unfortunately doing that resulted in a bunch of rote changes and additional lifetime parameters. I don't know if it makes sense to take this in the current form, but sharing it for discussion. I have an idea of how this could be split into two changes if that were preferable.

The major changes here are:
* Add an additional lifetime parameter to various Contexts. The additional lifetime parameter is necessary so that the contexts can be invariant over the `'a` lifetime parameter (which may appear in the stored data), while still allowing references to contexts with lifetimes shorter than `'a`.
* Add `Buf`-suffixed variants of the contexts that own their state (think `Path` vs. `PathBuf`). There is a function `get_ref` that obtains a `Context` (reference) for a `ContextBuf`.
* In order to create contexts within the `semi_honest` and `malicious` test helpers in `TestWorld`, the test closures had to be changed to return `Pin<Box<dyn Future>>`. The pair of bounds `H: Fn(SemiHonestContext<'a, F>, A) -> R + Send + Sync` and `R: Future<Output = O> + Send` (which refer to a lifetime parameter `'a` that has to outlive the test helper) change to `H: for<'c> Fn(MaliciousContext<'c, '_, F>, M) -> Pin<Box<dyn Future<Output = P> + 'c + Send>> + Send + Sync` which allows a shorter lifetime `'c`. What would be nice here is a way to declare `for<'c>` over the scope of both the `H` and `R` bounds describing the opaque future type.