### PR TITLE
Making the random data test actually check outputs

### DIFF
--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -777,14 +777,14 @@ pub mod tests {
     pub async fn random_ipa_check() {
         const MAX_BREAKDOWN_KEY: usize = 16;
         const MAX_TRIGGER_VALUE: u32 = 5;
-        const NUM_USERS: usize = 10;
-        const MAX_RECORDS_PER_USER: usize = 6;
+        const NUM_USERS: usize = 2;
+        const MAX_RECORDS_PER_USER: usize = 5;
         const NUM_MULTI_BITS: u32 = 3;
         const MAX_USER_ID: usize = 1_000_000_000_000;
         const SECONDS_IN_EPOCH: usize = 604_800;
 
         let random_seed: u64 = thread_rng().gen();
-        let random_seed = 5120075974259934184;
+        let random_seed = 7560046;
         println!("Using random seed: {random_seed}");
         let mut rng = StdRng::seed_from_u64(random_seed);
 
@@ -792,8 +792,10 @@ pub mod tests {
         let mut expected_results = vec![0_u32; MAX_BREAKDOWN_KEY];
         for per_user_cap in [1, 3] {
             println!("Running with a per-user-cap of {per_user_cap}.");
-            for _ in 0..NUM_USERS {
+            for i in 0..NUM_USERS {
                 let random_user_id = rng.gen_range(0..MAX_USER_ID);
+                let matches = 848468829005 == random_user_id;
+                println!("random user ID: {random_user_id}, is it the one? {matches}. This is index {i}."); // 848468829005
                 let num_records_for_user = rng.gen_range(1..MAX_RECORDS_PER_USER);
                 let mut records_for_user = Vec::with_capacity(num_records_for_user);
                 for _ in 0..num_records_for_user {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -573,7 +573,7 @@ pub mod tests {
         test_runner::{RngAlgorithm, TestRng},
     };
     use rand::rngs::StdRng;
-    use rand::{Rng, thread_rng};
+    use rand::{thread_rng, Rng};
     use rand_core::SeedableRng;
     use typenum::Unsigned;
 
@@ -772,30 +772,30 @@ pub mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::missing_panics_doc)]
+    #[allow(clippy::missing_panics_doc, clippy::too_many_lines)]
     //#[ignore]
     pub async fn random_ipa_check() {
         const MAX_BREAKDOWN_KEY: usize = 16;
         const MAX_TRIGGER_VALUE: u32 = 5;
-        const NUM_USERS: usize = 2;
-        const MAX_RECORDS_PER_USER: usize = 5;
+        const NUM_USERS: usize = 10;
+        const MAX_RECORDS_PER_USER: usize = 8;
         const NUM_MULTI_BITS: u32 = 3;
         const MAX_USER_ID: usize = 1_000_000_000_000;
         const SECONDS_IN_EPOCH: usize = 604_800;
 
-        let random_seed: u64 = thread_rng().gen();
-        let random_seed = 7560046;
+        let random_seed = thread_rng().gen();
         println!("Using random seed: {random_seed}");
-        let mut rng = StdRng::seed_from_u64(random_seed);
 
-        let mut raw_data = Vec::with_capacity(NUM_USERS * MAX_RECORDS_PER_USER);
-        let mut expected_results = vec![0_u32; MAX_BREAKDOWN_KEY];
         for per_user_cap in [1, 3] {
             println!("Running with a per-user-cap of {per_user_cap}.");
-            for i in 0..NUM_USERS {
+
+            let mut rng = StdRng::seed_from_u64(random_seed);
+
+            let mut raw_data = Vec::with_capacity(NUM_USERS * MAX_RECORDS_PER_USER);
+            let mut expected_results = vec![0_u32; MAX_BREAKDOWN_KEY];
+
+            for _ in 0..NUM_USERS {
                 let random_user_id = rng.gen_range(0..MAX_USER_ID);
-                let matches = 848468829005 == random_user_id;
-                println!("random user ID: {random_user_id}, is it the one? {matches}. This is index {i}."); // 848468829005
                 let num_records_for_user = rng.gen_range(1..MAX_RECORDS_PER_USER);
                 let mut records_for_user = Vec::with_capacity(num_records_for_user);
                 for _ in 0..num_records_for_user {
@@ -846,7 +846,7 @@ pub mod tests {
             }
             raw_data.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
 
-            println!("raw data (before secret-sharing): {raw_data:#?}");
+            //println!("raw data (before secret-sharing): {raw_data:#?}");
             println!("expected result: {expected_results:#?}");
             let records = raw_data
                 .iter()

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -572,7 +572,9 @@ pub mod tests {
         proptest,
         test_runner::{RngAlgorithm, TestRng},
     };
-    use rand::{thread_rng, Rng};
+    use rand::rngs::StdRng;
+    use rand::Rng;
+    use rand_core::SeedableRng;
     use typenum::Unsigned;
 
     #[tokio::test]
@@ -772,22 +774,22 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::missing_panics_doc)]
     //#[ignore]
-    pub async fn random_ipa_cap_one_check() {
+    pub async fn random_ipa_check() {
         const MAX_BREAKDOWN_KEY: usize = 16;
-        const NUM_USERS: usize = 20;
-        const MAX_RECORDS_PER_USER: usize = 10;
+        const NUM_USERS: usize = 1;
+        const MAX_RECORDS_PER_USER: usize = 2;
         const NUM_MULTI_BITS: u32 = 3;
         const MAX_USER_ID: usize = 1_000_000_000_000;
         const SECONDS_IN_EPOCH: usize = 604_800;
 
-        let mut rng = thread_rng();
+        let mut rng = StdRng::from_seed([1_u8; 32]);
 
         let mut raw_data = Vec::with_capacity(NUM_USERS * MAX_RECORDS_PER_USER);
         let mut expected_results = vec![0_u32; MAX_BREAKDOWN_KEY];
-        let per_user_cap: u32 = 1;
+        let per_user_cap: u32 = 3;
         for _ in 0..NUM_USERS {
             let random_user_id = rng.gen_range(0..MAX_USER_ID);
-            let num_records_for_user = rng.gen_range(1..MAX_RECORDS_PER_USER);
+            let num_records_for_user = MAX_RECORDS_PER_USER;// rng.gen_range(1..MAX_RECORDS_PER_USER);
             let mut records_for_user = Vec::with_capacity(num_records_for_user);
             for _ in 0..num_records_for_user {
                 let random_timestamp = rng.gen_range(0..SECONDS_IN_EPOCH);


### PR DESCRIPTION
The "random" IPA test did not actually validate that the output was correct.

This PR creates a single "random" IPA test, which uses a seeded random number generator and logs the seed. That way, if it ever fails, we can re-test the seed that led to the failure.

Since the logic differs (significantly) if the PER_USER_CAP is 1 or another number, the same input is tested twice, first with a PER_USER_CAP of 1, then with a PER_USER_CAP of 3.

The expected output is computed in a straightforward way that's easy to verify is correct.