### PR TITLE
Adding specialized functionality for when the per-user cap is one

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -22,6 +22,18 @@ impl AsRef<str> for Step {
     }
 }
 
+///
+/// When `PER_USER_CAP` is set to one, this function is called
+/// In this case, `trigger_value` is ignored entirely. Instead, each `trigger_report` counts as one.
+/// So in the event that a `source report` is followed by multiple `trigger reports`, only one will count.
+/// As such, this function can be simplified a great deal. All that matters is when a `source report` is
+/// immediately followed by a `trigger report` from the same `match key`. As such, each row only needs to
+/// be compared to the following row.
+/// If there are multiple attributed conversions from the same `match key` they will be removed in the
+/// next stage; `user capping`.
+///
+/// This method implements "last touch" attribution, so only the last `source report` before a `trigger report`
+/// will receive any credit.
 async fn accumulate_credit_cap_one<F, C, T>(
     ctx: C,
     input: &[MCAccumulateCreditInputRow<F, T>],

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -22,7 +22,7 @@ impl AsRef<str> for Step {
     }
 }
 
-pub async fn accumulate_credit_cap_one<F, C, T>(
+async fn accumulate_credit_cap_one<F, C, T>(
     ctx: C,
     input: &[MCAccumulateCreditInputRow<F, T>],
 ) -> Result<Vec<MCAccumulateCreditOutputRow<F, T>>, Error>

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -97,29 +97,16 @@ where
 {
     let input_len = input.len();
 
-    //
-    // Step 1. Initialize a local vector for the capping computation.
-    //
-    // * `original_credits` will have credit values of only source events
-    //
     let uncapped_credits = mask_source_credits(input, ctx.set_total_records(input_len)).await?;
 
-    assert_eq!(uncapped_credits.len(), input.len());
-
-    // helper_bits.len() = input.len() - 1
     let helper_bits = input
         .iter()
         .skip(1)
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
 
-    assert_eq!(helper_bits.len(), input.len() - 1);
-
-    // prefix_ors.len() = input.len()
     let prefix_ors =
         prefix_or_binary_tree_style(ctx.clone(), &helper_bits, &uncapped_credits).await?;
-
-    assert_eq!(prefix_ors.len(), input.len());
 
     let prefix_or_times_helper_bit_ctx = ctx
         .narrow(&Step::PrefixOrTimesHelperBit)
@@ -137,8 +124,6 @@ where
             }),
     )
     .await?;
-
-    assert_eq!(ever_any_subsequent_credit.len(), input.len() - 1);
 
     let potentially_cap_ctx = ctx
         .narrow(&Step::IfCurrentExceedsCapOrElse)
@@ -159,8 +144,6 @@ where
             }),
     )
     .await?;
-
-    assert_eq!(capped_credits.len(), input.len() - 1);
 
     let output = input
         .iter()

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -1,8 +1,8 @@
-pub(crate) mod accumulate_credit;
 pub mod aggregate_credit;
 pub mod credit_capping;
 pub mod input;
 
+pub(crate) mod accumulate_credit;
 use crate::protocol::boolean::or::or;
 use crate::{
     error::Error,

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -41,6 +41,10 @@ where
 }
 
 ///
+/// Computes a "prefix-OR" operation starting on each element in the list.
+/// Stops as soon as `helper_bits` indicates the following rows are not from
+/// the same `match key`.
+///
 /// ## Errors
 /// Fails if the multiplication protocol fails.
 ///

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -14,7 +14,7 @@ mod bitwise_gt_constant;
 mod bitwise_less_than_prime;
 mod dumb_bitwise_add_constant;
 mod generate_random_bits;
-mod or;
+pub mod or;
 pub mod random_bits_generator;
 mod solved_bits;
 mod xor;

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -6,6 +6,9 @@ use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
 
 /// Secure OR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
 /// It computes `[a] + [b] - [ab]`
