### PR TITLE
Pass by value not reference

### DIFF
--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Error> {
     let converted_shares = world
         .semi_honest(match_keys.clone(), |ctx, match_key| async move {
             convert_all_bits::<Fp32BitPrime, _, _>(
-                &ctx,
+                ctx.clone(),
                 &convert_all_bits_local(ctx.role(), &match_key),
                 BitArray40::BITS,
                 NUM_MULTI_BITS,

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -217,7 +217,7 @@ mod tests {
                         .map(|x| x.breakdown_key.clone())
                         .collect::<Vec<_>>();
                     let mut converted_bk_shares = convert_all_bits(
-                        &ctx,
+                        ctx.clone(),
                         &convert_all_bits_local(ctx.role(), &bk_shares),
                         BreakdownKey::BITS,
                         BreakdownKey::BITS,
@@ -281,7 +281,7 @@ mod tests {
                     |ctx, share: AccumulateCreditInputRow<Fp31, BreakdownKey>| async move {
                         let bk_shares = vec![share.breakdown_key];
                         let mut converted_bk_shares = convert_all_bits(
-                            &ctx,
+                            ctx.clone(),
                             &convert_all_bits_local(ctx.role(), &bk_shares),
                             BreakdownKey::BITS,
                             BreakdownKey::BITS,

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -517,7 +517,7 @@ mod tests {
                         .map(|x| x.breakdown_key.clone())
                         .collect::<Vec<_>>();
                     let mut converted_bk_shares = convert_all_bits(
-                        &ctx,
+                        ctx.clone(),
                         &convert_all_bits_local(ctx.role(), &bk_shares),
                         BreakdownKey::BITS,
                         BreakdownKey::BITS,

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -443,7 +443,7 @@ mod tests {
                         .map(|x| x.breakdown_key.clone())
                         .collect::<Vec<_>>();
                     let mut converted_bk_shares = convert_all_bits(
-                        &ctx,
+                        ctx.clone(),
                         &convert_all_bits_local(ctx.role(), &bk_shares),
                         BreakdownKey::BITS,
                         BreakdownKey::BITS,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -306,7 +306,7 @@ where
     // the outermost vector
     // Breakdown key modulus conversion
     let mut converted_bk_shares = convert_all_bits(
-        &ctx.narrow(&Step::ModulusConversionForBreakdownKeys),
+        ctx.narrow(&Step::ModulusConversionForBreakdownKeys),
         &convert_all_bits_local(ctx.role(), &bk_shares),
         BK::BITS,
         BK::BITS,
@@ -317,7 +317,7 @@ where
 
     // Match key modulus conversion, and then sort
     let converted_mk_shares = convert_all_bits(
-        &ctx.narrow(&Step::ModulusConversionForMatchKeys),
+        ctx.narrow(&Step::ModulusConversionForMatchKeys),
         &convert_all_bits_local(ctx.role(), &mk_shares),
         MK::BITS,
         num_multi_bits,
@@ -438,7 +438,7 @@ where
 
     // Match key modulus conversion, and then sort
     let converted_mk_shares = convert_all_bits(
-        &m_ctx.narrow(&Step::ModulusConversionForMatchKeys),
+        m_ctx.narrow(&Step::ModulusConversionForMatchKeys),
         &m_ctx
             .upgrade(convert_all_bits_local(m_ctx.role(), &mk_shares))
             .await?,
@@ -465,7 +465,7 @@ where
 
     // Breakdown key modulus conversion
     let mut converted_bk_shares = convert_all_bits(
-        &m_ctx.narrow(&Step::ModulusConversionForBreakdownKeys),
+        m_ctx.narrow(&Step::ModulusConversionForBreakdownKeys),
         &m_ctx
             .narrow(&Step::ModulusConversionForBreakdownKeys)
             .upgrade(convert_all_bits_local(m_ctx.role(), &bk_shares))

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -137,7 +137,7 @@ where
 /// # Panics
 /// Propagates panics from convert shares
 pub async fn convert_all_bits<F, C, S>(
-    ctx: &C,
+    ctx: C,
     locally_converted_bits: &[Vec<BitConversionTriple<S>>],
     num_bits: u32,
     num_multi_bits: u32,

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -102,7 +102,7 @@ mod tests {
                 )| async move {
                     let local_lists = convert_all_bits_local::<Fp31, _>(ctx.role(), &mk_shares);
                     let converted_shares = convert_all_bits(
-                        &ctx.narrow("convert_all_bits"),
+                        ctx.narrow("convert_all_bits"),
                         &local_lists,
                         MatchKey::BITS,
                         NUM_MULTI_BITS,
@@ -121,7 +121,7 @@ mod tests {
                         .map(|x| x.breakdown_key.clone())
                         .collect::<Vec<_>>();
                     let mut converted_bk_shares = convert_all_bits(
-                        &ctx,
+                        ctx.clone(),
                         &convert_all_bits_local(ctx.role(), &bk_shares),
                         BreakdownKey::BITS,
                         BreakdownKey::BITS,

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -185,7 +185,7 @@ mod tests {
                             .map(|x| x.breakdown_key.clone())
                             .collect::<Vec<_>>();
                         let mut converted_bk_shares = convert_all_bits(
-                            &ctx,
+                            ctx.clone(),
                             &convert_all_bits_local(ctx.role(), &bk_shares),
                             BreakdownKey::BITS,
                             BreakdownKey::BITS,

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -403,7 +403,7 @@ mod tests {
             .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
                 let local_lists = convert_all_bits_local::<Fp31, _>(ctx.role(), &mk_shares);
                 let converted_shares =
-                    convert_all_bits(&ctx, &local_lists, MatchKey::BITS, NUM_MULTI_BITS)
+                    convert_all_bits(ctx.clone(), &local_lists, MatchKey::BITS, NUM_MULTI_BITS)
                         .await
                         .unwrap();
                 generate_permutation_opt(ctx.narrow("sort"), converted_shares.iter())

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -252,7 +252,7 @@ mod tests {
             .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
                 let local_lists = convert_all_bits_local::<Fp31, _>(ctx.role(), &mk_shares);
                 let converted_shares =
-                    convert_all_bits(&ctx, &local_lists, BitArray40::BITS, NUM_MULTI_BITS)
+                    convert_all_bits(ctx.clone(), &local_lists, BitArray40::BITS, NUM_MULTI_BITS)
                         .await
                         .unwrap();
 
@@ -288,7 +288,7 @@ mod tests {
             .semi_honest(match_keys.clone(), |ctx, mk_shares| async move {
                 let local_lists = convert_all_bits_local(ctx.role(), &mk_shares);
                 let converted_shares =
-                    convert_all_bits(&ctx, &local_lists, BitArray40::BITS, NUM_MULTI_BITS)
+                    convert_all_bits(ctx.clone(), &local_lists, BitArray40::BITS, NUM_MULTI_BITS)
                         .await
                         .unwrap();
 


### PR DESCRIPTION
This one function was inconsistent, and that bothered me. Pretty much everywhere else we create a new context and pass that in. This was the one exception where we pass by reference.