### PR TITLE
Remove `b` bit from `prefix_or_binary_tree_style`

### DIFF
--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -58,7 +58,7 @@ where
 ///
 pub async fn prefix_or_binary_tree_style<F, C, S>(
     ctx: C,
-    helper_bits: &[S],
+    stop_bits: &[S],
     uncapped_credits: &[S],
 ) -> Result<Vec<S>, Error>
 where
@@ -66,92 +66,80 @@ where
     C: Context,
     S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
 {
-    assert_eq!(helper_bits.len() + 1, uncapped_credits.len());
+    assert_eq!(stop_bits.len() + 1, uncapped_credits.len());
 
     let num_rows = uncapped_credits.len();
-    let depth_0_ctx = ctx
-        .narrow(&InteractionPatternStep::from(0))
-        .set_total_records(num_rows - 1);
 
-    let b_times_sibling_credit_ctx = depth_0_ctx.narrow(&Step::BTimesSuccessorCredit);
+    let mut uncapped_credits = uncapped_credits.to_owned();
 
-    let mut prefix_or = try_join_all(
-        helper_bits
-            .iter()
-            .zip(uncapped_credits.iter().skip(1))
-            .enumerate()
-            .map(|(i, (b, sibling_credit))| {
-                let c1 = b_times_sibling_credit_ctx.clone();
-                let c2 = depth_0_ctx.clone();
-                let record_id = RecordId::from(i);
-                let original_credit = &uncapped_credits[i];
-                async move {
-                    let credit_update = S::multiply(c1, record_id, b, sibling_credit).await?;
-                    or(c2, record_id, original_credit, &credit_update).await
-                }
-            }),
-    )
-    .await?;
-    // This is crap and will resize the vector... it was too hard to fix...
-    prefix_or.push(uncapped_credits[num_rows - 1].clone());
-
-    // Create stop_bit vector.
-    // This vector is updated in each iteration to help accumulate values
+    // This vector is updated in each iteration to help accumulate credits
     // and determine when to stop accumulating.
-    let mut stop_bits = helper_bits.to_owned();
-    stop_bits.push(S::share_known_value(&ctx, F::ONE));
+    let mut stop_bits = stop_bits.to_owned();
+    stop_bits.push(S::ZERO);
 
     // Each loop the "step size" is doubled. This produces a "binary tree" like behavior
-    for (depth, step_size) in std::iter::successors(Some(2_usize), |prev| prev.checked_mul(2))
+    for (depth, step_size) in std::iter::successors(Some(1_usize), |prev| prev.checked_mul(2))
         .take_while(|&v| v < num_rows)
         .enumerate()
     {
+        let last_iteration = step_size * 2 >= num_rows;
         let end = num_rows - step_size;
         let depth_i_ctx = ctx
-            .narrow(&InteractionPatternStep::from(depth + 1))
+            .narrow(&InteractionPatternStep::from(depth))
             .set_total_records(end);
-        let b_times_sibling_credit_ctx = depth_i_ctx.narrow(&Step::BTimesSuccessorCredit);
-        let b_times_sibling_stop_bit_ctx = depth_i_ctx.narrow(&Step::BTimesSuccessorStopBit);
+        let new_credit_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorCredit);
+        let new_stop_bit_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorStopBit);
         let credit_or_ctx = depth_i_ctx.narrow(&Step::CurrentCreditOrCreditUpdate);
