### PR TITLE
Optimization: add to compute OR

### DIFF
--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -82,6 +82,7 @@ where
         .take_while(|&v| v < num_rows)
         .enumerate()
     {
+        let first_iteration = step_size == 1;
         let last_iteration = step_size * 2 >= num_rows;
         let end = num_rows - step_size;
         let depth_i_ctx = ctx
@@ -106,7 +107,11 @@ where
             credit_update_futures.push(async move {
                 let credit_update =
                     S::multiply(c1, record_id, current_stop_bit, sibling_credit).await?;
-                or(c3, record_id, current_credit, &credit_update).await
+                if first_iteration {
+                    Ok(credit_update + current_credit)
+                } else {
+                    or(c3, record_id, current_credit, &credit_update).await
+                }
             });
             if !last_iteration {
                 stop_bit_futures.push(async move {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1011,11 +1011,11 @@ pub mod tests {
         /// empirical value as of Feb 23, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46872;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13629;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13611;
 
-        /// empirical value as of Feb 23, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33621;
+        /// empirical value as of Feb 24, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33585;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
I found another small optimization!

The very first iteration of PREFIX-OR, we basically update the "credit" for each line to reflect: "Is either _this_ row a 1, or is the _following_ row a 1 (from the same match key)".

Thinking about this a bit, I realized it is *impossible* (in the first iteration) to both have `uncapped_credits[i] ==1` AND `uncapped_credits[i+1] == 1`. 

The reason this is impossible is because of how basic attribution is in the "cap = 1" case. 

The only way to have `uncapped_credits[i] == 1` is to have a source event, followed by a trigger event from the same person. If you had two adjacent rows that both met this condition, that would imply that is_trigger_event[i+1] is simultaneously both a source and trigger event.

Put another way, two consecutive source-events cannot both receive an attributed trigger event, and trigger events are all masked out. The closest you can get, is to alternate source and trigger events from the same person, which would result in uncapped_credits alternating between 0 and 1. 

Since two adjacent rows CANNOT simultaneously be 1, OR gets a lot simpler. Instead of `a + b - a*b`, it becomes just `a + b` (because we know a*b == 0).