### PR TITLE
Enable incremental compilation for release builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
+      CARGO_INCREMENTAL: 0
 
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ x25519-dalek = "2.0.0-pre.1"
 permutation = "0.4.1"
 proptest = "1.0.0"
 
+[profile.release]
+incremental = true
+
 [profile.bench]
 debug-assertions = true
 


### PR DESCRIPTION
It is [disabled](https://doc.rust-lang.org/cargo/reference/profiles.html#incremental) by default and it should help shortening the iteration cycle on benchmarks