### PR TITLE
Skipping the computation of 'stop bits' on the last iteration

### DIFF
--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -184,13 +184,15 @@ where
         .take_while(|&v| v < num_rows)
         .enumerate()
     {
+        let last_iteration = step_size * 2 >= num_rows;
         let end = num_rows - step_size;
         let depth_i_ctx = ctx
             .narrow(&InteractionPatternStep::from(depth + 1))
             .set_total_records(end);
         let new_value_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorCredit);
         let new_stop_bit_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorStopBit);
-        let mut futures = Vec::with_capacity(end);
+        let mut value_update_futures = Vec::with_capacity(end);
+        let mut stop_bit_futures = Vec::with_capacity(end);
 
         for i in 0..end {
             let c1 = new_value_ctx.clone();
@@ -198,25 +200,36 @@ where
             let record_id = RecordId::from(i);
             let current_stop_bit = &stop_bits[i];
             let sibling_stop_bit = &stop_bits[i + step_size];
-            let sibling_credit = &values[i + step_size];
-            futures.push(async move {
-                try_join(
-                    c1.multiply(record_id, current_stop_bit, sibling_credit),
-                    c2.multiply(record_id, current_stop_bit, sibling_stop_bit),
-                )
-                .await
+            let sibling_value = &values[i + step_size];
+            value_update_futures.push(async move {
+                c1.multiply(record_id, current_stop_bit, sibling_value)
+                    .await
             });
+            if !last_iteration {
+                stop_bit_futures.push(async move {
+                    c2.multiply(record_id, current_stop_bit, sibling_stop_bit)
+                        .await
+                });
+            }
         }
 
-        let results = try_join_all(futures).await?;
-
-        results
+        let value_updates = try_join_all(value_update_futures).await?;
+        value_updates
             .into_iter()
             .enumerate()
-            .for_each(|(i, (credit, stop_bit))| {
-                values[i] += &credit;
-                stop_bits[i] = stop_bit;
+            .for_each(|(i, value_update)| {
+                values[i] += &value_update;
             });
+
+        if !last_iteration {
+            let stop_bit_updates = try_join_all(stop_bit_futures).await?;
+            stop_bit_updates
+                .into_iter()
+                .enumerate()
+                .for_each(|(i, stop_bit_update)| {
+                    stop_bits[i] = stop_bit_update;
+                });
+        }
     }
     Ok(())
 }

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1001,17 +1001,17 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 22, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 10731;
+        /// empirical value as of Feb 23, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 10713;
 
-        /// empirical value as of Feb 22, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 26392;
+        /// empirical value as of Feb 23, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 26356;
 
-        /// empirical value as of Feb 22, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7551;
+        /// empirical value as of Feb 23, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 7542;
 
-        /// empirical value as of Feb 22, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18837;
+        /// empirical value as of Feb 23, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 18819;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
On the last iteration, there is no need to update the "stop bits" because they won't be read in the last iteration. We can skip this and save on communication bandwidth!