### PR TITLE
make `multiply` a method

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -54,7 +54,11 @@ where
     let credits = try_join_all(input.iter().skip(1).enumerate().map(|(i, x)| {
         let c = memoize_context.clone();
         let record_id = RecordId::from(i);
-        async move { T::multiply(c, record_id, &x.is_trigger_report, &x.helper_bit).await }
+        async move {
+            x.is_trigger_report
+                .multiply(&x.helper_bit, c, record_id)
+                .await
+        }
     }))
     .await?;
 
@@ -110,7 +114,7 @@ where
         let record_id = RecordId::from(i);
         let is_trigger_bit = &x.is_trigger_report;
         let helper_bit = &x.helper_bit;
-        async move { T::multiply(c, record_id, is_trigger_bit, helper_bit).await }
+        async move { is_trigger_bit.multiply(helper_bit, c, record_id).await }
     }))
     .await?;
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -278,7 +278,7 @@ where
                         let step = BitOpStep::from(check_idx);
                         let c = c2.narrow(&step);
                         let record_id = RecordId::from(i);
-                        async move { T::multiply(c, record_id, check, credit).await }
+                        async move { check.multiply(credit, c, record_id).await }
                     },
                 ))
                 .await

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -77,7 +77,11 @@ where
         try_join_all(input.iter().skip(1).enumerate().map(|(i, x)| {
             let c = stop_bit_context.clone();
             let record_id = RecordId::from(i);
-            async move { T::multiply(c, record_id, &x.is_trigger_report, &x.helper_bit).await }
+            async move {
+                x.is_trigger_report
+                    .multiply(&x.helper_bit, c, record_id)
+                    .await
+            }
         }))
         .await?,
     );
@@ -98,7 +102,7 @@ where
                         let c = t_delta_context.clone();
                         let record_id = RecordId::from(i);
                         let delta = curr.timestamp.clone() - &prev.timestamp;
-                        async move { T::multiply(c, record_id, &delta, &b).await }
+                        async move { delta.multiply(&b, c, record_id).await }
                     }),
             )
             .await?,
@@ -158,7 +162,9 @@ where
                     let compare_bit = one
                         - &bitwise_greater_than_constant(c2, record_id, &delta_bits, cap.into())
                             .await?;
-                    T::multiply(c3, record_id, &row.trigger_value, &compare_bit).await
+                    row.trigger_value
+                        .multiply(&compare_bit, c3, record_id)
+                        .await
                 }
             }),
     )

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -133,7 +133,7 @@ where
             |(i, (prefix_or, helper_bit))| {
                 let record_id = RecordId::from(i);
                 let c = prefix_or_times_helper_bit_ctx.clone();
-                async move { T::multiply(c, record_id, prefix_or, helper_bit).await }
+                async move { prefix_or.multiply(helper_bit, c, record_id).await }
             },
         ))
         .await?;
@@ -151,13 +151,9 @@ where
                 let c = potentially_cap_ctx.clone();
                 let one = T::share_known_value(&c, F::ONE);
                 async move {
-                    T::multiply(
-                        c,
-                        record_id,
-                        uncapped_credit,
-                        &(one - any_subsequent_credit),
-                    )
-                    .await
+                    uncapped_credit
+                        .multiply(&(one - any_subsequent_credit), c, record_id)
+                        .await
                 }
             }),
     )
@@ -193,13 +189,9 @@ where
             ))
             .enumerate()
             .map(|(i, (x, (ctx, one)))| async move {
-                T::multiply(
-                    ctx,
-                    RecordId::from(i),
-                    &x.trigger_value,
-                    &(one - &x.is_trigger_report),
-                )
-                .await
+                x.trigger_value
+                    .multiply(&(one - &x.is_trigger_report), ctx, RecordId::from(i))
+                    .await
             }),
     )
     .await

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -37,13 +37,9 @@ where
     //   = false_value + 0 * (true_value - false_value)
     //   = false_value
     Ok(false_value.clone()
-        + &S::multiply(
-            ctx,
-            record_id,
-            condition,
-            &(true_value.clone() - false_value),
-        )
-        .await?)
+        + &condition
+            .multiply(&(true_value.clone() - false_value), ctx, record_id)
+            .await?)
 }
 
 ///