-        let mut futures = Vec::with_capacity(end);
+        let mut credit_update_futures = Vec::with_capacity(end);
+        let mut stop_bit_futures = Vec::with_capacity(end);
 
         for i in 0..end {
-            let c1 = depth_i_ctx.clone();
-            let c2 = b_times_sibling_credit_ctx.clone();
-            let c3 = b_times_sibling_stop_bit_ctx.clone();
-            let c4 = credit_or_ctx.clone();
+            let c1 = new_credit_ctx.clone();
+            let c2 = new_stop_bit_ctx.clone();
+            let c3 = credit_or_ctx.clone();
             let record_id = RecordId::from(i);
-            let sibling_helper_bit = &helper_bits[i + step_size - 1];
             let current_stop_bit = &stop_bits[i];
             let sibling_stop_bit = &stop_bits[i + step_size];
-            let sibling_credit = &prefix_or[i + step_size];
-            let current_credit = &prefix_or[i];
-            futures.push(async move {
-                let b = S::multiply(c1, record_id, current_stop_bit, sibling_helper_bit).await?;
+            let sibling_credit = &uncapped_credits[i + step_size];
+            let current_credit = &uncapped_credits[i];
 
-                let (credit_update, new_stop_bit) = try_join(
-                    S::multiply(c2, record_id, &b, sibling_credit),
-                    S::multiply(c3, record_id, &b, sibling_stop_bit),
-                )
-                .await?;
-
-                let new_credit = or(c4, record_id, current_credit, &credit_update).await?;
-
-                Ok::<_, Error>((new_credit, new_stop_bit))
+            credit_update_futures.push(async move {
+                let credit_update =
+                    S::multiply(c1, record_id, current_stop_bit, sibling_credit).await?;
+                or(c3, record_id, current_credit, &credit_update).await
             });
+            if !last_iteration {
+                stop_bit_futures.push(async move {
+                    S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
+                });
+            }
         }
 
-        let results = try_join_all(futures).await?;
+        let credit_updates = if last_iteration {
+            try_join_all(credit_update_futures).await?
+        } else {
+            let (stop_bit_updates, credit_updates) = try_join(
+                try_join_all(stop_bit_futures),
+                try_join_all(credit_update_futures),
+            )
+            .await?;
 
-        results
+            stop_bit_updates
+                .into_iter()
+                .enumerate()
+                .for_each(|(i, stop_bit_update)| {
+                    stop_bits[i] = stop_bit_update;
+                });
+            credit_updates
+        };
+        credit_updates
             .into_iter()
             .enumerate()
-            .for_each(|(i, (credit, stop_bit))| {
-                prefix_or[i] = credit;
-                stop_bits[i] = stop_bit;
+            .for_each(|(i, credit_update)| {
+                uncapped_credits[i] = credit_update;
             });
     }
-    Ok(prefix_or)
+    Ok(uncapped_credits)
 }
 
 ///
@@ -178,7 +166,9 @@ where
 {
     let num_rows = values.len();
 
-    // Append [0] to the stop_bit vector.
+    // Append [0] to the stop_bit vector. What value we append doesn't matter because there's
+    // no successor if the current row is at the end of the vector. This is to align the length
+    // with `values` vector.
     // This vector is updated in each iteration to help accumulate values
     // and determine when to stop accumulating.
     stop_bits.push(S::ZERO);
@@ -191,7 +181,7 @@ where
         let last_iteration = step_size * 2 >= num_rows;
         let end = num_rows - step_size;
         let depth_i_ctx = ctx
-            .narrow(&InteractionPatternStep::from(depth + 1))
+            .narrow(&InteractionPatternStep::from(depth))
             .set_total_records(end);
         let new_value_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorCredit);
         let new_stop_bit_ctx = depth_i_ctx.narrow(&Step::CurrentStopBitTimesSuccessorStopBit);
@@ -243,9 +233,8 @@ where
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(clippy::enum_variant_names)]
 enum Step {
-    BTimesSuccessorCredit,
-    BTimesSuccessorStopBit,
     CurrentStopBitTimesSuccessorCredit,
     CurrentStopBitTimesSuccessorStopBit,
     CurrentCreditOrCreditUpdate,
@@ -256,8 +245,6 @@ impl crate::protocol::Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
-            Self::BTimesSuccessorCredit => "b_times_successor_credit",
-            Self::BTimesSuccessorStopBit => "b_times_successor_stop_bit",
             Self::CurrentStopBitTimesSuccessorCredit => "current_stop_bit_times_successor_credit",
             Self::CurrentStopBitTimesSuccessorStopBit => {
                 "current_stop_bit_times_successor_stop_bit"


### PR DESCRIPTION
Same as #487 + #490. The baseline result doesn't change because it only has 5 events, but the improvement is still 1 less mult from O(N log N) logic.