### PR TITLE
Attribution wrapper protocol

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Error> {
     const BATCHSIZE: usize = 100;
     const MAX_TRIGGER_VALUE: u128 = 5;
     const PER_USER_CAP: u32 = 3;
-    const MAX_BREAKDOWN_KEY: u128 = 4;
+    const MAX_BREAKDOWN_KEY: u32 = 4;
     const NUM_MULTI_BITS: u32 = 3;
 
     let mut config = TestWorldConfig::default();
@@ -57,6 +57,6 @@ async fn main() -> Result<(), Error> {
     let duration = start.elapsed();
     println!("rows {BATCHSIZE} benchmark complete after {duration:?}");
 
-    assert_eq!(MAX_BREAKDOWN_KEY, result[0].len().try_into().unwrap());
+    assert_eq!(MAX_BREAKDOWN_KEY, u32::try_from(result[0].len()).unwrap());
     Ok(())
 }

--- a/src/helpers/transport/query.rs
+++ b/src/helpers/transport/query.rs
@@ -120,7 +120,7 @@ impl Substep for QueryType {}
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct IpaQueryConfig {
     pub per_user_credit_cap: u32,
-    pub max_breakdown_key: u128,
+    pub max_breakdown_key: u32,
     pub num_multi_bits: u32,
 }
 

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -126,7 +126,7 @@ pub mod query {
                     #[derive(serde::Deserialize)]
                     struct IPAQueryConfigParam {
                         per_user_credit_cap: u32,
-                        max_breakdown_key: u128,
+                        max_breakdown_key: u32,
                         num_multi_bits: u32,
                     }
                     let Query(IPAQueryConfigParam {

--- a/src/protocol/attribution/malicious.rs
+++ b/src/protocol/attribution/malicious.rs
@@ -1,0 +1,120 @@
+use super::{
+    accumulate_credit::accumulate_credit,
+    aggregate_credit::malicious_aggregate_credit,
+    credit_capping::credit_capping,
+    input::{MCAccumulateCreditInputRow, MCAggregateCreditOutputRow},
+};
+use crate::{
+    bits::{Fp2Array, Serializable},
+    error::Error,
+    ff::Field,
+    protocol::{
+        boolean::bitwise_equal::bitwise_equal,
+        context::{Context, SemiHonestContext},
+        ipa::IPAModulusConvertedInputRow,
+        malicious::MaliciousValidator,
+        RecordId, Substep,
+    },
+    secret_sharing::replicated::{
+        malicious::AdditiveShare, semi_honest::AdditiveShare as SemiHonestAdditiveShare,
+    },
+};
+use futures::future::try_join_all;
+use std::iter::{repeat, zip};
+
+/// Performs a set of attribution protocols on the sorted IPA input.
+///
+/// # Errors
+/// propagates errors from multiplications
+pub async fn secure_attribution<'a, F, BK>(
+    sh_ctx: SemiHonestContext<'a>,
+    malicious_validator: MaliciousValidator<'a, F>,
+    sorted_rows: Vec<IPAModulusConvertedInputRow<F, AdditiveShare<F>>>,
+    per_user_credit_cap: u32,
+    max_breakdown_key: u32,
+    num_multi_bits: u32,
+) -> Result<Vec<MCAggregateCreditOutputRow<F, SemiHonestAdditiveShare<F>, BK>>, Error>
+where
+    F: Field,
+    BK: Fp2Array,
+    AdditiveShare<F>: Serializable,
+    SemiHonestAdditiveShare<F>: Serializable,
+{
+    let m_ctx = malicious_validator.context();
+
+    let futures = zip(
+        repeat(
+            m_ctx
+                .narrow(&Step::ComputeHelperBits)
+                .set_total_records(sorted_rows.len() - 1),
+        ),
+        sorted_rows.iter(),
+    )
+    .zip(sorted_rows.iter().skip(1))
+    .enumerate()
+    .map(|(i, ((m_ctx, row), next_row))| {
+        let record_id = RecordId::from(i);
+        async move { bitwise_equal(m_ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
+    });
+    let helper_bits = Some(AdditiveShare::ZERO)
+        .into_iter()
+        .chain(try_join_all(futures).await?);
+
+    let attribution_input_rows = zip(sorted_rows, helper_bits)
+        .map(|(row, hb)| {
+            MCAccumulateCreditInputRow::new(
+                row.is_trigger_bit,
+                hb,
+                row.breakdown_key,
+                row.trigger_value,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let accumulated_credits = accumulate_credit(
+        m_ctx.narrow(&Step::AccumulateCredit),
+        &attribution_input_rows,
+        per_user_credit_cap,
+    )
+    .await?;
+
+    let user_capped_credits = credit_capping(
+        m_ctx.narrow(&Step::PerformUserCapping),
+        &accumulated_credits,
+        per_user_credit_cap,
+    )
+    .await?;
+
+    let (malicious_validator, output) = malicious_aggregate_credit::<F, BK>(
+        malicious_validator,
+        sh_ctx,
+        user_capped_credits.into_iter(),
+        max_breakdown_key,
+        num_multi_bits,
+    )
+    .await?;
+
+    //Validate before returning the result to the report collector
+    malicious_validator.validate(output).await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Step {
+    ComputeHelperBits,
+    AccumulateCredit,
+    PerformUserCapping,
+    AggregateCredit,
+}
+
+impl Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::ComputeHelperBits => "compute_helper_bits",
+            Self::AccumulateCredit => "accumulate_credit",
+            Self::PerformUserCapping => "user_capping",
+            Self::AggregateCredit => "aggregate_credit",
+        }
+    }
+}

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -3,6 +3,8 @@ pub mod aggregate_credit;
 pub mod apply_attribution_window;
 pub mod credit_capping;
 pub mod input;
+pub mod malicious;
+pub mod semi_honest;
 
 use crate::{
     error::Error,

--- a/src/protocol/attribution/semi_honest.rs
+++ b/src/protocol/attribution/semi_honest.rs
@@ -1,0 +1,108 @@
+use super::{
+    accumulate_credit::accumulate_credit,
+    aggregate_credit::aggregate_credit,
+    credit_capping::credit_capping,
+    input::{MCAccumulateCreditInputRow, MCAggregateCreditOutputRow},
+};
+use crate::{
+    bits::{Fp2Array, Serializable},
+    error::Error,
+    ff::Field,
+    protocol::{
+        boolean::bitwise_equal::bitwise_equal,
+        context::{Context, SemiHonestContext},
+        ipa::IPAModulusConvertedInputRow,
+        RecordId, Substep,
+    },
+    secret_sharing::replicated::semi_honest::AdditiveShare,
+};
+use futures::future::try_join_all;
+use std::iter::{repeat, zip};
+
+/// Performs a set of attribution protocols on the sorted IPA input.
+///
+/// # Errors
+/// propagates errors from multiplications
+pub async fn secure_attribution<F, BK>(
+    ctx: SemiHonestContext<'_>,
+    sorted_rows: Vec<IPAModulusConvertedInputRow<F, AdditiveShare<F>>>,
+    per_user_credit_cap: u32,
+    max_breakdown_key: u32,
+    num_multi_bits: u32,
+) -> Result<Vec<MCAggregateCreditOutputRow<F, AdditiveShare<F>, BK>>, Error>
+where
+    F: Field,
+    BK: Fp2Array,
+    AdditiveShare<F>: Serializable,
+{
+    let futures = zip(
+        repeat(
+            ctx.narrow(&Step::ComputeHelperBits)
+                .set_total_records(sorted_rows.len() - 1),
+        ),
+        sorted_rows.iter(),
+    )
+    .zip(sorted_rows.iter().skip(1))
+    .enumerate()
+    .map(|(i, ((ctx, row), next_row))| {
+        let record_id = RecordId::from(i);
+        async move { bitwise_equal(ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
+    });
+    let helper_bits = Some(AdditiveShare::ZERO)
+        .into_iter()
+        .chain(try_join_all(futures).await?);
+
+    let attribution_input_rows = zip(sorted_rows, helper_bits)
+        .map(|(row, hb)| {
+            MCAccumulateCreditInputRow::new(
+                row.is_trigger_bit,
+                hb,
+                row.breakdown_key,
+                row.trigger_value,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let accumulated_credits = accumulate_credit(
+        ctx.narrow(&Step::AccumulateCredit),
+        &attribution_input_rows,
+        per_user_credit_cap,
+    )
+    .await?;
+
+    let user_capped_credits = credit_capping(
+        ctx.narrow(&Step::PerformUserCapping),
+        &accumulated_credits,
+        per_user_credit_cap,
+    )
+    .await?;
+
+    aggregate_credit::<F, BK>(
+        ctx.narrow(&Step::AggregateCredit),
+        user_capped_credits.into_iter(),
+        max_breakdown_key,
+        num_multi_bits,
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Step {
+    ComputeHelperBits,
+    AccumulateCredit,
+    PerformUserCapping,
+    AggregateCredit,
+}
+
+impl Substep for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::ComputeHelperBits => "compute_helper_bits",
+            Self::AccumulateCredit => "accumulate_credit",
+            Self::PerformUserCapping => "user_capping",
+            Self::AggregateCredit => "aggregate_credit",
+        }
+    }
+}

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -4,14 +4,8 @@ use crate::{
     ff::Field,
     helpers::Role,
     protocol::{
-        attribution::{
-            accumulate_credit::accumulate_credit,
-            aggregate_credit::{aggregate_credit, malicious_aggregate_credit},
-            credit_capping::credit_capping,
-            input::{MCAccumulateCreditInputRow, MCAggregateCreditOutputRow},
-        },
+        attribution::{input::MCAggregateCreditOutputRow, malicious, semi_honest},
         basics::Reshare,
-        boolean::bitwise_equal::bitwise_equal,
         context::{
             malicious::IPAModulusConvertedInputRowWrapper, Context, MaliciousContext,
             SemiHonestContext,
@@ -37,13 +31,9 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use futures::future::{try_join, try_join3, try_join_all};
+use futures::future::{try_join, try_join3};
 use generic_array::{ArrayLength, GenericArray};
-use std::{
-    iter::{repeat, zip},
-    marker::PhantomData,
-    ops::Add,
-};
+use std::{marker::PhantomData, ops::Add};
 use typenum::Unsigned;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -52,10 +42,6 @@ pub enum Step {
     ModulusConversionForBreakdownKeys,
     GenSortPermutationFromMatchKeys,
     ApplySortPermutation,
-    ComputeHelperBits,
-    AccumulateCredit,
-    PerformUserCapping,
-    AggregateCredit,
     AfterConvertAllBits,
 }
 
@@ -68,10 +54,6 @@ impl AsRef<str> for Step {
             Self::ModulusConversionForBreakdownKeys => "mod_conv_breakdown_key",
             Self::GenSortPermutationFromMatchKeys => "gen_sort_permutation_from_match_keys",
             Self::ApplySortPermutation => "apply_sort_permutation",
-            Self::ComputeHelperBits => "compute_helper_bits",
-            Self::AccumulateCredit => "accumulate_credit",
-            Self::PerformUserCapping => "user_capping",
-            Self::AggregateCredit => "aggregate_credit",
             Self::AfterConvertAllBits => "after_convert_all_bits",
         }
     }
@@ -202,10 +184,10 @@ where
 }
 
 pub struct IPAModulusConvertedInputRow<F: Field, T: Arithmetic<F>> {
-    mk_shares: Vec<T>,
-    is_trigger_bit: T,
-    breakdown_key: Vec<T>,
-    trigger_value: T,
+    pub mk_shares: Vec<T>,
+    pub is_trigger_bit: T,
+    pub breakdown_key: Vec<T>,
+    pub trigger_value: T,
     _marker: PhantomData<F>,
 }
 
@@ -287,7 +269,7 @@ pub async fn ipa<F, MK, BK>(
     ctx: SemiHonestContext<'_>,
     input_rows: &[IPAInputRow<F, MK, BK>],
     per_user_credit_cap: u32,
-    max_breakdown_key: u128,
+    max_breakdown_key: u32,
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
@@ -356,51 +338,10 @@ where
     .await
     .unwrap();
 
-    let futures = zip(
-        repeat(
-            ctx.narrow(&Step::ComputeHelperBits)
-                .set_total_records(sorted_rows.len() - 1),
-        ),
-        sorted_rows.iter(),
-    )
-    .zip(sorted_rows.iter().skip(1))
-    .enumerate()
-    .map(|(i, ((ctx, row), next_row))| {
-        let record_id = RecordId::from(i);
-        async move { bitwise_equal(ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
-    });
-    let helper_bits = Some(Replicated::ZERO)
-        .into_iter()
-        .chain(try_join_all(futures).await?);
-
-    let attribution_input_rows = zip(sorted_rows, helper_bits)
-        .map(|(row, hb)| {
-            MCAccumulateCreditInputRow::new(
-                row.is_trigger_bit,
-                hb,
-                row.breakdown_key,
-                row.trigger_value,
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let accumulated_credits = accumulate_credit(
-        ctx.narrow(&Step::AccumulateCredit),
-        &attribution_input_rows,
+    semi_honest::secure_attribution(
+        ctx,
+        sorted_rows,
         per_user_credit_cap,
-    )
-    .await?;
-
-    let user_capped_credits = credit_capping(
-        ctx.narrow(&Step::PerformUserCapping),
-        &accumulated_credits,
-        per_user_credit_cap,
-    )
-    .await?;
-
-    aggregate_credit::<F, BK>(
-        ctx.narrow(&Step::AggregateCredit),
-        user_capped_credits.into_iter(),
         max_breakdown_key,
         num_multi_bits,
     )
@@ -418,7 +359,7 @@ pub async fn ipa_malicious<'a, F, MK, BK>(
     sh_ctx: SemiHonestContext<'a>,
     input_rows: &[IPAInputRow<F, MK, BK>],
     per_user_credit_cap: u32,
-    max_breakdown_key: u128,
+    max_breakdown_key: u32,
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
@@ -513,60 +454,15 @@ where
     .await
     .unwrap();
 
-    let futures = zip(
-        repeat(
-            m_ctx
-                .narrow(&Step::ComputeHelperBits)
-                .set_total_records(sorted_rows.len() - 1),
-        ),
-        sorted_rows.iter(),
-    )
-    .zip(sorted_rows.iter().skip(1))
-    .enumerate()
-    .map(|(i, ((m_ctx, row), next_row))| {
-        let record_id = RecordId::from(i);
-        async move { bitwise_equal(m_ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
-    });
-    let helper_bits = Some(MaliciousReplicated::ZERO)
-        .into_iter()
-        .chain(try_join_all(futures).await?);
-
-    let attribution_input_rows = zip(sorted_rows, helper_bits)
-        .map(|(row, hb)| {
-            MCAccumulateCreditInputRow::new(
-                row.is_trigger_bit,
-                hb,
-                row.breakdown_key,
-                row.trigger_value,
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let accumulated_credits = accumulate_credit(
-        m_ctx.narrow(&Step::AccumulateCredit),
-        &attribution_input_rows,
-        per_user_credit_cap,
-    )
-    .await?;
-
-    let user_capped_credits = credit_capping(
-        m_ctx.narrow(&Step::PerformUserCapping),
-        &accumulated_credits,
-        per_user_credit_cap,
-    )
-    .await?;
-
-    let (malicious_validator, output) = malicious_aggregate_credit::<F, BK>(
-        malicious_validator,
+    malicious::secure_attribution(
         sh_ctx,
-        user_capped_credits.into_iter(),
+        malicious_validator,
+        sorted_rows,
+        per_user_credit_cap,
         max_breakdown_key,
         num_multi_bits,
     )
-    .await?;
-
-    //Validate before returning the result to the report collector
-    malicious_validator.validate(output).await
+    .await
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
@@ -607,7 +503,7 @@ pub mod tests {
             [6, 0],
             [7, 0],
         ];
-        const MAX_BREAKDOWN_KEY: u128 = 8;
+        const MAX_BREAKDOWN_KEY: u32 = 8;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::new().await;
@@ -656,7 +552,7 @@ pub mod tests {
         const COUNT: usize = 5;
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 2], [2, 3]];
-        const MAX_BREAKDOWN_KEY: u128 = 3;
+        const MAX_BREAKDOWN_KEY: u32 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::new().await;
@@ -703,7 +599,7 @@ pub mod tests {
     async fn cap_of_one() {
         const PER_USER_CAP: u32 = 1;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 1], [2, 0], [3, 0], [4, 0], [5, 1], [6, 1]];
-        const MAX_BREAKDOWN_KEY: u128 = 7;
+        const MAX_BREAKDOWN_KEY: u32 = 7;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::new().await;
@@ -892,7 +788,7 @@ pub mod tests {
                     ctx,
                     &input_rows,
                     per_user_cap,
-                    max_breakdown_key as u128,
+                    u32::try_from(max_breakdown_key).unwrap(),
                     NUM_MULTI_BITS,
                 )
                 .await
@@ -1021,7 +917,7 @@ pub mod tests {
     /// "catch all" type of test to make sure we don't miss an accidental regression.
     #[tokio::test]
     pub async fn communication_baseline() {
-        const MAX_BREAKDOWN_KEY: u128 = 3;
+        const MAX_BREAKDOWN_KEY: u32 = 3;
         const NUM_MULTI_BITS: u32 = 3;
 
         /// empirical value as of Feb 27, 2023.

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -18,8 +18,8 @@ fn semi_honest_ipa() {
             shuttle::future::block_on(async {
                 const BATCHSIZE: usize = 5;
                 const PER_USER_CAP: u32 = 10;
-                const MAX_BREAKDOWN_KEY: u128 = 8;
-                const MAX_TRIGGER_VALUE: u128 = 5;
+                const MAX_BREAKDOWN_KEY: u32 = 8;
+                const MAX_TRIGGER_VALUE: u32 = 5;
                 const NUM_MULTI_BITS: u32 = 3;
                 const MAX_MATCH_KEY: u128 = 3;
 
@@ -56,7 +56,7 @@ fn semi_honest_ipa() {
                         .await
                         .reconstruct();
 
-                assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
+                assert_eq!(MAX_BREAKDOWN_KEY, u32::try_from(result.len()).unwrap());
             });
         },
         10,
@@ -70,8 +70,8 @@ fn malicious_ipa() {
             shuttle::future::block_on(async {
                 const BATCHSIZE: usize = 5;
                 const PER_USER_CAP: u32 = 10;
-                const MAX_BREAKDOWN_KEY: u128 = 8;
-                const MAX_TRIGGER_VALUE: u128 = 5;
+                const MAX_BREAKDOWN_KEY: u32 = 8;
+                const MAX_TRIGGER_VALUE: u32 = 5;
                 const NUM_MULTI_BITS: u32 = 3;
                 const MAX_MATCH_KEY: u128 = 3;
 
@@ -108,7 +108,7 @@ fn malicious_ipa() {
                         .await
                         .reconstruct();
 
-                assert_eq!(MAX_BREAKDOWN_KEY, result.len() as u128);
+                assert_eq!(MAX_BREAKDOWN_KEY, u32::try_from(result.len()).unwrap());
             });
         },
         4,


### PR DESCRIPTION
Wraps the three attribution sub-protocols (accumulate, cap, aggregate) into one protocol, making it more friendly for callers that they do not need to know the details and the order of the sub-protocols.

It also lays the foundation of calling `apply_attribution_window` protocol. This wrapper protocol can determine whether to apply the attribution window logic depending on a parameter, and sub-protocols' behaviors will change accordingly. All these details will be contained in this super protocol.