### PR TITLE
Format imports with rustfmt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check --config imports_granularity=Crate
 
       - name: Clippy
         if: ${{ success() || failure() }}

--- a/benches/ct/arithmetic_circuit.rs
+++ b/benches/ct/arithmetic_circuit.rs
@@ -1,8 +1,7 @@
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
-use raw_ipa::ff::Fp31;
-use raw_ipa::test_fixture::circuit;
+use raw_ipa::{ff::Fp31, test_fixture::circuit};
 use tokio::runtime::Builder;
 
 pub fn criterion_benchmark(c: &mut Criterion) {

--- a/benches/iai/arithmetic_circuit.rs
+++ b/benches/iai/arithmetic_circuit.rs
@@ -1,6 +1,5 @@
 use iai::black_box;
-use raw_ipa::ff::Fp31;
-use raw_ipa::test_fixture::circuit;
+use raw_ipa::{ff::Fp31, test_fixture::circuit};
 use tokio::runtime::Builder;
 
 pub fn iai_benchmark() {

--- a/benches/oneshot/arithmetic_circuit.rs
+++ b/benches/oneshot/arithmetic_circuit.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
-use raw_ipa::ff::{Field, Fp31};
-use raw_ipa::test_fixture::circuit;
+use raw_ipa::{
+    ff::{Field, Fp31},
+    test_fixture::circuit,
+};
 use std::time::Instant;
 
 #[derive(Debug, Parser)]

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -6,8 +6,7 @@ use raw_ipa::{
     protocol::{ipa::ipa, BreakdownKey, MatchKey},
     test_fixture::{input::GenericReportTestInput, Runner, TestWorld, TestWorldConfig},
 };
-use std::num::NonZeroUsize;
-use std::time::Instant;
+use std::{num::NonZeroUsize, time::Instant};
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), Error> {

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -13,8 +13,7 @@ use raw_ipa::{
     secret_sharing::SharedValue,
     test_fixture::{join3, Reconstruct, Runner, TestWorld, TestWorldConfig},
 };
-use std::num::NonZeroUsize;
-use std::time::Instant;
+use std::{num::NonZeroUsize, time::Instant};
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), Error> {

--- a/pre-commit
+++ b/pre-commit
@@ -53,9 +53,9 @@ stashfile=$(mktemp .pre-commit.stashXXXXXX)
 trap 'set +e;git stash pop -q; rm -f "$stashfile"; restore_merge_files' EXIT
 save_merge_files
 git stash push -k -u -q -m "pre-commit stash"
-if ! errors=($(cargo fmt -- --check -l)); then
+if ! errors=($(cargo fmt -- --check --config imports_granularity=Crate -l)); then
     echo "Formatting errors found."
-    echo "Run \`cargo fmt\` to fix the following files:"
+    echo "Run \`cargo fmt -- --config imports_granularity=Crate\` to fix the following files:"
     for err in "${errors[@]}"; do
         echo "  $err"
     done

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -6,8 +6,7 @@ use raw_ipa::{
     net::{discovery::PeerDiscovery, HttpTransport},
     query::Processor,
 };
-use std::error::Error;
-use std::sync::Arc;
+use std::{error::Error, sync::Arc};
 
 use tracing::info;
 

--- a/src/bin/ipa_bench/cmd.rs
+++ b/src/bin/ipa_bench/cmd.rs
@@ -3,12 +3,14 @@ use crate::sample::Sample;
 use super::gen_events::generate_events;
 
 use clap::Parser;
-use rand::rngs::StdRng;
-use rand::SeedableRng;
+use rand::{rngs::StdRng, SeedableRng};
 use raw_ipa::cli::Verbosity;
-use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::{io, process};
+use std::{
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+    process,
+};
 use tracing::{debug, error, info};
 
 const DEFAULT_EVENT_GEN_COUNT: u32 = 100_000;

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -2,9 +2,10 @@ use crate::models::{Epoch, Event, EventTimestamp, GenericReport, MatchKey, Numbe
 
 use super::sample::Sample;
 use bitvec::view::BitViewSized;
-use rand::distributions::Bernoulli;
-use rand::distributions::Distribution;
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{
+    distributions::{Bernoulli, Distribution},
+    CryptoRng, Rng, RngCore,
+};
 use std::io;
 use tracing::{debug, info, trace};
 
@@ -170,8 +171,7 @@ fn add_event_timestamps(rhs: EventTimestamp, lhs: EventTimestamp) -> EventTimest
 mod tests {
     use super::{gen_reports, generate_events, EventTimestamp, GenericReport};
     use crate::{gen_events::add_event_timestamps, models::Epoch, sample::Sample};
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
+    use rand::{rngs::StdRng, SeedableRng};
     use std::{
         cmp::Ordering,
         io::{Cursor, Write},

--- a/src/bin/ipa_bench/models.rs
+++ b/src/bin/ipa_bench/models.rs
@@ -1,8 +1,10 @@
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Formatter};
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
-use std::ops::Range;
+use std::{
+    fmt::{Debug, Formatter},
+    io::{Error as IoError, ErrorKind as IoErrorKind},
+    ops::Range,
+};
 
 // Type aliases to indicate whether the parameter should be encrypted, secret shared, etc.
 // Underlying types are temporalily assigned for PoC.

--- a/src/bin/ipa_bench/sample.rs
+++ b/src/bin/ipa_bench/sample.rs
@@ -1,6 +1,7 @@
-use rand::distributions::Distribution;
-use rand::distributions::WeightedIndex;
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{
+    distributions::{Distribution, WeightedIndex},
+    CryptoRng, Rng, RngCore,
+};
 use std::time::Duration;
 
 use crate::config::Config;

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -11,9 +11,7 @@ use raw_ipa::{
     net::{discovery::PeerDiscovery, MpcHelperClient},
     protocol::{BreakdownKey, MatchKey},
 };
-use std::error::Error;
-use std::fmt::Debug;
-use std::path::PathBuf;
+use std::{error::Error, fmt::Debug, path::PathBuf};
 
 #[derive(Debug, Parser)]
 #[clap(

--- a/src/bits/fp2_array.rs
+++ b/src/bits/fp2_array.rs
@@ -1,5 +1,7 @@
-use crate::bits::{Fp2Array, Serializable};
-use crate::secret_sharing::SharedValue;
+use crate::{
+    bits::{Fp2Array, Serializable},
+    secret_sharing::SharedValue,
+};
 use bitvec::prelude::{BitArr, Lsb0};
 use generic_array::GenericArray;
 use typenum::{Unsigned, U1, U5, U8};

--- a/src/chunkscan.rs
+++ b/src/chunkscan.rs
@@ -1,10 +1,12 @@
 use crate::error::BoxError;
 use futures::{ready, Stream};
 use pin_project::pin_project;
-use std::future::Future;
-use std::mem;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tracing::error;
 
 /// A variant of stream transform that combines semantic of `StreamExt::chunks` and `StreamExt::scan`.

--- a/src/cli/metric_collector.rs
+++ b/src/cli/metric_collector.rs
@@ -1,9 +1,10 @@
 use crate::telemetry::stats::Metrics;
 use metrics_tracing_context::TracingContextLayer;
-use metrics_util::debugging::{DebuggingRecorder, Snapshotter};
-use metrics_util::layers::Layer;
-use std::io::stderr;
-use std::thread;
+use metrics_util::{
+    debugging::{DebuggingRecorder, Snapshotter},
+    layers::Layer,
+};
+use std::{io::stderr, thread};
 
 /// Collects metrics using `DebuggingRecorder` and dumps them to `stderr` when dropped.
 pub struct CollectorHandle {

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -1,8 +1,10 @@
 use crate::ff::Field;
 
-use std::fs::File;
-use std::io;
-use std::io::{stdin, BufRead, BufReader, Read};
+use std::{
+    fs::File,
+    io,
+    io::{stdin, BufRead, BufReader, Read},
+};
 
 use crate::{bits::Fp2Array, ipa_test_input, test_fixture::input::GenericReportTestInput};
 use std::path::PathBuf;
@@ -112,10 +114,12 @@ impl BufRead for InputSource {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::cli::playbook::input::InputItem;
-    use crate::ff::{Fp31, Fp32BitPrime};
-    use crate::secret_sharing::IntoShares;
-    use crate::test_fixture::Reconstruct;
+    use crate::{
+        cli::playbook::input::InputItem,
+        ff::{Fp31, Fp32BitPrime},
+        secret_sharing::IntoShares,
+        test_fixture::Reconstruct,
+    };
 
     #[test]
     fn from_str() {
@@ -155,8 +159,7 @@ mod tests {
 
     mod input_source {
         use super::*;
-        use crate::cli::playbook::input::InputSource;
-        use crate::ff::Field;
+        use crate::{cli::playbook::input::InputSource, ff::Field};
 
         #[test]
         fn multiline() {

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 use futures_util::future::try_join_all;
 use generic_array::{ArrayLength, GenericArray};
-use std::fmt::Debug;
-use std::ops::Add;
+use std::{fmt::Debug, ops::Add};
 use typenum::Unsigned;
 
 /// Secure multiplication. Each input must be a valid tuple of field values.

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -1,5 +1,4 @@
-use crate::cli::install_collector;
-use crate::cli::metric_collector::CollectorHandle;
+use crate::cli::{install_collector, metric_collector::CollectorHandle};
 use clap::Parser;
 use metrics_tracing_context::MetricsLayer;
 use std::io::stderr;

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,5 +1,7 @@
-use crate::bits::{BooleanOps, Serializable};
-use crate::secret_sharing::SharedValue;
+use crate::{
+    bits::{BooleanOps, Serializable},
+    secret_sharing::SharedValue,
+};
 use generic_array::{ArrayLength, GenericArray};
 use std::fmt::Debug;
 

--- a/src/helpers/buffers/fsv.rs
+++ b/src/helpers/buffers/fsv.rs
@@ -1,7 +1,5 @@
-use bitvec::bitvec;
-use bitvec::prelude::BitVec;
-use std::fmt::Debug;
-use std::num::NonZeroUsize;
+use bitvec::{bitvec, prelude::BitVec};
+use std::{fmt::Debug, num::NonZeroUsize};
 
 /// A store of bytes that allows for random access inserts, but contiguous removal.
 ///

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -5,7 +5,7 @@ mod send;
 mod unordered_receiver;
 
 pub use receive::ReceiveBuffer;
-pub use {send::Config as SendBufferConfig, send::SendBuffer};
+pub use send::{Config as SendBufferConfig, SendBuffer};
 
 #[cfg(debug_assertions)]
 mod waiting {

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
-use crate::bits::Serializable;
-use crate::helpers::{messaging::Message, Error};
+use crate::{
+    bits::Serializable,
+    helpers::{messaging::Message, Error},
+};
 use bitvec::{bitvec, vec::BitVec};
 use futures::FutureExt;
 use generic_array::GenericArray;

--- a/src/helpers/buffers/receive.rs
+++ b/src/helpers/buffers/receive.rs
@@ -2,9 +2,10 @@ use crate::{
     helpers::{network::ChannelId, MessagePayload, MESSAGE_PAYLOAD_SIZE_BYTES},
     protocol::RecordId,
 };
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::fmt::Debug;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+};
 use tokio::sync::oneshot;
 
 /// Local buffer for messages that are either awaiting requests to receive them or requests

--- a/src/helpers/buffers/send.rs
+++ b/src/helpers/buffers/send.rs
@@ -1,5 +1,6 @@
 use crate::helpers::{
-    buffers::fsv::FixedSizeByteVec, network::ChannelId, network::MessageEnvelope,
+    buffers::fsv::FixedSizeByteVec,
+    network::{ChannelId, MessageEnvelope},
     MESSAGE_PAYLOAD_SIZE_BYTES,
 };
 use std::{collections::HashMap, num::NonZeroUsize};

--- a/src/helpers/error.rs
+++ b/src/helpers/error.rs
@@ -1,10 +1,9 @@
-use crate::helpers::TransportError;
 use crate::{
     error::BoxError,
     helpers::{
         messaging::{Message, ReceiveRequest, SendRequest},
         network::{ChannelId, MessageChunks},
-        HelperIdentity, Role,
+        HelperIdentity, Role, TransportError,
     },
     protocol::{RecordId, Step},
 };

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -23,9 +23,11 @@ use crate::{
 use futures::StreamExt;
 use futures_util::stream::FuturesUnordered;
 use generic_array::GenericArray;
-use std::fmt::{Debug, Formatter};
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use std::{
+    fmt::{Debug, Formatter},
+    num::NonZeroUsize,
+    time::Duration,
+};
 use tinyvec::array_vec;
 use tracing::Instrument;
 use typenum::Unsigned;
@@ -374,12 +376,12 @@ fn print_state(role: Role, send_buf: &SendBuffer, receive_buf: &ReceiveBuffer) {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::ff::Fp31;
-    use crate::helpers::messaging::TotalRecords;
-    use crate::helpers::Role;
-    use crate::protocol::context::Context;
-    use crate::protocol::{RecordId, Step};
-    use crate::test_fixture::{TestWorld, TestWorldConfig};
+    use crate::{
+        ff::Fp31,
+        helpers::{messaging::TotalRecords, Role},
+        protocol::{context::Context, RecordId, Step},
+        test_fixture::{TestWorld, TestWorldConfig},
+    };
     use std::num::NonZeroUsize;
 
     #[tokio::test]

--- a/src/helpers/network.rs
+++ b/src/helpers/network.rs
@@ -1,19 +1,18 @@
 #![allow(dead_code)] // will use these soon
 
-use crate::helpers::transport::CommandOrigin;
-use crate::helpers::{MessagePayload, RoleAssignment};
-use crate::protocol::RecordId;
 use crate::{
     helpers::{
-        transport::{SubscriptionType, Transport, TransportCommand},
-        Error, Role,
+        transport::{CommandOrigin, SubscriptionType, Transport, TransportCommand},
+        Error, MessagePayload, Role, RoleAssignment,
     },
-    protocol::{QueryId, Step},
+    protocol::{QueryId, RecordId, Step},
     sync::{Arc, Mutex},
 };
 use futures::{Stream, StreamExt};
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct MessageEnvelope {

--- a/src/helpers/time.rs
+++ b/src/helpers/time.rs
@@ -1,7 +1,9 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 /// Simple timer that only works in the presence of tokio runtime. Any other runtime will
 /// make it a no-op.

--- a/src/helpers/transport/bytearrstream/aligned.rs
+++ b/src/helpers/transport/bytearrstream/aligned.rs
@@ -2,10 +2,12 @@ use crate::{error::BoxError, helpers::transport::bytearrstream::Item};
 use bytes::Bytes;
 use futures::{ready, Stream};
 use futures_util::stream::BoxStream;
-use std::collections::VecDeque;
-use std::fmt::{Debug, Formatter};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    collections::VecDeque,
+    fmt::{Debug, Formatter},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 /// Wraps a [`BoxStream`] and produce a new stream that has chunks of exactly size `size_in_bytes`.
 /// # Errors

--- a/src/helpers/transport/bytearrstream/mod.rs
+++ b/src/helpers/transport/bytearrstream/mod.rs
@@ -6,8 +6,10 @@ use crate::error::BoxError;
 use bytes::Bytes;
 use futures::Stream;
 use futures_util::stream::{self, BoxStream};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 #[cfg(feature = "web-app")]
 use futures_util::TryStreamExt;

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -2,16 +2,18 @@
 //!
 //! [`specification`]: https://github.com/patcg-individual-drafts/ipa/pull/31
 
-use hpke::aead::AeadTag;
-use hpke::generic_array::typenum::Unsigned;
-use hpke::{single_shot_open_in_place_detached, OpModeR};
+use hpke::{
+    aead::AeadTag, generic_array::typenum::Unsigned, single_shot_open_in_place_detached, OpModeR,
+};
 use std::io;
 
 mod info;
 mod registry;
 
-use crate::bits::{BitArray40, Serializable};
-use crate::secret_sharing::replicated::semi_honest::XorShare;
+use crate::{
+    bits::{BitArray40, Serializable},
+    secret_sharing::replicated::semi_honest::XorShare,
+};
 pub use info::Info;
 pub use registry::KeyRegistry;
 
@@ -276,8 +278,7 @@ mod tests {
     mod proptests {
         use super::*;
         use proptest::prelude::ProptestConfig;
-        use rand::distributions::Alphanumeric;
-        use rand::Rng;
+        use rand::{distributions::Alphanumeric, Rng};
 
         proptest::proptest! {
             #![proptest_config(ProptestConfig::with_cases(50))]

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -204,8 +204,7 @@ mod tests {
     };
     use futures::join;
     use hyper_tls::native_tls::TlsConnector;
-    use std::fmt::Debug;
-    use std::future::Future;
+    use std::{fmt::Debug, future::Future};
     use tokio::sync::mpsc;
 
     async fn setup_server(

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -87,8 +87,10 @@ pub mod query {
     use async_trait::async_trait;
     use axum::extract::{FromRequest, Query, RequestParts};
     use hyper::header::HeaderName;
-    use std::fmt::{Display, Formatter};
-    use std::str::FromStr;
+    use std::{
+        fmt::{Display, Formatter},
+        str::FromStr,
+    };
 
     /// wrapper around [`QueryConfig`] to enable extraction from an `Axum` request. To be used with
     /// the `create` and `prepare` commands

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -13,8 +13,7 @@ use crate::{
 use axum::Router;
 use axum_server::{tls_rustls::RustlsConfig, Handle};
 use metrics::increment_counter;
-use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::{collections::HashMap, net::SocketAddr};
 use tower_http::trace::TraceLayer;
 use tracing::Span;
 

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -14,8 +14,10 @@ use crate::{
     task::JoinHandle,
 };
 use async_trait::async_trait;
-use std::collections::{hash_map::Entry, HashMap};
-use std::net::SocketAddr;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    net::SocketAddr,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -1,10 +1,13 @@
-use super::do_the_binary_tree_thing;
-use super::input::{MCAccumulateCreditInputRow, MCAccumulateCreditOutputRow};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic;
+use super::{
+    do_the_binary_tree_thing,
+    input::{MCAccumulateCreditInputRow, MCAccumulateCreditOutputRow},
+};
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, RecordId},
+    secret_sharing::Arithmetic,
+};
 use futures::future::try_join_all;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -149,23 +152,27 @@ where
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::accumulation_test_input;
-    use crate::ff::{Field, Fp31, Fp32BitPrime};
-    use crate::helpers::Role;
-    use crate::protocol::attribution::input::MCAccumulateCreditOutputRow;
-    use crate::protocol::attribution::{
-        accumulate_credit::accumulate_credit,
-        input::{AccumulateCreditInputRow, MCAccumulateCreditInputRow},
+    use crate::{
+        accumulation_test_input,
+        ff::{Field, Fp31, Fp32BitPrime},
+        helpers::Role,
+        protocol::{
+            attribution::{
+                accumulate_credit::accumulate_credit,
+                input::{
+                    AccumulateCreditInputRow, MCAccumulateCreditInputRow,
+                    MCAccumulateCreditOutputRow,
+                },
+            },
+            context::Context,
+            modulus_conversion::{convert_all_bits, convert_all_bits_local},
+            sort::apply_sort::shuffle::Resharable,
+            BreakdownKey, MatchKey, RecordId,
+        },
+        rand::thread_rng,
+        secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SharedValue},
+        test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
     };
-    use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
-    use crate::protocol::sort::apply_sort::shuffle::Resharable;
-    use crate::protocol::{context::Context, RecordId};
-    use crate::protocol::{BreakdownKey, MatchKey};
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::input::GenericReportTestInput;
-    use crate::test_fixture::{Reconstruct, Runner, TestWorld};
     use rand::Rng;
 
     #[tokio::test]

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -445,16 +445,19 @@ impl AsRef<str> for Step {
 mod tests {
 
     use super::aggregate_credit;
-    use crate::aggregation_test_input;
-    use crate::bits::Fp2Array;
-    use crate::ff::{Field, Fp32BitPrime};
-    use crate::protocol::attribution::input::{AggregateCreditInputRow, MCAggregateCreditInputRow};
-    use crate::protocol::context::Context;
-    use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
-    use crate::protocol::{BreakdownKey, MatchKey};
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::input::GenericReportTestInput;
-    use crate::test_fixture::{Reconstruct, Runner, TestWorld};
+    use crate::{
+        aggregation_test_input,
+        bits::Fp2Array,
+        ff::{Field, Fp32BitPrime},
+        protocol::{
+            attribution::input::{AggregateCreditInputRow, MCAggregateCreditInputRow},
+            context::Context,
+            modulus_conversion::{convert_all_bits, convert_all_bits_local},
+            BreakdownKey, MatchKey,
+        },
+        secret_sharing::SharedValue,
+        test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
+    };
 
     #[tokio::test]
     pub async fn aggregate() {

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -3,12 +3,19 @@ use super::{
     input::{MCCreditCappingInputRow, MCCreditCappingOutputRow},
     prefix_or_binary_tree_style,
 };
-use crate::ff::Field;
-use crate::protocol::boolean::random_bits_generator::RandomBitsGenerator;
-use crate::protocol::boolean::{bitwise_greater_than_constant, BitDecomposition};
-use crate::protocol::context::Context;
-use crate::protocol::{RecordId, Substep};
-use crate::{error::Error, secret_sharing::Arithmetic};
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        boolean::{
+            bitwise_greater_than_constant, random_bits_generator::RandomBitsGenerator,
+            BitDecomposition,
+        },
+        context::Context,
+        RecordId, Substep,
+    },
+    secret_sharing::Arithmetic,
+};
 use futures::future::try_join_all;
 use std::iter::{repeat, zip};
 
@@ -370,14 +377,14 @@ mod tests {
     use crate::{
         accumulation_test_input,
         ff::{Field, Fp32BitPrime},
-        protocol::attribution::{
-            credit_capping::credit_capping,
-            input::{CreditCappingInputRow, MCCreditCappingInputRow},
-        },
-        protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local},
         protocol::{
+            attribution::{
+                credit_capping::credit_capping,
+                input::{CreditCappingInputRow, MCCreditCappingInputRow},
+            },
             context::Context,
-            {BreakdownKey, MatchKey},
+            modulus_conversion::{convert_all_bits, convert_all_bits_local},
+            BreakdownKey, MatchKey,
         },
         secret_sharing::SharedValue,
         test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},

--- a/src/protocol/attribution/input.rs
+++ b/src/protocol/attribution/input.rs
@@ -1,17 +1,20 @@
-use crate::bits::{Fp2Array, Serializable};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::Role;
-use crate::protocol::context::Context;
-use crate::protocol::sort::apply_sort::shuffle::Resharable;
-use crate::protocol::{RecordId, Substep};
-use crate::secret_sharing::replicated::malicious::{
-    AdditiveShare as MaliciousReplicated, DowngradeMalicious,
-    ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
+use crate::{
+    bits::{Fp2Array, Serializable},
+    error::Error,
+    ff::Field,
+    helpers::Role,
+    protocol::{context::Context, sort::apply_sort::shuffle::Resharable, RecordId, Substep},
+    secret_sharing::{
+        replicated::{
+            malicious::{
+                AdditiveShare as MaliciousReplicated, DowngradeMalicious,
+                ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
+            },
+            semi_honest::{AdditiveShare as Replicated, AdditiveShare, XorShare},
+        },
+        Arithmetic,
+    },
 };
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-use crate::secret_sharing::replicated::semi_honest::{AdditiveShare, XorShare};
-use crate::secret_sharing::Arithmetic;
 use async_trait::async_trait;
 use futures::future::{try_join, try_join3};
 use generic_array::GenericArray;

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -3,11 +3,10 @@ pub mod credit_capping;
 pub mod input;
 
 pub(crate) mod accumulate_credit;
-use crate::protocol::boolean::or::or;
 use crate::{
     error::Error,
     ff::Field,
-    protocol::{context::Context, RecordId, Substep},
+    protocol::{boolean::or::or, context::Context, RecordId, Substep},
     repeat64str,
     secret_sharing::Arithmetic as ArithmeticSecretSharing,
 };

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -1,10 +1,12 @@
-use crate::protocol::basics::{reveal::Reveal, SecureMul};
-use crate::protocol::context::SemiHonestContext;
-use crate::protocol::prss::SharedRandomness;
 use crate::{
     error::Error,
     ff::Field,
-    protocol::{context::Context, RecordId},
+    protocol::{
+        basics::{reveal::Reveal, SecureMul},
+        context::{Context, SemiHonestContext},
+        prss::SharedRandomness,
+        RecordId,
+    },
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
 
@@ -75,13 +77,14 @@ pub async fn check_zero<F: Field>(
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::error::Error;
-    use crate::ff::{Field, Fp31};
-    use crate::protocol::context::Context;
-    use crate::protocol::{basics::check_zero, RecordId};
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::{IntoShares, SharedValue};
-    use crate::test_fixture::TestWorld;
+    use crate::{
+        error::Error,
+        ff::{Field, Fp31},
+        protocol::{basics::check_zero, context::Context, RecordId},
+        rand::thread_rng,
+        secret_sharing::{IntoShares, SharedValue},
+        test_fixture::TestWorld,
+    };
     use futures_util::future::try_join3;
 
     #[tokio::test]

--- a/src/protocol/basics/mod.rs
+++ b/src/protocol/basics/mod.rs
@@ -4,9 +4,7 @@ pub(crate) mod reshare;
 pub(crate) mod reveal;
 pub(crate) mod sum_of_product;
 
-pub use {
-    check_zero::check_zero,
-    mul::{MultiplyZeroPositions, SecureMul, ZeroPositions},
-    reshare::Reshare,
-    reveal::{reveal_permutation, Reveal},
-};
+pub use check_zero::check_zero;
+pub use mul::{MultiplyZeroPositions, SecureMul, ZeroPositions};
+pub use reshare::Reshare;
+pub use reveal::{reveal_permutation, Reveal};

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -1,11 +1,13 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::{
-    basics::{MultiplyZeroPositions, SecureMul, ZeroPositions},
-    context::{Context, MaliciousContext},
-    RecordId,
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        basics::{MultiplyZeroPositions, SecureMul, ZeroPositions},
+        context::{Context, MaliciousContext},
+        RecordId,
+    },
+    secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated,
 };
-use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -67,8 +69,10 @@ pub async fn multiply<F>(
 where
     F: Field,
 {
-    use crate::protocol::context::SpecialAccessToMaliciousContext;
-    use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+    use crate::{
+        protocol::context::SpecialAccessToMaliciousContext,
+        secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
+    };
 
     let duplicate_multiply_ctx = ctx.narrow(&Step::DuplicateMultiply);
     let random_constant_ctx = ctx.narrow(&Step::RandomnessForValidation);

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -1,10 +1,17 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::{MaliciousContext, SemiHonestContext};
-use crate::protocol::RecordId;
-use crate::secret_sharing::{
-    replicated::malicious::AdditiveShare as MaliciousReplicated,
-    replicated::semi_honest::AdditiveShare as Replicated, SecretSharing, SharedValue,
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        context::{MaliciousContext, SemiHonestContext},
+        RecordId,
+    },
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        SecretSharing, SharedValue,
+    },
 };
 use async_trait::async_trait;
 

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -1,13 +1,15 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::Direction;
-use crate::protocol::prss::SharedRandomness;
-use crate::protocol::{
-    basics::{mul::sparse::MultiplyWork, MultiplyZeroPositions},
-    context::{Context, SemiHonestContext},
-    RecordId,
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::Direction,
+    protocol::{
+        basics::{mul::sparse::MultiplyWork, MultiplyZeroPositions},
+        context::{Context, SemiHonestContext},
+        prss::SharedRandomness,
+        RecordId,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 
 /// IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -78,10 +80,12 @@ where
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod test {
-    use crate::ff::{Field, Fp31};
-    use crate::protocol::{basics::SecureMul, context::Context, RecordId};
-    use crate::rand::{thread_rng, Rng};
-    use crate::test_fixture::{Reconstruct, Runner, TestWorld};
+    use crate::{
+        ff::{Field, Fp31},
+        protocol::{basics::SecureMul, context::Context, RecordId},
+        rand::{thread_rng, Rng},
+        test_fixture::{Reconstruct, Runner, TestWorld},
+    };
     use futures::future::try_join_all;
     use rand::distributions::{Distribution, Standard};
     use std::iter::{repeat, zip};

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -184,7 +184,6 @@ impl MultiplyWork for MultiplyZeroPositions {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 pub(in crate::protocol) mod test {
-    use crate::secret_sharing::IntoShares;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         helpers::{
@@ -198,7 +197,7 @@ pub(in crate::protocol) mod test {
             BitOpStep, RECORD_0,
         },
         rand::{thread_rng, Rng},
-        secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+        secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use futures::future::try_join;

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -1,15 +1,20 @@
-use crate::ff::Field;
-use crate::protocol::context::{Context, MaliciousContext};
-use crate::protocol::prss::SharedRandomness;
-use crate::protocol::sort::ReshareStep::RandomnessForValidation;
-use crate::secret_sharing::{
-    replicated::malicious::AdditiveShare as MaliciousReplicated,
-    replicated::semi_honest::AdditiveShare as Replicated, SecretSharing, SharedValue,
-};
 use crate::{
     error::Error,
+    ff::Field,
     helpers::{Direction, Role},
-    protocol::{context::SemiHonestContext, sort::ReshareStep::ReshareRx, RecordId},
+    protocol::{
+        context::{Context, MaliciousContext, SemiHonestContext},
+        prss::SharedRandomness,
+        sort::ReshareStep::{RandomnessForValidation, ReshareRx},
+        RecordId,
+    },
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        SecretSharing, SharedValue,
+    },
 };
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
@@ -103,8 +108,10 @@ impl<F: Field> Reshare<F> for MaliciousContext<'_, F> {
         record_id: RecordId,
         to_helper: Role,
     ) -> Result<Self::Share, Error> {
-        use crate::protocol::context::SpecialAccessToMaliciousContext;
-        use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+        use crate::{
+            protocol::context::SpecialAccessToMaliciousContext,
+            secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
+        };
         let random_constant_ctx = self.narrow(&RandomnessForValidation);
 
         let (rx, x) = try_join(
@@ -131,12 +138,10 @@ mod tests {
 
         use crate::rand::thread_rng;
 
-        use crate::ff::Fp32BitPrime;
-        use crate::protocol::context::Context;
-        use crate::protocol::prss::SharedRandomness;
         use crate::{
+            ff::Fp32BitPrime,
             helpers::Role,
-            protocol::{basics::Reshare, RecordId},
+            protocol::{basics::Reshare, context::Context, prss::SharedRandomness, RecordId},
             test_fixture::{Reconstruct, Runner, TestWorld},
         };
 
@@ -198,21 +203,25 @@ mod tests {
     mod malicious {
         use futures::future::try_join;
 
-        use crate::error::Error;
-        use crate::ff::{Field, Fp32BitPrime};
-        use crate::helpers::{Direction, Role};
-        use crate::protocol::basics::Reshare;
-        use crate::protocol::context::{Context, MaliciousContext, SemiHonestContext};
-        use crate::protocol::malicious::MaliciousValidator;
-        use crate::protocol::prss::SharedRandomness;
-        use crate::protocol::sort::ReshareStep::{RandomnessForValidation, ReshareRx};
-        use crate::protocol::RecordId;
-        use crate::rand::{thread_rng, Rng};
-        use crate::secret_sharing::{
-            replicated::malicious::AdditiveShare as MaliciousReplicated,
-            replicated::semi_honest::AdditiveShare as Replicated,
+        use crate::{
+            error::Error,
+            ff::{Field, Fp32BitPrime},
+            helpers::{Direction, Role},
+            protocol::{
+                basics::Reshare,
+                context::{Context, MaliciousContext, SemiHonestContext},
+                malicious::MaliciousValidator,
+                prss::SharedRandomness,
+                sort::ReshareStep::{RandomnessForValidation, ReshareRx},
+                RecordId,
+            },
+            rand::{thread_rng, Rng},
+            secret_sharing::replicated::{
+                malicious::AdditiveShare as MaliciousReplicated,
+                semi_honest::AdditiveShare as Replicated,
+            },
+            test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use crate::test_fixture::{Reconstruct, Runner, TestWorld};
 
         /// Relies on semi-honest protocol tests that enforce reshare to communicate and produce
         /// new shares.
@@ -289,8 +298,10 @@ mod tests {
             to_helper: Role,
             additive_error: F,
         ) -> Result<MaliciousReplicated<F>, Error> {
-            use crate::protocol::context::SpecialAccessToMaliciousContext;
-            use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+            use crate::{
+                protocol::context::SpecialAccessToMaliciousContext,
+                secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
+            };
             let random_constant_ctx = ctx.narrow(&RandomnessForValidation);
 
             let (rx, x) = try_join(

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -1,12 +1,21 @@
 use std::iter::{repeat, zip};
 
-use crate::ff::Field;
-use crate::protocol::context::{Context, MaliciousContext, SemiHonestContext};
-use crate::secret_sharing::{
-    replicated::malicious::AdditiveShare as MaliciousReplicated,
-    replicated::semi_honest::AdditiveShare as Replicated, SecretSharing, SharedValue,
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::Direction,
+    protocol::{
+        context::{Context, MaliciousContext, SemiHonestContext},
+        RecordId,
+    },
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        SecretSharing, SharedValue,
+    },
 };
-use crate::{error::Error, helpers::Direction, protocol::RecordId};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
 use futures::future::{try_join, try_join_all};
@@ -120,24 +129,26 @@ pub async fn reveal_permutation<F: Field, S: SecretSharing<F>, C: Context<F, Sha
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::rand::thread_rng;
-    use crate::test_fixture::Runner;
+    use crate::{rand::thread_rng, test_fixture::Runner};
     use futures::future::{try_join, try_join3};
     use proptest::prelude::Rng;
     use std::iter::zip;
 
-    use crate::secret_sharing::IntoShares;
     use crate::{
         error::Error,
         ff::{Field, Fp31},
         helpers::Direction,
-        protocol::{basics::Reveal, malicious::MaliciousValidator},
         protocol::{
+            basics::Reveal,
             context::{Context, MaliciousContext},
+            malicious::MaliciousValidator,
             RecordId,
         },
-        secret_sharing::replicated::malicious::{
-            AdditiveShare as MaliciousReplicated, ThisCodeIsAuthorizedToDowngradeFromMalicious,
+        secret_sharing::{
+            replicated::malicious::{
+                AdditiveShare as MaliciousReplicated, ThisCodeIsAuthorizedToDowngradeFromMalicious,
+            },
+            IntoShares,
         },
         test_fixture::{join3v, TestWorld},
     };

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -1,13 +1,16 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::Direction;
-use crate::protocol::prss::SharedRandomness;
-use crate::protocol::{
-    context::{Context, MaliciousContext},
-    RecordId,
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::Direction,
+    protocol::{
+        context::{Context, MaliciousContext},
+        prss::SharedRandomness,
+        RecordId,
+    },
+    secret_sharing::replicated::{
+        malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+    },
 };
-use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 use futures::future::try_join;
 use std::fmt::Debug;
 
@@ -68,8 +71,10 @@ pub async fn sum_of_products<F>(
 where
     F: Field,
 {
-    use crate::protocol::context::SpecialAccessToMaliciousContext;
-    use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+    use crate::{
+        protocol::context::SpecialAccessToMaliciousContext,
+        secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
+    };
 
     assert_eq!(a.len(), b.len());
     let vec_len = a.len();

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -1,10 +1,17 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::{MaliciousContext, SemiHonestContext};
-use crate::protocol::RecordId;
-use crate::secret_sharing::{
-    replicated::malicious::AdditiveShare as MaliciousReplicated,
-    replicated::semi_honest::AdditiveShare as Replicated, SecretSharing, SharedValue,
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        context::{MaliciousContext, SemiHonestContext},
+        RecordId,
+    },
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        SecretSharing, SharedValue,
+    },
 };
 use async_trait::async_trait;
 

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -1,12 +1,14 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::Direction;
-use crate::protocol::prss::SharedRandomness;
-use crate::protocol::{
-    context::{Context, SemiHonestContext},
-    RecordId,
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::Direction,
+    protocol::{
+        context::{Context, SemiHonestContext},
+        prss::SharedRandomness,
+        RecordId,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
 
 /// Sum of product protocol developed using IKHC multiplication protocol
 /// for use with replicated secret sharing over some field F.
@@ -72,12 +74,12 @@ mod test {
 
     use crate::rand::thread_rng;
 
-    use crate::ff::{Field, Fp31};
-    use crate::protocol::basics::sum_of_product::SecureSop;
-    use crate::protocol::context::Context;
-    use crate::protocol::RecordId;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::{Reconstruct, Runner, TestWorld};
+    use crate::{
+        ff::{Field, Fp31},
+        protocol::{basics::sum_of_product::SecureSop, context::Context, RecordId},
+        secret_sharing::SharedValue,
+        test_fixture::{Reconstruct, Runner, TestWorld},
+    };
 
     #[tokio::test]
     async fn basic() {

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -1,11 +1,14 @@
-use super::bitwise_less_than_prime::BitwiseLessThanPrime;
-use super::dumb_bitwise_add_constant::{bitwise_add_constant, bitwise_add_constant_maybe};
-use super::random_bits_generator::RandomBitsGenerator;
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use super::{
+    bitwise_less_than_prime::BitwiseLessThanPrime,
+    dumb_bitwise_add_constant::{bitwise_add_constant, bitwise_add_constant_maybe},
+    random_bits_generator::RandomBitsGenerator,
+};
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 
 /// This is an implementation of "3. Bit-Decomposition" from I. Damgård et al..
 ///

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -1,9 +1,10 @@
 use super::xor;
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::boolean::no_ones;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{boolean::no_ones, context::Context, BitOpStep, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 use futures::future::try_join_all;
 use std::iter::zip;
 
@@ -97,11 +98,10 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         protocol::{context::Context, RecordId},
-        test_fixture::{get_bits, Reconstruct, TestWorld},
+        test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
     };
 
     use super::{bitwise_equal, bitwise_equal_constant};

--- a/src/protocol/boolean/bitwise_gt_constant.rs
+++ b/src/protocol/boolean/bitwise_gt_constant.rs
@@ -1,8 +1,10 @@
 use super::or::or;
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, BitOpStep, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 
 /// Compares the `[a]` and `c`, and returns `1` iff `a > c`
 ///
@@ -122,12 +124,13 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::bitwise_greater_than_constant;
-    use crate::ff::{Field, Fp31, Fp32BitPrime};
-    use crate::protocol::context::Context;
-    use crate::protocol::RecordId;
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::{into_bits, Reconstruct, Runner, TestWorld};
+    use crate::{
+        ff::{Field, Fp31, Fp32BitPrime},
+        protocol::{context::Context, RecordId},
+        rand::thread_rng,
+        secret_sharing::SharedValue,
+        test_fixture::{into_bits, Reconstruct, Runner, TestWorld},
+    };
     use proptest::prelude::Rng;
     use rand::{distributions::Standard, prelude::Distribution};
 

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -1,10 +1,10 @@
-use super::any_ones;
-use super::or::or;
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::boolean::multiply_all_shares;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use super::{any_ones, or::or};
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{boolean::multiply_all_shares, context::Context, BitOpStep, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 use futures::future::try_join;
 use std::cmp::Ordering;
 
@@ -201,12 +201,11 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::BitwiseLessThanPrime;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         protocol::{context::Context, RecordId},
-        test_fixture::{get_bits, Reconstruct, TestWorld},
+        secret_sharing::SharedValue,
+        test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};
 

--- a/src/protocol/boolean/dumb_bitwise_add_constant.rs
+++ b/src/protocol/boolean/dumb_bitwise_add_constant.rs
@@ -1,7 +1,9 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, BitOpStep, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///
@@ -192,13 +194,14 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::bitwise_add_constant;
-    use crate::protocol::boolean::dumb_bitwise_add_constant::bitwise_add_constant_maybe;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
-        protocol::{context::Context, RecordId},
-        test_fixture::{into_bits, Reconstruct, TestWorld},
+        protocol::{
+            boolean::dumb_bitwise_add_constant::bitwise_add_constant_maybe, context::Context,
+            RecordId,
+        },
+        secret_sharing::SharedValue,
+        test_fixture::{into_bits, Reconstruct, Runner, TestWorld},
     };
     use bitvec::macros::internal::funty::Fundamental;
     use rand::{distributions::Standard, prelude::Distribution};

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -1,9 +1,13 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::MaliciousContext;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        context::{Context, MaliciousContext},
+        BitOpStep, RecordId,
+    },
+    secret_sharing::replicated::malicious::AdditiveShare as MaliciousReplicated,
+};
 use async_trait::async_trait;
 use futures::future::try_join_all;
 

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,13 +1,17 @@
-use crate::bits::{BitArray40, Fp2Array};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple};
-use crate::protocol::prss::SharedRandomness;
-use crate::protocol::{context::Context, BitOpStep, RecordId};
-use crate::secret_sharing::{
-    replicated::semi_honest::AdditiveShare as Replicated,
-    replicated::semi_honest::XorShare as XorReplicated, Arithmetic as ArithmeticSecretSharing,
-    SecretSharing, SharedValue,
+use crate::{
+    bits::{BitArray40, Fp2Array},
+    error::Error,
+    ff::Field,
+    protocol::{
+        context::Context,
+        modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple},
+        prss::SharedRandomness,
+        BitOpStep, RecordId,
+    },
+    secret_sharing::{
+        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue,
+    },
 };
 use async_trait::async_trait;
 use futures::future::try_join_all;

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -1,9 +1,13 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::SemiHonestContext;
-use crate::protocol::{context::Context, RecordId};
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        context::{Context, SemiHonestContext},
+        RecordId,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+};
 use async_trait::async_trait;
 
 #[async_trait]

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -1,12 +1,13 @@
 use futures::future::try_join_all;
 
-use crate::error::Error;
-use crate::ff::Field;
-use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
+use crate::{
+    error::Error,
+    ff::Field,
+    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+};
 use std::iter::repeat;
 
-use super::context::Context;
-use super::{BitOpStep, RecordId};
+use super::{context::Context, BitOpStep, RecordId};
 
 mod bit_decomposition;
 pub mod bitwise_equal;
@@ -19,12 +20,11 @@ pub mod random_bits_generator;
 mod solved_bits;
 mod xor;
 
+pub use bit_decomposition::BitDecomposition;
+pub use bitwise_gt_constant::bitwise_greater_than_constant;
+pub use generate_random_bits::RandomBits;
 pub use solved_bits::RandomBitsShare;
 pub use xor::{xor, xor_sparse};
-pub use {
-    bit_decomposition::BitDecomposition, bitwise_gt_constant::bitwise_greater_than_constant,
-    generate_random_bits::RandomBits,
-};
 
 /// Converts the given number to a sequence of `{0,1} ⊆ F`, and creates a
 /// local replicated share.

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -1,8 +1,9 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 
 /// Secure OR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
 /// It computes `[a] + [b] - [ab]`

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -1,10 +1,11 @@
 use super::solved_bits::{solved_bits, RandomBitsShare};
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::messaging::TotalRecords;
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::messaging::TotalRecords,
+    protocol::{context::Context, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 use std::{
     marker::PhantomData,
     sync::atomic::{AtomicU32, AtomicUsize, Ordering},

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,11 +1,15 @@
 use super::bitwise_less_than_prime::BitwiseLessThanPrime;
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::{context::Context, RecordId};
-use crate::secret_sharing::replicated::malicious::{
-    AdditiveShare as MaliciousReplicated, DowngradeMalicious, UnauthorizedDowngradeWrapper,
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, RecordId},
+    secret_sharing::{
+        replicated::malicious::{
+            AdditiveShare as MaliciousReplicated, DowngradeMalicious, UnauthorizedDowngradeWrapper,
+        },
+        Arithmetic as ArithmeticSecretSharing, SecretSharing,
+    },
 };
-use crate::secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing};
 use async_trait::async_trait;
 use std::marker::PhantomData;
 
@@ -145,13 +149,11 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::protocol::boolean::solved_bits::solved_bits;
-    use crate::secret_sharing::SharedValue;
-    use crate::test_fixture::Runner;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
-        protocol::{context::Context, RecordId},
-        test_fixture::{bits_to_value, Reconstruct, TestWorld},
+        protocol::{boolean::solved_bits::solved_bits, context::Context, RecordId},
+        secret_sharing::SharedValue,
+        test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
     };
     use rand::{distributions::Standard, prelude::Distribution};
     use std::iter::zip;

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -1,9 +1,13 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::protocol::basics::{MultiplyZeroPositions, ZeroPositions};
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::secret_sharing::Arithmetic as ArithmeticSecretSharing;
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{
+        basics::{MultiplyZeroPositions, ZeroPositions},
+        context::Context,
+        RecordId,
+    },
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+};
 
 /// Secure XOR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
 /// It computes `[a] + [b] - 2[ab]`

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,30 +1,40 @@
-use std::iter::{repeat, zip};
-use std::marker::PhantomData;
+use std::{
+    iter::{repeat, zip},
+    marker::PhantomData,
+};
 
 use async_trait::async_trait;
 use futures::future::{try_join, try_join_all};
 
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::messaging::{Gateway, Mesh, TotalRecords};
-use crate::helpers::Role;
-use crate::protocol::attribution::input::MCCappedCreditsWithAggregationBit;
-use crate::protocol::basics::mul::malicious::Step::RandomnessForValidation;
-use crate::protocol::basics::{SecureMul, ZeroPositions};
-use crate::protocol::context::prss::InstrumentedIndexedSharedRandomness;
-use crate::protocol::context::{
-    Context, InstrumentedSequentialSharedRandomness, SemiHonestContext,
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::{
+        messaging::{Gateway, Mesh, TotalRecords},
+        Role,
+    },
+    protocol::{
+        attribution::input::MCCappedCreditsWithAggregationBit,
+        basics::{mul::malicious::Step::RandomnessForValidation, SecureMul, ZeroPositions},
+        context::{
+            prss::InstrumentedIndexedSharedRandomness, Context,
+            InstrumentedSequentialSharedRandomness, SemiHonestContext,
+        },
+        malicious::MaliciousValidatorAccumulator,
+        modulus_conversion::BitConversionTriple,
+        prss::Endpoint as PrssEndpoint,
+        BitOpStep, RecordId, Step, Substep, RECORD_0,
+    },
+    repeat64str,
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        Arithmetic,
+    },
+    sync::Arc,
 };
-use crate::protocol::malicious::MaliciousValidatorAccumulator;
-use crate::protocol::modulus_conversion::BitConversionTriple;
-use crate::protocol::prss::Endpoint as PrssEndpoint;
-use crate::protocol::{BitOpStep, RecordId, Step, Substep, RECORD_0};
-use crate::repeat64str;
-use crate::secret_sharing::replicated::{
-    malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
-};
-use crate::secret_sharing::Arithmetic;
-use crate::sync::Arc;
 
 /// Represents protocol context in malicious setting, i.e. secure against one active adversary
 /// in 3 party MPC ring.

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -1,8 +1,14 @@
-use crate::helpers::messaging::{Mesh, TotalRecords};
-use crate::helpers::Role;
-use crate::protocol::basics::{Reveal, SecureMul};
-use crate::protocol::{Step, Substep};
-use crate::secret_sharing::{SecretSharing, SharedValue};
+use crate::{
+    helpers::{
+        messaging::{Mesh, TotalRecords},
+        Role,
+    },
+    protocol::{
+        basics::{Reveal, SecureMul},
+        Step, Substep,
+    },
+    secret_sharing::{SecretSharing, SharedValue},
+};
 
 pub mod malicious;
 mod prss;
@@ -13,9 +19,10 @@ pub use malicious::{MaliciousContext, NoRecord, UpgradeContext, UpgradeToMalicio
 pub use prss::{InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness};
 pub use semi_honest::SemiHonestContext;
 
-use super::basics::sum_of_product::SecureSop;
-use super::basics::Reshare;
-use super::boolean::RandomBits;
+use super::{
+    basics::{sum_of_product::SecureSop, Reshare},
+    boolean::RandomBits,
+};
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
 /// generator and communication channel.
@@ -85,21 +92,21 @@ pub trait Context<V: SharedValue>:
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::ff::{Field, Fp31};
-    use crate::helpers::Direction;
-    use crate::protocol::malicious::Step::MaliciousProtocol;
-    use crate::protocol::prss::SharedRandomness;
-    use crate::protocol::RecordId;
-    use crate::secret_sharing::replicated::{
-        malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+    use crate::{
+        ff::{Field, Fp31},
+        helpers::Direction,
+        protocol::{malicious::Step::MaliciousProtocol, prss::SharedRandomness, RecordId},
+        secret_sharing::replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        telemetry::metrics::{INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED},
     };
-    use crate::telemetry::metrics::{
-        INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED,
+    use futures_util::{future::join_all, try_join};
+    use rand::{
+        distributions::{Distribution, Standard},
+        Rng,
     };
-    use futures_util::future::join_all;
-    use futures_util::try_join;
-    use rand::distributions::{Distribution, Standard};
-    use rand::Rng;
     use std::iter::repeat;
 
     use super::*;

--- a/src/protocol/context/prss.rs
+++ b/src/protocol/context/prss.rs
@@ -1,12 +1,16 @@
 //! Metric-aware PRSS decorators
 
-use crate::helpers::Role;
-use crate::protocol::prss::{
-    IndexedSharedRandomness, SequentialSharedRandomness, SharedRandomness,
+use crate::{
+    helpers::Role,
+    protocol::{
+        prss::{IndexedSharedRandomness, SequentialSharedRandomness, SharedRandomness},
+        Step,
+    },
+    telemetry::{
+        labels::{ROLE, STEP},
+        metrics::{INDEXED_PRSS_GENERATED, SEQUENTIAL_PRSS_GENERATED},
+    },
 };
-use crate::protocol::Step;
-use crate::telemetry::labels::{ROLE, STEP};
-use crate::telemetry::metrics::{INDEXED_PRSS_GENERATED, SEQUENTIAL_PRSS_GENERATED};
 use rand_core::{Error, RngCore};
 use std::sync::Arc;
 

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -1,15 +1,21 @@
-use crate::ff::Field;
-use crate::helpers::messaging::{Gateway, Mesh, TotalRecords};
-use crate::helpers::Role;
-use crate::protocol::context::{
-    Context, InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness,
-    MaliciousContext,
+use crate::{
+    ff::Field,
+    helpers::{
+        messaging::{Gateway, Mesh, TotalRecords},
+        Role,
+    },
+    protocol::{
+        context::{
+            Context, InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness,
+            MaliciousContext,
+        },
+        malicious::MaliciousValidatorAccumulator,
+        prss::Endpoint as PrssEndpoint,
+        Step, Substep,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    sync::Arc,
 };
-use crate::protocol::malicious::MaliciousValidatorAccumulator;
-use crate::protocol::prss::Endpoint as PrssEndpoint;
-use crate::protocol::{Step, Substep};
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-use crate::sync::Arc;
 
 use std::marker::PhantomData;
 

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -35,10 +35,10 @@ use crate::{
 use async_trait::async_trait;
 use futures::future::{try_join, try_join3, try_join_all};
 use generic_array::{ArrayLength, GenericArray};
-use std::ops::Add;
 use std::{
     iter::{repeat, zip},
     marker::PhantomData,
+    ops::Add,
 };
 use typenum::Unsigned;
 
@@ -558,22 +558,23 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 pub mod tests {
     use super::{ipa, ipa_malicious, IPAInputRow};
-    use crate::bits::{Fp2Array, Serializable};
-    use crate::ff::{Field, Fp31, Fp32BitPrime};
-    use crate::ipa_test_input;
-    use crate::protocol::{BreakdownKey, MatchKey};
-    use crate::secret_sharing::IntoShares;
-    use crate::telemetry::metrics::RECORDS_SENT;
-    use crate::test_fixture::{
-        input::GenericReportTestInput, Reconstruct, Runner, TestWorld, TestWorldConfig,
+    use crate::{
+        bits::{Fp2Array, Serializable},
+        ff::{Field, Fp31, Fp32BitPrime},
+        ipa_test_input,
+        protocol::{BreakdownKey, MatchKey},
+        secret_sharing::IntoShares,
+        telemetry::metrics::RECORDS_SENT,
+        test_fixture::{
+            input::GenericReportTestInput, Reconstruct, Runner, TestWorld, TestWorldConfig,
+        },
     };
     use generic_array::GenericArray;
     use proptest::{
         proptest,
         test_runner::{RngAlgorithm, TestRng},
     };
-    use rand::rngs::StdRng;
-    use rand::{thread_rng, Rng};
+    use rand::{rngs::StdRng, thread_rng, Rng};
     use rand_core::SeedableRng;
     use typenum::Unsigned;
 

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -259,18 +259,21 @@ impl<'a, F: Field> MaliciousValidator<'a, F> {
 mod tests {
     use std::iter::{repeat, zip};
 
-    use crate::error::Error;
-    use crate::ff::{Field, Fp31, Fp32BitPrime};
-    use crate::helpers::Role;
-    use crate::protocol::basics::SecureMul;
-    use crate::protocol::context::Context;
-    use crate::protocol::{malicious::MaliciousValidator, RecordId};
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::{
-        replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
-        replicated::semi_honest::AdditiveShare as Replicated, IntoShares,
+    use crate::{
+        error::Error,
+        ff::{Field, Fp31, Fp32BitPrime},
+        helpers::Role,
+        protocol::{basics::SecureMul, context::Context, malicious::MaliciousValidator, RecordId},
+        rand::thread_rng,
+        secret_sharing::{
+            replicated::{
+                malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
+                semi_honest::AdditiveShare as Replicated,
+            },
+            IntoShares,
+        },
+        test_fixture::{join3v, Reconstruct, Runner, TestWorld},
     };
-    use crate::test_fixture::{join3v, Reconstruct, Runner, TestWorld};
     use futures::future::try_join_all;
     use proptest::prelude::Rng;
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -12,9 +12,11 @@ use crate::{
     bits::{BitArray40, BitArray8},
     error::Error,
 };
-use std::fmt::{Debug, Formatter};
-use std::hash::Hash;
-use std::ops::AddAssign;
+use std::{
+    fmt::{Debug, Formatter},
+    hash::Hash,
+    ops::AddAssign,
+};
 
 pub type MatchKey = BitArray40;
 pub type BreakdownKey = BitArray8;

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -1,5 +1,5 @@
-use crate::bits::Fp2Array;
 use crate::{
+    bits::Fp2Array,
     error::Error,
     ff::Field,
     helpers::Role,
@@ -197,20 +197,18 @@ where
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::ff::{Field, Fp32BitPrime};
-    use crate::helpers::{Direction, Role};
-    use crate::protocol::context::Context;
-    use crate::protocol::malicious::MaliciousValidator;
-    use crate::protocol::MatchKey;
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
     use crate::{
         error::Error,
-        ff::Fp31,
+        ff::{Field, Fp31, Fp32BitPrime},
+        helpers::{Direction, Role},
         protocol::{
+            context::Context,
+            malicious::MaliciousValidator,
             modulus_conversion::{convert_bit, convert_bit_local, BitConversionTriple},
-            RecordId,
+            MatchKey, RecordId,
         },
+        rand::thread_rng,
+        secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use proptest::prelude::Rng;

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -1,8 +1,6 @@
-use crate::ff::Field;
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-use aes::cipher::KeyInit;
+use crate::{ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated};
 use aes::{
-    cipher::{generic_array::GenericArray, BlockEncrypt},
+    cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit},
     Aes256,
 };
 use hkdf::Hkdf;

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -9,8 +9,10 @@ pub use crypto::{Generator, GeneratorFactory, KeyExchange, SharedRandomness};
 pub use no_op::{Generator, GeneratorFactory, KeyExchange, SharedRandomness};
 
 use super::Step;
-use crate::rand::{CryptoRng, RngCore};
-use crate::sync::{Arc, Mutex};
+use crate::{
+    rand::{CryptoRng, RngCore},
+    sync::{Arc, Mutex},
+};
 
 use std::{collections::HashMap, fmt::Debug};
 #[cfg(debug_assertions)]
@@ -263,9 +265,12 @@ impl EndpointSetup {
 #[cfg(all(test, not(feature = "shuttle")))]
 pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
-    use crate::protocol::prss::SharedRandomness;
-    use crate::rand::{thread_rng, Rng};
-    use crate::{ff::Fp31, protocol::Step, test_fixture::make_participants};
+    use crate::{
+        ff::Fp31,
+        protocol::{prss::SharedRandomness, Step},
+        rand::{thread_rng, Rng},
+        test_fixture::make_participants,
+    };
     use rand::prelude::SliceRandom;
     use std::mem::drop;
 

--- a/src/protocol/prss/no_op.rs
+++ b/src/protocol/prss/no_op.rs
@@ -1,6 +1,8 @@
-use crate::ff::Field;
-use crate::rand::{CryptoRng, RngCore};
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
+use crate::{
+    ff::Field,
+    rand::{CryptoRng, RngCore},
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+};
 
 use std::fmt::Debug;
 

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,14 +1,19 @@
-use crate::error::Error;
-use crate::ff::Field;
-use crate::helpers::{Direction, Role};
-use crate::protocol::sort::{
-    apply::{apply, apply_inv},
-    shuffle::{shuffle_for_helper, ShuffleOrUnshuffle},
-    ShuffleStep::{self, Step1, Step2, Step3},
+use crate::{
+    error::Error,
+    ff::Field,
+    helpers::{Direction, Role},
+    protocol::{
+        context::Context,
+        sort::{
+            apply::{apply, apply_inv},
+            shuffle::{shuffle_for_helper, ShuffleOrUnshuffle},
+            ShuffleStep::{self, Step1, Step2, Step3},
+        },
+        RecordId,
+    },
+    repeat64str,
+    secret_sharing::{Arithmetic, SecretSharing, SharedValue},
 };
-use crate::protocol::{context::Context, RecordId};
-use crate::repeat64str;
-use crate::secret_sharing::{Arithmetic, SecretSharing, SharedValue};
 use async_trait::async_trait;
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
@@ -160,23 +165,32 @@ where
 mod tests {
 
     mod semi_honest {
-        use crate::accumulation_test_input;
-        use crate::bits::Fp2Array;
-        use crate::protocol::attribution::input::{
-            AccumulateCreditInputRow, MCAccumulateCreditInputRow,
+        use crate::{
+            accumulation_test_input,
+            bits::Fp2Array,
+            protocol::{
+                attribution::input::{AccumulateCreditInputRow, MCAccumulateCreditInputRow},
+                modulus_conversion::{convert_all_bits, convert_all_bits_local},
+                BreakdownKey, MatchKey,
+            },
+            rand::{thread_rng, Rng},
         };
-        use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
-        use crate::protocol::{BreakdownKey, MatchKey};
-        use crate::rand::{thread_rng, Rng};
 
-        use crate::ff::{Fp31, Fp32BitPrime};
-        use crate::protocol::context::Context;
-        use crate::protocol::sort::apply_sort::shuffle::shuffle_shares;
-        use crate::protocol::sort::shuffle::get_two_of_three_random_permutations;
-        use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-        use crate::secret_sharing::SharedValue;
-        use crate::test_fixture::input::GenericReportTestInput;
-        use crate::test_fixture::{bits_to_value, get_bits, Reconstruct, Runner, TestWorld};
+        use crate::{
+            ff::{Fp31, Fp32BitPrime},
+            protocol::{
+                context::Context,
+                sort::{
+                    apply_sort::shuffle::shuffle_shares,
+                    shuffle::get_two_of_three_random_permutations,
+                },
+            },
+            secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SharedValue},
+            test_fixture::{
+                bits_to_value, get_bits, input::GenericReportTestInput, Reconstruct, Runner,
+                TestWorld,
+            },
+        };
         use std::collections::HashSet;
 
         #[tokio::test]

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -1,5 +1,4 @@
-use crate::secret_sharing::SecretSharing;
-use crate::{error::Error, ff::Field, protocol::context::Context};
+use crate::{error::Error, ff::Field, protocol::context::Context, secret_sharing::SecretSharing};
 use embed_doc_image::embed_doc_image;
 
 use super::{apply::apply, shuffle::unshuffle_shares, ComposeStep::UnshuffleRho};
@@ -46,15 +45,17 @@ pub async fn compose<F: Field, S: SecretSharing<F>, C: Context<F, Share = S>>(
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    use crate::protocol::context::Context;
-    use crate::rand::thread_rng;
-    use crate::test_fixture::{Reconstruct, Runner};
     use crate::{
         ff::Fp31,
-        protocol::sort::{
-            apply::apply, compose::compose, generate_permutation::shuffle_and_reveal_permutation,
+        protocol::{
+            context::Context,
+            sort::{
+                apply::apply, compose::compose,
+                generate_permutation::shuffle_and_reveal_permutation,
+            },
         },
-        test_fixture::TestWorld,
+        rand::thread_rng,
+        test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use rand::seq::SliceRandom;
 

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -5,18 +5,21 @@ use crate::{
         basics::reveal_permutation,
         context::{Context, MaliciousContext},
         malicious::MaliciousValidator,
-        sort::SortStep::{
-            ApplyInv, BitPermutationStep, ComposeStep, ShuffleRevealPermutation, SortKeys,
-        },
         sort::{
             bit_permutation::bit_permutation,
             ShuffleRevealStep::{RevealPermutation, ShufflePermutation},
+            SortStep::{
+                ApplyInv, BitPermutationStep, ComposeStep, ShuffleRevealPermutation, SortKeys,
+            },
         },
         IpaProtocolStep::Sort,
     },
     secret_sharing::{
-        replicated::malicious::AdditiveShare as MaliciousReplicated,
-        replicated::semi_honest::AdditiveShare as Replicated, SecretSharing,
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::AdditiveShare as Replicated,
+        },
+        SecretSharing,
     },
 };
 
@@ -26,8 +29,7 @@ use super::{
     secureapplyinv::secureapplyinv,
     shuffle::{get_two_of_three_random_permutations, shuffle_shares},
 };
-use crate::protocol::context::SemiHonestContext;
-use crate::protocol::sort::ShuffleRevealStep::GeneratePermutation;
+use crate::protocol::{context::SemiHonestContext, sort::ShuffleRevealStep::GeneratePermutation};
 use embed_doc_image::embed_doc_image;
 
 #[derive(Debug)]
@@ -359,19 +361,24 @@ mod tests {
 
     use rand::seq::SliceRandom;
 
-    use crate::bits::Fp2Array;
-    use crate::protocol::modulus_conversion::{convert_all_bits, convert_all_bits_local};
-    use crate::protocol::sort::generate_permutation_opt::generate_permutation_opt;
-    use crate::protocol::MatchKey;
-    use crate::rand::{thread_rng, Rng};
-    use crate::secret_sharing::SharedValue;
+    use crate::{
+        bits::Fp2Array,
+        protocol::{
+            modulus_conversion::{convert_all_bits, convert_all_bits_local},
+            sort::generate_permutation_opt::generate_permutation_opt,
+            MatchKey,
+        },
+        rand::{thread_rng, Rng},
+        secret_sharing::SharedValue,
+    };
 
-    use crate::protocol::context::{Context, SemiHonestContext};
-    use crate::test_fixture::{join3, Runner};
     use crate::{
         ff::{Field, Fp31},
-        protocol::sort::generate_permutation::shuffle_and_reveal_permutation,
-        test_fixture::{generate_shares, Reconstruct, TestWorld},
+        protocol::{
+            context::{Context, SemiHonestContext},
+            sort::generate_permutation::shuffle_and_reveal_permutation,
+        },
+        test_fixture::{generate_shares, join3, Reconstruct, Runner, TestWorld},
     };
 
     #[tokio::test]

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -1,14 +1,15 @@
-use crate::secret_sharing::SecretSharing;
 use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, sort::ApplyInvStep::ShuffleInputs},
+    secret_sharing::SecretSharing,
 };
 use embed_doc_image::embed_doc_image;
 
-use super::apply_sort::Resharable;
 use super::{
-    apply::apply_inv, apply_sort::shuffle_shares as shuffle_vectors, shuffle::shuffle_shares,
+    apply::apply_inv,
+    apply_sort::{shuffle_shares as shuffle_vectors, Resharable},
+    shuffle::shuffle_shares,
 };
 #[embed_doc_image("secureapplyinv", "images/sort/secureapplyinv.png")]
 
@@ -81,15 +82,17 @@ mod tests {
         use proptest::prelude::Rng;
         use rand::seq::SliceRandom;
 
-        use crate::protocol::context::Context;
-        use crate::protocol::sort::secureapplyinv::{secureapplyinv, secureapplyinv_multi};
-        use crate::test_fixture::{Reconstruct, Runner};
         use crate::{
             ff::Fp31,
-            protocol::sort::{
-                apply::apply_inv, generate_permutation::shuffle_and_reveal_permutation,
+            protocol::{
+                context::Context,
+                sort::{
+                    apply::apply_inv,
+                    generate_permutation::shuffle_and_reveal_permutation,
+                    secureapplyinv::{secureapplyinv, secureapplyinv_multi},
+                },
             },
-            test_fixture::TestWorld,
+            test_fixture::{Reconstruct, Runner, TestWorld},
         };
 
         #[tokio::test]

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -2,15 +2,14 @@ use std::iter::{repeat, zip};
 
 use embed_doc_image::embed_doc_image;
 use futures::future::try_join_all;
-use rand::seq::SliceRandom;
-use rand::Rng;
+use rand::{seq::SliceRandom, Rng};
 
-use crate::secret_sharing::SecretSharing;
 use crate::{
     error::Error,
     ff::Field,
     helpers::{Direction, Role},
     protocol::{context::Context, RecordId, Substep},
+    secret_sharing::SecretSharing,
 };
 
 use super::{
@@ -214,12 +213,16 @@ mod tests {
     }
 
     mod semi_honest {
-        use crate::ff::Fp31;
-        use crate::protocol::context::Context;
-        use crate::protocol::sort::shuffle::{
-            get_two_of_three_random_permutations, shuffle_shares, unshuffle_shares,
+        use crate::{
+            ff::Fp31,
+            protocol::{
+                context::Context,
+                sort::shuffle::{
+                    get_two_of_three_random_permutations, shuffle_shares, unshuffle_shares,
+                },
+            },
+            test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use crate::test_fixture::{Reconstruct, Runner, TestWorld};
         use std::collections::HashSet;
 
         #[tokio::test]
@@ -300,12 +303,16 @@ mod tests {
     }
 
     mod malicious {
-        use crate::ff::Fp31;
-        use crate::protocol::context::Context;
-        use crate::protocol::sort::shuffle::{
-            get_two_of_three_random_permutations, shuffle_shares, unshuffle_shares,
+        use crate::{
+            ff::Fp31,
+            protocol::{
+                context::Context,
+                sort::shuffle::{
+                    get_two_of_three_random_permutations, shuffle_shares, unshuffle_shares,
+                },
+            },
+            test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use crate::test_fixture::{Reconstruct, Runner, TestWorld};
         use std::collections::HashSet;
 
         #[tokio::test]

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,4 +1,3 @@
-use crate::secret_sharing::Arithmetic;
 use crate::{
     bits::{Fp2Array, Serializable},
     ff::{Field, FieldType, Fp31},
@@ -14,7 +13,7 @@ use crate::{
         ipa::{ipa, IPAInputRow},
         BreakdownKey, MatchKey, Step,
     },
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Arithmetic},
     task::JoinHandle,
 };
 use futures_util::StreamExt;
@@ -72,8 +71,7 @@ async fn execute_test_multiply<F: Field>(
 where
     Replicated<F>: Serializable,
 {
-    use crate::protocol::basics::SecureMul;
-    use crate::protocol::RecordId;
+    use crate::protocol::{basics::SecureMul, RecordId};
 
     let mut results = Vec::new();
     while let Some(v) = input.next().await {

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -16,8 +16,10 @@ use crate::{
 use futures::StreamExt;
 use futures_util::future::try_join;
 use pin_project::pin_project;
-use std::collections::hash_map::Entry;
-use std::fmt::{Debug, Formatter};
+use std::{
+    collections::hash_map::Entry,
+    fmt::{Debug, Formatter},
+};
 use tokio::sync::oneshot;
 
 #[allow(dead_code)]

--- a/src/query/state.rs
+++ b/src/query/state.rs
@@ -1,11 +1,13 @@
-use crate::helpers::messaging::Gateway;
-use crate::helpers::query::QueryConfig;
-use crate::protocol::QueryId;
-use crate::query::ProtocolResult;
-use crate::task::JoinHandle;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use crate::{
+    helpers::{messaging::Gateway, query::QueryConfig},
+    protocol::QueryId,
+    query::ProtocolResult,
+    task::JoinHandle,
+};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Arc, Mutex},
+};
 
 /// The status of query processing
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -47,7 +49,7 @@ pub enum QueryState {
 
 impl QueryState {
     pub fn transition(cur_state: &Self, new_state: Self) -> Result<Self, StateError> {
-        use {QueryState::AwaitingInputs, QueryState::Empty, QueryState::Preparing};
+        use QueryState::{AwaitingInputs, Empty, Preparing};
 
         match (cur_state, &new_state) {
             // If query is not running, coordinator initial state is preparing

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -7,8 +7,7 @@ mod scheme;
 pub use into_shares::IntoShares;
 pub use scheme::{Arithmetic, Boolean, SecretSharing};
 
-use crate::bits::Serializable;
-use crate::ff::ArithmeticOps;
+use crate::{bits::Serializable, ff::ArithmeticOps};
 use std::fmt::Debug;
 
 pub trait SharedValue:

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -17,8 +17,10 @@ use crate::{
 use async_trait::async_trait;
 use futures::future::{join, join_all};
 use generic_array::{ArrayLength, GenericArray};
-use std::fmt::{Debug, Formatter};
-use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
+};
 use typenum::Unsigned;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -277,13 +279,15 @@ impl<T> ThisCodeIsAuthorizedToDowngradeFromMalicious<T> for UnauthorizedDowngrad
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::{AdditiveShare, Downgrade, ThisCodeIsAuthorizedToDowngradeFromMalicious};
-    use crate::ff::{Field, Fp31};
-    use crate::helpers::Role;
-    use crate::rand::thread_rng;
-    use crate::secret_sharing::{
-        replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, IntoShares,
+    use crate::{
+        ff::{Field, Fp31},
+        helpers::Role,
+        rand::thread_rng,
+        secret_sharing::{
+            replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, IntoShares,
+        },
+        test_fixture::Reconstruct,
     };
-    use crate::test_fixture::Reconstruct;
     use proptest::prelude::Rng;
 
     #[test]

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -5,8 +5,10 @@ use crate::{
     secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue},
 };
 use generic_array::{ArrayLength, GenericArray};
-use std::fmt::{Debug, Formatter};
-use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
+};
 use typenum::Unsigned;
 
 #[derive(Clone, PartialEq, Eq)]

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -1,15 +1,16 @@
-use crate::bits::{Fp2Array, Serializable};
-use crate::helpers::Role;
-use crate::secret_sharing::{Boolean as BooleanSecretSharing, SecretSharing};
+use crate::{
+    bits::{Fp2Array, Serializable},
+    helpers::Role,
+    secret_sharing::{Boolean as BooleanSecretSharing, SecretSharing},
+};
 use aes::cipher::generic_array::GenericArray;
 
 use generic_array::ArrayLength;
 use typenum::Unsigned;
 
-use std::ops::Add;
 use std::{
     fmt::{Debug, Formatter},
-    ops::{BitXor, BitXorAssign},
+    ops::{Add, BitXor, BitXorAssign},
 };
 
 #[derive(Clone, PartialEq, Eq)]

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -1,6 +1,8 @@
 use super::SharedValue;
-use crate::bits::{BooleanRefOps, Fp2Array};
-use crate::ff::ArithmeticRefOps;
+use crate::{
+    bits::{BooleanRefOps, Fp2Array},
+    ff::ArithmeticRefOps,
+};
 use std::fmt::Debug;
 
 /// Secret sharing scheme i.e. Replicated secret sharing

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -9,8 +9,7 @@ pub mod labels {
 }
 
 pub mod metrics {
-    use metrics::describe_counter;
-    use metrics::Unit;
+    use metrics::{describe_counter, Unit};
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
     pub const RECORDS_SENT: &str = "records.sent";

--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -1,14 +1,15 @@
-use std::collections::hash_map::Iter;
-use std::collections::HashMap;
-use std::fmt::Debug;
+use std::{
+    collections::{hash_map::Iter, HashMap},
+    fmt::Debug,
+};
 
 use metrics::{KeyName, Label, SharedString};
 
-use crate::helpers::Role;
-use crate::protocol::Step;
-use crate::telemetry::labels;
-use metrics_util::debugging::{DebugValue, Snapshot};
-use metrics_util::{CompositeKey, MetricKind};
+use crate::{helpers::Role, protocol::Step, telemetry::labels};
+use metrics_util::{
+    debugging::{DebugValue, Snapshot},
+    CompositeKey, MetricKind,
+};
 
 /// Simple counter stats
 #[derive(Debug, Default)]

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -1,12 +1,16 @@
 //!
 //! Export metrics collected during protocol run in CSV format. Metrics are partitioned by step.
 
-use crate::telemetry::labels;
-use crate::telemetry::metrics::{INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED};
-use crate::telemetry::stats::Metrics;
-use std::collections::{BTreeMap, HashMap};
-use std::io;
-use std::io::{Error, Write};
+use crate::telemetry::{
+    labels,
+    metrics::{INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED},
+    stats::Metrics,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    io,
+    io::{Error, Write},
+};
 
 pub trait CsvExporter {
     /// Writes the serialized version of this instance into the provided writer in CSV format.

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -1,11 +1,11 @@
-use crate::ff::Field;
-use crate::helpers::messaging::TotalRecords;
-use crate::protocol::basics::SecureMul;
-use crate::protocol::context::Context;
-use crate::protocol::RecordId;
-use crate::rand::thread_rng;
-use crate::secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares};
-use crate::test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld};
+use crate::{
+    ff::Field,
+    helpers::messaging::TotalRecords,
+    protocol::{basics::SecureMul, context::Context, RecordId},
+    rand::thread_rng,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
+    test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld},
+};
 use futures_util::future::join_all;
 
 /// Creates an arithmetic circuit with the given width and depth.

--- a/src/test_fixture/input/mod.rs
+++ b/src/test_fixture/input/mod.rs
@@ -1,6 +1,8 @@
-use crate::bits::Fp2Array;
-use crate::ff::Field;
-use crate::secret_sharing::replicated::semi_honest::{AdditiveShare, XorShare};
+use crate::{
+    bits::Fp2Array,
+    ff::Field,
+    secret_sharing::replicated::semi_honest::{AdditiveShare, XorShare},
+};
 
 pub mod sharing;
 

--- a/src/test_fixture/input/sharing.rs
+++ b/src/test_fixture/input/sharing.rs
@@ -1,19 +1,22 @@
 use super::{GenericReportShare, GenericReportTestInput};
-use crate::bits::Fp2Array;
-use crate::ff::Field;
-use crate::protocol::attribution::input::{
-    AccumulateCreditInputRow, AggregateCreditInputRow, MCAccumulateCreditInputRow,
-    MCAggregateCreditOutputRow,
+use crate::{
+    bits::Fp2Array,
+    ff::Field,
+    protocol::{
+        attribution::input::{
+            AccumulateCreditInputRow, AggregateCreditInputRow, MCAccumulateCreditInputRow,
+            MCAggregateCreditOutputRow,
+        },
+        ipa::IPAInputRow,
+    },
+    rand::Rng,
+    secret_sharing::{
+        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        IntoShares,
+    },
+    test_fixture::Reconstruct,
 };
-use crate::protocol::ipa::IPAInputRow;
-use crate::rand::Rng;
-use crate::secret_sharing::replicated::semi_honest::{
-    AdditiveShare as Replicated, XorShare as XorReplicated,
-};
-use crate::secret_sharing::IntoShares;
-use crate::test_fixture::Reconstruct;
-use rand::distributions::Standard;
-use rand::prelude::Distribution;
+use rand::{distributions::Standard, prelude::Distribution};
 
 impl<F, MK, BK> IntoShares<GenericReportShare<F, MK, BK>> for GenericReportTestInput<F, MK, BK>
 where

--- a/src/test_fixture/metrics.rs
+++ b/src/test_fixture/metrics.rs
@@ -1,14 +1,16 @@
-use crate::telemetry::metrics::register;
-use crate::telemetry::stats::Metrics;
-use crate::test_fixture::logging;
+use crate::{
+    telemetry::{metrics::register, stats::Metrics},
+    test_fixture::logging,
+};
 use metrics::KeyName;
 use metrics_tracing_context::TracingContextLayer;
-use metrics_util::debugging::{DebuggingRecorder, Snapshotter};
-use metrics_util::layers::Layer;
+use metrics_util::{
+    debugging::{DebuggingRecorder, Snapshotter},
+    layers::Layer,
+};
 use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
-use tracing::span::EnteredSpan;
-use tracing::Level;
+use tracing::{span::EnteredSpan, Level};
 
 // TODO: move to OnceCell from std once it is stabilized
 static ONCE: OnceCell<Snapshotter> = OnceCell::new();

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -8,19 +8,16 @@ pub mod metrics;
 pub mod net;
 pub mod transport;
 
-use crate::ff::{Field, Fp31};
-use crate::protocol::context::Context;
-use crate::protocol::prss::Endpoint as PrssEndpoint;
-use crate::protocol::Substep;
-use crate::rand::thread_rng;
-use crate::secret_sharing::{
-    replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SecretSharing,
+use crate::{
+    ff::{Field, Fp31},
+    protocol::{context::Context, prss::Endpoint as PrssEndpoint, Substep},
+    rand::thread_rng,
+    secret_sharing::{
+        replicated::semi_honest::AdditiveShare as Replicated, IntoShares, SecretSharing,
+    },
 };
-use futures::future::try_join_all;
-use futures::TryFuture;
-use rand::distributions::Standard;
-use rand::prelude::Distribution;
-use rand::rngs::mock::StepRng;
+use futures::{future::try_join_all, TryFuture};
+use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
 pub use sharing::{get_bits, into_bits, Reconstruct};
 use std::fmt::Debug;
 pub use world::{Runner, TestWorld, TestWorldConfig};

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,13 +1,16 @@
-use crate::bits::Fp2Array;
-use crate::ff::Field;
-use crate::protocol::boolean::RandomBitsShare;
-use crate::secret_sharing::{
-    replicated::malicious::AdditiveShare as MaliciousReplicated,
-    replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
-    SecretSharing,
+use crate::{
+    bits::Fp2Array,
+    ff::Field,
+    protocol::boolean::RandomBitsShare,
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        },
+        SecretSharing,
+    },
 };
-use std::borrow::Borrow;
-use std::iter::zip;
+use std::{borrow::Borrow, iter::zip};
 
 /// Deconstructs a field value into N values, one for each bit.
 pub fn into_bits<F: Field>(v: F) -> Vec<F> {

--- a/src/test_fixture/transport/mod.rs
+++ b/src/test_fixture/transport/mod.rs
@@ -14,8 +14,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use routing::Switch;
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+};
 use tokio::sync::mpsc::{channel, Sender};
 use tokio_stream::wrappers::ReceiverStream;
 

--- a/src/test_fixture/transport/network.rs
+++ b/src/test_fixture/transport/network.rs
@@ -1,7 +1,8 @@
-use crate::helpers::{HelperIdentity, Transport};
-use crate::sync::Arc;
-use crate::sync::Weak;
-use crate::test_fixture::transport::InMemoryTransport;
+use crate::{
+    helpers::{HelperIdentity, Transport},
+    sync::{Arc, Weak},
+    test_fixture::transport::InMemoryTransport,
+};
 
 /// Container for all active transports
 #[derive(Clone)]

--- a/src/test_fixture/transport/routing.rs
+++ b/src/test_fixture/transport/routing.rs
@@ -13,8 +13,10 @@ use futures::StreamExt;
 use futures_util::stream::SelectAll;
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;
-use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::Instrument;
 

--- a/src/test_fixture/transport/util.rs
+++ b/src/test_fixture/transport/util.rs
@@ -1,7 +1,7 @@
-use crate::helpers::{
-    HelperIdentity, SubscriptionType, Transport, TransportCommand, TransportError,
+use crate::{
+    helpers::{HelperIdentity, SubscriptionType, Transport, TransportCommand, TransportError},
+    sync::Arc,
 };
-use crate::sync::Arc;
 
 use async_trait::async_trait;
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -3,8 +3,6 @@ use async_trait::async_trait;
 use futures::{future::join_all, Future};
 use rand::{distributions::Standard, prelude::Distribution};
 
-use crate::sync::atomic::{AtomicUsize, Ordering};
-use crate::test_fixture::metrics::MetricsHandle;
 use crate::{
     ff::Field,
     helpers::{
@@ -19,23 +17,27 @@ use crate::{
         prss::Endpoint as PrssEndpoint,
     },
     secret_sharing::replicated::malicious::DowngradeMalicious,
-    test_fixture::{logging, make_participants},
+    sync::atomic::{AtomicUsize, Ordering},
+    test_fixture::{logging, make_participants, metrics::MetricsHandle},
 };
 
 use std::io::stdout;
 
-use std::mem::ManuallyDrop;
-use std::num::NonZeroUsize;
-use std::sync::atomic::AtomicBool;
-use std::{fmt::Debug, iter::zip, sync::Arc};
+use std::{
+    fmt::Debug,
+    iter::zip,
+    mem::ManuallyDrop,
+    num::NonZeroUsize,
+    sync::{atomic::AtomicBool, Arc},
+};
 
-use crate::helpers::network::Network;
-use crate::helpers::RoleAssignment;
-use crate::protocol::{QueryId, Substep};
-use crate::secret_sharing::IntoShares;
-use crate::telemetry::stats::Metrics;
-use crate::telemetry::StepStatsCsvExporter;
-use crate::test_fixture::transport::InMemoryNetwork;
+use crate::{
+    helpers::{network::Network, RoleAssignment},
+    protocol::{QueryId, Substep},
+    secret_sharing::IntoShares,
+    telemetry::{stats::Metrics, StepStatsCsvExporter},
+    test_fixture::transport::InMemoryNetwork,
+};
 use tracing::Level;
 
 use super::{sharing::ValidateMalicious, Reconstruct};

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -1,12 +1,15 @@
 #![cfg(all(feature = "shuttle", test))]
 
-use crate::ff::Fp32BitPrime;
-use crate::helpers::Direction;
-use crate::protocol::context::{Context, SemiHonestContext};
-use crate::protocol::RecordId;
-use crate::secret_sharing::replicated::semi_honest::AdditiveShare as Replicated;
-use crate::test_fixture::Reconstruct;
-use crate::test_fixture::{Runner, TestWorld};
+use crate::{
+    ff::Fp32BitPrime,
+    helpers::Direction,
+    protocol::{
+        context::{Context, SemiHonestContext},
+        RecordId,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    test_fixture::{Reconstruct, Runner, TestWorld},
+};
 use futures_util::future::{try_join, try_join_all};
 
 #[test]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,6 +1,5 @@
 use hyper::Uri;
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
 /// # Errors
 /// if serializing to string fails


### PR DESCRIPTION
This change uses [unstable rustfmt option](
https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#imports_granularity) to auto format imports. There is a [little trick](https://github.com/rust-lang/rustfmt/issues/5511) to make it work on a stable channel. It seems to me that benefits outweigh the inconvenience of adding arguments to `cargo fmt`. 

It also updates pre-commit and CI checks and fixes imports for pretty much every file. 