### PR TITLE
Move ArithmeticRefOps to SecretSharing

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic;
+use crate::secret_sharing::SecretSharing;
 use futures::future::try_join_all;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -36,7 +36,7 @@ pub async fn accumulate_credit<F, C, T>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
 {
     let num_rows = input.len();
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -27,7 +27,7 @@ use crate::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::AdditiveShare as Replicated,
         },
-        Arithmetic,
+        SecretSharing,
     },
 };
 
@@ -226,7 +226,7 @@ fn add_aggregation_bits_and_breakdown_keys<F, C, T, BK>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
     BK: Fp2Array,
 {
     let zero = T::ZERO;

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -2,12 +2,13 @@ use super::{
     do_the_binary_tree_thing, if_else,
     input::{MCCreditCappingInputRow, MCCreditCappingOutputRow},
 };
+use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
 use crate::protocol::boolean::{bitwise_greater_than_constant, BitDecomposition};
 use crate::protocol::context::Context;
 use crate::protocol::{RecordId, Substep};
-use crate::{error::Error, secret_sharing::Arithmetic};
+use crate::secret_sharing::SecretSharing;
 use futures::future::try_join_all;
 use std::{
     iter::{repeat, zip},
@@ -27,7 +28,7 @@ pub async fn credit_capping<F, C, T>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
 {
     let input_len = input.len();
 
@@ -87,7 +88,7 @@ async fn mask_source_credits<F, C, T>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
 {
     try_join_all(
         input
@@ -117,7 +118,7 @@ async fn credit_prefix_sum<'a, F, C, T, I>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F> + 'a,
+    T: SecretSharing<F> + 'a,
     I: Iterator<Item = &'a T>,
 {
     let helper_bits = input
@@ -137,7 +138,7 @@ async fn is_credit_larger_than_cap<F, C, T>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
 {
     //TODO: `cap` is publicly known value for each query. We can avoid creating shares every time.
     let random_bits_generator =
@@ -190,7 +191,7 @@ async fn compute_final_credits<F, C, T>(
 where
     F: Field,
     C: Context<F, Share = T>,
-    T: Arithmetic<F>,
+    T: SecretSharing<F>,
 {
     let num_rows = input.len();
     let cap = ctx.share_known_value(F::from(cap.into()));

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     ff::Field,
     protocol::{context::Context, RecordId, Substep},
     repeat64str,
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::SecretSharing,
 };
 use futures::future::{try_join, try_join_all};
 
@@ -24,7 +24,7 @@ async fn if_else<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)
@@ -60,7 +60,7 @@ pub async fn do_the_binary_tree_thing<'a, F, C, S, I>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F> + 'a,
+    S: SecretSharing<F> + 'a,
     I: Iterator<Item = &'a S>,
 {
     let num_rows = helper_bits.len() + 1;

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -5,7 +5,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 
 /// This is an implementation of "3. Bit-Decomposition" from I. Damgård et al..
 ///
@@ -31,7 +31,7 @@ impl BitDecomposition {
     ) -> Result<Vec<S>, Error>
     where
         F: Field,
-        S: ArithmeticSecretSharing<F>,
+        S: SecretSharing<F>,
         C: Context<F, Share = S>,
     {
         // step 1 in the paper is just describing the input, `[a]_p` where `a ∈ F_p`

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::boolean::no_ones;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 use futures::future::try_join_all;
 use std::iter::zip;
 
@@ -23,7 +23,7 @@ pub async fn bitwise_equal_constant<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     assert!(a.len() <= 128);
 
@@ -55,7 +55,7 @@ pub async fn bitwise_equal<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     debug_assert!(a.len() == b.len());
     let xored_bits = xor_all_the_bits(ctx.narrow(&Step::XORAllTheBits), record_id, a, b).await?;
@@ -71,7 +71,7 @@ async fn xor_all_the_bits<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let xor = zip(a, b).enumerate().map(|(i, (a_bit, b_bit))| {
         let c = ctx.narrow(&BitOpStep::from(i));

--- a/src/protocol/boolean/bitwise_gt_constant.rs
+++ b/src/protocol/boolean/bitwise_gt_constant.rs
@@ -2,7 +2,7 @@ use super::or::or;
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 
 /// Compares the `[a]` and `c`, and returns `1` iff `a > c`
 ///
@@ -26,7 +26,7 @@ pub async fn bitwise_greater_than_constant<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     assert!(a.len() <= 128);
 
@@ -49,7 +49,7 @@ async fn first_differing_bit<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let one = ctx.share_known_value(F::ONE);
 

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::boolean::multiply_all_shares;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 use futures::future::try_join;
 use std::cmp::Ordering;
 
@@ -26,7 +26,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context<F, Share = S>,
-        S: ArithmeticSecretSharing<F>,
+        S: SecretSharing<F>,
     {
         let one = ctx.share_known_value(F::ONE);
         let gtoe = Self::greater_than_or_equal_to_prime(ctx, record_id, x).await?;
@@ -41,7 +41,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context<F, Share = S>,
-        S: ArithmeticSecretSharing<F>,
+        S: SecretSharing<F>,
     {
         let prime = F::PRIME.into();
         let l = u128::BITS - prime.leading_zeros();
@@ -91,7 +91,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context<F, Share = S>,
-        S: ArithmeticSecretSharing<F>,
+        S: SecretSharing<F>,
     {
         let prime = F::PRIME.into();
         let l = u128::BITS - prime.leading_zeros();
@@ -149,7 +149,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context<F, Share = S>,
-        S: ArithmeticSecretSharing<F>,
+        S: SecretSharing<F>,
     {
         let prime = F::PRIME.into();
         debug_assert!(prime & 0b111 == 0b011);

--- a/src/protocol/boolean/dumb_bitwise_add_constant.rs
+++ b/src/protocol/boolean/dumb_bitwise_add_constant.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///
@@ -46,7 +46,7 @@ pub async fn bitwise_add_constant<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 
@@ -125,7 +125,7 @@ pub async fn bitwise_add_constant_maybe<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     assert!(a.len() < 128);
     assert_eq!(

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -6,8 +6,7 @@ use crate::protocol::prss::SharedRandomness;
 use crate::protocol::{context::Context, BitOpStep, RecordId};
 use crate::secret_sharing::{
     replicated::semi_honest::AdditiveShare as Replicated,
-    replicated::semi_honest::XorShare as XorReplicated, Arithmetic as ArithmeticSecretSharing,
-    SecretSharing, SharedValue,
+    replicated::semi_honest::XorShare as XorReplicated, SecretSharing, SharedValue,
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;
@@ -59,7 +58,7 @@ async fn convert_triples_to_shares<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let futures = triples.iter().enumerate().map(|(i, t)| {
         let c = ctx.narrow(&BitOpStep::from(i));

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -2,7 +2,7 @@ use futures::future::try_join_all;
 
 use crate::error::Error;
 use crate::ff::Field;
-use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
+use crate::secret_sharing::SecretSharing;
 use std::iter::repeat;
 
 use super::context::Context;
@@ -83,7 +83,7 @@ where
 fn flip_bits<F, S>(one: S, x: &[S]) -> Vec<S>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     x.iter()
         .zip(repeat(one))
@@ -97,7 +97,7 @@ pub(crate) async fn any_ones<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> R
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let one = ctx.share_known_value(F::ONE);
     let res = no_ones(ctx, record_id, x).await?;
@@ -108,7 +108,7 @@ pub(crate) async fn no_ones<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Re
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let one = ctx.share_known_value(F::ONE);
     let inverted_elements = flip_bits(one.clone(), x);

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -2,11 +2,11 @@ use crate::error::Error;
 use crate::ff::Field;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 
 /// Secure OR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
 /// It computes `[a] + [b] - [ab]`
-pub async fn or<F: Field, C: Context<F, Share = S>, S: ArithmeticSecretSharing<F>>(
+pub async fn or<F: Field, C: Context<F, Share = S>, S: SecretSharing<F>>(
     ctx: C,
     record_id: RecordId,
     a: &S,

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -4,7 +4,7 @@ use crate::ff::Field;
 use crate::helpers::messaging::TotalRecords;
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 use std::{
     marker::PhantomData,
     sync::atomic::{AtomicU32, AtomicUsize, Ordering},
@@ -27,7 +27,7 @@ pub struct RandomBitsGenerator<F, S, C> {
 impl<F, S, C> RandomBitsGenerator<F, S, C>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
     C: Context<F, Share = S>,
 {
     #[must_use]

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -5,7 +5,7 @@ use crate::protocol::{context::Context, RecordId};
 use crate::secret_sharing::replicated::malicious::{
     AdditiveShare as MaliciousReplicated, DowngradeMalicious, UnauthorizedDowngradeWrapper,
 };
-use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
+use crate::secret_sharing::SecretSharing;
 use async_trait::async_trait;
 use std::marker::PhantomData;
 
@@ -73,7 +73,7 @@ pub async fn solved_bits<F, S, C>(
 ) -> Result<Option<RandomBitsShare<F, S>>, Error>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
     C: Context<F, Share = S>,
 {
     //
@@ -113,7 +113,7 @@ async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Resu
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let c_b =
         BitwiseLessThanPrime::less_than_prime(ctx.narrow(&Step::IsPLessThanB), record_id, b_b)

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -3,7 +3,7 @@ use crate::ff::Field;
 use crate::protocol::basics::{MultiplyZeroPositions, ZeroPositions};
 use crate::protocol::context::Context;
 use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::secret_sharing::SecretSharing;
 
 /// Secure XOR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
 /// It computes `[a] + [b] - 2[ab]`
@@ -13,7 +13,7 @@ pub async fn xor<F, C, S>(ctx: C, record_id: RecordId, a: &S, b: &S) -> Result<S
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     xor_sparse(ctx, record_id, a, b, ZeroPositions::NONE).await
 }
@@ -31,7 +31,7 @@ pub async fn xor_sparse<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let ab = ctx.multiply_sparse(record_id, a, b, zeros_at).await?;
     Ok(-(ab * F::from(2)) + a + b)

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -20,10 +20,12 @@ use crate::protocol::modulus_conversion::BitConversionTriple;
 use crate::protocol::prss::Endpoint as PrssEndpoint;
 use crate::protocol::{BitOpStep, RecordId, Step, Substep, RECORD_0};
 use crate::repeat64str;
-use crate::secret_sharing::replicated::{
-    malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+use crate::secret_sharing::{
+    replicated::{
+        malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+    },
+    SecretSharing,
 };
-use crate::secret_sharing::Arithmetic;
 use crate::sync::Arc;
 
 /// Represents protocol context in malicious setting, i.e. secure against one active adversary
@@ -310,7 +312,7 @@ impl<'a, F: Field>
     }
 }
 
-pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: Arithmetic<F>> {
+pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: SecretSharing<F>> {
     pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub trigger_value: T,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -28,7 +28,7 @@ use crate::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
         },
-        Arithmetic,
+        SecretSharing,
     },
 };
 
@@ -197,7 +197,7 @@ where
     }
 }
 
-pub struct IPAModulusConvertedInputRow<F: Field, T: Arithmetic<F>> {
+pub struct IPAModulusConvertedInputRow<F: Field, T: SecretSharing<F>> {
     pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub breakdown_key: Vec<T>,
@@ -205,7 +205,7 @@ pub struct IPAModulusConvertedInputRow<F: Field, T: Arithmetic<F>> {
     _marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> IPAModulusConvertedInputRow<F, T> {
+impl<F: Field, T: SecretSharing<F>> IPAModulusConvertedInputRow<F, T> {
     pub fn new(
         mk_shares: Vec<T>,
         is_trigger_bit: T,
@@ -223,7 +223,7 @@ impl<F: Field, T: Arithmetic<F>> IPAModulusConvertedInputRow<F, T> {
 }
 
 #[async_trait]
-impl<F: Field + Sized, T: Arithmetic<F>> Resharable<F> for IPAModulusConvertedInputRow<F, T> {
+impl<F: Field + Sized, T: SecretSharing<F>> Resharable<F> for IPAModulusConvertedInputRow<F, T> {
     type Share = T;
 
     async fn reshare<C>(&self, ctx: C, record_id: RecordId, to_helper: Role) -> Result<Self, Error>

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
-        Arithmetic as ArithmeticSecretSharing,
+        SecretSharing,
     },
 };
 use futures::future::try_join_all;
@@ -112,7 +112,7 @@ pub async fn convert_bit<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let (sh0, sh1, sh2) = (
         &locally_converted_bits.0[0],
@@ -142,7 +142,7 @@ pub async fn convert_all_bits<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let ctx = ctx.set_total_records(locally_converted_bits.len());
 
@@ -178,7 +178,7 @@ pub async fn convert_bit_list<F, C, S>(
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     try_join_all(
         zip(repeat(ctx), locally_converted_bits.iter())

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -8,7 +8,7 @@ use crate::protocol::sort::{
 };
 use crate::protocol::{context::Context, RecordId};
 use crate::repeat64str;
-use crate::secret_sharing::{Arithmetic, SecretSharing, SharedValue};
+use crate::secret_sharing::{SecretSharing, SharedValue};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
@@ -41,7 +41,7 @@ impl From<usize> for InnerVectorElementStep {
 }
 
 #[async_trait]
-impl<T: Arithmetic<F>, F: Field> Resharable<F> for Vec<T> {
+impl<T: SecretSharing<F>, F: Field> Resharable<F> for Vec<T> {
     type Share = T;
 
     /// This is intended to be used for resharing vectors of bit-decomposed values.

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::SecretSharing,
 };
 
 use embed_doc_image::embed_doc_image;
@@ -32,12 +32,7 @@ use futures::future::try_join_all;
 ///
 /// ## Errors
 /// It will propagate errors from multiplication protocol.
-pub async fn bit_permutation<
-    'a,
-    F: Field,
-    S: ArithmeticSecretSharing<F>,
-    C: Context<F, Share = S>,
->(
+pub async fn bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context<F, Share = S>>(
     ctx: C,
     input: &[S],
 ) -> Result<Vec<S>, Error> {

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BitOpStep, RecordId},
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+    secret_sharing::SecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -26,12 +26,7 @@ use std::iter::repeat;
 ///       a. Calculate accumulated `prefix_sum` = s + `mult_output`
 /// 4. Compute the final output using sum of products executed in parallel for each record.
 #[allow(dead_code)]
-pub async fn multi_bit_permutation<
-    'a,
-    F: Field,
-    S: ArithmeticSecretSharing<F>,
-    C: Context<F, Share = S>,
->(
+pub async fn multi_bit_permutation<'a, F: Field, S: SecretSharing<F>, C: Context<F, Share = S>>(
     ctx: C,
     input: &[Vec<S>],
 ) -> Result<Vec<S>, Error> {
@@ -102,7 +97,7 @@ async fn check_everything<F, C, S>(ctx: C, record_idx: usize, record: &[S]) -> R
 where
     F: Field,
     C: Context<F, Share = S>,
-    S: ArithmeticSecretSharing<F>,
+    S: SecretSharing<F>,
 {
     let num_bits = record.len();
     let precomputed_combinations =

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,4 +1,3 @@
-use crate::secret_sharing::Arithmetic;
 use crate::{
     bits::{Fp2Array, Serializable},
     ff::{Field, FieldType, Fp31},
@@ -14,7 +13,7 @@ use crate::{
         ipa::{ipa, IPAInputRow},
         BreakdownKey, MatchKey, Step,
     },
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SecretSharing},
     task::JoinHandle,
 };
 use futures_util::StreamExt;
@@ -47,7 +46,8 @@ where
     }
 }
 
-impl<F: Field, T: Arithmetic<F>, BK: Fp2Array> Result for Vec<MCAggregateCreditOutputRow<F, T, BK>>
+impl<F: Field, T: SecretSharing<F>, BK: Fp2Array> Result
+    for Vec<MCAggregateCreditOutputRow<F, T, BK>>
 where
     T: Serializable,
 {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -5,7 +5,7 @@ mod scheme;
 
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 pub use into_shares::IntoShares;
-pub use scheme::{Arithmetic, Boolean, SecretSharing};
+pub use scheme::{Boolean, SecretSharing};
 
 use crate::bits::Serializable;
 use crate::ff::ArithmeticOps;

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -10,8 +10,8 @@ use crate::{
         },
     },
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare,
-        Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue,
+        replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, SecretSharing,
+        SharedValue,
     },
 };
 use async_trait::async_trait;
@@ -30,8 +30,6 @@ pub struct AdditiveShare<V: SharedValue> {
 impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
     const ZERO: Self = AdditiveShare::ZERO;
 }
-
-impl<V: SharedValue> ArithmeticSecretSharing<V> for AdditiveShare<V> {}
 
 /// A trait that is implemented for various collections of `replicated::malicious::AdditiveShare`.
 /// This allows a protocol to downgrade to ordinary `replicated::semi_honest::AdditiveShare`

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -2,7 +2,7 @@ use crate::{
     bits::Serializable,
     ff::Field,
     helpers::Role,
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue},
+    secret_sharing::{SecretSharing, SharedValue},
 };
 use generic_array::{ArrayLength, GenericArray};
 use std::fmt::{Debug, Formatter};
@@ -15,8 +15,6 @@ pub struct AdditiveShare<V: SharedValue>(V, V);
 impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
     const ZERO: Self = AdditiveShare::ZERO;
 }
-
-impl<V: SharedValue> ArithmeticSecretSharing<V> for AdditiveShare<V> {}
 
 impl<V: SharedValue + Debug> Debug for AdditiveShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -6,10 +6,9 @@ use aes::cipher::generic_array::GenericArray;
 use generic_array::ArrayLength;
 use typenum::Unsigned;
 
-use std::ops::Add;
 use std::{
     fmt::{Debug, Formatter},
-    ops::{BitXor, BitXorAssign},
+    ops::{Add, AddAssign, BitXor, BitXorAssign, Mul, Neg, Sub, SubAssign},
 };
 
 #[derive(Clone, PartialEq, Eq)]
@@ -85,6 +84,74 @@ impl<V: Fp2Array> BitXorAssign<&Self> for XorShare<V> {
     fn bitxor_assign(&mut self, rhs: &Self) {
         self.0 ^= rhs.0;
         self.1 ^= rhs.1;
+    }
+}
+
+impl<V: Fp2Array> Add<Self> for &XorShare<V> {
+    type Output = XorShare<V>;
+
+    // `Add` for `Fp2Array` implementation is XOR
+    fn add(self, rhs: Self) -> Self::Output {
+        XorShare(self.0 + rhs.0, self.1 + rhs.1)
+    }
+}
+
+impl<V: Fp2Array> Add<&Self> for XorShare<V> {
+    type Output = Self;
+
+    fn add(mut self, rhs: &Self) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl<V: Fp2Array> AddAssign<&Self> for XorShare<V> {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.0 += rhs.0;
+        self.1 += rhs.1;
+    }
+}
+
+impl<V: Fp2Array> Sub<Self> for &XorShare<V> {
+    type Output = XorShare<V>;
+
+    // `Sub` for `Fp2Array` implementation is XOR
+    fn sub(self, rhs: Self) -> Self::Output {
+        XorShare(self.0 - rhs.0, self.1 - rhs.1)
+    }
+}
+
+impl<V: Fp2Array> Sub<&Self> for XorShare<V> {
+    type Output = Self;
+
+    fn sub(mut self, rhs: &Self) -> Self::Output {
+        self -= rhs;
+        self
+    }
+}
+
+impl<V: Fp2Array> SubAssign<&Self> for XorShare<V> {
+    fn sub_assign(&mut self, rhs: &Self) {
+        self.0 -= rhs.0;
+        self.1 -= rhs.1;
+    }
+}
+
+impl<V: Fp2Array> Mul<V> for XorShare<V> {
+    type Output = Self;
+
+    // `Mul` for `Fp2Array` implementation is AND
+    fn mul(self, rhs: V) -> Self::Output {
+        Self(self.0 * rhs, self.1 * rhs)
+    }
+}
+
+impl<V: Fp2Array> Neg for XorShare<V> {
+    type Output = Self;
+
+    // `Neg` for `Fp2Array` implementation is NOT
+    fn neg(self) -> Self::Output {
+        Self(-self.0, -self.1)
     }
 }
 

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -4,11 +4,11 @@ use crate::ff::ArithmeticRefOps;
 use std::fmt::Debug;
 
 /// Secret sharing scheme i.e. Replicated secret sharing
-pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
+pub trait SecretSharing<V: SharedValue>:
+    Clone + Debug + Sized + Send + Sync + ArithmeticRefOps<V>
+{
     const ZERO: Self;
 }
-/// Secret share of a secret that has additive and multiplicative properties.
-pub trait Arithmetic<V: SharedValue>: SecretSharing<V> + ArithmeticRefOps<V> {}
 
 /// Secret share of a secret with bit operations
 pub trait Boolean<V: Fp2Array>: SecretSharing<V> + BooleanRefOps {}


### PR DESCRIPTION
Similar to the previous PR #466, where `ArithmeticOps` was moved to `SharedValue` for `Fp2Array` to also support arithmetic operations, this PR does the same for `SecretSharing`. Now `ArithmeticRefOps` is moved to `SecretSharing` so that `XorShare` supports arithmetic operations. Internally, they are implemented by bit operations i.e., + => ^, * => &.