### PR TITLE
Remove the intermediate `b` bit

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -135,7 +135,7 @@ where
     // of other elements, allowing the algorithm to be executed in parallel.
 
     // generate powers of 2 that fit into input len. If num_rows is 15, this will produce [1, 2, 4, 8]
-    do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(ctx, helper_bits, &mut credits).await?;
 
     let output = input
         .iter()

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -115,7 +115,10 @@ where
     }))
     .await?;
 
-    let credits = input.iter().map(|x| &x.trigger_value);
+    let mut credits = input
+        .iter()
+        .map(|x| x.trigger_value.clone())
+        .collect::<Vec<_>>();
 
     // 2. Accumulate (up to 4 multiplications)
     //
@@ -132,7 +135,7 @@ where
     // of other elements, allowing the algorithm to be executed in parallel.
 
     // generate powers of 2 that fit into input len. If num_rows is 15, this will produce [1, 2, 4, 8]
-    let credits = do_the_binary_tree_thing(ctx, &helper_bits, credits).await?;
+    let credits = do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
 
     let output = input
         .iter()

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -135,7 +135,7 @@ where
     // of other elements, allowing the algorithm to be executed in parallel.
 
     // generate powers of 2 that fit into input len. If num_rows is 15, this will produce [1, 2, 4, 8]
-    let credits = do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
 
     let output = input
         .iter()

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -89,7 +89,7 @@ where
         .map(|x| x.credit.clone())
         .collect::<Vec<_>>();
 
-    let credits = do_the_binary_tree_thing(ctx.clone(), &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(ctx.clone(), &helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input
@@ -188,7 +188,7 @@ where
         .map(|x| x.credit.clone())
         .collect::<Vec<_>>();
 
-    let credits = do_the_binary_tree_thing(m_ctx, &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(m_ctx, &helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -84,9 +84,12 @@ where
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
 
-    let credits = sorted_input.iter().map(|x| &x.credit);
+    let mut credits = sorted_input
+        .iter()
+        .map(|x| x.credit.clone())
+        .collect::<Vec<_>>();
 
-    let credits = do_the_binary_tree_thing(ctx.clone(), &helper_bits, credits).await?;
+    let credits = do_the_binary_tree_thing(ctx.clone(), &helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input
@@ -180,9 +183,12 @@ where
         .map(|x| x.helper_bit.clone())
         .collect::<Vec<_>>();
 
-    let credits = sorted_input.iter().map(|x| &x.credit);
+    let mut credits = sorted_input
+        .iter()
+        .map(|x| x.credit.clone())
+        .collect::<Vec<_>>();
 
-    let credits = do_the_binary_tree_thing(m_ctx, &helper_bits, credits).await?;
+    let credits = do_the_binary_tree_thing(m_ctx, &helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -89,7 +89,7 @@ where
         .map(|x| x.credit.clone())
         .collect::<Vec<_>>();
 
-    do_the_binary_tree_thing(ctx.clone(), &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(ctx.clone(), helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input
@@ -188,7 +188,7 @@ where
         .map(|x| x.credit.clone())
         .collect::<Vec<_>>();
 
-    do_the_binary_tree_thing(m_ctx, &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(m_ctx, helper_bits, &mut credits).await?;
 
     // Prepare the sidecar for sorting
     let aggregated_credits = sorted_input

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -219,7 +219,7 @@ where
 
     let mut credits = original_credits.cloned().collect::<Vec<_>>();
 
-    do_the_binary_tree_thing(ctx, &helper_bits, &mut credits).await?;
+    do_the_binary_tree_thing(ctx, helper_bits, &mut credits).await?;
 
     Ok(credits)
 }

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -162,10 +162,10 @@ where
 /// ## Panics
 /// Nah, it doesn't.
 ///
-pub async fn do_the_binary_tree_thing<'a, F, C, S>(
+pub async fn do_the_binary_tree_thing<F, C, S>(
     ctx: C,
-    stop_bits: &[S],
-    values: &'a mut [S],
+    mut stop_bits: Vec<S>,
+    values: &mut [S],
 ) -> Result<(), Error>
 where
     F: Field,
@@ -174,10 +174,9 @@ where
 {
     let num_rows = values.len();
 
-    // Create stop_bit vector.
+    // Append [0] to the stop_bit vector.
     // This vector is updated in each iteration to help accumulate values
     // and determine when to stop accumulating.
-    let mut stop_bits = stop_bits.to_owned();
     stop_bits.push(S::ZERO);
 
     // Each loop the "step size" is doubled. This produces a "binary tree" like behavior

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -162,21 +162,17 @@ where
 /// ## Panics
 /// Nah, it doesn't.
 ///
-pub async fn do_the_binary_tree_thing<F, C, S>(
+pub async fn do_the_binary_tree_thing<'a, F, C, S>(
     ctx: C,
     stop_bits: &[S],
-    values: &mut [S],
-) -> Result<Vec<S>, Error>
+    values: &'a mut [S],
+) -> Result<(), Error>
 where
     F: Field,
     C: Context<F, Share = S>,
     S: ArithmeticSecretSharing<F>,
 {
     let num_rows = values.len();
-
-    // Create value vector.
-    // This vector is updated in each iteration by adding `value * stop_bit`.
-    let mut values = values.to_owned();
 
     // Create stop_bit vector.
     // This vector is updated in each iteration to help accumulate values
@@ -223,7 +219,7 @@ where
                 stop_bits[i] = stop_bit;
             });
     }
-    Ok(values)
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1001,17 +1001,17 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 4, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 10740;
+        /// empirical value as of Feb 22, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 10731;
 
-        /// empirical value as of Feb 14, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 26410;
+        /// empirical value as of Feb 22, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 26392;
 
-        /// empirical value as of Feb 20, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7557;
+        /// empirical value as of Feb 22, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7551;
 
-        /// empirical value as of Feb 20, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18849;
+        /// empirical value as of Feb 22, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18837;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
The aggregation protocols accumulate values using a binary-tree style prefix-sum. The current code computes an intermediate `b` bit and multiply it by `credit` to determine whether a value should be accumulated in each iteration.

How we currently compute the `b` bit is by `sibling_helper_bit * current_stop_bit`. Since the initial `stop_bit` is computed by `sibling_helper_bit * sibling_is_trigger_bit`, we can eliminate `b` and just compute `current_stop_bit * sibling_value`.

Since call sites do not need helper_bits after calling `do_the_binary_tree_thing()`, I changed helper_bits to move. We also don't need to handle a special case for depth 0 and not need to create new vectors for credits, I changed credits to mutable borrow.

This change reduces 1 mult from per depth * N rows * 3 protocols, and 3N heap allocations * 3 protocols.

```
Baseline for semi-honest IPA (cap = 1) has improved! Expected 7557, got 7551.
Baseline for malicious IPA (cap = 1) has improved! Expected 18849, got 18837.
Baseline for semi-honest IPA (cap = 3) has improved! Expected 10740, got 10731.
Baseline for malicious IPA (cap = 3) has improved! Expected 26410, got 26392.
```