### PR TITLE
Optimizing aggregation for small breakdown key counts

### DIFF
--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -1,3 +1,5 @@
+use futures::future::try_join_all;
+
 use crate::{
     bits::{Fp2Array, Serializable},
     error::Error,
@@ -10,17 +12,19 @@ use crate::{
                 MCCappedCreditsWithAggregationBit,
             },
         },
+        basics::{SecureMul, ShareKnownValue},
         context::{Context, MaliciousContext, SemiHonestContext},
         malicious::MaliciousValidator,
         modulus_conversion::split_into_multi_bit_slices,
         sort::{
             apply_sort::apply_sort_permutation,
+            check_everything,
             generate_permutation::{
                 generate_permutation_and_reveal_shuffled,
                 malicious_generate_permutation_and_reveal_shuffled,
             },
         },
-        BasicProtocols, Substep,
+        BasicProtocols, BitOpStep, RecordId, Substep,
     },
     secret_sharing::{
         replicated::{
@@ -48,6 +52,9 @@ where
     BK: Fp2Array,
     for<'a> Replicated<F>: Serializable + BasicProtocols<SemiHonestContext<'a>, F>,
 {
+    if max_breakdown_key <= 32 {
+        return simple_aggregate_credit(ctx, capped_credits, max_breakdown_key).await;
+    }
     //
     // 1. Add aggregation bits and new rows per unique breakdown_key
     //
@@ -217,6 +224,84 @@ where
         .collect::<Vec<_>>();
 
     Ok((malicious_validator, result))
+}
+
+async fn simple_aggregate_credit<F, BK>(
+    ctx: SemiHonestContext<'_>,
+    capped_credits: &[MCAggregateCreditInputRow<F, Replicated<F>>],
+    max_breakdown_key: u128,
+) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
+where
+    F: Field,
+    BK: Fp2Array,
+    for<'a> Replicated<F>: Serializable + BasicProtocols<SemiHonestContext<'a>, F>,
+{
+    let mut sums = vec![Replicated::ZERO; max_breakdown_key as usize];
+    let to_take = usize::try_from(max_breakdown_key).unwrap();
+
+    let equality_check_context = ctx
+        .narrow(&Step::ComputeEqualityChecks)
+        .set_total_records(capped_credits.len());
+    let check_times_credit_context = ctx
+        .narrow(&Step::CheckTimesCredit)
+        .set_total_records(capped_credits.len());
+
+    let futures = capped_credits.iter().enumerate().map(|(i, row)| {
+        let c1 = equality_check_context.clone();
+        let c2 = check_times_credit_context.clone();
+        let credit = &row.credit;
+        let valid_bits_count = (u128::BITS - (max_breakdown_key - 1).leading_zeros()) as usize;
+        let copy_of_valid_bk_bits = row
+            .breakdown_key
+            .iter()
+            .take(valid_bits_count)
+            .cloned()
+            .collect::<Vec<_>>();
+        async move {
+            let equality_checks = check_everything(c1.clone(), i, &copy_of_valid_bk_bits).await?;
+            let futures =
+                equality_checks
+                    .iter()
+                    .take(to_take)
+                    .enumerate()
+                    .map(|(check_idx, check)| {
+                        let step = BitOpStep::from(check_idx);
+                        let c = c2.narrow(&step);
+                        let record_id = RecordId::from(i);
+                        async move { Replicated::multiply(c, record_id, check, credit).await }
+                    });
+            try_join_all(futures).await
+        }
+    });
+    let increments = try_join_all(futures).await?;
+    for increments_for_row in increments {
+        for (i, increment) in increments_for_row.iter().enumerate() {
+            sums[i] += increment;
+        }
+    }
+
+    let zero = Replicated::ZERO;
+    let one = Replicated::share_known_value(&ctx, F::ONE);
+
+    Ok(sums
+        .into_iter()
+        .enumerate()
+        .map(|(i, sum)| {
+            let breakdown_key = u128::try_from(i).unwrap();
+            let bk_bits = BK::truncate_from(breakdown_key);
+            let converted_bk = (0..BK::BITS)
+                .map(|i| {
+                    if bk_bits[i] {
+                        one.clone()
+                    } else {
+                        zero.clone()
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            MCAggregateCreditOutputRow::new(converted_bk, sum)
+        })
+        .collect())
 }
 
 fn add_aggregation_bits_and_breakdown_keys<F, C, T, BK>(
@@ -414,6 +499,8 @@ async fn malicious_sort_by_aggregation_bit<'a, F: Field>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Step {
+    ComputeEqualityChecks,
+    CheckTimesCredit,
     SortByBreakdownKey,
     SortByAttributionBit,
     GeneratePermutationByBreakdownKey,
@@ -427,6 +514,8 @@ impl Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
+            Self::ComputeEqualityChecks => "compute_equality_checks",
+            Self::CheckTimesCredit => "check_times_credit",
             Self::SortByBreakdownKey => "sort_by_breakdown_key",
             Self::SortByAttributionBit => "sort_by_attribution_bit",
             Self::GeneratePermutationByBreakdownKey => "generate_permutation_by_breakdown_key",

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1027,13 +1027,13 @@ pub mod tests {
         /// empirical value as of Feb 27, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 17181;
 
-        /// empirical value as of Feb 27, 2023.
+        /// empirical value as of Feb 24, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46746;
 
         /// empirical value as of Feb 27, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 11784;
 
-        /// empirical value as of Feb 27, 2023.
+        /// empirical value as of Feb 24, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33525;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -595,10 +595,19 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::missing_panics_doc)]
     pub async fn semi_honest() {
-        const COUNT: usize = 5;
+        const COUNT: usize = 7;
         const PER_USER_CAP: u32 = 3;
-        const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 2], [2, 3]];
-        const MAX_BREAKDOWN_KEY: u128 = 3;
+        const EXPECTED: &[[u128; 2]] = &[
+            [0, 0],
+            [1, 2],
+            [2, 3],
+            [3, 0],
+            [4, 0],
+            [5, 0],
+            [6, 0],
+            [7, 0],
+        ];
+        const MAX_BREAKDOWN_KEY: u128 = 8;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::new().await;
@@ -914,7 +923,7 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::missing_panics_doc)]
     pub async fn random_ipa_check() {
-        const MAX_BREAKDOWN_KEY: usize = 16;
+        const MAX_BREAKDOWN_KEY: usize = 64;
         const MAX_TRIGGER_VALUE: u32 = 5;
         const NUM_USERS: usize = 10;
         const MAX_RECORDS_PER_USER: usize = 8;
@@ -1015,16 +1024,16 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 24, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 19146;
+        /// empirical value as of Feb 27, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 17181;
 
-        /// empirical value as of Feb 24, 2023.
+        /// empirical value as of Feb 27, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46746;
 
-        /// empirical value as of Feb 24, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13581;
+        /// empirical value as of Feb 27, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 11784;
 
-        /// empirical value as of Feb 24, 2023.
+        /// empirical value as of Feb 27, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 33525;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -170,7 +170,7 @@ where
         pregenerate_all_combinations(ctx, record_idx, record, num_bits).await?;
 
     // This loop just iterates over all the possible values this N-bit input could potentially represent
-    // and checks if the bits are equal to this value. It does so my computing a linear combination of the
+    // and checks if the bits are equal to this value. It does so by computing a linear combination of the
     // pre-computed coefficients.
     //
     // Observe that whether a given precomputed coefficient contributes to a

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -12,6 +12,14 @@ mod shuffle;
 use crate::{protocol::Substep, repeat64str};
 use std::fmt::Debug;
 
+use crate::{
+    error::Error,
+    ff::Field,
+    protocol::{context::Context, BasicProtocols, BitOpStep, RecordId},
+    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+};
+use futures::future::try_join_all;
+
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum SortStep {
     BitPermutationStep,
@@ -136,4 +144,140 @@ impl AsRef<str> for MultiBitPermutationStep {
             Self::MultiplyAcrossBits => "multiply_across_bits",
         }
     }
+}
+
+///
+/// This function accepts a sequence of N secret-shared bits.
+/// When considered as a bitwise representation of an N-bit unsigned number, it's clear that there are exactly
+/// `2^N` possible values this could have.
+/// This function checks all of these possible values, and returns a vector of secret-shared results.
+/// Only one result will be a secret-sharing of one, all of the others will be secret-sharings of zero.
+///
+/// # Errors
+/// If any multiplication fails, or if the record is too long (e.g. more than 64 multiplications required)
+pub async fn check_everything<F, C, S>(
+    ctx: C,
+    record_idx: usize,
+    record: &[S],
+) -> Result<Vec<S>, Error>
+where
+    F: Field,
+    C: Context,
+    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+{
+    let num_bits = record.len();
+    let precomputed_combinations =
+        pregenerate_all_combinations(ctx, record_idx, record, num_bits).await?;
+
+    // This loop just iterates over all the possible values this N-bit input could potentially represent
+    // and checks if the bits are equal to this value. It does so my computing a linear combination of the
+    // pre-computed coefficients.
+    //
+    // Observe that whether a given precomputed coefficient contributes to a
+    // given equality check follows a Sierpiński triangle
+    // https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle#/media/File:Multigrade_operator_AND.svg.
+    //
+    // For example, for a three bit value, we have the following:
+    // 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1
+    // 0 | 1 | 0 | 1 | 0 | 1 | 0 | 1
+    // 0 | 0 | 1 | 1 | 0 | 0 | 1 | 1
+    // 0 | 0 | 0 | 1 | 0 | 0 | 0 | 1
+    // 0 | 0 | 0 | 0 | 1 | 1 | 1 | 1
+    // 0 | 0 | 0 | 0 | 0 | 1 | 0 | 1
+    // 0 | 0 | 0 | 0 | 0 | 0 | 1 | 1
+    // 0 | 0 | 0 | 0 | 0 | 0 | 0 | 1
+    //
+    // This can be computed from row (i) and column (j) indices with i & j == i
+    //
+    // The sign of the inclusion is less obvious, but we discovered that this
+    // can be found by taking the same row (i) and column (j) indices:
+    // 1. Invert the row index and bitwise AND the values: a = !i & j
+    // 2. Count the number of bits that are set: b = a.count_ones()
+    // 3. An odd number means a positive coefficient; an odd number means a negative.
+    //
+    // For example, for a three bit value, step 1 produces (in binary):
+    // 000 | 001 | 010 | 011 | 100 | 101 | 110 | 111
+    // 000 | 000 | 010 | 010 | 100 | 100 | 110 | 110
+    // 000 | 001 | 000 | 001 | 100 | 101 | 100 | 101
+    // 000 | 000 | 000 | 000 | 100 | 100 | 100 | 100
+    // 000 | 001 | 010 | 011 | 000 | 001 | 010 | 011
+    // 000 | 000 | 010 | 010 | 000 | 000 | 010 | 010
+    // 000 | 001 | 000 | 001 | 000 | 001 | 000 | 001
+    // 000 | 000 | 000 | 000 | 000 | 000 | 000 | 000
+    //
+    // Where 000, 101, 011, and 110 mean positive contributions, and
+    // 001, 010, 100, and 111 mean negative contributions.
+    let side_length = 1 << num_bits;
+    let mut equality_checks = Vec::with_capacity(side_length);
+    for i in 0..side_length {
+        let mut check = S::ZERO;
+        for (j, combination) in precomputed_combinations.iter().enumerate() {
+            let bit: i8 = i8::from((i & j) == i);
+            if bit > 0 {
+                if (!i & j).count_ones() & 1 == 1 {
+                    check -= combination;
+                } else {
+                    check += combination;
+                }
+            }
+        }
+        equality_checks.push(check);
+    }
+    Ok(equality_checks)
+}
+
+//
+// Every equality check can be computed as a linear combination of coefficients.
+// For example, if we are given a 3-bit number `[x_3, x_2, x_1]`,
+// we can check if it is equal to 4, by computing:
+// $x_3(1-x_2)(1-x_1)$,
+// which expands to:
+// $x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3$
+//
+// Since we need to check all possible values, it makes sense to pre-compute all
+// of the coefficients that are used across all of these equality checks. In this way,
+// we can minimize the total number of multiplications needed.
+//
+// We must pre-compute all combinations of bit values. The following loop does so.
+// It does so by starting with the array `[1]`.
+// The next step is to multiply this by `x_1` and append it to the end of the array.
+// Now the array is `[1, x_1]`.
+// The next step is to mulitply all of these values by `x_2` and append them to the end of the array.
+// Now the array is `[1, x_1, x_2, x_1*x_2]`
+// The next step is to mulitply all of these values of `x_3` and append them to the end of the array.
+// Now the array is `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
+// This process continues for as many steps as there are bits of input.
+async fn pregenerate_all_combinations<F, C, S>(
+    ctx: C,
+    record_idx: usize,
+    input: &[S],
+    num_bits: usize,
+) -> Result<Vec<S>, Error>
+where
+    F: Field,
+    C: Context,
+    S: SecretSharing<F> + BasicProtocols<C, F>,
+{
+    let record_id = RecordId::from(record_idx);
+    let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
+    precomputed_combinations.push(S::share_known_value(&ctx, F::ONE));
+    for (bit_idx, bit) in input.iter().enumerate() {
+        let step = 1 << bit_idx;
+        let mut multiplication_results =
+            try_join_all(precomputed_combinations.iter().skip(1).enumerate().map(
+                |(j, precomputed_combination)| {
+                    let child_idx = j + step;
+                    S::multiply(
+                        ctx.narrow(&BitOpStep::from(child_idx)),
+                        record_id,
+                        precomputed_combination,
+                        bit,
+                    )
+                },
+            ))
+            .await?;
+        precomputed_combinations.push(bit.clone());
+        precomputed_combinations.append(&mut multiplication_results);
+    }
+    Ok(precomputed_combinations)
 }

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::Error,
     ff::Field,
-    protocol::{context::Context, BasicProtocols, BitOpStep, RecordId},
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+    protocol::{context::Context, sort::check_everything, BasicProtocols, RecordId},
+    secret_sharing::Arithmetic as ArithmeticSecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -93,135 +93,6 @@ pub async fn multi_bit_permutation<
     Ok(one_off_permutation)
 }
 
-///
-/// This function accepts a sequence of N secret-shared bits.
-/// When considered as a bitwise representation of an N-bit unsigned number, it's clear that there are exactly
-/// `2^N` possible values this could have.
-/// This function checks all of these possible values, and returns a vector of secret-shared results.
-/// Only one result will be a secret-sharing of one, all of the others will be secret-sharings of zero.
-async fn check_everything<F, C, S>(ctx: C, record_idx: usize, record: &[S]) -> Result<Vec<S>, Error>
-where
-    F: Field,
-    C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
-{
-    let num_bits = record.len();
-    let precomputed_combinations =
-        pregenerate_all_combinations(ctx, record_idx, record, num_bits).await?;
-
-    // This loop just iterates over all the possible values this N-bit input could potentially represent
-    // and checks if the bits are equal to this value. It does so my computing a linear combination of the
-    // pre-computed coefficients.
-    //
-    // Observe that whether a given precomputed coefficient contributes to a
-    // given equality check follows a Sierpiński triangle
-    // https://en.wikipedia.org/wiki/Sierpi%C5%84ski_triangle#/media/File:Multigrade_operator_AND.svg.
-    //
-    // For example, for a three bit value, we have the following:
-    // 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1
-    // 0 | 1 | 0 | 1 | 0 | 1 | 0 | 1
-    // 0 | 0 | 1 | 1 | 0 | 0 | 1 | 1
-    // 0 | 0 | 0 | 1 | 0 | 0 | 0 | 1
-    // 0 | 0 | 0 | 0 | 1 | 1 | 1 | 1
-    // 0 | 0 | 0 | 0 | 0 | 1 | 0 | 1
-    // 0 | 0 | 0 | 0 | 0 | 0 | 1 | 1
-    // 0 | 0 | 0 | 0 | 0 | 0 | 0 | 1
-    //
-    // This can be computed from row (i) and column (j) indices with i & j == i
-    //
-    // The sign of the inclusion is less obvious, but we discovered that this
-    // can be found by taking the same row (i) and column (j) indices:
-    // 1. Invert the row index and bitwise AND the values: a = !i & j
-    // 2. Count the number of bits that are set: b = a.count_ones()
-    // 3. An odd number means a positive coefficient; an odd number means a negative.
-    //
-    // For example, for a three bit value, step 1 produces (in binary):
-    // 000 | 001 | 010 | 011 | 100 | 101 | 110 | 111
-    // 000 | 000 | 010 | 010 | 100 | 100 | 110 | 110
-    // 000 | 001 | 000 | 001 | 100 | 101 | 100 | 101
-    // 000 | 000 | 000 | 000 | 100 | 100 | 100 | 100
-    // 000 | 001 | 010 | 011 | 000 | 001 | 010 | 011
-    // 000 | 000 | 010 | 010 | 000 | 000 | 010 | 010
-    // 000 | 001 | 000 | 001 | 000 | 001 | 000 | 001
-    // 000 | 000 | 000 | 000 | 000 | 000 | 000 | 000
-    //
-    // Where 000, 101, 011, and 110 mean positive contributions, and
-    // 001, 010, 100, and 111 mean negative contributions.
-    let side_length = 1 << num_bits;
-    let mut equality_checks = Vec::with_capacity(side_length);
-    for i in 0..side_length {
-        let mut check = S::ZERO;
-        for (j, combination) in precomputed_combinations.iter().enumerate() {
-            let bit: i8 = i8::from((i & j) == i);
-            if bit > 0 {
-                if (!i & j).count_ones() & 1 == 1 {
-                    check -= combination;
-                } else {
-                    check += combination;
-                }
-            }
-        }
-        equality_checks.push(check);
-    }
-    Ok(equality_checks)
-}
-
-//
-// Every equality check can be computed as a linear combination of coefficients.
-// For example, if we are given a 3-bit number `[x_3, x_2, x_1]`,
-// we can check if it is equal to 4, by computing:
-// $x_3(1-x_2)(1-x_1)$,
-// which expands to:
-// $x_3 - x_2*x_3 - x_1*x_3 + x_1*x_2*x_3$
-//
-// Since we need to check all possible values, it makes sense to pre-compute all
-// of the coefficients that are used across all of these equality checks. In this way,
-// we can minimize the total number of multiplications needed.
-//
-// We must pre-compute all combinations of bit values. The following loop does so.
-// It does so by starting with the array `[1]`.
-// The next step is to multiply this by `x_1` and append it to the end of the array.
-// Now the array is `[1, x_1]`.
-// The next step is to mulitply all of these values by `x_2` and append them to the end of the array.
-// Now the array is `[1, x_1, x_2, x_1*x_2]`
-// The next step is to mulitply all of these values of `x_3` and append them to the end of the array.
-// Now the array is `[1, x_1, x_2, x_1*x_2, x_3, x_1*x_3, x_2*x_3, x_1*x_2*x_3]`
-// This process continues for as many steps as there are bits of input.
-async fn pregenerate_all_combinations<F, C, S>(
-    ctx: C,
-    record_idx: usize,
-    input: &[S],
-    num_bits: usize,
-) -> Result<Vec<S>, Error>
-where
-    F: Field,
-    C: Context,
-    S: SecretSharing<F> + BasicProtocols<C, F>,
-{
-    let record_id = RecordId::from(record_idx);
-    let mut precomputed_combinations = Vec::with_capacity(1 << num_bits);
-    precomputed_combinations.push(S::share_known_value(&ctx, F::ONE));
-    for (bit_idx, bit) in input.iter().enumerate() {
-        let step = 1 << bit_idx;
-        let mut multiplication_results =
-            try_join_all(precomputed_combinations.iter().skip(1).enumerate().map(
-                |(j, precomputed_combination)| {
-                    let child_idx = j + step;
-                    S::multiply(
-                        ctx.narrow(&BitOpStep::from(child_idx)),
-                        record_id,
-                        precomputed_combination,
-                        bit,
-                    )
-                },
-            ))
-            .await?;
-        precomputed_combinations.push(bit.clone());
-        precomputed_combinations.append(&mut multiplication_results);
-    }
-    Ok(precomputed_combinations)
-}
-
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use futures::future::try_join_all;
@@ -229,12 +100,10 @@ mod tests {
     use super::multi_bit_permutation;
     use crate::{
         ff::{Field, Fp31},
-        protocol::context::Context,
+        protocol::{context::Context, sort::check_everything},
         secret_sharing::SharedValue,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-
-    use super::check_everything;
 
     const INPUT: [[u128; 3]; 6] = [
         [0, 0, 1],


### PR DESCRIPTION
When there are very few breakdown keys (i.e. less than 32) it's less communication to just check each breakdown key for equality for every possible breakdown key. Sorting is better when there are a large number of breakdowns.

I did an analysis, plotting the total communication for both approaches. Results: https://docs.google.com/spreadsheets/d/1Nix-mr6VBpGFOnKIwIvniAV3KO5vhk3ydSwxcfh2-OM/edit?usp=sharing

<img width="662" alt="Screenshot 2023-02-27 at 14 52 19" src="https://user-images.githubusercontent.com/52456851/221494419-fa3d2e92-9369-4526-9e69-8ac92ba18f18.png">
