### PR TITLE
move `RecordBinding` to a more appropriate home

### DIFF
--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -3,15 +3,13 @@ use crate::{
     ff::Field,
     helpers::{Direction, Role},
     protocol::{
-        context::{
-            malicious::RecordBinding, Context, MaliciousContext, NoRecord, SemiHonestContext,
-        },
+        context::{Context, MaliciousContext, SemiHonestContext},
         prss::SharedRandomness,
         sort::{
             apply_sort::shuffle::InnerVectorElementStep,
             ReshareStep::{RandomnessForValidation, ReshareRx},
         },
-        RecordId,
+        NoRecord, RecordBinding, RecordId,
     },
     secret_sharing::replicated::{
         malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -5,11 +5,9 @@ use crate::{
     ff::Field,
     helpers::Direction,
     protocol::{
-        context::{
-            malicious::RecordBinding, Context, MaliciousContext, NoRecord, SemiHonestContext,
-        },
+        context::{Context, MaliciousContext, SemiHonestContext},
         sort::generate_permutation::ShuffledPermutationWrapper,
-        RecordId,
+        NoRecord, RecordBinding, RecordId,
     },
     secret_sharing::{
         replicated::{

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -26,7 +26,7 @@ use crate::{
         malicious::MaliciousValidatorAccumulator,
         modulus_conversion::BitConversionTriple,
         prss::Endpoint as PrssEndpoint,
-        BitOpStep, RecordId, Step, Substep, RECORD_0,
+        BitOpStep, NoRecord, RecordBinding, RecordId, Step, Substep, RECORD_0,
     },
     repeat64str,
     secret_sharing::{
@@ -508,10 +508,15 @@ impl<'a, F: Field> ContextInner<'a, F> {
     }
 }
 
-/// Helper to prevent using the record ID multiple times to implement an upgrade.
+/// Special context type used for malicious upgrades.
+///
+/// The `B: RecordBinding` type parameter is used to prevent using the record ID multiple times to
+/// implement an upgrade. For example, trying to use the record ID to iterate over both the inner
+/// and outer vectors in a `Vec<Vec<T>>` is an error. Instead, one level of iteration can use the
+/// record ID and the other can use something like a `BitOpStep`.
 ///
 /// ```no_run
-/// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
+/// use raw_ipa::protocol::{context::{UpgradeContext, UpgradeToMalicious}, NoRecord, RecordId};
 /// use raw_ipa::ff::Fp31;
 /// use raw_ipa::secret_sharing::replicated::{
 ///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
@@ -524,7 +529,7 @@ impl<'a, F: Field> ContextInner<'a, F> {
 /// ```
 ///
 /// ```compile_fail
-/// use raw_ipa::protocol::{context::{NoRecord, UpgradeContext, UpgradeToMalicious}, RecordId};
+/// use raw_ipa::protocol::{context::{UpgradeContext, UpgradeToMalicious}, NoRecord, RecordId};
 /// use raw_ipa::ff::Fp31;
 /// use raw_ipa::secret_sharing::replicated::{
 ///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
@@ -533,14 +538,6 @@ impl<'a, F: Field> ContextInner<'a, F> {
 /// // is used internally for vector indexing.
 /// let _ = <UpgradeContext<Fp31, RecordId> as UpgradeToMalicious<Vec<Replicated<Fp31>>, _>>::upgrade;
 /// ```
-pub trait RecordBinding: Copy + Send + Sync + 'static {}
-
-#[derive(Clone, Copy)]
-pub struct NoRecord;
-impl RecordBinding for NoRecord {}
-
-impl RecordBinding for RecordId {}
-
 pub struct UpgradeContext<'a, F: Field, B: RecordBinding = NoRecord> {
     upgrade_ctx: SemiHonestContext<'a>,
     inner: &'a ContextInner<'a, F>,

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -11,7 +11,7 @@ mod prss;
 mod semi_honest;
 
 pub(super) use malicious::SpecialAccessToMaliciousContext;
-pub use malicious::{MaliciousContext, NoRecord, UpgradeContext, UpgradeToMalicious};
+pub use malicious::{MaliciousContext, UpgradeContext, UpgradeToMalicious};
 pub use prss::{InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness};
 pub use semi_honest::SemiHonestContext;
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -320,3 +320,18 @@ impl AddAssign<usize> for RecordId {
         self.0 += u32::try_from(rhs).unwrap();
     }
 }
+
+/// Helper used when an operation may or may not be associated with a specific record. This is
+/// also used to prevent some kinds of invalid uses of record ID iteration. For example, trying to
+/// use the record ID to iterate over both the inner and outer vectors in a `Vec<Vec<T>>` is an
+/// error. Instead, one level of iteration can use the record ID and the other can use something
+/// like a `BitOpStep`.
+///
+/// There are some doc tests on `UpgradeContext` showing the use of `RecordBinding`.
+pub trait RecordBinding: Copy + Send + Sync + 'static {}
+
+#[derive(Clone, Copy)]
+pub struct NoRecord;
+impl RecordBinding for NoRecord {}
+
+impl RecordBinding for RecordId {}

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -3,13 +3,13 @@ use crate::{
     helpers::Direction,
     protocol::{
         basics::Reshare,
-        context::{Context, NoRecord},
+        context::Context,
         sort::{
             apply::{apply, apply_inv},
             shuffle::{shuffle_for_helper, ShuffleOrUnshuffle},
             ShuffleStep::{self, Step1, Step2, Step3},
         },
-        RecordId,
+        NoRecord, RecordId,
     },
     repeat64str,
 };

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -3,13 +3,13 @@ use crate::{
     ff::Field,
     protocol::{
         basics::{Reshare, Reveal},
-        context::{Context, MaliciousContext, NoRecord},
+        context::{Context, MaliciousContext},
         malicious::MaliciousValidator,
         sort::{
             ShuffleRevealStep::{RevealPermutation, ShufflePermutation},
             SortStep::{ShuffleRevealPermutation, SortKeys},
         },
-        RecordId,
+        NoRecord, RecordId,
     },
     secret_sharing::{
         replicated::{

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -5,11 +5,7 @@ use crate::{
     error::Error,
     ff::Field,
     helpers::{Direction, Role},
-    protocol::{
-        basics::Reshare,
-        context::{Context, NoRecord},
-        RecordId, Substep,
-    },
+    protocol::{basics::Reshare, context::Context, NoRecord, RecordId, Substep},
     secret_sharing::SecretSharing,
 };
 

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -3,10 +3,11 @@ use crate::{
     ff::Field,
     protocol::{
         basics::Reveal,
-        context::{Context, MaliciousContext, NoRecord},
+        context::{Context, MaliciousContext},
         sort::{
             generate_permutation::ShuffledPermutationWrapper, ShuffleRevealStep::RevealPermutation,
         },
+        NoRecord,
     },
     secret_sharing::{
         replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare,


### PR DESCRIPTION
When I originally added this it was only used for malicious upgrades, but that has changed, so this PR moves it out of the malicious context module and into `protocol` (which is also where `RecordId` lives).