### PR TITLE
Impl Reshare for XorShare

### DIFF
--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -8,7 +8,6 @@
 //!
 use crate::{
     bits::Serializable,
-    ff::Field,
     helpers::{
         buffers::{ReceiveBuffer, SendBuffer, SendBufferConfig},
         network::{ChannelId, MessageEnvelope, Network},
@@ -17,6 +16,7 @@ use crate::{
         Error, MessagePayload, Role, MESSAGE_PAYLOAD_SIZE_BYTES,
     },
     protocol::{RecordId, Step},
+    secret_sharing::SharedValue,
     task::JoinHandle,
     telemetry::{labels::STEP, metrics::RECORDS_SENT},
 };
@@ -40,7 +40,7 @@ use shuttle::future as tokio;
 pub trait Message: Debug + Send + Serializable + 'static {}
 
 /// Any field value can be send as a message
-impl<F: Field> Message for F {}
+impl<S: SharedValue> Message for S {}
 
 /// Entry point to the messaging layer managing communication channels for protocols and provides
 /// the ability to send and receive messages from helper peers. Protocols request communication

--- a/src/helpers/messaging.rs
+++ b/src/helpers/messaging.rs
@@ -39,7 +39,7 @@ use shuttle::future as tokio;
 /// Trait for messages sent between helpers. Everything needs to be serializable and safe to send.
 pub trait Message: Debug + Send + Serializable + 'static {}
 
-/// Any field value can be send as a message
+/// Any secret shared value can be send as a message
 impl<S: SharedValue> Message for S {}
 
 /// Entry point to the messaging layer managing communication channels for protocols and provides

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -136,7 +136,7 @@ mod tests {
     use super::*;
     use generic_array::GenericArray;
 
-    use crate::bits::Serializable;
+    use crate::{bits::Serializable, secret_sharing::replicated::ReplicatedSecretSharing};
     use hpke::{single_shot_seal_in_place_detached, OpModeS};
     use rand::rngs::StdRng;
     use rand_core::{CryptoRng, RngCore, SeedableRng};

--- a/src/net/server/handlers/query/results.rs
+++ b/src/net/server/handlers/query/results.rs
@@ -40,7 +40,9 @@ mod tests {
         net::server::handlers::query::test_helpers::{assert_req_fails_with, IntoFailingReq},
         protocol::QueryId,
         query::ProtocolResult,
-        secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+        secret_sharing::replicated::{
+            semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+        },
     };
     use axum::http::Request;
     use futures::pin_mut;

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -8,7 +8,9 @@ use crate::{
         prss::SharedRandomness,
         RecordId,
     },
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
 };
 
 /// IKHC multiplication protocol

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -1,9 +1,5 @@
 use crate::{
-    ff::Field,
-    helpers::Role,
-    secret_sharing::replicated::{
-        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
-    },
+    ff::Field, helpers::Role, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
 
 /// A description of a replicated secret sharing, with zero values at known positions.
@@ -112,7 +108,10 @@ impl ZeroPositions {
     pub fn check<F: Field>(self, role: Role, which: &str, v: &Replicated<F>) {
         #[cfg(debug_assertions)]
         {
-            use crate::helpers::Direction::Right;
+            use crate::{
+                helpers::Direction::Right, secret_sharing::replicated::ReplicatedSecretSharing,
+            };
+
             let flags = <[bool; 3]>::from(self);
             if flags[role as usize] {
                 assert_eq!(

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -1,5 +1,9 @@
 use crate::{
-    ff::Field, helpers::Role, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    ff::Field,
+    helpers::Role,
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
 };
 
 /// A description of a replicated secret sharing, with zero values at known positions.
@@ -200,7 +204,7 @@ pub(in crate::protocol) mod test {
         secret_sharing::{
             replicated::{
                 malicious::AdditiveShare as MaliciousReplicated,
-                semi_honest::AdditiveShare as Replicated,
+                semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
             },
             IntoShares,
         },

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -1,10 +1,12 @@
 use crate::{
+    bits::Fp2Array,
     error::Error,
     ff::Field,
     helpers::{Direction, Role},
     protocol::{
         context::{
             malicious::RecordBinding, Context, MaliciousContext, NoRecord, SemiHonestContext,
+            SpecialAccessToMaliciousContext,
         },
         prss::SharedRandomness,
         sort::{
@@ -13,8 +15,13 @@ use crate::{
         },
         RecordId,
     },
-    secret_sharing::replicated::{
-        malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+    secret_sharing::{
+        replicated::{
+            malicious::AdditiveShare as MaliciousReplicated,
+            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+            ReplicatedSecretSharing,
+        },
+        SharedValue,
     },
 };
 use async_trait::async_trait;
@@ -65,6 +72,55 @@ pub trait ReshareBorrowed<C: Context, B: RecordBinding> {
         C: 'fut;
 }
 
+/// A common semi-honest reshare algorithm for `AdditiveShare<F: Field>` and `XorShare<B: Fp2Array>`.
+/// We compute the new shares by adding/subtracting shared values and random values. Since `Fp2Array`
+/// implements `ArithmeticOps` using binary operations i.e., `Add`/`Sub` -> `BitXor`, we can use the
+/// same code for both sharing schemes.
+async fn semi_honest_reshare<'a, 'fut, V: SharedValue, S: ReplicatedSecretSharing<V>>(
+    ctx: SemiHonestContext<'a>,
+    record_id: RecordId,
+    to_helper: Role,
+    share: &S,
+    (r0, r1): (V, V),
+) -> Result<(V, V), Error>
+where
+    SemiHonestContext<'a>: 'fut,
+{
+    let channel = ctx.mesh();
+
+    // `to_helper.left` calculates part1 = (self.0 + self.1) - r1 and sends part1 to `to_helper.right`
+    // This is same as (a1 + a2) - r2 in the diagram
+    if ctx.role() == to_helper.peer(Direction::Left) {
+        let part1 = share.left() + share.right() - r1;
+        channel
+            .send(to_helper.peer(Direction::Right), record_id, part1)
+            .await?;
+
+        // Sleep until `to_helper.right` sends us their part2 value
+        let part2 = channel
+            .receive(to_helper.peer(Direction::Right), record_id)
+            .await?;
+
+        Ok((part1 + part2, r1))
+    } else if ctx.role() == to_helper.peer(Direction::Right) {
+        // `to_helper.right` calculates part2 = (self.left() - r0) and sends it to `to_helper.left`
+        // This is same as (a3 - r3) in the diagram
+        let part2 = share.left() - r0;
+        channel
+            .send(to_helper.peer(Direction::Left), record_id, part2)
+            .await?;
+
+        // Sleep until `to_helper.left` sends us their part1 value
+        let part1: V = channel
+            .receive(to_helper.peer(Direction::Left), record_id)
+            .await?;
+
+        Ok((r0, part1 + part2))
+    } else {
+        Ok((r0, r1))
+    }
+}
+
 #[async_trait]
 /// Reshare(i, \[x\])
 /// This implements semi-honest reshare algorithm of "Efficient Secure Three-Party Sorting Protocol with an Honest Majority" at communication cost of 2R.
@@ -80,40 +136,9 @@ impl<'a, F: Field> Reshare<SemiHonestContext<'a>, RecordId> for Replicated<F> {
     where
         SemiHonestContext<'a>: 'fut,
     {
-        let channel = ctx.mesh();
-        let (r0, r1) = ctx.prss().generate_fields(record_id);
-
-        // `to_helper.left` calculates part1 = (self.0 + self.1) - r1 and sends part1 to `to_helper.right`
-        // This is same as (a1 + a2) - r2 in the diagram
-        if ctx.role() == to_helper.peer(Direction::Left) {
-            let part1 = self.left() + self.right() - r1;
-            channel
-                .send(to_helper.peer(Direction::Right), record_id, part1)
-                .await?;
-
-            // Sleep until `to_helper.right` sends us their part2 value
-            let part2 = channel
-                .receive(to_helper.peer(Direction::Right), record_id)
-                .await?;
-
-            Ok(Replicated::new(part1 + part2, r1))
-        } else if ctx.role() == to_helper.peer(Direction::Right) {
-            // `to_helper.right` calculates part2 = (self.left() - r0) and sends it to `to_helper.left`
-            // This is same as (a3 - r3) in the diagram
-            let part2 = self.left() - r0;
-            channel
-                .send(to_helper.peer(Direction::Left), record_id, part2)
-                .await?;
-
-            // Sleep until `to_helper.left` sends us their part1 value
-            let part1: F = channel
-                .receive(to_helper.peer(Direction::Left), record_id)
-                .await?;
-
-            Ok(Replicated::new(r0, part1 + part2))
-        } else {
-            Ok(Replicated::new(r0, r1))
-        }
+        let r = ctx.prss().generate_fields(record_id);
+        let (s0, s1) = semi_honest_reshare(ctx, record_id, to_helper, self, r).await?;
+        Ok(Replicated::new(s0, s1))
     }
 }
 
@@ -153,6 +178,45 @@ impl<'a, F: Field> Reshare<MaliciousContext<'a, F>, RecordId> for MaliciousRepli
         let malicious_input = MaliciousReplicated::new(x, rx);
         random_constant_ctx.accumulate_macs(record_id, &malicious_input);
         Ok(malicious_input)
+    }
+}
+
+#[async_trait]
+/// Reshare algorithm for xor secret shares.
+impl<'a, B: Fp2Array> Reshare<SemiHonestContext<'a>, RecordId> for XorReplicated<B> {
+    async fn reshare<'fut>(
+        &self,
+        ctx: SemiHonestContext<'a>,
+        record_id: RecordId,
+        to_helper: Role,
+    ) -> Result<Self, Error>
+    where
+        SemiHonestContext<'a>: 'fut,
+    {
+        let r = ctx.prss().generate_bit_arrays(record_id);
+        let (s0, s1) = semi_honest_reshare(ctx, record_id, to_helper, self, r).await?;
+        Ok(XorReplicated::new(s0, s1))
+    }
+}
+
+#[async_trait]
+/// Malicious version of xor resharing is executed in semi-honest context.
+///
+/// As of March 2023, we aren't sure what is a proper way of doing reshare in malicious context.
+/// We believe that, even though an additive attack is possible, a malicious helper can ONLY
+/// corrupt the protocol output, but cannot learn any private info.
+impl<'a, F: Field, B: Fp2Array> Reshare<MaliciousContext<'a, F>, RecordId> for XorReplicated<B> {
+    async fn reshare<'fut>(
+        &self,
+        ctx: MaliciousContext<'a, F>,
+        record_id: RecordId,
+        to_helper: Role,
+    ) -> Result<Self, Error>
+    where
+        MaliciousContext<'a, F>: 'fut,
+    {
+        self.reshare(ctx.semi_honest_context(), record_id, to_helper)
+            .await
     }
 }
 
@@ -242,14 +306,16 @@ mod tests {
         use proptest::prelude::Rng;
 
         use crate::{
+            bits::BitArray40,
             ff::Fp32BitPrime,
             helpers::Role,
             protocol::{basics::Reshare, context::Context, prss::SharedRandomness, RecordId},
             rand::thread_rng,
+            secret_sharing::replicated::semi_honest::XorShare,
             test_fixture::{Reconstruct, Runner, TestWorld},
         };
 
-        /// Validates that reshare protocol actually generates new shares using PRSS.
+        /// Validates that reshare protocol actually generates new additive shares using PRSS.
         #[tokio::test]
         async fn generates_unique_shares() {
             let world = TestWorld::new().await;
@@ -276,6 +342,37 @@ mod tests {
                 // if reshare cheated and just returned its input without adding randomness,
                 // this test will catch it with the probability of error (1/|F|)^2.
                 // Using 32 bit field is sufficient to consider error probability negligible
+                assert_eq!(secret, reshared_secret);
+            }
+        }
+
+        /// Validates that reshare protocol actually generates new xor shares using PRSS.
+        #[tokio::test]
+        async fn generates_unique_xor_shares() {
+            let world = TestWorld::new().await;
+
+            for &target in Role::all() {
+                let secret = thread_rng().gen::<BitArray40>();
+                let shares = world
+                    .semi_honest(secret, |ctx, share: XorShare<BitArray40>| async move {
+                        let record_id = RecordId::from(0);
+                        let ctx = ctx.set_total_records(1);
+
+                        // run reshare protocol for all helpers except the one that does not know the input
+                        if ctx.role() == target {
+                            // test follows the reshare protocol
+                            ctx.prss().generate_bit_arrays(record_id).into()
+                        } else {
+                            share.reshare(ctx, record_id, target).await.unwrap()
+                        }
+                    })
+                    .await;
+
+                let reshared_secret = shares.reconstruct();
+
+                // if reshare cheated and just returned its input without adding randomness,
+                // this test will catch it with the probability of error (1/|F|)^2.
+                // Using 40-bit array is sufficient to consider error probability negligible
                 assert_eq!(secret, reshared_secret);
             }
         }
@@ -322,7 +419,7 @@ mod tests {
             rand::{thread_rng, Rng},
             secret_sharing::replicated::{
                 malicious::AdditiveShare as MaliciousReplicated,
-                semi_honest::AdditiveShare as Replicated,
+                semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
             },
             test_fixture::{Reconstruct, Runner, TestWorld},
         };

--- a/src/protocol/basics/share_known_value.rs
+++ b/src/protocol/basics/share_known_value.rs
@@ -7,6 +7,7 @@ use crate::{
         replicated::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::{AdditiveShare as Replicated, XorShare},
+            ReplicatedSecretSharing,
         },
         SharedValue,
     },

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     secret_sharing::replicated::{
         malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
+        ReplicatedSecretSharing,
     },
 };
 use futures::future::try_join;

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -7,7 +7,9 @@ use crate::{
         prss::SharedRandomness,
         RecordId,
     },
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
 };
 
 /// Sum of product protocol developed using IKHC multiplication protocol

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -10,7 +10,10 @@ use crate::{
         BitOpStep, RecordId,
     },
     secret_sharing::{
-        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        replicated::{
+            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+            ReplicatedSecretSharing,
+        },
         Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue,
     },
 };

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -11,6 +11,7 @@ use crate::{
     secret_sharing::replicated::{
         malicious::{AdditiveShare as MaliciousReplicated, DowngradeMalicious},
         semi_honest::AdditiveShare as Replicated,
+        ReplicatedSecretSharing,
     },
     sync::{Arc, Mutex, Weak},
 };
@@ -272,6 +273,7 @@ mod tests {
                     ThisCodeIsAuthorizedToDowngradeFromMalicious,
                 },
                 semi_honest::AdditiveShare as Replicated,
+                ReplicatedSecretSharing,
             },
             IntoShares,
         },

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -10,7 +10,10 @@ use crate::{
         IpaProtocolStep, RecordId,
     },
     secret_sharing::{
-        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        replicated::{
+            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+            ReplicatedSecretSharing,
+        },
         Arithmetic as ArithmeticSecretSharing,
     },
 };
