### PR TITLE
Add constructor to CappedCreditsWIthAggregationBit struct

### DIFF
--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -30,7 +30,6 @@ use crate::{
         Arithmetic,
     },
 };
-use std::marker::PhantomData;
 
 /// Aggregation step for Oblivious Attribution protocol.
 /// # Panics
@@ -89,12 +88,13 @@ where
     let aggregated_credits = sorted_input
         .iter()
         .enumerate()
-        .map(|(i, x)| MCCappedCreditsWithAggregationBit {
-            helper_bit: x.helper_bit.clone(),
-            aggregation_bit: x.aggregation_bit.clone(),
-            breakdown_key: x.breakdown_key.clone(),
-            credit: credits[i].clone(),
-            _marker: PhantomData,
+        .map(|(i, x)| {
+            MCCappedCreditsWithAggregationBit::new(
+                x.helper_bit.clone(),
+                x.aggregation_bit.clone(),
+                x.breakdown_key.clone(),
+                credits[i].clone(),
+            )
         })
         .collect::<Vec<_>>();
 
@@ -180,12 +180,13 @@ where
     let aggregated_credits = sorted_input
         .iter()
         .enumerate()
-        .map(|(i, x)| MCCappedCreditsWithAggregationBit {
-            helper_bit: x.helper_bit.clone(),
-            aggregation_bit: x.aggregation_bit.clone(),
-            breakdown_key: x.breakdown_key.clone(),
-            credit: credits[i].clone(),
-            _marker: PhantomData,
+        .map(|(i, x)| {
+            MCCappedCreditsWithAggregationBit::new(
+                x.helper_bit.clone(),
+                x.aggregation_bit.clone(),
+                x.breakdown_key.clone(),
+                credits[i].clone(),
+            )
         })
         .collect::<Vec<_>>();
 
@@ -241,13 +242,12 @@ where
                 })
                 .collect::<Vec<_>>();
 
-            MCCappedCreditsWithAggregationBit {
-                breakdown_key: converted_bk,
-                helper_bit: zero.clone(),
-                aggregation_bit: zero.clone(),
-                credit: zero.clone(),
-                _marker: PhantomData,
-            }
+            MCCappedCreditsWithAggregationBit::new(
+                zero.clone(),
+                zero.clone(),
+                converted_bk,
+                zero.clone(),
+            )
         })
         .collect::<Vec<_>>();
 
@@ -255,12 +255,13 @@ where
     unique_breakdown_keys.append(
         &mut capped_credits
             .iter()
-            .map(|x| MCCappedCreditsWithAggregationBit {
-                breakdown_key: x.breakdown_key.clone(),
-                credit: x.credit.clone(),
-                helper_bit: one.clone(),
-                aggregation_bit: one.clone(),
-                _marker: PhantomData,
+            .map(|x| {
+                MCCappedCreditsWithAggregationBit::new(
+                    one.clone(),
+                    one.clone(),
+                    x.breakdown_key.clone(),
+                    x.credit.clone(),
+                )
             })
             .collect::<Vec<_>>(),
     );

--- a/src/protocol/attribution/input.rs
+++ b/src/protocol/attribution/input.rs
@@ -76,18 +76,15 @@ impl<F: Field> DowngradeMalicious for MCCappedCreditsWithAggregationBit<F, Malic
     /// For ShuffledPermutationWrapper on downgrading, we return revealed permutation. This runs reveal on the malicious context
     async fn downgrade(self) -> UnauthorizedDowngradeWrapper<Self::Target> {
         // Note that this clones the values rather than moving them.
-        // This code is only used in test code, so that's probably OK.
-        UnauthorizedDowngradeWrapper::new(Self::Target {
-            helper_bit: self.helper_bit.x().access_without_downgrade().clone(),
-            aggregation_bit: self.aggregation_bit.x().access_without_downgrade().clone(),
-            breakdown_key: self
-                .breakdown_key
+        UnauthorizedDowngradeWrapper::new(Self::Target::new(
+            self.helper_bit.x().access_without_downgrade().clone(),
+            self.aggregation_bit.x().access_without_downgrade().clone(),
+            self.breakdown_key
                 .into_iter()
                 .map(|bk| bk.x().access_without_downgrade().clone())
                 .collect::<Vec<_>>(),
-            credit: self.credit.x().access_without_downgrade().clone(),
-            _marker: PhantomData,
-        })
+            self.credit.x().access_without_downgrade().clone(),
+        ))
     }
 }
 //
@@ -103,12 +100,24 @@ pub struct AggregateCreditInputRow<F: Field, BK: BitArray> {
 pub type MCAggregateCreditInputRow<F, T> = MCCreditCappingOutputRow<F, T>;
 
 #[derive(Debug)]
-pub struct MCCappedCreditsWithAggregationBit<F: Field, T: Arithmetic<F>> {
+pub struct MCCappedCreditsWithAggregationBit<F, T> {
     pub helper_bit: T,
     pub aggregation_bit: T,
     pub breakdown_key: Vec<T>,
     pub credit: T,
-    pub _marker: PhantomData<F>,
+    marker: PhantomData<F>,
+}
+
+impl<F: Field, T: Arithmetic<F>> MCCappedCreditsWithAggregationBit<F, T> {
+    pub fn new(helper_bit: T, aggregation_bit: T, breakdown_key: Vec<T>, credit: T) -> Self {
+        Self {
+            helper_bit,
+            aggregation_bit,
+            breakdown_key,
+            credit,
+            marker: PhantomData,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -251,17 +260,20 @@ impl<F: Field + Sized, T: Arithmetic<F>> Resharable<F> for MCCappedCreditsWithAg
 
         let (breakdown_key, mut fields) = try_join(
             f_breakdown_key,
-            try_join_all([f_aggregation_bit, f_helper_bit, f_value]),
+            try_join_all([f_helper_bit, f_aggregation_bit, f_value]),
         )
         .await?;
 
-        Ok(MCCappedCreditsWithAggregationBit {
+        let value = fields.pop().unwrap();
+        let aggregation_bit = fields.pop().unwrap();
+        let helper_bit = fields.pop().unwrap();
+
+        Ok(MCCappedCreditsWithAggregationBit::new(
+            helper_bit,
+            aggregation_bit,
             breakdown_key,
-            helper_bit: fields.remove(0),
-            aggregation_bit: fields.remove(0),
-            credit: fields.remove(0),
-            _marker: PhantomData,
-        })
+            value,
+        ))
     }
 }
 

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -375,13 +375,12 @@ impl<'a, F: Field>
                 ZeroPositions::Pvvv,
             )
             .await?;
-        Ok(MCCappedCreditsWithAggregationBit {
+        Ok(MCCappedCreditsWithAggregationBit::new(
             helper_bit,
             aggregation_bit,
             breakdown_key,
             credit,
-            _marker: PhantomData,
-        })
+        ))
     }
 }
 


### PR DESCRIPTION
to avoid exposing `PhantomData` marker