### PR TITLE
Build integration between new transport and OrderingMpsc 

### DIFF
--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -4,6 +4,7 @@ mod receive;
 mod send;
 mod unordered_receiver;
 
+pub use ordering_mpsc::ordering_mpsc;
 pub use receive::ReceiveBuffer;
 pub use send::{Config as SendBufferConfig, SendBuffer};
 

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -198,12 +198,14 @@ impl<M: Message> OrderingMpscReceiver<M> {
 }
 
 impl<M: Message> Debug for OrderingMpscReceiver<M> {
+    #[cfg(debug_assertions)]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if cfg!(debug_assertions) {
-            write!(f, "OrderingMpscReceiver[{}]", self.name)
-        } else {
-            write!(f, "OrderingMpscReceiver")
-        }
+        write!(f, "OrderingMpscReceiver[{}]", self.name)
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OrderingMpscReceiver")
     }
 }
 

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -357,8 +357,7 @@ mod unit {
             ordering_mpsc,
         },
     };
-    use futures::{future::join, FutureExt};
-    use futures_util::StreamExt;
+    use futures::{future::join, FutureExt, StreamExt};
     use generic_array::GenericArray;
     use std::{mem, num::NonZeroUsize};
 
@@ -457,9 +456,9 @@ mod unit {
     async fn recv_stream() {
         let (tx, mut rx) = ordering_mpsc("test", NonZeroUsize::new(2).unwrap());
         tx.send_test(1).await;
-        assert!(StreamExt::next(&mut rx).now_or_never().is_none());
+        assert!(rx.next().now_or_never().is_none());
         tx.send_test(0).await;
-        assert!(StreamExt::next(&mut rx).now_or_never().flatten().is_some());
+        assert!(rx.next().now_or_never().flatten().is_some());
     }
 }
 

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -457,7 +457,7 @@ mod unit {
     async fn recv_stream() {
         let (tx, mut rx) = ordering_mpsc("test", NonZeroUsize::new(2).unwrap());
         tx.send_test(1).await;
-        assert_eq!(None, StreamExt::next(&mut rx).now_or_never());
+        assert!(StreamExt::next(&mut rx).now_or_never().is_none());
         tx.send_test(0).await;
         assert!(StreamExt::next(&mut rx).now_or_never().flatten().is_some());
     }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -16,6 +16,10 @@ pub use transport::{
     TransportError,
 };
 
+/// to test integration between in memory transport and mpsc buffer.
+#[cfg(test)]
+pub use buffers::ordering_mpsc;
+
 use crate::helpers::{
     Direction::{Left, Right},
     Role::{H1, H2, H3},

--- a/src/helpers/transport/channelled_transport.rs
+++ b/src/helpers/transport/channelled_transport.rs
@@ -104,7 +104,7 @@ pub trait ChannelledTransport: Send + Sync + 'static {
 
     fn identity(&self) -> HelperIdentity;
 
-    async fn send<D: Stream<Item = Vec<u8>> + Send + 'static, Q, S, R>(
+    async fn send<D, Q, S, R>(
         &self,
         dest: HelperIdentity,
         route: R,
@@ -115,7 +115,8 @@ pub trait ChannelledTransport: Send + Sync + 'static {
         Option<Step>: From<S>,
         Q: QueryIdBinding,
         S: StepBinding,
-        R: RouteParams<RouteId, Q, S>;
+        R: RouteParams<RouteId, Q, S>,
+        D: Stream<Item = Vec<u8>> + Send + 'static;
 
     /// Return the stream of records to be received from another helper for the specific query
     /// and step

--- a/src/helpers/transport/channelled_transport.rs
+++ b/src/helpers/transport/channelled_transport.rs
@@ -100,16 +100,15 @@ impl RouteParams<RouteId, QueryId, Step> for (RouteId, QueryId, Step) {
 /// Transport that supports per-query,per-step channels
 #[async_trait]
 pub trait ChannelledTransport: Send + Sync + 'static {
-    type DataStream: Stream<Item = Vec<u8>>;
     type RecordsStream: Stream<Item = Vec<u8>>;
 
     fn identity(&self) -> HelperIdentity;
 
-    async fn send<Q, S, R>(
+    async fn send<D: Stream<Item = Vec<u8>> + Send + 'static, Q, S, R>(
         &self,
         dest: HelperIdentity,
         route: R,
-        data: Self::DataStream,
+        data: D,
     ) -> Result<(), io::Error>
     where
         Option<QueryId>: From<Q>,

--- a/src/test_fixture/transport/channeled_transport.rs
+++ b/src/test_fixture/transport/channeled_transport.rs
@@ -129,7 +129,7 @@ impl ChannelledTransport for InMemoryChannelledTransport {
         Option<Step>: From<S>,
     {
         let channel = self.get_channel(dest);
-        let packet = Addr::from_route(self.identity, &route);
+        let addr = Addr::from_route(self.identity, &route);
 
         channel
             .send((packet, InMemoryStream::wrap(data)))

--- a/src/test_fixture/transport/channeled_transport.rs
+++ b/src/test_fixture/transport/channeled_transport.rs
@@ -132,7 +132,7 @@ impl ChannelledTransport for InMemoryChannelledTransport {
         let addr = Addr::from_route(self.identity, &route);
 
         channel
-            .send((packet, InMemoryStream::wrap(data)))
+            .send((addr, InMemoryStream::wrap(data)))
             .await
             .map_err(|_e| {
                 io::Error::new::<String>(io::ErrorKind::ConnectionAborted, "channel closed".into())


### PR DESCRIPTION
see commit messages. Basically this PR does two things
* Make `OrderingMpscReceiver` implement a stream
* Get rid of one associated type on transport and make `send` method to take any stream provided by the caller.