### PR TITLE
Remove trailing bits from the bit decomposition protocol

### DIFF
--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -10,11 +10,11 @@ use std::iter::repeat;
 
 use super::{basics::ShareKnownValue, context::Context, BitOpStep, RecordId};
 
+mod add_constant;
 mod bit_decomposition;
 pub mod bitwise_equal;
 mod bitwise_gt_constant;
 mod bitwise_less_than_prime;
-mod dumb_bitwise_add_constant;
 mod generate_random_bits;
 pub mod or;
 pub mod random_bits_generator;

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1015,11 +1015,11 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u128 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
-        /// empirical value as of Feb 24, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 19146;
+        /// empirical value as of Feb 27, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 19119;
 
-        /// empirical value as of Feb 24, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46746;
+        /// empirical value as of Feb 27, 2023.
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 46692;
 
         /// empirical value as of Feb 24, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 13581;
@@ -1071,8 +1071,8 @@ pub mod tests {
                 "Baseline for semi-honest IPA (cap = {per_user_cap}) has DEGRADED! Expected {semi_honest_baseline}, got {records_sent}.");
 
             if records_sent < semi_honest_baseline {
-                tracing::warn!("Baseline for semi-honest IPA (cap = {per_user_cap}) has improved! Expected {semi_honest_baseline}, got {records_sent}.\
-                                Strongly consider adjusting the baseline, so the gains won't be accidentally offset by a regression.");
+                tracing::warn!("Baseline for semi-honest IPA (cap = {per_user_cap}) has improved! Expected {semi_honest_baseline}, got {records_sent}. \
+                                Consider adjusting the baseline, so the gains won't be accidentally offset by a regression.");
             }
 
             let world = TestWorld::new_with(*TestWorldConfig::default().enable_metrics()).await;


### PR DESCRIPTION
We just throw these out, so remove 'em.  The function now operates modulo 2^l, which is all we use.  We can't do the same for the earlier addition as we need to know about the overflow.

Savings are modest.  So 3 multiplications per event. 27 records in semi-honest; 54 in malicious for our 9 event test.

I also renamed both functions.  The old names annoyed me, because context provided a lot of information that was again repeated in the name.  The new names are shorter.  We should remove "bitwise" from other "boolean" functions, because bitwise is implied in most cases.