@@ -210,7 +213,9 @@ mod tests {
             MatchKey, RecordId,
         },
         rand::thread_rng,
-        secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+        secret_sharing::replicated::{
+            semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+        },
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use proptest::prelude::Rng;

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -1,4 +1,6 @@
-use crate::{ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated};
+use crate::{
+    bits::Fp2Array, ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+};
 use aes::{
     cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit},
     Aes256,
@@ -20,6 +22,13 @@ pub trait SharedRandomness {
     fn generate_fields<F: Field, I: Into<u128>>(&self, index: I) -> (F, F) {
         let (l, r) = self.generate_values(index);
         (F::from(l), F::from(r))
+    }
+
+    /// Generate two sequences of random Fp2 bits.
+    #[must_use]
+    fn generate_bit_arrays<B: Fp2Array, I: Into<u128>>(&self, index: I) -> (B, B) {
+        let (l, r) = self.generate_values(index);
+        (B::truncate_from(l), B::truncate_from(r))
     }
 
     ///

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -1,5 +1,9 @@
 use crate::{
-    bits::Fp2Array, ff::Field, secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    bits::Fp2Array,
+    ff::Field,
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
 };
 use aes::{
     cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit},

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -122,6 +122,7 @@ mod tests {
                 BreakdownKey, MatchKey,
             },
             rand::{thread_rng, Rng},
+            secret_sharing::replicated::ReplicatedSecretSharing,
         };
 
         use crate::{

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -1,4 +1,4 @@
-use super::SharedValue;
+use super::{replicated::ReplicatedSecretSharing, SharedValue};
 use crate::{
     bits::Fp2Array,
     rand::{thread_rng, Rng},

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -266,7 +266,10 @@ mod tests {
         helpers::Role,
         rand::thread_rng,
         secret_sharing::{
-            replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, IntoShares,
+            replicated::{
+                semi_honest::AdditiveShare as SemiHonestAdditiveShare, ReplicatedSecretSharing,
+            },
+            IntoShares,
         },
         test_fixture::Reconstruct,
     };

--- a/src/secret_sharing/replicated/mod.rs
+++ b/src/secret_sharing/replicated/mod.rs
@@ -4,6 +4,7 @@ pub mod malicious;
 pub mod semi_honest;
 
 pub trait ReplicatedSecretSharing<V: SharedValue>: SecretSharing<V> {
+    fn new(a: V, b: V) -> Self;
     fn left(&self) -> V;
     fn right(&self) -> V;
 }

--- a/src/secret_sharing/replicated/mod.rs
+++ b/src/secret_sharing/replicated/mod.rs
@@ -1,2 +1,9 @@
+use super::{SecretSharing, SharedValue};
+
 pub mod malicious;
 pub mod semi_honest;
+
+pub trait ReplicatedSecretSharing<V: SharedValue>: SecretSharing<V> {
+    fn left(&self) -> V;
+    fn right(&self) -> V;
+}

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -37,17 +37,16 @@ impl<V: SharedValue> AdditiveShare<V> {
     /// Replicated secret share where both left and right values are `F::ZERO`
     pub const ZERO: Self = Self(V::ZERO, V::ZERO);
 
-    #[must_use]
-    pub fn new(a: V, b: V) -> Self {
-        Self(a, b)
-    }
-
     pub fn as_tuple(&self) -> (V, V) {
         (self.0, self.1)
     }
 }
 
 impl<V: SharedValue> ReplicatedSecretSharing<V> for AdditiveShare<V> {
+    fn new(a: V, b: V) -> Self {
+        Self(a, b)
+    }
+
     fn left(&self) -> V {
         self.0
     }
@@ -166,7 +165,7 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::AdditiveShare;
-    use crate::ff::Fp31;
+    use crate::{ff::Fp31, secret_sharing::replicated::ReplicatedSecretSharing};
 
     fn secret_share(
         a: u8,

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -1,6 +1,9 @@
 use crate::{
     bits::Serializable,
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue},
+    secret_sharing::{
+        replicated::ReplicatedSecretSharing, Arithmetic as ArithmeticSecretSharing, SecretSharing,
+        SharedValue,
+    },
 };
 use generic_array::{ArrayLength, GenericArray};
 use std::{
@@ -42,12 +45,14 @@ impl<V: SharedValue> AdditiveShare<V> {
     pub fn as_tuple(&self) -> (V, V) {
         (self.0, self.1)
     }
+}
 
-    pub fn left(&self) -> V {
+impl<V: SharedValue> ReplicatedSecretSharing<V> for AdditiveShare<V> {
+    fn left(&self) -> V {
         self.0
     }
 
-    pub fn right(&self) -> V {
+    fn right(&self) -> V {
         self.1
     }
 }

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -36,11 +36,6 @@ impl<V: Fp2Array> Default for XorShare<V> {
 }
 
 impl<V: Fp2Array> XorShare<V> {
-    #[must_use]
-    pub fn new(a: V, b: V) -> Self {
-        Self(a, b)
-    }
-
     pub fn as_tuple(&self) -> (V, V) {
         (self.0, self.1)
     }
@@ -50,6 +45,10 @@ impl<V: Fp2Array> XorShare<V> {
 }
 
 impl<V: Fp2Array> ReplicatedSecretSharing<V> for XorShare<V> {
+    fn new(a: V, b: V) -> Self {
+        Self(a, b)
+    }
+
     fn left(&self) -> V {
         self.0
     }
@@ -83,12 +82,6 @@ impl<V: Fp2Array> BitXorAssign<&Self> for XorShare<V> {
     }
 }
 
-impl<V: Fp2Array> From<(V, V)> for XorShare<V> {
-    fn from(s: (V, V)) -> Self {
-        XorShare::new(s.0, s.1)
-    }
-}
-
 impl<V: Fp2Array> Serializable for XorShare<V>
 where
     V::Size: Add<V::Size>,
@@ -114,7 +107,10 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::XorShare;
-    use crate::bits::{BitArray40, Serializable};
+    use crate::{
+        bits::{BitArray40, Serializable},
+        secret_sharing::replicated::ReplicatedSecretSharing,
+    };
 
     use generic_array::GenericArray;
 

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -9,6 +9,7 @@ use std::fmt::Debug;
 pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
     const ZERO: Self;
 }
+
 /// Secret share of a secret that has additive and multiplicative properties.
 pub trait Arithmetic<V: SharedValue>: SecretSharing<V> + ArithmeticRefOps<V> {}
 

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -6,6 +6,7 @@ use crate::{
         replicated::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+            ReplicatedSecretSharing,
         },
         SecretSharing,
     },

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -4,7 +4,9 @@ use crate::{
     ff::Fp32BitPrime,
     helpers::Direction,
     protocol::{context::Context, RecordId},
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
     test_fixture::{Reconstruct, Runner, TestWorld},
 };
 use futures_util::future::{try_join, try_join_all};


### PR DESCRIPTION
Implement `Reshare` trait for semi-honest and malicious `XorShare`. For now, the malicious XOR reshare implementation is the same as semi-honest.