### PR TITLE
Minor optimization. Skip one row.

### DIFF
--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -113,24 +113,20 @@ where
         .collect::<Vec<_>>();
 
     let prefix_ors =
-        prefix_or_binary_tree_style(ctx.clone(), &helper_bits, &uncapped_credits).await?;
+        prefix_or_binary_tree_style(ctx.clone(), &helper_bits[1..], &uncapped_credits[1..]).await?;
 
     let prefix_or_times_helper_bit_ctx = ctx
         .narrow(&Step::PrefixOrTimesHelperBit)
         .set_total_records(input.len() - 1);
-    let ever_any_subsequent_credit = try_join_all(
-        prefix_ors
-            .iter()
-            .skip(1)
-            .zip(helper_bits.iter())
-            .enumerate()
-            .map(|(i, (prefix_or, helper_bit))| {
+    let ever_any_subsequent_credit =
+        try_join_all(prefix_ors.iter().zip(helper_bits.iter()).enumerate().map(
+            |(i, (prefix_or, helper_bit))| {
                 let record_id = RecordId::from(i);
                 let c = prefix_or_times_helper_bit_ctx.clone();
                 async move { c.multiply(record_id, prefix_or, helper_bit).await }
-            }),
-    )
-    .await?;
+            },
+        ))
+        .await?;
 
     let potentially_cap_ctx = ctx
         .narrow(&Step::IfCurrentExceedsCapOrElse)

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -973,10 +973,10 @@ pub mod tests {
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 26410;
 
         /// empirical value as of Feb 20, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7575;
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7557;
 
         /// empirical value as of Feb 20, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18885;
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18849;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
Extremely minor performance improvement.

In the PER_USER_CAP = 1 variant of the code:
...we checking if we need to filter out a given row.
...we do that by checking if the _following_ rows contain at least one contribution from the same user.

So that means nobody was ever reading the very *first* row.

This PR just avoids computing this value which was never read.