@@ -108,8 +104,9 @@ where
             let current_credit = &uncapped_credits[i];
 
             credit_update_futures.push(async move {
-                let credit_update =
-                    S::multiply(c1, record_id, current_stop_bit, sibling_credit).await?;
+                let credit_update = current_stop_bit
+                    .multiply(sibling_credit, c1, record_id)
+                    .await?;
                 if first_iteration {
                     Ok(credit_update + current_credit)
                 } else {
@@ -119,7 +116,9 @@ where
             if i < next_end {
                 let sibling_stop_bit = &stop_bits[i + step_size];
                 stop_bit_futures.push(async move {
-                    S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
+                    current_stop_bit
+                        .multiply(sibling_stop_bit, c2, record_id)
+                        .await
                 });
             }
         }
@@ -194,12 +193,16 @@ where
             let current_stop_bit = &stop_bits[i];
             let sibling_value = &values[i + step_size];
             value_update_futures.push(async move {
-                S::multiply(c1, record_id, current_stop_bit, sibling_value).await
+                current_stop_bit
+                    .multiply(sibling_value, c1, record_id)
+                    .await
             });
             if i < next_end {
                 let sibling_stop_bit = &stop_bits[i + step_size];
                 stop_bit_futures.push(async move {
-                    S::multiply(c2, record_id, current_stop_bit, sibling_stop_bit).await
+                    current_stop_bit
+                        .multiply(sibling_stop_bit, c2, record_id)
+                        .await
                 });
             }
         }

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -63,8 +63,9 @@ pub async fn check_zero<F: Field>(
 ) -> Result<bool, Error> {
     let r_sharing = ctx.prss().generate_replicated(record_id);
 
-    let rv_share =
-        Replicated::multiply(ctx.narrow(&Step::MultiplyWithR), record_id, &r_sharing, v).await?;
+    let rv_share = r_sharing
+        .multiply(v, ctx.narrow(&Step::MultiplyWithR), record_id)
+        .await?;
     let rv = rv_share
         .reveal(ctx.narrow(&Step::RevealR), record_id)
         .await?;

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -84,7 +84,6 @@ mod test {
         ff::{Field, Fp31},
         protocol::{basics::SecureMul, context::Context, RecordId},
         rand::{thread_rng, Rng},
-        secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use futures::future::try_join_all;
@@ -114,7 +113,7 @@ mod test {
 
         let res = world
             .semi_honest((a, b), |ctx, (a, b)| async move {
-                Replicated::multiply(ctx.set_total_records(1), RecordId::from(0), &a, &b)
+                a.multiply(&b, ctx.set_total_records(1), RecordId::from(0))
                     .await
                     .unwrap()
             })
@@ -145,7 +144,7 @@ mod test {
                     )
                     .enumerate()
                     .map(|(i, (ctx, (a_share, b_share)))| async move {
-                        Replicated::multiply(ctx, RecordId::from(i), &a_share, &b_share).await
+                        a_share.multiply(&b_share, ctx, RecordId::from(i)).await
                     }),
                 )
                 .await
@@ -166,14 +165,10 @@ mod test {
 
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
-                Replicated::multiply(
-                    ctx.set_total_records(1),
-                    RecordId::from(0),
-                    &a_share,
-                    &b_share,
-                )
-                .await
-                .unwrap()
+                a_share
+                    .multiply(&b_share, ctx.set_total_records(1), RecordId::from(0))
+                    .await
+                    .unwrap()
             })
             .await;
 

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -197,13 +197,7 @@ pub(in crate::protocol) mod test {
             BitOpStep, RECORD_0,
         },
         rand::{thread_rng, Rng},
-        secret_sharing::{
-            replicated::{
-                malicious::AdditiveShare as MaliciousReplicated,
-                semi_honest::AdditiveShare as Replicated,
-            },
-            IntoShares,
-        },
+        secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
     use futures::future::try_join;
@@ -385,15 +379,9 @@ pub(in crate::protocol) mod test {
                 let v2 = SparseField::new(rng.gen::<Fp31>(), b);
                 let result = world
                     .semi_honest((v1, v2), |ctx, (v_a, v_b)| async move {
-                        Replicated::multiply_sparse(
-                            ctx.set_total_records(1),
-                            RECORD_0,
-                            &v_a,
-                            &v_b,
-                            (a, b),
-                        )
-                        .await
-                        .unwrap()
+                        v_a.multiply_sparse(&v_b, ctx.set_total_records(1), RECORD_0, (a, b))
+                            .await
+                            .unwrap()
                     })
                     .await;
                 check_output_zeros(&result, (a, b));
@@ -426,15 +414,10 @@ pub(in crate::protocol) mod test {
                         .await
                         .unwrap();
 
-                        let m_ab = MaliciousReplicated::multiply_sparse(
-                            m_ctx,
-                            RECORD_0,
-                            &m_a,
-                            &m_b,
-                            (a, b),
-                        )
-                        .await
-                        .unwrap();
+                        let m_ab = m_a
+                            .multiply_sparse(&m_b, m_ctx, RECORD_0, (a, b))
+                            .await
+                            .unwrap();
 
                         v.validate(m_ab).await.unwrap()
                     })

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -68,23 +68,15 @@ where
     for (bit_index, bit) in a.iter().enumerate().skip(1) {
         let mult_result = if last_carry_known_to_be_zero {
             // TODO: this makes me sad
-            let _ = S::multiply(
-                ctx.narrow(&BitOpStep::from(bit_index)),
-                record_id,
-                &S::ZERO,
-                &S::ZERO,
-            ) // this is stupid
-            .await?;
+            let _ = S::ZERO
+                .multiply(&S::ZERO, ctx.narrow(&BitOpStep::from(bit_index)), record_id) // this is stupid
+                .await?;
 
             S::ZERO
         } else {
-            S::multiply(
-                ctx.narrow(&BitOpStep::from(bit_index)),
-                record_id,
-                &last_carry,
-                bit,
-            )
-            .await?
+            last_carry
+                .multiply(bit, ctx.narrow(&BitOpStep::from(bit_index)), record_id)
+                .await?
         };
 
         let next_bit_a_one = (b >> bit_index) & 1 == 1;
@@ -149,20 +141,21 @@ where
     );
     let mut output = Vec::with_capacity(a.len() + 1);
 
-    let mut last_carry =
-        S::multiply(ctx.narrow(&BitOpStep::from(0)), record_id, &a[0], maybe).await?;
+    let mut last_carry = a[0]
+        .multiply(maybe, ctx.narrow(&BitOpStep::from(0)), record_id)
+        .await?;
     output.push(-last_carry.clone() * F::from(2) + &a[0] + maybe);
 
     let ctx_other = ctx.narrow(&Step::CarryXorBitTimesMaybe);
     for (bit_index, bit) in a.iter().enumerate().skip(1).take(el - 1) {
         let next_bit = (b >> bit_index) & 1;
-        let carry_times_bit = S::multiply(
-            ctx.narrow(&BitOpStep::from(bit_index)),
-            record_id,
-            bit,
-            &last_carry,
-        )
-        .await?;
+        let carry_times_bit = bit
+            .multiply(
+                &last_carry,
+                ctx.narrow(&BitOpStep::from(bit_index)),
+                record_id,
+            )
+            .await?;
 
         if next_bit == 0 {
             let next_carry = carry_times_bit;
@@ -173,13 +166,13 @@ where
         } else {
             let carry_xor_bit = -carry_times_bit.clone() * F::from(2) + &last_carry + bit;
 
-            let carry_xor_bit_times_maybe = S::multiply(
-                ctx_other.narrow(&BitOpStep::from(bit_index)),
-                record_id,
-                &carry_xor_bit,
-                maybe,
-            )
-            .await?;
+            let carry_xor_bit_times_maybe = carry_xor_bit
+                .multiply(
+                    maybe,
+                    ctx_other.narrow(&BitOpStep::from(bit_index)),
+                    record_id,
+                )
+                .await?;
 
             let next_carry = carry_xor_bit_times_maybe + &carry_times_bit;
 

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -65,11 +65,10 @@ where
         let half = shares_to_multiply.len() / 2;
         let mut multiplications = Vec::with_capacity(half);
         for i in 0..half {
-            multiplications.push(S::multiply(
+            multiplications.push(shares_to_multiply[2 * i].multiply(
+                &shares_to_multiply[2 * i + 1],
                 ctx.narrow(&BitOpStep::from(mult_count)),
                 record_id,
-                &shares_to_multiply[2 * i],
-                &shares_to_multiply[2 * i + 1],
             ));
             mult_count += 1;
         }

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -16,7 +16,7 @@ pub async fn or<F: Field, C: Context, S: ArithmeticSecretSharing<F> + SecureMul<
     a: &S,
     b: &S,
 ) -> Result<S, Error> {
-    let ab = S::multiply(ctx, record_id, a, b).await?;
+    let ab = a.multiply(b, ctx, record_id).await?;
     Ok(-ab + a + b)
 }
 

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -37,7 +37,7 @@ where
     C: Context,
     S: ArithmeticSecretSharing<F> + SecureMul<C>,
 {
-    let ab = S::multiply_sparse(ctx, record_id, a, b, zeros_at).await?;
+    let ab = a.multiply_sparse(b, ctx, record_id, zeros_at).await?;
     Ok(-(ab * F::from(2)) + a + b)
 }
 

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -439,14 +439,14 @@ impl<'a, F: Field> ContextInner<'a, F> {
         x: Replicated<F>,
         zeros_at: ZeroPositions,
     ) -> Result<MaliciousReplicated<F>, Error> {
-        let rx = Replicated::multiply_sparse(
-            ctx.clone(),
-            record_id,
-            &x,
-            &self.r_share,
-            (zeros_at, ZeroPositions::Pvvv),
-        )
-        .await?;
+        let rx = x
+            .multiply_sparse(
+                &self.r_share,
+                ctx.clone(),
+                record_id,
+                (zeros_at, ZeroPositions::Pvvv),
+            )
+            .await?;
         let m = MaliciousReplicated::new(x, rx);
         let ctx = ctx.narrow(&RandomnessForValidation);
         let prss = ctx.prss();

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -267,10 +267,7 @@ mod tests {
         rand::thread_rng,
         secret_sharing::{
             replicated::{
-                malicious::{
-                    AdditiveShare as MaliciousReplicated,
-                    ThisCodeIsAuthorizedToDowngradeFromMalicious,
-                },
+                malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious,
                 semi_honest::AdditiveShare as Replicated,
             },
             IntoShares,
@@ -314,13 +311,9 @@ mod tests {
                 let (a_malicious, b_malicious) =
                     v.context().upgrade((a_share, b_share)).await.unwrap();
 
-                let m_result = MaliciousReplicated::multiply(
-                    m_ctx.set_total_records(1),
-                    RecordId::from(0),
-                    &a_malicious,
-                    &b_malicious,
-                )
-                .await?;
+                let m_result = a_malicious
+                    .multiply(&b_malicious, m_ctx.set_total_records(1), RecordId::from(0))
+                    .await?;
 
                 // Save some cloned values so that we can check them.
                 let r_share = v.r_share().clone();
@@ -445,13 +438,9 @@ mod tests {
                         zip(m_input.iter(), m_input.iter().skip(1)),
                     )
                     .map(|((i, ctx), (a_malicious, b_malicious))| async move {
-                        MaliciousReplicated::multiply(
-                            ctx,
-                            RecordId::from(i),
-                            a_malicious,
-                            b_malicious,
-                        )
-                        .await
+                        a_malicious
+                            .multiply(b_malicious, ctx, RecordId::from(i))
+                            .await
                     }),
                 )
                 .await?;

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -57,7 +57,7 @@ pub async fn bit_permutation<
             .enumerate()
             .map(|(i, (ctx, (x, sum)))| async move {
                 let record_id = RecordId::from(i);
-                S::multiply(ctx, record_id, &x, &sum).await
+                x.multiply(&sum, ctx, record_id).await
             });
     let mut mult_output = try_join_all(async_multiply).await?;
 

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -267,11 +267,10 @@ where
             try_join_all(precomputed_combinations.iter().skip(1).enumerate().map(
                 |(j, precomputed_combination)| {
                     let child_idx = j + step;
-                    S::multiply(
+                    precomputed_combination.multiply(
+                        bit,
                         ctx.narrow(&BitOpStep::from(child_idx)),
                         record_id,
-                        precomputed_combination,
-                        bit,
                     )
                 },
             ))

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -82,10 +82,10 @@ where
             match a {
                 None => a = Some(share),
                 Some(a_v) => {
-                    let result =
-                        Replicated::multiply(ctx.clone(), RecordId::from(record_id), &a_v, &share)
-                            .await
-                            .unwrap();
+                    let result = a_v
+                        .multiply(&share, ctx.clone(), RecordId::from(record_id))
+                        .await
+                        .unwrap();
                     results.push(result);
                     record_id += 1;
                     a = None;

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -40,12 +40,11 @@ async fn circuit(world: &TestWorld, record_id: RecordId, depth: u8) -> [Replicat
         a = async move {
             let mut coll = Vec::new();
             for (i, ctx) in bit_ctx.iter().enumerate() {
-                let mul = Replicated::multiply(
+                let mul = a[i].multiply(
+                    &b[i],
                     ctx.narrow(&"mult".to_string())
                         .set_total_records(TotalRecords::Indeterminate),
                     record_id,
-                    &a[i],
-                    &b[i],
                 );
                 coll.push(mul);
             }


### PR DESCRIPTION
I think this is the last cleanup from https://github.com/private-attribution/ipa/pull/488#discussion_r1115059175. Reshare and reveal were done previously. This PR does multiply. The remaining things in `protocol::basics` are:

* `sum_of_products` is still an associated function, but it's less clear the right way to make that a method. If it's implemented as a method on slices, then various things that currently require `S: BasicProtocols` instead need to require `[S]: SumOfProducts`, which somewhat offsets any ergonomic benefit of being able to call as a method rather than an associated function. Sum-of-products is only used a couple places anyways.
* `share_known_value` is an associated function, but that makes sense because it's a constructor of sorts, not an operation on a value.
* `check_zero` is just a plain function, and it doesn't seem that important to make a trait out of it.