### PR TITLE
In memory transport with channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ no-prss = []
 # TODO Consider moving out benches as well
 web-app = ["axum", "axum-server", "enable-serde", "hex", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
-test-fixture = []
+test-fixture = ["enable-serde"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 enable-benches = ["cli", "test-fixture", "criterion", "iai"]

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -79,6 +79,10 @@ impl From<i32> for HelperIdentity {
 
 #[cfg(any(test, feature = "test-fixture"))]
 impl HelperIdentity {
+    pub const ONE: Self = Self { id: 1 };
+    pub const TWO: Self = Self { id: 2 };
+    pub const THREE: Self = Self { id: 3 };
+
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn make_three() -> [Self; 3] {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -67,6 +67,16 @@ impl From<HelperIdentity> for hyper::header::HeaderValue {
     }
 }
 
+#[cfg(test)]
+impl From<i32> for HelperIdentity {
+    fn from(value: i32) -> Self {
+        usize::try_from(value)
+            .ok()
+            .and_then(|id| HelperIdentity::try_from(id).ok())
+            .unwrap()
+    }
+}
+
 #[cfg(any(test, feature = "test-fixture"))]
 impl HelperIdentity {
     #[must_use]

--- a/src/helpers/transport/channelled_transport.rs
+++ b/src/helpers/transport/channelled_transport.rs
@@ -120,12 +120,9 @@ pub trait ChannelledTransport: Send + Sync + 'static {
 
     /// Return the stream of records to be received from another helper for the specific query
     /// and step
-    ///
-    /// ## Errors
-    /// When stream has been received already
     fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Step>>(
         &self,
         from: HelperIdentity,
         route: R,
-    ) -> Result<Self::RecordsStream, io::Error>;
+    ) -> Self::RecordsStream;
 }

--- a/src/helpers/transport/channelled_transport.rs
+++ b/src/helpers/transport/channelled_transport.rs
@@ -1,0 +1,33 @@
+use std::future::Future;
+use std::io;
+use futures::Stream;
+use crate::helpers::HelperIdentity;
+use crate::helpers::query::QueryConfig;
+use crate::protocol::QueryId;
+use async_trait::async_trait;
+
+pub trait SendData : Send {
+    type Body: Stream<Item = Vec<u8>> + Send;
+
+    fn into(self) -> (String, Self::Body);
+}
+
+// pub struct TransportVtable {
+//     pub receive_query: fn::<F>(QueryConfig) -> F;
+// }
+
+/// Transport that supports per-step channels
+#[async_trait]
+pub trait ChannelledTransport: Send + Sync + 'static {
+    /// Returns the identity of the helper that runs this transport
+    fn identity(&self) -> HelperIdentity;
+
+    // fn set_receive_query_cb<C: FnOnce(QueryConfig) -> F, F: Future<Output = Result<QueryId, String>>>(&self, callback: C);
+
+    // /// receive new request to initiate a query.
+    // fn receive_query<C: FnOnce(QueryConfig) -> F, F: Future<Output = Result<QueryId, String>>>(&self, callback: C);
+
+    // async fn receive_step() -> (QueryId, ChannelId, Data, CloseRequestFut);
+
+    async fn send<S: SendData>(&self, dest: HelperIdentity, data: S) -> Result<(), io::Error>;
+}

--- a/src/helpers/transport/channelled_transport.rs
+++ b/src/helpers/transport/channelled_transport.rs
@@ -1,33 +1,131 @@
-use std::future::Future;
 use std::io;
-use futures::Stream;
+
 use crate::helpers::HelperIdentity;
-use crate::helpers::query::QueryConfig;
-use crate::protocol::QueryId;
+use futures::Stream;
+
+use crate::protocol::{QueryId, Step};
 use async_trait::async_trait;
 
-pub trait SendData : Send {
-    type Body: Stream<Item = Vec<u8>> + Send;
-
-    fn into(self) -> (String, Self::Body);
+pub trait ResourceIdentifier: Sized {}
+pub trait QueryIdBinding: Sized
+where
+    Option<QueryId>: From<Self>,
+{
+}
+pub trait StepBinding: Sized
+where
+    Option<Step>: From<Self>,
+{
 }
 
-// pub struct TransportVtable {
-//     pub receive_query: fn::<F>(QueryConfig) -> F;
-// }
+pub struct NoResourceIdentifier;
+pub struct NoQueryId;
+pub struct NoStep;
 
-/// Transport that supports per-step channels
+#[derive(Debug, Copy, Clone)]
+pub enum RouteId {
+    Records,
+    ReceiveQuery,
+}
+
+impl ResourceIdentifier for NoResourceIdentifier {}
+impl ResourceIdentifier for RouteId {}
+
+impl From<NoQueryId> for Option<QueryId> {
+    fn from(_: NoQueryId) -> Self {
+        None
+    }
+}
+
+impl QueryIdBinding for NoQueryId {}
+impl QueryIdBinding for QueryId {}
+
+impl From<NoStep> for Option<Step> {
+    fn from(_: NoStep) -> Self {
+        None
+    }
+}
+
+impl StepBinding for NoStep {}
+impl StepBinding for Step {}
+
+pub trait RouteParams<R: ResourceIdentifier, Q: QueryIdBinding, S: StepBinding>: Send
+where
+    Option<QueryId>: From<Q>,
+    Option<Step>: From<S>,
+{
+    fn resource_identifier(&self) -> R;
+    fn query_id(&self) -> Q;
+    fn step(&self) -> S;
+
+    fn extra(&self) -> &str;
+}
+
+impl RouteParams<NoResourceIdentifier, QueryId, Step> for (QueryId, Step) {
+    fn resource_identifier(&self) -> NoResourceIdentifier {
+        NoResourceIdentifier
+    }
+
+    fn query_id(&self) -> QueryId {
+        self.0
+    }
+
+    fn step(&self) -> Step {
+        self.1.clone()
+    }
+
+    fn extra(&self) -> &str {
+        ""
+    }
+}
+
+impl RouteParams<RouteId, QueryId, Step> for (RouteId, QueryId, Step) {
+    fn resource_identifier(&self) -> RouteId {
+        self.0
+    }
+
+    fn query_id(&self) -> QueryId {
+        self.1
+    }
+
+    fn step(&self) -> Step {
+        self.2.clone()
+    }
+
+    fn extra(&self) -> &str {
+        ""
+    }
+}
+
+/// Transport that supports per-query,per-step channels
 #[async_trait]
 pub trait ChannelledTransport: Send + Sync + 'static {
-    /// Returns the identity of the helper that runs this transport
+    type DataStream: Stream<Item = Vec<u8>>;
+    type RecordsStream: Stream<Item = Vec<u8>>;
+
     fn identity(&self) -> HelperIdentity;
 
-    // fn set_receive_query_cb<C: FnOnce(QueryConfig) -> F, F: Future<Output = Result<QueryId, String>>>(&self, callback: C);
+    async fn send<Q, S, R>(
+        &self,
+        dest: HelperIdentity,
+        route: R,
+        data: Self::DataStream,
+    ) -> Result<(), io::Error>
+    where
+        Option<QueryId>: From<Q>,
+        Option<Step>: From<S>,
+        Q: QueryIdBinding,
+        S: StepBinding,
+        R: RouteParams<RouteId, Q, S>;
 
-    // /// receive new request to initiate a query.
-    // fn receive_query<C: FnOnce(QueryConfig) -> F, F: Future<Output = Result<QueryId, String>>>(&self, callback: C);
-
-    // async fn receive_step() -> (QueryId, ChannelId, Data, CloseRequestFut);
-
-    async fn send<S: SendData>(&self, dest: HelperIdentity, data: S) -> Result<(), io::Error>;
+    /// Return the stream of records to be received from another helper for the specific query
+    /// and step
+    ///
+    /// ## Errors
+    /// When stream has been received already
+    fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Step>>(
+        &self,
+        from: HelperIdentity,
+        route: R,
+    ) -> Result<Self::RecordsStream, io::Error>;
 }

--- a/src/helpers/transport/mod.rs
+++ b/src/helpers/transport/mod.rs
@@ -1,12 +1,15 @@
 pub mod query;
 
 mod bytearrstream;
-mod error;
 mod channelled_transport;
+mod error;
 
 pub use bytearrstream::{AlignedByteArrStream, ByteArrStream};
+pub use channelled_transport::{
+    ChannelledTransport, NoResourceIdentifier, QueryIdBinding, ResourceIdentifier, RouteId,
+    RouteParams, StepBinding,
+};
 pub use error::Error as TransportError;
-pub use channelled_transport::{ChannelledTransport as ChannelledTransport, SendData};
 
 use crate::{
     helpers::HelperIdentity,

--- a/src/helpers/transport/mod.rs
+++ b/src/helpers/transport/mod.rs
@@ -2,9 +2,11 @@ pub mod query;
 
 mod bytearrstream;
 mod error;
+mod channelled_transport;
 
 pub use bytearrstream::{AlignedByteArrStream, ByteArrStream};
 pub use error::Error as TransportError;
+pub use channelled_transport::{ChannelledTransport as ChannelledTransport, SendData};
 
 use crate::{
     helpers::HelperIdentity,

--- a/src/helpers/transport/query.rs
+++ b/src/helpers/transport/query.rs
@@ -4,11 +4,13 @@ use crate::{
     protocol::{QueryId, Substep},
     query::ProtocolResult,
 };
+use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use tokio::sync::oneshot;
 
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct QueryConfig {
     pub field_type: FieldType,
     pub query_type: QueryType,
@@ -89,6 +91,7 @@ impl From<QueryCommand> for TransportCommand {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum QueryType {
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
     TestMultiply,
@@ -114,6 +117,7 @@ impl AsRef<str> for QueryType {
 impl Substep for QueryType {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct IpaQueryConfig {
     pub per_user_credit_cap: u32,
     pub max_breakdown_key: u128,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod protocol;
 pub mod query;
 pub mod secret_sharing;
 pub mod telemetry;
-#[cfg(feature = "enable-serde")]
+#[cfg(all(feature = "enable-serde", feature = "web-app"))]
 pub mod uri;
 
 #[cfg(any(test, feature = "test-fixture"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod test_fixture;
 
 mod tests;
 
+extern crate core;
 #[cfg(all(feature = "shuttle", test))]
 extern crate shuttle_crate as shuttle;
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     bits::{BitArray40, BitArray8},
     error::Error,
 };
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::ops::AddAssign;
 
@@ -73,6 +73,12 @@ impl Substep for str {}
 )]
 pub struct Step {
     id: String,
+}
+
+impl Display for Step {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
+    }
 }
 
 impl Step {
@@ -214,6 +220,14 @@ impl Debug for Step {
     serde(into = "&'static str", try_from = "&str")
 )]
 pub struct QueryId;
+
+impl Display for QueryId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // fail when query id becomes meaningful and change the display implementation
+        let _ = QueryId;
+        write!(f, "{self:?}")
+    }
+}
 
 impl QueryId {
     fn repr() -> &'static str {

--- a/src/test_fixture/transport/channeled_transport.rs
+++ b/src/test_fixture/transport/channeled_transport.rs
@@ -1,0 +1,301 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::Hash;
+use std::io;
+use std::iter::Once;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, Weak};
+use std::task::Waker;
+use async_trait::async_trait;
+use futures::Stream;
+use tokio::sync::mpsc::{Receiver, Sender};
+use crate::helpers::HelperIdentity;
+use crate::helpers::query::{QueryConfig, QueryType};
+use crate::helpers::transport::{ChannelledTransport, SendData};
+use crate::protocol::QueryId;
+use futures::StreamExt;
+use futures_util::stream;
+use sha2::digest::Output;
+use crate::ff::FieldType;
+
+#[derive(Debug)]
+struct InMemoryPacket {
+    meta: String,
+    data: Vec<u8>,
+}
+
+type ConnectionTx = Sender<InMemoryPacket>;
+type ConnectionRx = Receiver<InMemoryPacket>;
+
+impl SendData for InMemoryPacket {
+    type Body = stream::Iter<Once<Vec<u8>>>;
+
+    fn into(self) -> (String, Self::Body) {
+        (self.meta, stream::iter(std::iter::once(self.data)))
+    }
+}
+
+
+impl InMemoryPacket {
+    async fn new_from<S: SendData>(input: S) -> Self {
+        let (meta, body) = input.into();
+        let body = body.map(|chunk| stream::iter(chunk)).flatten().collect::<Vec<u8>>().await;
+
+        Self {
+            meta,
+            data: body,
+        }
+    }
+
+    pub fn receive_query(config: QueryConfig) -> Self {
+        todo!()
+    }
+}
+
+struct Callbacks<RCQ> {
+    receive_query: RCQ,
+}
+
+type InMemoryCallbacks = Callbacks<
+    // receive
+    fn(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>>
+>;
+
+// trait TransportCallbacks {
+//     type RQC: Fn(QueryConfig) -> Pin<Box<dyn Future<Output = Result<QueryId, String>> + Send>>;
+//
+//     fn receive_query() -> Self::RQC;
+// }
+//
+// struct Foo {}
+//
+// impl TransportCallbacks for Foo {
+//     type RQC = ();
+//
+//     fn receive_query() -> Self::RQC {
+//         todo!()
+//     }
+// }
+
+trait ReceiveQueryCallback: FnMut(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>> + Send {}
+
+impl<F: FnMut(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>> + Send> ReceiveQueryCallback for F {}
+
+struct MyCallbacks<RQC: ReceiveQueryCallback> {
+    receive_query: RQC,
+}
+
+
+struct LockedBox<V> {
+    value: Arc<Mutex<Option<V>>>,
+    waker: Option<Waker>,
+}
+
+impl<V> LockedBox<V> {
+    pub fn new(value: Arc<Mutex<Option<V>>>, waker: Waker) -> Self {
+        Self {
+            value,
+            waker: Some(waker),
+        }
+    }
+    pub fn set(mut self, value: V) {
+        *self.value.lock().unwrap() = Some(value);
+        self.waker.take().expect("waker should not be taken").wake();
+    }
+}
+
+impl<V> Drop for LockedBox<V> {
+    fn drop(&mut self) {
+        assert!(self.waker.is_none())
+    }
+}
+
+struct Envelope<I, O> {
+    input: I,
+    output: Arc<Mutex<Option<O>>>,
+    waker: Waker,
+}
+
+impl<I, O> Envelope<I, O> {
+    fn consume(self) -> (I, LockedBox<O>) {
+        (self.input, LockedBox::new(self.output, self.waker))
+    }
+}
+
+#[async_trait]
+trait CustomizedTransport {
+    async fn receive_query(&self) -> Envelope<QueryConfig, QueryId>;
+}
+
+
+struct Setup {
+    identity: HelperIdentity,
+    rx: ConnectionRx,
+    callbacks: InMemoryCallbacks,
+    connections: HashMap<HelperIdentity, ConnectionTx>,
+}
+
+impl Setup {
+    pub fn new(identity: HelperIdentity, rx: ConnectionRx, callbacks: InMemoryCallbacks) -> Self {
+        Self {
+            identity,
+            rx,
+            callbacks,
+            connections: HashMap::default(),
+        }
+    }
+
+    pub fn connect(&mut self, peer: HelperIdentity, tx: ConnectionTx) {
+        self.connections.insert(peer, tx).unwrap();
+    }
+
+    pub fn setup(self) -> InMemoryChannelledTransport {
+        let transport = InMemoryChannelledTransport::new(
+            self.identity,
+            self.connections,
+        );
+        InMemoryChannelledTransport::listen(self.callbacks, self.rx);
+
+        transport
+    }
+}
+
+struct InMemoryChannelledTransport {
+    identity: HelperIdentity,
+    connections: HashMap<HelperIdentity, ConnectionTx>,
+}
+
+impl InMemoryChannelledTransport {
+    pub fn listen2<F: ReceiveQueryCallback + 'static + Sync>(mut callbacks: MyCallbacks<F>, mut rx: ConnectionRx) {
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                println!("received a packet: {msg:?}");
+                let qc = QueryConfig {
+                    field_type: FieldType::Fp31,
+                    query_type: QueryType::TestMultiply,
+                };
+                let query_id = (callbacks.receive_query)(qc)
+                    .await
+                    .expect("Should be able to receive a new query request");
+            };
+        });
+    }
+    pub fn listen(callbacks: InMemoryCallbacks, mut rx: ConnectionRx) {
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                println!("received a packet: {msg:?}");
+                let qc = QueryConfig {
+                    field_type: FieldType::Fp31,
+                    query_type: QueryType::TestMultiply,
+                };
+                let query_id = (callbacks.receive_query)(qc)
+                    .await
+                    .expect("Should be able to receive a new query request");
+            };
+        });
+    }
+}
+
+impl InMemoryChannelledTransport {
+    pub fn new(identity: HelperIdentity, connections: HashMap<HelperIdentity, ConnectionTx>) -> Self {
+        Self {
+            identity,
+            connections,
+        }
+    }
+}
+
+
+impl InMemoryChannelledTransport {
+    async fn get_channel(&self, dest: HelperIdentity) -> ConnectionTx {
+        self.connections.get(&dest).expect(&format!("Should have an active connection from {:?} to {:?}", self.identity, dest)).clone()
+    }
+}
+
+
+fn upgrade(transport: &Weak<InMemoryChannelledTransport>) -> Arc<InMemoryChannelledTransport> {
+    let this = transport.upgrade().expect("Transport should not be destroyed");
+    this
+}
+
+
+#[async_trait]
+impl ChannelledTransport for Weak<InMemoryChannelledTransport> {
+    fn identity(&self) -> HelperIdentity {
+        upgrade(self).identity
+    }
+
+    async fn send<S: SendData>(&self, dest: HelperIdentity, data: S) -> Result<(), io::Error> {
+        let channel = upgrade(self)
+            .get_channel(dest)
+            .await;
+
+        let packet = InMemoryPacket::new_from(data).await;
+
+        channel.send(packet).await.map_err(|e| io::Error::new::<String>(io::ErrorKind::ConnectionAborted, "channel closed".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc::channel;
+    use tokio::sync::oneshot;
+    use crate::helpers::HelperIdentity;
+    use super::*;
+
+    // async fn test_cb_trait<T: TransportCallbacks>() {
+    //     let rqc = T::receive_query();
+    //     let qc = QueryConfig {
+    //         field_type: FieldType::Fp31,
+    //         query_type: QueryType::TestMultiply,
+    //     };
+    //     let query_id = rqc(qc).await.unwrap();
+    //     println!("query id = {query_id:?}");
+    // }
+
+    #[tokio::test]
+    async fn callback() {
+        let id = HelperIdentity::try_from(1).unwrap();
+        let (tx, rx) = channel(1);
+        let (signal_tx, signal_rx) = oneshot::channel::<()>();
+        let cb = InMemoryCallbacks {
+            receive_query: |(query_config)| Box::pin(async move {
+                println!("received: {query_config:?}");
+                // signal_tx.send(()).unwrap();
+                Ok(QueryId)
+            })
+        };
+
+        // let mut signal_tx2 = Some(signal_tx);
+        let signal_tx2 = Some(signal_tx);
+        let my_cb = MyCallbacks {
+            receive_query: |(query_config)| Box::pin(async {
+                println!("received: {query_config:?}");
+                let y = signal_tx2.as_ref();
+                // signal_tx2.take().unwrap().send(()).unwrap();
+                Ok(QueryId)
+            })
+        };
+
+        let setup = Setup::new(id, rx, cb);
+        tx.send(InMemoryPacket::receive_query(QueryConfig {
+            field_type: FieldType::Fp32BitPrime,
+            query_type: QueryType::TestMultiply,
+        })).await.unwrap();
+
+        // signal_rx.await.unwrap();
+    }
+
+    // #[tokio::test]
+    // async fn basic_comm() {
+    //     let re
+    //     let identities = HelperIdentity::make_three()
+    //         .map(|id| {
+    //             let (tx, rx) = channel(1);
+    //             Setup::new(id, rx)
+    //         });
+    //
+    //
+    // }
+}

--- a/src/test_fixture/transport/channeled_transport.rs
+++ b/src/test_fixture/transport/channeled_transport.rs
@@ -1,16 +1,6 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
-use std::future::Future;
+#![allow(dead_code)]
 
-use std::io;
-
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
-
-use crate::ff::FieldType;
-use crate::helpers::query::{QueryConfig, QueryType};
+use crate::helpers::query::QueryConfig;
 use crate::helpers::transport::{
     ChannelledTransport, NoResourceIdentifier, QueryIdBinding, RouteId, RouteParams, StepBinding,
 };
@@ -22,6 +12,14 @@ use futures::StreamExt;
 use futures_util::future::Either;
 use futures_util::stream;
 use serde::de::DeserializeOwned;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
@@ -206,10 +204,6 @@ impl InMemoryPacket {
             step: Some(step),
             params: String::new(),
         }
-        // Self {
-        //     addr: "records".to_string(),
-        //     params: serde_json::to_string(&(query_id, from, step.as_ref())).unwrap(),
-        // }
     }
 }
 
@@ -396,6 +390,8 @@ impl ChannelledTransport for InMemoryChannelledTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ff::FieldType;
+    use crate::helpers::query::QueryType;
     use crate::helpers::HelperIdentity;
     use crate::protocol::Step;
     use futures_util::stream::poll_immediate;

--- a/src/test_fixture/transport/channeled_transport.rs
+++ b/src/test_fixture/transport/channeled_transport.rs
@@ -1,301 +1,579 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::future::Future;
-use std::hash::Hash;
+
 use std::io;
-use std::iter::Once;
-use std::marker::PhantomData;
+
 use std::pin::Pin;
-use std::sync::{Arc, Mutex, Weak};
-use std::task::Waker;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+use crate::ff::FieldType;
+use crate::helpers::query::{QueryConfig, QueryType};
+use crate::helpers::transport::{
+    ChannelledTransport, NoResourceIdentifier, QueryIdBinding, RouteId, RouteParams, StepBinding,
+};
+use crate::helpers::HelperIdentity;
+use crate::protocol::{QueryId, Step};
 use async_trait::async_trait;
 use futures::Stream;
-use tokio::sync::mpsc::{Receiver, Sender};
-use crate::helpers::HelperIdentity;
-use crate::helpers::query::{QueryConfig, QueryType};
-use crate::helpers::transport::{ChannelledTransport, SendData};
-use crate::protocol::QueryId;
 use futures::StreamExt;
+use futures_util::future::Either;
 use futures_util::stream;
-use sha2::digest::Output;
-use crate::ff::FieldType;
+use serde::de::DeserializeOwned;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::Instrument;
 
-#[derive(Debug)]
 struct InMemoryPacket {
-    meta: String,
-    data: Vec<u8>,
+    addr: RouteId,
+    origin: Option<HelperIdentity>,
+    query_id: Option<QueryId>,
+    step: Option<Step>,
+    params: String,
 }
 
-type ConnectionTx = Sender<InMemoryPacket>;
-type ConnectionRx = Receiver<InMemoryPacket>;
-
-impl SendData for InMemoryPacket {
-    type Body = stream::Iter<Once<Vec<u8>>>;
-
-    fn into(self) -> (String, Self::Body) {
-        (self.meta, stream::iter(std::iter::once(self.data)))
+impl InMemoryPacket {
+    fn from_route<Q: QueryIdBinding, S: StepBinding, R: RouteParams<RouteId, Q, S>>(
+        origin: HelperIdentity,
+        route: &R,
+    ) -> Self
+    where
+        Option<QueryId>: From<Q>,
+        Option<Step>: From<S>,
+    {
+        Self {
+            addr: route.resource_identifier(),
+            origin: Some(origin),
+            query_id: route.query_id().into(),
+            step: route.step().into(),
+            params: route.extra().to_string(),
+        }
     }
 }
 
+impl Debug for InMemoryPacket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "InMemoryPacket[addr={:?}, query_id={:?}, step={:?}, params={}]",
+            self.addr, self.query_id, self.step, self.params
+        )
+    }
+}
+
+type ConnectionTx = Sender<(InMemoryPacket, InMemoryStream)>;
+type ConnectionRx = Receiver<(InMemoryPacket, InMemoryStream)>;
+
+type StreamCollection<S> = HashMap<(QueryId, HelperIdentity, Step), Either<S, Waker>>;
+
+pub struct ReceiveRecords<S> {
+    inner: ReceiveRecordsInner<S>,
+}
+
+struct StreamWaiter<S> {
+    addr: (QueryId, HelperIdentity, Step),
+    coll_ptr: Arc<Mutex<StreamCollection<S>>>,
+}
+
+impl<S: Stream> StreamWaiter<S> {
+    fn check(&self, waker: &Waker) -> Option<S> {
+        let mut streams = self.coll_ptr.lock().unwrap();
+        match streams.insert(self.addr.clone(), Either::Right(waker.clone())) {
+            None => None,
+            Some(either) => {
+                match either {
+                    Either::Left(stream) => {
+                        // TODO: if stream has been consumed, nothing prevents transport client
+                        // to call receive again with the same arguments. It may be fine though
+                        // as it won't ever return `Poll::Ready`
+                        Some(stream)
+                    }
+                    Either::Right(old_waker) => {
+                        assert!(old_waker.will_wake(waker));
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum ReceiveRecordsInner<S> {
+    Uninitialized(StreamWaiter<S>),
+    Initialized(S),
+}
+
+impl<S: Stream + Unpin> Stream for ReceiveRecords<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<S: Stream + Unpin> Stream for ReceiveRecordsInner<S> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = Pin::get_mut(self);
+        loop {
+            match this {
+                ReceiveRecordsInner::Uninitialized(waiter) => match waiter.check(cx.waker()) {
+                    None => {
+                        return Poll::Pending;
+                    }
+                    Some(stream) => *this = ReceiveRecordsInner::Initialized(stream),
+                },
+                ReceiveRecordsInner::Initialized(stream) => {
+                    return stream.poll_next_unpin(cx);
+                }
+            }
+        }
+    }
+}
+
+type StreamItem = Vec<u8>;
+
+struct InMemoryStream {
+    /// There is only one reason for this to have dynamic dispatch: tests that use from_iter method.
+    inner: Option<Pin<Box<dyn Stream<Item = StreamItem> + Send>>>,
+}
+
+impl Debug for InMemoryStream {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InMemoryStream")
+    }
+}
+
+impl InMemoryStream {
+    fn empty() -> Self {
+        Self { inner: None }
+    }
+
+    fn from_iter<I>(input: I) -> Self
+    where
+        I: IntoIterator<Item = StreamItem>,
+        I::IntoIter: Send + 'static,
+    {
+        Self {
+            inner: Some(Box::pin(stream::iter(input.into_iter()))),
+        }
+    }
+}
+
+impl From<Receiver<StreamItem>> for InMemoryStream {
+    fn from(value: Receiver<StreamItem>) -> Self {
+        Self {
+            inner: Some(Box::pin(ReceiverStream::new(value))),
+        }
+    }
+}
+
+impl Stream for InMemoryStream {
+    type Item = StreamItem;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = Pin::get_mut(self);
+        match &mut this.inner {
+            None => Poll::Ready(None),
+            Some(s) => s.poll_next_unpin(cx),
+        }
+    }
+}
 
 impl InMemoryPacket {
-    async fn new_from<S: SendData>(input: S) -> Self {
-        let (meta, body) = input.into();
-        let body = body.map(|chunk| stream::iter(chunk)).flatten().collect::<Vec<u8>>().await;
-
-        Self {
-            meta,
-            data: body,
-        }
+    pub fn into<T: DeserializeOwned>(self) -> T {
+        serde_json::from_str(&self.params).unwrap()
     }
 
     pub fn receive_query(config: QueryConfig) -> Self {
-        todo!()
+        Self {
+            addr: RouteId::ReceiveQuery,
+            origin: None,
+            query_id: None,
+            step: None,
+            params: serde_json::to_string(&config).unwrap(),
+        }
+    }
+
+    pub fn records(from: HelperIdentity, query_id: QueryId, step: Step) -> Self {
+        Self {
+            addr: RouteId::Records,
+            origin: Some(from),
+            query_id: Some(query_id),
+            step: Some(step),
+            params: String::new(),
+        }
+        // Self {
+        //     addr: "records".to_string(),
+        //     params: serde_json::to_string(&(query_id, from, step.as_ref())).unwrap(),
+        // }
     }
 }
 
-struct Callbacks<RCQ> {
-    receive_query: RCQ,
+trait ReceiveQueryCallback:
+    FnMut(QueryConfig) -> Pin<Box<dyn Future<Output = Result<QueryId, String>> + Send>> + Send
+{
 }
 
-type InMemoryCallbacks = Callbacks<
-    // receive
-    fn(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>>
->;
+impl<
+        F: FnMut(QueryConfig) -> Pin<Box<dyn Future<Output = Result<QueryId, String>> + Send>> + Send,
+    > ReceiveQueryCallback for F
+{
+}
 
-// trait TransportCallbacks {
-//     type RQC: Fn(QueryConfig) -> Pin<Box<dyn Future<Output = Result<QueryId, String>> + Send>>;
-//
-//     fn receive_query() -> Self::RQC;
-// }
-//
-// struct Foo {}
-//
-// impl TransportCallbacks for Foo {
-//     type RQC = ();
-//
-//     fn receive_query() -> Self::RQC {
-//         todo!()
-//     }
-// }
-
-trait ReceiveQueryCallback: FnMut(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>> + Send {}
-
-impl<F: FnMut(QueryConfig) -> Pin<Box<dyn Future<Output=Result<QueryId, String>> + Send>> + Send> ReceiveQueryCallback for F {}
-
-struct MyCallbacks<RQC: ReceiveQueryCallback> {
+struct TransportCallbacks<RQC: ReceiveQueryCallback> {
     receive_query: RQC,
 }
 
-
-struct LockedBox<V> {
-    value: Arc<Mutex<Option<V>>>,
-    waker: Option<Waker>,
-}
-
-impl<V> LockedBox<V> {
-    pub fn new(value: Arc<Mutex<Option<V>>>, waker: Waker) -> Self {
-        Self {
-            value,
-            waker: Some(waker),
-        }
-    }
-    pub fn set(mut self, value: V) {
-        *self.value.lock().unwrap() = Some(value);
-        self.waker.take().expect("waker should not be taken").wake();
-    }
-}
-
-impl<V> Drop for LockedBox<V> {
-    fn drop(&mut self) {
-        assert!(self.waker.is_none())
-    }
-}
-
-struct Envelope<I, O> {
-    input: I,
-    output: Arc<Mutex<Option<O>>>,
-    waker: Waker,
-}
-
-impl<I, O> Envelope<I, O> {
-    fn consume(self) -> (I, LockedBox<O>) {
-        (self.input, LockedBox::new(self.output, self.waker))
-    }
-}
-
-#[async_trait]
-trait CustomizedTransport {
-    async fn receive_query(&self) -> Envelope<QueryConfig, QueryId>;
-}
-
-
-struct Setup {
+struct Setup<CB: ReceiveQueryCallback> {
     identity: HelperIdentity,
+    tx: ConnectionTx,
     rx: ConnectionRx,
-    callbacks: InMemoryCallbacks,
+    callbacks: TransportCallbacks<CB>,
     connections: HashMap<HelperIdentity, ConnectionTx>,
 }
 
-impl Setup {
-    pub fn new(identity: HelperIdentity, rx: ConnectionRx, callbacks: InMemoryCallbacks) -> Self {
+impl<CB: ReceiveQueryCallback + 'static> Setup<CB> {
+    pub fn new(identity: HelperIdentity, callbacks: TransportCallbacks<CB>) -> Self {
+        let (tx, rx) = channel(1);
         Self {
             identity,
+            tx,
             rx,
             callbacks,
             connections: HashMap::default(),
         }
     }
 
-    pub fn connect(&mut self, peer: HelperIdentity, tx: ConnectionTx) {
-        self.connections.insert(peer, tx).unwrap();
+    pub fn connect(&mut self, other: &mut Self) {
+        assert!(self
+            .connections
+            .insert(other.identity, other.tx.clone())
+            .is_none());
+        assert!(other
+            .connections
+            .insert(self.identity, self.tx.clone())
+            .is_none());
     }
 
-    pub fn setup(self) -> InMemoryChannelledTransport {
-        let transport = InMemoryChannelledTransport::new(
-            self.identity,
-            self.connections,
-        );
-        InMemoryChannelledTransport::listen(self.callbacks, self.rx);
+    pub fn finish(self) -> (ConnectionTx, InMemoryChannelledTransport) {
+        let transport = InMemoryChannelledTransport::new(self.identity, self.connections);
+        transport.listen(self.callbacks, self.rx);
 
-        transport
+        (self.tx, transport)
     }
 }
 
 struct InMemoryChannelledTransport {
     identity: HelperIdentity,
     connections: HashMap<HelperIdentity, ConnectionTx>,
+    record_streams: Arc<Mutex<StreamCollection<InMemoryStream>>>,
 }
 
 impl InMemoryChannelledTransport {
-    pub fn listen2<F: ReceiveQueryCallback + 'static + Sync>(mut callbacks: MyCallbacks<F>, mut rx: ConnectionRx) {
-        tokio::spawn(async move {
-            while let Some(msg) = rx.recv().await {
-                println!("received a packet: {msg:?}");
-                let qc = QueryConfig {
-                    field_type: FieldType::Fp31,
-                    query_type: QueryType::TestMultiply,
+    pub fn listen<CB: ReceiveQueryCallback + 'static>(
+        &self,
+        mut callbacks: TransportCallbacks<CB>,
+        mut rx: ConnectionRx,
+    ) {
+        tokio::spawn({
+            let streams = Arc::clone(&self.record_streams);
+            async move {
+                while let Some((msg, stream)) = rx.recv().await {
+                    tracing::trace!("received new packet: {msg:?}");
+
+                    match msg.addr {
+                        RouteId::ReceiveQuery => {
+                            let qc = msg.into::<QueryConfig>();
+                            let _query_id = (callbacks.receive_query)(qc)
+                                .await
+                                .expect("Should be able to receive a new query request");
+                        }
+                        RouteId::Records => {
+                            let query_id = msg.query_id.unwrap();
+                            let step = msg.step.unwrap();
+                            let from = msg.origin.unwrap();
+                            let mut streams = streams.lock().unwrap();
+                            match streams.entry((query_id, from, step)) {
+                                Entry::Occupied(mut entry) => {
+                                    match entry.get_mut() {
+                                        Either::Left(_) => {
+                                            panic!("{:?} entry already has an active stream", entry.key());
+                                        }
+                                        waker_entry @ Either::Right(_) => {
+                                            let Either::Right(waker) = std::mem::replace(waker_entry, Either::Left(stream)) else {
+                                                unreachable!()
+                                            };
+                                            waker.wake();
+                                        }
+                                    }
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(Either::Left(stream));
+                                }
+                            }
+                        }
+                    }
                 };
-                let query_id = (callbacks.receive_query)(qc)
-                    .await
-                    .expect("Should be able to receive a new query request");
-            };
-        });
-    }
-    pub fn listen(callbacks: InMemoryCallbacks, mut rx: ConnectionRx) {
-        tokio::spawn(async move {
-            while let Some(msg) = rx.recv().await {
-                println!("received a packet: {msg:?}");
-                let qc = QueryConfig {
-                    field_type: FieldType::Fp31,
-                    query_type: QueryType::TestMultiply,
-                };
-                let query_id = (callbacks.receive_query)(qc)
-                    .await
-                    .expect("Should be able to receive a new query request");
-            };
-        });
+            }
+        }.instrument(tracing::info_span!("transport_loop", id=?self.identity).or_current()));
     }
 }
 
 impl InMemoryChannelledTransport {
-    pub fn new(identity: HelperIdentity, connections: HashMap<HelperIdentity, ConnectionTx>) -> Self {
+    pub fn new(
+        identity: HelperIdentity,
+        connections: HashMap<HelperIdentity, ConnectionTx>,
+    ) -> Self {
         Self {
             identity,
             connections,
+            record_streams: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 }
 
-
 impl InMemoryChannelledTransport {
-    async fn get_channel(&self, dest: HelperIdentity) -> ConnectionTx {
-        self.connections.get(&dest).expect(&format!("Should have an active connection from {:?} to {:?}", self.identity, dest)).clone()
+    fn get_channel(&self, dest: HelperIdentity) -> ConnectionTx {
+        self.connections
+            .get(&dest)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Should have an active connection from {:?} to {:?}",
+                    self.identity, dest
+                )
+            })
+            .clone()
     }
 }
-
-
-fn upgrade(transport: &Weak<InMemoryChannelledTransport>) -> Arc<InMemoryChannelledTransport> {
-    let this = transport.upgrade().expect("Transport should not be destroyed");
-    this
-}
-
 
 #[async_trait]
-impl ChannelledTransport for Weak<InMemoryChannelledTransport> {
+impl ChannelledTransport for InMemoryChannelledTransport {
+    type DataStream = InMemoryStream;
+    type RecordsStream = ReceiveRecords<Self::DataStream>;
+
     fn identity(&self) -> HelperIdentity {
-        upgrade(self).identity
+        self.identity
     }
 
-    async fn send<S: SendData>(&self, dest: HelperIdentity, data: S) -> Result<(), io::Error> {
-        let channel = upgrade(self)
-            .get_channel(dest)
-            .await;
+    async fn send<Q: QueryIdBinding, S: StepBinding, R: RouteParams<RouteId, Q, S>>(
+        &self,
+        dest: HelperIdentity,
+        route: R,
+        data: Self::DataStream,
+    ) -> Result<(), io::Error>
+    where
+        Option<QueryId>: From<Q>,
+        Option<Step>: From<S>,
+    {
+        let channel = self.get_channel(dest);
+        let packet = InMemoryPacket::from_route(self.identity, &route);
 
-        let packet = InMemoryPacket::new_from(data).await;
+        channel.send((packet, data)).await.map_err(|_e| {
+            io::Error::new::<String>(io::ErrorKind::ConnectionAborted, "channel closed".into())
+        })
+    }
 
-        channel.send(packet).await.map_err(|e| io::Error::new::<String>(io::ErrorKind::ConnectionAborted, "channel closed".into()))
+    fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Step>>(
+        &self,
+        from: HelperIdentity,
+        route: R,
+    ) -> Result<Self::RecordsStream, io::Error> {
+        let query_id = route.query_id();
+        let step = route.step();
+        Ok(ReceiveRecords {
+            inner: ReceiveRecordsInner::Uninitialized(StreamWaiter {
+                addr: (query_id, from, step),
+                coll_ptr: Arc::clone(&self.record_streams),
+            }),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::helpers::HelperIdentity;
+    use crate::protocol::Step;
+    use futures_util::stream::poll_immediate;
     use tokio::sync::mpsc::channel;
     use tokio::sync::oneshot;
-    use crate::helpers::HelperIdentity;
-    use super::*;
 
-    // async fn test_cb_trait<T: TransportCallbacks>() {
-    //     let rqc = T::receive_query();
-    //     let qc = QueryConfig {
-    //         field_type: FieldType::Fp31,
-    //         query_type: QueryType::TestMultiply,
-    //     };
-    //     let query_id = rqc(qc).await.unwrap();
-    //     println!("query id = {query_id:?}");
-    // }
+    const STEP: &str = "in-memory-transport";
 
-    #[tokio::test]
-    async fn callback() {
-        let id = HelperIdentity::try_from(1).unwrap();
-        let (tx, rx) = channel(1);
-        let (signal_tx, signal_rx) = oneshot::channel::<()>();
-        let cb = InMemoryCallbacks {
-            receive_query: |(query_config)| Box::pin(async move {
-                println!("received: {query_config:?}");
-                // signal_tx.send(()).unwrap();
-                Ok(QueryId)
-            })
-        };
-
-        // let mut signal_tx2 = Some(signal_tx);
-        let signal_tx2 = Some(signal_tx);
-        let my_cb = MyCallbacks {
-            receive_query: |(query_config)| Box::pin(async {
-                println!("received: {query_config:?}");
-                let y = signal_tx2.as_ref();
-                // signal_tx2.take().unwrap().send(()).unwrap();
-                Ok(QueryId)
-            })
-        };
-
-        let setup = Setup::new(id, rx, cb);
-        tx.send(InMemoryPacket::receive_query(QueryConfig {
-            field_type: FieldType::Fp32BitPrime,
-            query_type: QueryType::TestMultiply,
-        })).await.unwrap();
-
-        // signal_rx.await.unwrap();
+    fn stub_callbacks() -> TransportCallbacks<impl ReceiveQueryCallback> {
+        TransportCallbacks {
+            receive_query: move |_| Box::pin(async { unimplemented!() }),
+        }
     }
 
-    // #[tokio::test]
-    // async fn basic_comm() {
-    //     let re
-    //     let identities = HelperIdentity::make_three()
-    //         .map(|id| {
-    //             let (tx, rx) = channel(1);
-    //             Setup::new(id, rx)
-    //         });
-    //
-    //
-    // }
+    fn one_transport_setup<I: Into<i32>, C: ReceiveQueryCallback + 'static>(
+        id: I,
+        cb: TransportCallbacks<C>,
+    ) -> Setup<C> {
+        let id = HelperIdentity::from(id.into());
+
+        Setup::new(id, cb)
+    }
+
+    fn one_transport<I: Into<i32>, C: ReceiveQueryCallback + 'static>(
+        id: I,
+        cb: TransportCallbacks<C>,
+    ) -> (ConnectionTx, InMemoryChannelledTransport) {
+        one_transport_setup(id, cb).finish()
+    }
+
+    #[tokio::test]
+    async fn callback_is_called() {
+        let (signal_tx, signal_rx) = oneshot::channel();
+        let signal_tx = Arc::new(Mutex::new(Some(signal_tx)));
+        let (tx, _transport) = one_transport(
+            1,
+            TransportCallbacks {
+                receive_query: move |query_config| {
+                    Box::pin({
+                        let signal_tx = Arc::clone(&signal_tx);
+                        async move {
+                            // this works because callback is only called once
+                            signal_tx
+                                .lock()
+                                .unwrap()
+                                .take()
+                                .unwrap()
+                                .send(query_config)
+                                .unwrap();
+                            Ok(QueryId)
+                        }
+                    })
+                },
+            },
+        );
+        let expected = QueryConfig {
+            field_type: FieldType::Fp32BitPrime,
+            query_type: QueryType::TestMultiply,
+        };
+        tx.send((
+            InMemoryPacket::receive_query(expected),
+            InMemoryStream::empty(),
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(expected, signal_rx.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn receive_not_ready() {
+        let (tx, transport) = one_transport(1, stub_callbacks());
+        let from = HelperIdentity::from(2);
+        let expected = vec![vec![1], vec![2]];
+
+        let mut stream = transport
+            .receive(from, (QueryId, Step::from(STEP)))
+            .unwrap();
+
+        // make sure it is not ready as it hasn't received the records stream yet.
+        assert!(matches!(
+            poll_immediate(&mut stream).next().await,
+            Some(Poll::Pending)
+        ));
+        tx.send((
+            InMemoryPacket::records(from, QueryId, Step::from(STEP)),
+            InMemoryStream::from_iter(expected.clone()),
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(expected, stream.collect::<Vec<_>>().await);
+    }
+
+    #[tokio::test]
+    async fn receive_ready() {
+        let (tx, transport) = one_transport(1, stub_callbacks());
+        let from = HelperIdentity::from(2);
+        let expected = vec![vec![1], vec![2]];
+
+        tx.send((
+            InMemoryPacket::records(from, QueryId, Step::from(STEP)),
+            InMemoryStream::from_iter(expected.clone()),
+        ))
+        .await
+        .unwrap();
+        let stream = transport
+            .receive(from, (QueryId, Step::from(STEP)))
+            .unwrap();
+
+        assert_eq!(expected, stream.collect::<Vec<_>>().await);
+    }
+
+    #[tokio::test]
+    async fn two_helpers() {
+        async fn send_and_verify(
+            from: HelperIdentity,
+            to: HelperIdentity,
+            transports: &HashMap<HelperIdentity, InMemoryChannelledTransport>,
+        ) {
+            let (sink, stream) = channel(1);
+            let stream = InMemoryStream::from(stream);
+
+            let from_transport = transports.get(&from).unwrap();
+            let to_transport = transports.get(&to).unwrap();
+            let step = Step::from(STEP);
+
+            let mut recv = to_transport.receive(from, (QueryId, step.clone())).unwrap();
+            assert!(matches!(
+                poll_immediate(&mut recv).next().await,
+                Some(Poll::Pending)
+            ));
+
+            from_transport
+                .send(to, (RouteId::Records, QueryId, step.clone()), stream)
+                .await
+                .unwrap();
+            sink.send(vec![1, 2, 3]).await.unwrap();
+            assert_eq!(vec![1, 2, 3], recv.next().await.unwrap());
+            assert!(matches!(
+                poll_immediate(&mut recv).next().await,
+                Some(Poll::Pending)
+            ));
+
+            sink.send(vec![4, 5, 6]).await.unwrap();
+            assert_eq!(vec![4, 5, 6], recv.next().await.unwrap());
+            assert!(matches!(
+                poll_immediate(&mut recv).next().await,
+                Some(Poll::Pending)
+            ));
+
+            drop(sink);
+            assert!(matches!(poll_immediate(&mut recv).next().await, None));
+        }
+
+        let mut setup1 = one_transport_setup(1, stub_callbacks());
+        let mut setup2 = one_transport_setup(2, stub_callbacks());
+
+        setup1.connect(&mut setup2);
+
+        let (_, transport1) = setup1.finish();
+        let (_, transport2) = setup2.finish();
+        let transports = HashMap::from([
+            (HelperIdentity::from(1), transport1),
+            (HelperIdentity::from(2), transport2),
+        ]);
+
+        send_and_verify(
+            HelperIdentity::from(1),
+            HelperIdentity::from(2),
+            &transports,
+        )
+        .await;
+        send_and_verify(
+            HelperIdentity::from(2),
+            HelperIdentity::from(1),
+            &transports,
+        )
+        .await;
+    }
 }

--- a/src/test_fixture/transport/mod.rs
+++ b/src/test_fixture/transport/mod.rs
@@ -1,6 +1,7 @@
 mod network;
 mod routing;
 mod util;
+mod channeled_transport;
 
 pub use network::InMemoryNetwork;
 pub use util::{DelayedTransport, FailingTransport};
@@ -16,8 +17,13 @@ use async_trait::async_trait;
 use routing::Switch;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::io::Error;
 use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
+use crate::helpers::query::QueryConfig;
+use crate::helpers::transport::{ChannelledTransport, SendData};
+use crate::protocol::QueryId;
 
 /// In memory transport setup includes creating resources
 /// to create a connection to every other peer in the network.

--- a/src/test_fixture/transport/mod.rs
+++ b/src/test_fixture/transport/mod.rs
@@ -1,7 +1,7 @@
+mod channeled_transport;
 mod network;
 mod routing;
 mod util;
-mod channeled_transport;
 
 pub use network::InMemoryNetwork;
 pub use util::{DelayedTransport, FailingTransport};
@@ -17,13 +17,9 @@ use async_trait::async_trait;
 use routing::Switch;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::future::Future;
-use std::io::Error;
+
 use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
-use crate::helpers::query::QueryConfig;
-use crate::helpers::transport::{ChannelledTransport, SendData};
-use crate::protocol::QueryId;
 
 /// In memory transport setup includes creating resources
 /// to create a connection to every other peer in the network.


### PR DESCRIPTION
Some things are still looking clunky, but I am not sure if there is a better way to deal with it. 

I tested major use cases (send/receive and receive query). As we discussed with @martinthomson the first iteration would be to agree on the transport API and build new infra in parallel with the existing one