+///
+/// ## Errors
+/// Fails if the multiplication protocol fails.
 pub async fn or<F: Field, C: Context<F, Share = S>, S: ArithmeticSecretSharing<F>>(
     ctx: C,
     record_id: RecordId,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -674,7 +674,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn cap_of_one_semi_honest() {
+    async fn cap_of_one() {
         const PER_USER_CAP: u32 = 1;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 1], [2, 0], [3, 0], [4, 0], [5, 1], [6, 1]];
         const MAX_BREAKDOWN_KEY: u128 = 7;
@@ -706,8 +706,35 @@ pub mod tests {
         );
 
         let result: Vec<GenericReportTestInput<Fp31, MatchKey, BreakdownKey>> = world
-            .semi_honest(records, |ctx, input_rows| async move {
+            .semi_honest(records.clone(), |ctx, input_rows| async move {
                 ipa::<Fp31, MatchKey, BreakdownKey>(
+                    ctx,
+                    &input_rows,
+                    PER_USER_CAP,
+                    MAX_BREAKDOWN_KEY,
+                    NUM_MULTI_BITS,
+                )
+                .await
+                .unwrap()
+            })
+            .await
+            .reconstruct();
+
+        assert_eq!(EXPECTED.len(), result.len());
+
+        for (i, expected) in EXPECTED.iter().enumerate() {
+            assert_eq!(
+                *expected,
+                [
+                    result[i].breakdown_key.as_u128(),
+                    result[i].trigger_value.as_u128()
+                ]
+            );
+        }
+
+        let result: Vec<GenericReportTestInput<_, MatchKey, BreakdownKey>> = world
+            .semi_honest(records, |ctx, input_rows| async move {
+                ipa_malicious::<_, MatchKey, BreakdownKey>(
                     ctx,
                     &input_rows,
                     PER_USER_CAP,
@@ -777,6 +804,115 @@ pub mod tests {
             .reconstruct();
 
         assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
+    }
+
+    struct TestRawDataRecord {
+        user_id: usize,
+        timestamp: usize,
+        is_trigger_report: bool,
+        breakdown_key: usize,
+    }
+
+    #[tokio::test]
+    #[allow(clippy::missing_panics_doc)]
+    #[ignore]
+    pub async fn random_ipa_cap_one_check() {
+        const MAX_BREAKDOWN_KEY: usize = 16;
+        const NUM_USERS: usize = 20;
+        const MAX_RECORDS_PER_USER: usize = 10;
+        const NUM_MULTI_BITS: u32 = 3;
+        const MAX_USER_ID: usize = 1_000_000_000_000;
+        const SECONDS_IN_EPOCH: usize = 604_800;
+
+        let mut rng = thread_rng();
+
+        let mut raw_data = Vec::with_capacity(NUM_USERS * MAX_RECORDS_PER_USER);
+        let mut expected_results = vec![0_u128; MAX_BREAKDOWN_KEY];
+        for _ in 0..NUM_USERS {
+            let random_user_id = rng.gen_range(0..MAX_USER_ID);
+            let num_records_for_user = rng.gen_range(1..MAX_RECORDS_PER_USER);
+            let mut records_for_user = Vec::with_capacity(num_records_for_user);
+            for _ in 0..num_records_for_user {
+                let random_timestamp = rng.gen_range(0..SECONDS_IN_EPOCH);
+                let is_trigger_report = rng.gen::<bool>();
+                let random_breakdown_key = if is_trigger_report {
+                    0
+                } else {
+                    rng.gen_range(0..MAX_BREAKDOWN_KEY)
+                };
+                records_for_user.push(TestRawDataRecord {
+                    user_id: random_user_id,
+                    timestamp: random_timestamp,
+                    is_trigger_report,
+                    breakdown_key: random_breakdown_key,
+                });
+            }
+
+            // sort in reverse time order
+            records_for_user.sort_unstable_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+            let mut encountered_trigger = false;
+            let mut contributed_once = false;
+            for record in &records_for_user {
+                if contributed_once {
+                    continue;
+                }
+
+                if record.is_trigger_report {
+                    encountered_trigger = true;
+                } else if encountered_trigger {
+                    expected_results[record.breakdown_key] += 1;
+                    contributed_once = true;
+                    encountered_trigger = false;
+                }
+            }
+
+            raw_data.append(&mut records_for_user);
+        }
+        raw_data.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+        let records = raw_data
+            .iter()
+            .map(|x| {
+                ipa_test_input!(
+                    {
+                        match_key: x.user_id,
+                        is_trigger_report: x.is_trigger_report,
+                        breakdown_key: x.breakdown_key,
+                        trigger_value: 0, // unused
+                    };
+                    (Fp32BitPrime, MatchKey, BreakdownKey)
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let world = TestWorld::new().await;
+
+        let result: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = world
+            .semi_honest(records, |ctx, input_rows| async move {
+                ipa::<Fp32BitPrime, MatchKey, BreakdownKey>(
+                    ctx,
+                    &input_rows,
+                    1,
+                    MAX_BREAKDOWN_KEY as u128,
+                    NUM_MULTI_BITS,
+                )
+                .await
+                .unwrap()
+            })
+            .await
+            .reconstruct();
+
+        assert_eq!(MAX_BREAKDOWN_KEY, result.len());
+        for (i, expected) in expected_results.iter().enumerate() {
+            assert_eq!(
+                [i as u128, *expected],
+                [
+                    result[i].breakdown_key.as_u128(),
+                    result[i].trigger_value.as_u128()
+                ]
+            );
+        }
     }
 
     fn serde_internal(

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -674,7 +674,7 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn cap_of_one_malicious() {
+    async fn cap_of_one_semi_honest() {
         const PER_USER_CAP: u32 = 1;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 1], [2, 0], [3, 0], [4, 0], [5, 1], [6, 1]];
         const MAX_BREAKDOWN_KEY: u128 = 7;

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -370,8 +370,12 @@ where
         })
         .collect::<Vec<_>>();
 
-    let accumulated_credits =
-        accumulate_credit(ctx.narrow(&Step::AccumulateCredit), &attribution_input_rows).await?;
+    let accumulated_credits = accumulate_credit(
+        ctx.narrow(&Step::AccumulateCredit),
+        &attribution_input_rows,
+        per_user_credit_cap,
+    )
+    .await?;
 
     let user_capped_credits = credit_capping(
         ctx.narrow(&Step::PerformUserCapping),
@@ -528,6 +532,7 @@ where
     let accumulated_credits = accumulate_credit(
         m_ctx.narrow(&Step::AccumulateCredit),
         &attribution_input_rows,
+        per_user_credit_cap,
     )
     .await?;
 
@@ -655,6 +660,66 @@ pub mod tests {
             })
             .await
             .reconstruct();
+        assert_eq!(EXPECTED.len(), result.len());
+
+        for (i, expected) in EXPECTED.iter().enumerate() {
+            assert_eq!(
+                *expected,
+                [
+                    result[i].breakdown_key.as_u128(),
+                    result[i].trigger_value.as_u128()
+                ]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cap_of_one_malicious() {
+        const PER_USER_CAP: u32 = 1;
+        const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 1], [2, 0], [3, 0], [4, 0], [5, 1], [6, 1]];
+        const MAX_BREAKDOWN_KEY: u128 = 7;
+        const NUM_MULTI_BITS: u32 = 3;
+
+        let world = TestWorld::new().await;
+
+        let records: Vec<GenericReportTestInput<Fp31, MatchKey, BreakdownKey>> = ipa_test_input!(
+            [
+                { match_key: 12345, is_trigger_report: 0, breakdown_key: 0, trigger_value: 0 }, // Irrelevant
+                { match_key: 12345, is_trigger_report: 0, breakdown_key: 1, trigger_value: 0 }, // A
+                { match_key: 68362, is_trigger_report: 0, breakdown_key: 2, trigger_value: 0 }, // B
+                { match_key: 12345, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // This will be attributed to A
+                { match_key: 77777, is_trigger_report: 1, breakdown_key: 1, trigger_value: 0 }, // Irrelevant
+                { match_key: 68362, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // This will be attributed to B, but will be capped
+                { match_key: 12345, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // Irrelevant
+                { match_key: 68362, is_trigger_report: 0, breakdown_key: 3, trigger_value: 0 }, // C
+                { match_key: 77777, is_trigger_report: 0, breakdown_key: 4, trigger_value: 0 }, // Irrelevant
+                { match_key: 68362, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // This will be attributed to C, but will be capped
+                { match_key: 81818, is_trigger_report: 0, breakdown_key: 6, trigger_value: 0 }, // E
+                { match_key: 68362, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // Irrelevant
+                { match_key: 81818, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // This will be attributed to E
+                { match_key: 68362, is_trigger_report: 0, breakdown_key: 5, trigger_value: 0 }, // D
+                { match_key: 99999, is_trigger_report: 0, breakdown_key: 6, trigger_value: 0 }, // Irrelevant
+                { match_key: 68362, is_trigger_report: 1, breakdown_key: 0, trigger_value: 0 }, // This will be attributed to D
+
+            ];
+            (Fp31, MatchKey, BreakdownKey)
+        );
+
+        let result: Vec<GenericReportTestInput<Fp31, MatchKey, BreakdownKey>> = world
+            .semi_honest(records, |ctx, input_rows| async move {
+                ipa::<Fp31, MatchKey, BreakdownKey>(
+                    ctx,
+                    &input_rows,
+                    PER_USER_CAP,
+                    MAX_BREAKDOWN_KEY,
+                    NUM_MULTI_BITS,
+                )
+                .await
+                .unwrap()
+            })
+            .await
+            .reconstruct();
+
         assert_eq!(EXPECTED.len(), result.len());
 
         for (i, expected) in EXPECTED.iter().enumerate() {


### PR DESCRIPTION
One common ads use-case is to just *count* conversions. In this case, the "trigger value" is irrelevant. Every conversion counts the same, just one.

Furthermore, a common use-case is to *count distinct* users. Another way of saying this, is that each user can at most contribute a value of *one* to the output. 

In this special case, we can completely avoid bit-decomposition, and indeed we can avoid large chunks of the IPA protocol entirely. As this is not a rare use-case, it seems worthwhile to specialise this, so that we can run a much faster, more communication efficient algorithm.

Testing out on 1000 rows, "Records Sent" drops from 2,286,120 to 1,652,889 - a 27.7% drop in total communication.

Looking at the breakdown by stage:

- Accumulate drops from 77,796 to 2,997 (now it's just ONE multiplication per row!)
- User Capping drops from 668,790 to 110,601 (no more bit-decomposition! Just a prefix-OR!)





























































