### PR TITLE
Enable LTO on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ proptest = "1.0.0"
 
 [profile.release]
 incremental = true
+lto = "thin"
 
 [profile.bench]
 debug-assertions = true


### PR DESCRIPTION
This will make the running of IPA quite a bit faster, but the compiling quite a bit slower.  I've opted for "thin", which isn't the full LTO, but it should still help a fair bit with performance.

Run time is hard to measure (on my machine, it varies a LOT), but the slowest LTO run is faster than the fastest non-LTO.

Closes #510.