### PR TITLE
Save MERGE_* in pre-commit execution

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -26,24 +26,24 @@ if [[ "$1" == "install" ]]; then
 fi
 
 save_merge_files() {
-    # MERGE_[HEAD|MODE|MSG]
+    # Move MERGE_[HEAD|MODE|MSG] files to the root directory, and let `git stash push` saves them.
     for f in "$root"/.git/MERGE_*; do
 	if [[ -e "$f" ]]; then
             t=$(basename $f)
-            cp -f "$f" "$t"
+            mv -f "$f" "$t"
 	fi
     done
 }
 
 restore_merge_files() {
+    # Moves MERGE files restored by `git stash pop` back into .git/ directory.
     for f in MERGE_*; do
 	if [[ -e "$f" ]]; then
-            t=$(basename $f)
-	    if [[ -e "${root}/.git/${t}" ]]; then
-		echo "Failed to restore ${t}. File already exists"
-		exit 1
+	    if [[ -e "${root}/.git/${f}" ]]; then
+		echo "Failed to restore ${f}. File already exists" 1>&2
+	    else
+		mv -f "$f" "${root}/.git/${f}"
 	    fi
-            mv -f "$f" "${root}/.git/${t}"
 	fi
     done
 }

--- a/pre-commit
+++ b/pre-commit
@@ -25,9 +25,33 @@ if [[ "$1" == "install" ]]; then
     exit
 fi
 
+save_merge_files() {
+    # MERGE_[HEAD|MODE|MSG]
+    for f in "$root"/.git/MERGE_*; do
+	if [[ -e "$f" ]]; then
+            t=$(basename $f)
+            cp -f "$f" "$t"
+	fi
+    done
+}
+
+restore_merge_files() {
+    for f in MERGE_*; do
+	if [[ -e "$f" ]]; then
+            t=$(basename $f)
+	    if [[ -e "${root}/.git/${t}" ]]; then
+		echo "Failed to restore ${t}. File already exists"
+		exit 1
+	    fi
+            mv -f "$f" "${root}/.git/${t}"
+	fi
+    done
+}
+
 # Check formatting.
 stashfile=$(mktemp .pre-commit.stashXXXXXX)
-trap 'set +e;git stash pop -q; rm -f "$stashfile"' EXIT
+trap 'set +e;git stash pop -q; rm -f "$stashfile"; restore_merge_files' EXIT
+save_merge_files
 git stash push -k -u -q -m "pre-commit stash"
 if ! errors=($(cargo fmt -- --check -l)); then
     echo "Formatting errors found."

--- a/pre-commit
+++ b/pre-commit
@@ -26,7 +26,7 @@ if [[ "$1" == "install" ]]; then
 fi
 
 save_merge_files() {
-    # Move MERGE_[HEAD|MODE|MSG] files to the root directory, and let `git stash push` saves them.
+    # Move MERGE_[HEAD|MODE|MSG] files to the root directory, and let `git stash push` save them.
     for f in "$root"/.git/MERGE_*; do
 	if [[ -e "$f" ]]; then
             t=$(basename $f)


### PR DESCRIPTION
When `git commit` is executed to finalize a merge process, MERGE_* files in .git/ are silently removed by `git stash push` in `pre-commit` script. This results in merge's `git commit` to fail, and one needs to restart the merging process from the beginning.