### PR TITLE
Make oneshot IPA compile again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,3 +95,6 @@ jobs:
 
       - name: Run concurrency tests
         run: cargo test --features shuttle
+
+      - name: Run IPA bench
+        run: cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ async-trait = "0.1.57"
 axum = { version = "0.5.16", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.2", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 bitvec = "1.0.1"
+# TODO: the only place where we use bytes is in ByteArrStream. ordering_mpsc is a replacement for it
+# so we can remove this dependency after migrating to it. It is added only to avoid having `web-app` feature enabled
+# by default.
+bytes = "1.4.0"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
 comfy-table = { version = "6.0.0", optional = true }
 config = "0.13.2"
@@ -90,7 +94,7 @@ bench = false
 
 [[bin]]
 name = "test_mpc"
-required-features = ["cli"]
+required-features = ["cli", "web-app"]
 bench = false
 
 [[bench]]

--- a/pre-commit
+++ b/pre-commit
@@ -53,3 +53,5 @@ cargo clippy --tests --features shuttle -- -D warnings || error "Clippy concurre
 cargo test || error "Test failures"
 
 cargo test --features shuttle || error "Concurrency test failures"
+
+cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches" || error "Failed to run IPA benchmark"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,12 +1,15 @@
 mod metric_collector;
+#[cfg(feature = "web-app")]
 pub mod playbook;
 mod verbosity;
 
+#[cfg(feature = "web-app")]
 use crate::{net::discovery::Conf, test_fixture::net::localhost_config};
 pub use metric_collector::{install_collector, CollectorHandle};
 pub use verbosity::Verbosity;
 
 #[must_use]
+#[cfg(feature = "web-app")]
 pub fn helpers_config() -> Conf {
     localhost_config([3001, 3002, 3003])
 }

--- a/src/cli/playbook/ipa.rs
+++ b/src/cli/playbook/ipa.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "web-app")]
+
 use crate::{
     bits::{BitArray, Serializable},
     cli::playbook::InputSource,

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "web-app")]
+
 use crate::{
     bits::Serializable,
     cli::playbook::InputSource,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -59,6 +59,7 @@ impl TryFrom<usize> for HelperIdentity {
     }
 }
 
+#[cfg(feature = "web-app")]
 impl From<HelperIdentity> for hyper::header::HeaderValue {
     fn from(id: HelperIdentity) -> Self {
         // does not implement `From<u8>`

--- a/src/helpers/transport/bytearrstream/aligned.rs
+++ b/src/helpers/transport/bytearrstream/aligned.rs
@@ -1,7 +1,7 @@
 use crate::{error::BoxError, helpers::transport::bytearrstream::Item};
+use bytes::Bytes;
 use futures::{ready, Stream};
 use futures_util::stream::BoxStream;
-use bytes::Bytes;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;

--- a/src/helpers/transport/bytearrstream/aligned.rs
+++ b/src/helpers/transport/bytearrstream/aligned.rs
@@ -1,7 +1,7 @@
 use crate::{error::BoxError, helpers::transport::bytearrstream::Item};
 use futures::{ready, Stream};
 use futures_util::stream::BoxStream;
-use hyper::body::Bytes;
+use bytes::Bytes;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;

--- a/src/helpers/transport/bytearrstream/mod.rs
+++ b/src/helpers/transport/bytearrstream/mod.rs
@@ -3,15 +3,17 @@ mod aligned;
 pub use aligned::ByteArrStream as AlignedByteArrStream;
 
 use crate::error::BoxError;
-use axum::extract::BodyStream;
 use futures::Stream;
 use futures_util::{
     stream::{self, BoxStream},
-    TryStreamExt,
 };
-use hyper::body::Bytes;
+use bytes::Bytes;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+#[cfg(feature = "web-app")]
+use futures_util::TryStreamExt;
+
 
 /// represents the item of an underlying stream
 type Item = Result<Bytes, BoxError>;
@@ -33,8 +35,9 @@ impl ByteArrStream {
     }
 }
 
-impl From<BodyStream> for ByteArrStream {
-    fn from(stream: BodyStream) -> Self {
+#[cfg(feature = "web-app")]
+impl From<axum::extract::BodyStream> for ByteArrStream {
+    fn from(stream: axum::extract::BodyStream) -> Self {
         ByteArrStream::new(Box::pin(stream.map_err(<BoxError>::from)) as BoxStream<'static, Item>)
     }
 }

--- a/src/helpers/transport/bytearrstream/mod.rs
+++ b/src/helpers/transport/bytearrstream/mod.rs
@@ -3,17 +3,14 @@ mod aligned;
 pub use aligned::ByteArrStream as AlignedByteArrStream;
 
 use crate::error::BoxError;
-use futures::Stream;
-use futures_util::{
-    stream::{self, BoxStream},
-};
 use bytes::Bytes;
+use futures::Stream;
+use futures_util::stream::{self, BoxStream};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[cfg(feature = "web-app")]
 use futures_util::TryStreamExt;
-
 
 /// represents the item of an underlying stream
 type Item = Result<Bytes, BoxError>;

--- a/src/test_fixture/net.rs
+++ b/src/test_fixture/net.rs
@@ -1,9 +1,10 @@
+#![cfg(feature = "web-app")]
+
 use crate::net::discovery::Conf;
 use std::fmt::Debug;
 
 /// Creates a new config for helpers configured to run on local machine using unique port.
 #[allow(clippy::missing_panics_doc)]
-#[cfg(feature = "web-app")]
 pub fn localhost_config<P: TryInto<u16>>(ports: [P; 3]) -> Conf
 where
     P::Error: Debug,


### PR DESCRIPTION
After merging https://github.com/private-attribution/ipa/pull/464, oneshot IPA benchmark stopped compiling w/o
default features enabled. This commit fixes it by gating web-app
features behind `web-app` feature flag.

One place where it was particularly problematic was `ByteArrStream`
with a strong dependency on Hyper. I had to replace it with `Bytes`.