### PR TITLE
Remove bitwise ops from Galois Field

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,7 +1,4 @@
-use crate::{
-    ff::{BooleanOps, Serializable},
-    secret_sharing::SharedValue,
-};
+use crate::{ff::Serializable, secret_sharing::SharedValue};
 use generic_array::{ArrayLength, GenericArray};
 use std::fmt::Debug;
 
@@ -49,8 +46,6 @@ impl<F: Field> Serializable for F {
         Self::from(u128::from_le_bytes(buf_to))
     }
 }
-
-pub trait BinaryField: Field + BooleanOps {}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -3,13 +3,16 @@
 // This is where we store arithmetic shared secret data models.
 
 mod field;
+mod galois_field;
 mod prime_field;
 
-pub use field::{BinaryField, Field, FieldType, Int};
+pub use field::{Field, FieldType, Int};
+pub use galois_field::{Gf40Bit, Gf8Bit};
 pub use prime_field::{Fp31, Fp32BitPrime};
 
 use crate::secret_sharing::SharedValue;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use generic_array::{ArrayLength, GenericArray};
+use std::ops::{Add, AddAssign, BitXor, BitXorAssign, Index, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
@@ -63,21 +66,10 @@ where
 {
 }
 
-use generic_array::{ArrayLength, GenericArray};
-use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Index, Not};
-
-mod galois_field;
-pub use galois_field::{Gf40Bit, Gf8Bit};
-
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`
 pub trait GaloisField:
-    SharedValue
-    + BooleanOps
-    + TryFrom<u128>
-    + Into<u128>
-    + Index<usize, Output = bool>
-    + Index<u32, Output = bool>
+    SharedValue + TryFrom<u128> + Into<u128> + Index<usize, Output = bool> + Index<u32, Output = bool>
 {
     const POLYNOMIAL: u128;
 
@@ -89,30 +81,6 @@ pub trait GaloisField:
     fn as_u128(self) -> u128 {
         <Self as Into<u128>>::into(self)
     }
-}
-
-pub trait BooleanOps:
-    BitAnd<Output = Self>
-    + BitAndAssign
-    + BitOr<Output = Self>
-    + BitOrAssign
-    + BitXor<Output = Self>
-    + BitXorAssign
-    + Not<Output = Self>
-    + Sized
-{
-}
-
-impl<T> BooleanOps for T where
-    T: BitAnd<Output = Self>
-        + BitAndAssign
-        + BitOr<Output = Self>
-        + BitOrAssign
-        + BitXor<Output = Self>
-        + BitXorAssign
-        + Not<Output = Self>
-        + Sized
-{
 }
 
 pub trait BooleanRefOps:

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -39,7 +39,7 @@ where
     fn share_with<R: Rng>(self, rng: &mut R) -> [XorShare<V>; 3] {
         let s0 = rng.gen::<V>();
         let s1 = rng.gen::<V>();
-        let s2 = self ^ s0 ^ s1;
+        let s2 = self - (s0 + s1);
         [
             XorShare::new(s0, s1),
             XorShare::new(s1, s2),

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -62,7 +62,7 @@ impl<V: GaloisField> BitXor<Self> for &XorShare<V> {
     type Output = XorShare<V>;
 
     fn bitxor(self, rhs: Self) -> Self::Output {
-        XorShare(self.0 ^ rhs.0, self.1 ^ rhs.1)
+        XorShare(self.0 + rhs.0, self.1 + rhs.1)
     }
 }
 
@@ -77,8 +77,8 @@ impl<V: GaloisField> BitXor<&Self> for XorShare<V> {
 
 impl<V: GaloisField> BitXorAssign<&Self> for XorShare<V> {
     fn bitxor_assign(&mut self, rhs: &Self) {
-        self.0 ^= rhs.0;
-        self.1 ^= rhs.1;
+        self.0 += rhs.0;
+        self.1 += rhs.1;
     }
 }
 
@@ -143,11 +143,11 @@ mod tests {
         expected_value: u128,
     ) {
         assert_eq!(
-            a1.0 ^ a2.0 ^ a3.0,
+            a1.0 + a2.0 + a3.0,
             Gf40Bit::try_from(expected_value).unwrap()
         );
         assert_eq!(
-            a1.1 ^ a2.1 ^ a3.1,
+            a1.1 + a2.1 + a3.1,
             Gf40Bit::try_from(expected_value).unwrap()
         );
     }

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -70,15 +70,15 @@ impl<B: GaloisField> Reconstruct<B> for [&XorReplicated<B>; 3] {
         let s2 = &self[2];
 
         assert_eq!(
-            s0.left() ^ s1.left() ^ s2.left(),
-            s0.right() ^ s1.right() ^ s2.right(),
+            s0.left() + s1.left() + s2.left(),
+            s0.right() + s1.right() + s2.right(),
         );
 
         assert_eq!(s0.right(), s1.left());
         assert_eq!(s1.right(), s2.left());
         assert_eq!(s2.right(), s0.left());
 
-        s0.left() ^ s1.left() ^ s2.left()
+        s0.left() + s1.left() + s2.left()
     }
 }
 


### PR DESCRIPTION
This leaves GF with just arithmetic operations which will let us treat GF exactly the same as prime fields.

Next up is removing bitwise operations from `XorShare`, and merge `AdditiveShare` and `XorShare`.