### PR TITLE
eliminate use of downgrade auth trait in attribution::input

### DIFF
--- a/src/helpers/map.rs
+++ b/src/helpers/map.rs
@@ -1,0 +1,37 @@
+/// Trait for transforming values in the manner of `Option::map` or `Iter::map`.
+///
+/// This is currently used to implement [malicious downgrades], and can be used to
+/// generically implement other operations in the future.
+///
+/// The type parameter `M` represents the mapping being performed. It is analogous to the `F`
+/// closure type parameter on `Option::map`.
+///
+/// [malicious downgrades]: crate::secret_sharing::replicated::malicious::UncheckedDowngrade
+pub trait Map<M: Mapping> {
+    type Output;
+
+    fn map(self) -> Self::Output;
+}
+
+pub trait Mapping {}
+
+impl<T, U, M: Mapping> Map<M> for (T, U)
+where
+    T: Map<M>,
+    U: Map<M>,
+{
+    type Output = (<T as Map<M>>::Output, <U as Map<M>>::Output);
+    fn map(self) -> Self::Output {
+        (self.0.map(), self.1.map())
+    }
+}
+
+impl<T, M: Mapping> Map<M> for Vec<T>
+where
+    T: Map<M>,
+{
+    type Output = Vec<<T as Map<M>>::Output>;
+    fn map(self) -> Self::Output {
+        self.into_iter().map(<T as Map<M>>::map).collect()
+    }
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,3 +1,4 @@
+pub mod map;
 pub mod messaging;
 pub mod network;
 pub mod transport;
@@ -9,6 +10,7 @@ mod time;
 
 pub use buffers::SendBufferConfig;
 pub use error::{Error, Result};
+pub use map::{Map, Mapping};
 pub use messaging::GatewayConfig;
 pub use prss_protocol::negotiate as negotiate_prss;
 pub use transport::{


### PR DESCRIPTION
Partly prompted by https://github.com/private-attribution/ipa/pull/458#discussion_r1096418881 and partly because I'm looking at handling of downgrades for `ShuffledPermutationWrapper` in the context of https://github.com/private-attribution/ipa/pull/469#discussion_r1106472691.

With a more complicated version of the map trait that allows for contexts and record IDs, this could possibly be extended to support upgrades, reveals, and reshares, but I stopped myself before I went that far.

My thoughts for ShuffledPermutationWrapper are to add another trait (something like `MaliciousOutput`) that takes a context. `MaliciousOutput` can be implemented for anything that is `Downgrade` and will just not use the context in that case. `MaliciousOutput` will also be implemented for `ShuffledPermutation` to reveal the permutation. A more general version would implement some kind of `Reveal` trait and implement `MaliciousOutput` for anything that is `Reveal`, but again, that seems like unnecessary complexity.

Besides the issue of needing a context to reveal the permutation, I think it's somewhat incorrect to put a reveal operation in the same class with downgrades. Whether the output value needs to be downgraded or revealed isn't implied by the output data type -- it's dictated by the role of the value in the protocol.