### PR TITLE
Run concurrency tests in release mode

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
         run: cargo build --features shuttle
 
       - name: Run concurrency tests
-        run: cargo test --features shuttle
+        run: cargo test --release --features shuttle
 
       - name: Run IPA bench
         run: cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,6 +92,9 @@ jobs:
         run: cargo build --benches --features enable-benches
 
       - name: Build concurrency tests
+        run: cargo build --release --features shuttle
+
+      - name: Build concurrency tests (debug mode)
         run: cargo build --features shuttle
 
       - name: Run concurrency tests

--- a/pre-commit
+++ b/pre-commit
@@ -76,7 +76,7 @@ cargo clippy --tests --features shuttle -- -D warnings || error "Clippy concurre
 
 cargo test || error "Test failures"
 
-cargo test --features shuttle || error "Concurrency test failures"
+cargo test --release --features shuttle || error "Concurrency test failures"
 
 cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches" || error "Failed to run IPA benchmark"
 


### PR DESCRIPTION
It leads to quite significant improvement in runtime. In debug mode it currently takes ~40 seconds on my machine to run them all. In release mode, it only takes 3 seconds

before

```bash
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.59s
```

after

```bash
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.49s
```