### PR TITLE
Remove the last stop_bit computation from each binary-tree depth

### DIFF
--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -94,6 +94,7 @@ where
         let mut stop_bit_futures = Vec::with_capacity(end);
 
         for i in 0..end {
+            let last_row = i == end - 1;
             let c1 = new_credit_ctx.clone();
             let c2 = new_stop_bit_ctx.clone();
             let c3 = credit_or_ctx.clone();
@@ -108,7 +109,7 @@ where
                     S::multiply(c1, record_id, current_stop_bit, sibling_credit).await?;
                 or(c3, record_id, current_credit, &credit_update).await
             });
-            if !last_iteration {
+            if !last_iteration && !last_row {
                 stop_bit_futures.push(async move {
                     S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
                 });
@@ -189,6 +190,7 @@ where
         let mut stop_bit_futures = Vec::with_capacity(end);
 
         for i in 0..end {
+            let last_row = i == end - 1;
             let c1 = new_value_ctx.clone();
             let c2 = new_stop_bit_ctx.clone();
             let record_id = RecordId::from(i);
@@ -198,7 +200,7 @@ where
             value_update_futures.push(async move {
                 S::multiply(c1, record_id, current_stop_bit, sibling_value).await
             });
-            if !last_iteration {
+            if !last_iteration && !last_row {
                 stop_bit_futures.push(async move {
                     S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
                 });

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -75,7 +75,6 @@ where
     // This vector is updated in each iteration to help accumulate credits
     // and determine when to stop accumulating.
     let mut stop_bits = stop_bits.to_owned();
-    stop_bits.push(S::ZERO);
 
     // Each loop the "step size" is doubled. This produces a "binary tree" like behavior
     for (depth, step_size) in std::iter::successors(Some(1_usize), |prev| prev.checked_mul(2))
@@ -100,7 +99,6 @@ where
             let c3 = credit_or_ctx.clone();
             let record_id = RecordId::from(i);
             let current_stop_bit = &stop_bits[i];
-            let sibling_stop_bit = &stop_bits[i + step_size];
             let sibling_credit = &uncapped_credits[i + step_size];
             let current_credit = &uncapped_credits[i];
 
@@ -110,6 +108,7 @@ where
                 or(c3, record_id, current_credit, &credit_update).await
             });
             if !last_iteration && !last_row {
+                let sibling_stop_bit = &stop_bits[i + step_size];
                 stop_bit_futures.push(async move {
                     S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
                 });
@@ -167,13 +166,6 @@ where
 {
     let num_rows = values.len();
 
-    // Append [0] to the stop_bit vector. What value we append doesn't matter because there's
-    // no successor if the current row is at the end of the vector. This is to align the length
-    // with `values` vector.
-    // This vector is updated in each iteration to help accumulate values
-    // and determine when to stop accumulating.
-    stop_bits.push(S::ZERO);
-
     // Each loop the "step size" is doubled. This produces a "binary tree" like behavior
     for (depth, step_size) in std::iter::successors(Some(1_usize), |prev| prev.checked_mul(2))
         .take_while(|&v| v < num_rows)
@@ -195,12 +187,12 @@ where
             let c2 = new_stop_bit_ctx.clone();
             let record_id = RecordId::from(i);
             let current_stop_bit = &stop_bits[i];
-            let sibling_stop_bit = &stop_bits[i + step_size];
             let sibling_value = &values[i + step_size];
             value_update_futures.push(async move {
                 S::multiply(c1, record_id, current_stop_bit, sibling_value).await
             });
             if !last_iteration && !last_row {
+                let sibling_stop_bit = &stop_bits[i + step_size];
                 stop_bit_futures.push(async move {
                     S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
                 });

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1005,17 +1005,17 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 19209;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 19182;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46872;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46818;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13629;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13614;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33621;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33591;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
In #487, I changed how we compute the prefix-sum. Determining whether we should accumulate the `sibling_value` only depends on the `current_stop_bit`. That means we skip the bottom stop bits at `stop_bits[(num_rows - step_size + 1)..]`, which allows us to reduce 1 mult from each depth = log N mult reduction.