### PR TITLE
Rename Arithmetic and Boolean secret sharing traits

### DIFF
--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BasicProtocols, RecordId},
-    secret_sharing::Arithmetic,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join_all;
 
@@ -44,7 +44,7 @@ async fn accumulate_credit_cap_one<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let num_rows = input.len();
 
@@ -93,7 +93,7 @@ pub async fn accumulate_credit<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     if per_user_credit_cap == 1 {
         return Ok(accumulate_credit_cap_one(ctx, input)

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -29,7 +29,7 @@ use crate::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::AdditiveShare as Replicated,
         },
-        Arithmetic,
+        Linear as LinearSecretSharing,
     },
 };
 
@@ -243,7 +243,7 @@ async fn simple_aggregate_credit<F, C, T, BK>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F> + Serializable,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable,
     BK: GaloisField,
 {
     let mut sums = vec![T::ZERO; max_breakdown_key as usize];
@@ -323,7 +323,7 @@ fn add_aggregation_bits_and_breakdown_keys<F, C, T, BK>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
     BK: GaloisField,
 {
     let zero = T::ZERO;

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -10,7 +10,7 @@ use crate::{
         context::Context,
         BasicProtocols, RecordId,
     },
-    secret_sharing::Arithmetic,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::{repeat, zip};
@@ -30,7 +30,7 @@ async fn apply_attribution_window<F, C, T>(
 where
     F: Field,
     C: Context + RandomBits<F, Share = T>,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let mut t_deltas = prefix_sum_time_deltas(&ctx, input).await?;
 
@@ -59,7 +59,7 @@ async fn prefix_sum_time_deltas<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let num_rows = input.len();
 
@@ -131,7 +131,7 @@ async fn zero_out_expired_trigger_values<F, C, T>(
 where
     F: Field,
     C: Context + RandomBits<F, Share = T>,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     // Compare the accumulated timestamp deltas with the specified attribution window
     // cap value, and zero-out trigger event values that exceed the cap.

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -12,7 +12,7 @@ use crate::{
         context::Context,
         BasicProtocols, RecordId, Substep,
     },
-    secret_sharing::Arithmetic,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::{repeat, zip};
@@ -30,7 +30,7 @@ pub async fn credit_capping<F, C, T>(
 where
     F: Field,
     C: Context + RandomBits<F, Share = T>,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -107,7 +107,7 @@ async fn credit_capping_max_one<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let input_len = input.len();
 
@@ -175,7 +175,7 @@ async fn mask_source_credits<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     try_join_all(
         input
@@ -202,7 +202,7 @@ async fn credit_prefix_sum<'a, F, C, T, I>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + SecureMul<C> + 'a,
+    T: LinearSecretSharing<F> + SecureMul<C> + 'a,
     I: Iterator<Item = &'a T>,
 {
     let helper_bits = input
@@ -226,7 +226,7 @@ async fn is_credit_larger_than_cap<F, C, T>(
 where
     F: Field,
     C: Context + RandomBits<F, Share = T>,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let random_bits_generator =
         RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForComparison));
@@ -264,7 +264,7 @@ async fn compute_final_credits<F, C, T>(
 where
     F: Field,
     C: Context,
-    T: Arithmetic<F> + BasicProtocols<C, F>,
+    T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let num_rows = input.len();
     let cap = T::share_known_value(&ctx, F::from(cap.into()));

--- a/src/protocol/attribution/input.rs
+++ b/src/protocol/attribution/input.rs
@@ -11,7 +11,7 @@ use crate::{
             },
             semi_honest::{AdditiveShare as Replicated, AdditiveShare, XorShare},
         },
-        Arithmetic,
+        Linear as LinearSecretSharing,
     },
 };
 use async_trait::async_trait;
@@ -33,7 +33,7 @@ pub struct ApplyAttributionWindowInputRow<F: Field, BK: GaloisField> {
 }
 
 #[derive(Debug)]
-pub struct MCApplyAttributionWindowInputRow<F: Field, T: Arithmetic<F>> {
+pub struct MCApplyAttributionWindowInputRow<F: Field, T: LinearSecretSharing<F>> {
     pub timestamp: T,
     pub is_trigger_report: T,
     pub helper_bit: T,
@@ -42,7 +42,7 @@ pub struct MCApplyAttributionWindowInputRow<F: Field, T: Arithmetic<F>> {
     _marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> MCApplyAttributionWindowInputRow<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> MCApplyAttributionWindowInputRow<F, T> {
     pub fn new(
         timestamp: T,
         is_trigger_report: T,
@@ -75,7 +75,7 @@ pub struct AccumulateCreditInputRow<F: Field, BK: GaloisField> {
 }
 
 #[derive(Debug)]
-pub struct MCAccumulateCreditInputRow<F: Field, T: Arithmetic<F>> {
+pub struct MCAccumulateCreditInputRow<F: Field, T: LinearSecretSharing<F>> {
     pub is_trigger_report: T,
     pub helper_bit: T,
     pub breakdown_key: Vec<T>,
@@ -83,7 +83,7 @@ pub struct MCAccumulateCreditInputRow<F: Field, T: Arithmetic<F>> {
     _marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> MCAccumulateCreditInputRow<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> MCAccumulateCreditInputRow<F, T> {
     pub fn new(
         is_trigger_report: T,
         helper_bit: T,
@@ -109,12 +109,12 @@ pub type CreditCappingInputRow<F, BK> = AccumulateCreditInputRow<F, BK>;
 pub type MCCreditCappingInputRow<F, T> = MCAccumulateCreditInputRow<F, T>;
 
 #[derive(Debug)]
-pub struct MCCreditCappingOutputRow<F: Field, T: Arithmetic<F>> {
+pub struct MCCreditCappingOutputRow<F: Field, T: LinearSecretSharing<F>> {
     pub breakdown_key: Vec<T>,
     pub credit: T,
     _marker: PhantomData<F>,
 }
-impl<F: Field, T: Arithmetic<F>> MCCreditCappingOutputRow<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> MCCreditCappingOutputRow<F, T> {
     pub fn new(breakdown_key: Vec<T>, credit: T) -> Self {
         Self {
             breakdown_key,
@@ -181,7 +181,7 @@ pub struct MCCappedCreditsWithAggregationBit<F, T> {
     marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> MCCappedCreditsWithAggregationBit<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> MCCappedCreditsWithAggregationBit<F, T> {
     pub fn new(helper_bit: T, aggregation_bit: T, breakdown_key: Vec<T>, credit: T) -> Self {
         Self {
             helper_bit,
@@ -202,7 +202,7 @@ pub struct MCAggregateCreditOutputRow<F, T, BK> {
     _marker: PhantomData<(F, BK)>,
 }
 
-impl<F: Field, T: Arithmetic<F>, BK: GaloisField> MCAggregateCreditOutputRow<F, T, BK>
+impl<F: Field, T: LinearSecretSharing<F>, BK: GaloisField> MCAggregateCreditOutputRow<F, T, BK>
 where
     T: Serializable,
 {
@@ -269,7 +269,7 @@ where
 impl<F, T, C> Reshare<C, RecordId> for MCAccumulateCreditInputRow<F, T>
 where
     F: Field,
-    T: Arithmetic<F> + Reshare<C, RecordId>,
+    T: LinearSecretSharing<F> + Reshare<C, RecordId>,
     C: Context,
 {
     async fn reshare<'fut>(
@@ -321,7 +321,7 @@ where
 impl<F, T, C> Reshare<C, RecordId> for MCCappedCreditsWithAggregationBit<F, T>
 where
     F: Field,
-    T: Arithmetic<F> + Reshare<C, RecordId>,
+    T: LinearSecretSharing<F> + Reshare<C, RecordId>,
     C: Context,
 {
     async fn reshare<'fut>(

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         basics::SecureMul, boolean::or::or, context::Context, BasicProtocols, RecordId, Substep,
     },
     repeat64str,
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::{try_join, try_join_all};
 
@@ -28,7 +28,7 @@ async fn if_else<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)
@@ -63,7 +63,7 @@ pub async fn prefix_or_binary_tree_style<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     assert_eq!(stop_bits.len() + 1, uncapped_credits.len());
 
@@ -167,7 +167,7 @@ pub async fn do_the_binary_tree_thing<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let num_rows = values.len();
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{basics::SecureMul, context::Context, BasicProtocols, BitOpStep, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
@@ -48,7 +48,7 @@ pub async fn add_constant<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 
@@ -130,7 +130,7 @@ pub async fn maybe_add_constant_mod2l<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let el = usize::try_from(u128::BITS - F::PRIME.into().leading_zeros()).unwrap();
     assert!(a.len() >= el);

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -8,7 +8,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BasicProtocols, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 /// This is an implementation of "3. Bit-Decomposition" from I. Damgård et al..
@@ -35,7 +35,7 @@ impl BitDecomposition {
     ) -> Result<Vec<S>, Error>
     where
         F: Field,
-        S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+        S: LinearSecretSharing<F> + BasicProtocols<C, F>,
         C: Context + RandomBits<F, Share = S>,
     {
         // step 1 in the paper is just describing the input, `[a]_p` where `a ∈ F_p`

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -5,7 +5,7 @@ use crate::{
     protocol::{
         basics::SecureMul, boolean::no_ones, context::Context, BasicProtocols, BitOpStep, RecordId,
     },
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::zip;
@@ -26,7 +26,7 @@ pub async fn bitwise_equal_constant<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     assert!(a.len() <= 128);
 
@@ -58,7 +58,7 @@ pub async fn bitwise_equal<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     debug_assert!(a.len() == b.len());
     let xored_bits = xor_all_the_bits(ctx.narrow(&Step::XORAllTheBits), record_id, a, b).await?;
@@ -74,7 +74,7 @@ async fn xor_all_the_bits<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let xor = zip(a, b).enumerate().map(|(i, (a_bit, b_bit))| {
         let c = ctx.narrow(&BitOpStep::from(i));

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -5,7 +5,7 @@ use crate::{
     protocol::{
         boolean::multiply_all_shares, context::Context, BasicProtocols, BitOpStep, RecordId,
     },
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join;
 use std::cmp::Ordering;
@@ -28,7 +28,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context,
-        S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+        S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
         let one = S::share_known_value(&ctx, F::ONE);
         let gtoe = Self::greater_than_or_equal_to_prime(ctx, record_id, x).await?;
@@ -43,7 +43,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context,
-        S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+        S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
         let prime = F::PRIME.into();
         let l = u128::BITS - prime.leading_zeros();
@@ -93,7 +93,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context,
-        S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+        S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
         let prime = F::PRIME.into();
         let l = u128::BITS - prime.leading_zeros();
@@ -150,7 +150,7 @@ impl BitwiseLessThanPrime {
     where
         F: Field,
         C: Context,
-        S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+        S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
         let prime = F::PRIME.into();
         debug_assert!(prime & 0b111 == 0b011);

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -7,7 +7,7 @@ use crate::{
         context::Context,
         BasicProtocols, BitOpStep, RecordId,
     },
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
@@ -69,7 +69,7 @@ pub async fn greater_than_constant<F, C, S>(
 where
     F: Field,
     C: Context + RandomBits<F, Share = S>,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     use GreaterThanConstantStep as Step;
 
@@ -183,7 +183,7 @@ pub async fn bitwise_greater_than_constant<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     assert!(a.len() <= 128);
 
@@ -215,7 +215,7 @@ pub async fn bitwise_less_than_constant<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     assert!(a.len() <= 128);
 
@@ -245,7 +245,7 @@ async fn first_differing_bit<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let one = S::share_known_value(ctx, F::ONE);
 

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -13,7 +13,7 @@ use crate::{
             semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
             ReplicatedSecretSharing,
         },
-        Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue,
+        Linear as LinearSecretSharing, SecretSharing, SharedValue,
     },
 };
 use async_trait::async_trait;
@@ -65,7 +65,7 @@ async fn convert_triples_to_shares<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let futures = triples.iter().enumerate().map(|(i, t)| {
         let c = ctx.narrow(&BitOpStep::from(i));

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{basics::SecureMul, BasicProtocols},
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+    secret_sharing::{Linear as LinearSecretSharing, SecretSharing},
 };
 use std::iter::repeat;
 
@@ -84,7 +84,7 @@ where
 fn flip_bits<F, S>(one: S, x: &[S]) -> Vec<S>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F>,
+    S: LinearSecretSharing<F>,
 {
     x.iter()
         .zip(repeat(one))
@@ -98,7 +98,7 @@ pub(crate) async fn any_ones<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> R
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let one = S::share_known_value(&ctx, F::ONE);
     let res = no_ones(ctx, record_id, x).await?;
@@ -109,7 +109,7 @@ pub(crate) async fn no_ones<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Re
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let one = S::share_known_value(&ctx, F::ONE);
     let inverted_elements = flip_bits(one.clone(), x);

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{basics::SecureMul, context::Context, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 /// Secure OR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
@@ -10,7 +10,7 @@ use crate::{
 ///
 /// ## Errors
 /// Fails if the multiplication protocol fails.
-pub async fn or<F: Field, C: Context, S: ArithmeticSecretSharing<F> + SecureMul<C>>(
+pub async fn or<F: Field, C: Context, S: LinearSecretSharing<F> + SecureMul<C>>(
     ctx: C,
     record_id: RecordId,
     a: &S,

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -7,7 +7,7 @@ use crate::{
     ff::Field,
     helpers::messaging::TotalRecords,
     protocol::{context::Context, BasicProtocols, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use std::{
     marker::PhantomData,
@@ -31,7 +31,7 @@ pub struct RandomBitsGenerator<F, S, C> {
 impl<F, S, C> RandomBitsGenerator<F, S, C>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {
     #[must_use]

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -7,7 +7,7 @@ use crate::{
         replicated::malicious::{
             AdditiveShare as MaliciousReplicated, DowngradeMalicious, UnauthorizedDowngradeWrapper,
         },
-        Arithmetic as ArithmeticSecretSharing, SecretSharing,
+        Linear as LinearSecretSharing, SecretSharing,
     },
 };
 use async_trait::async_trait;
@@ -77,7 +77,7 @@ pub async fn solved_bits<F, S, C>(
 ) -> Result<Option<RandomBitsShare<F, S>>, Error>
 where
     F: Field,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {
     //
@@ -117,7 +117,7 @@ async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Resu
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let c_b =
         BitwiseLessThanPrime::less_than_prime(ctx.narrow(&Step::IsPLessThanB), record_id, b_b)

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -6,7 +6,7 @@ use crate::{
         context::Context,
         RecordId,
     },
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 /// Secure XOR protocol with two inputs, `a, b ∈ {0,1} ⊆ F_p`.
@@ -17,7 +17,7 @@ pub async fn xor<F, C, S>(ctx: C, record_id: RecordId, a: &S, b: &S) -> Result<S
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     xor_sparse(ctx, record_id, a, b, ZeroPositions::NONE).await
 }
@@ -35,7 +35,7 @@ pub async fn xor_sparse<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let ab = a.multiply_sparse(b, ctx, record_id, zeros_at).await?;
     Ok(-(ab * F::from(2)) + a + b)

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -34,7 +34,7 @@ use crate::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::AdditiveShare as Replicated,
         },
-        Arithmetic,
+        Linear as LinearSecretSharing,
     },
     sync::Arc,
 };
@@ -323,14 +323,14 @@ impl<'a, F: Field>
     }
 }
 
-pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: Arithmetic<F>> {
+pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: LinearSecretSharing<F>> {
     pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub trigger_value: T,
     _marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> IPAModulusConvertedInputRowWrapper<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRowWrapper<F, T> {
     pub fn new(mk_shares: Vec<T>, is_trigger_bit: T, trigger_value: T) -> Self {
         Self {
             mk_shares,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -25,7 +25,7 @@ use crate::{
             malicious::AdditiveShare as MaliciousReplicated,
             semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
         },
-        Arithmetic,
+        Linear as LinearSecretSharing,
     },
 };
 
@@ -182,7 +182,7 @@ where
     }
 }
 
-pub struct IPAModulusConvertedInputRow<F: Field, T: Arithmetic<F>> {
+pub struct IPAModulusConvertedInputRow<F: Field, T: LinearSecretSharing<F>> {
     pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub breakdown_key: Vec<T>,
@@ -190,7 +190,7 @@ pub struct IPAModulusConvertedInputRow<F: Field, T: Arithmetic<F>> {
     _marker: PhantomData<F>,
 }
 
-impl<F: Field, T: Arithmetic<F>> IPAModulusConvertedInputRow<F, T> {
+impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRow<F, T> {
     pub fn new(
         mk_shares: Vec<T>,
         is_trigger_bit: T,
@@ -211,7 +211,7 @@ impl<F: Field, T: Arithmetic<F>> IPAModulusConvertedInputRow<F, T> {
 impl<F, T, C> Reshare<C, RecordId> for IPAModulusConvertedInputRow<F, T>
 where
     F: Field,
-    T: Arithmetic<F> + Reshare<C, RecordId>,
+    T: LinearSecretSharing<F> + Reshare<C, RecordId>,
     C: Context,
 {
     async fn reshare<'fut>(

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -13,7 +13,7 @@ use crate::{
             semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
             ReplicatedSecretSharing,
         },
-        Arithmetic as ArithmeticSecretSharing,
+        Linear as LinearSecretSharing,
     },
 };
 use futures::future::try_join_all;
@@ -116,7 +116,7 @@ pub async fn convert_bit<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let (sh0, sh1, sh2) = (
         &locally_converted_bits.0[0],
@@ -146,7 +146,7 @@ pub async fn convert_all_bits<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let ctx = ctx.set_total_records(locally_converted_bits.len());
 
@@ -182,7 +182,7 @@ pub async fn convert_bit_list<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + SecureMul<C>,
+    S: LinearSecretSharing<F> + SecureMul<C>,
 {
     try_join_all(
         zip(repeat(ctx), locally_converted_bits.iter())

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BasicProtocols, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 
 use embed_doc_image::embed_doc_image;
@@ -35,7 +35,7 @@ use futures::future::try_join_all;
 pub async fn bit_permutation<
     'a,
     F: Field,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context,
 >(
     ctx: C,

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BasicProtocols, BitOpStep, RecordId},
-    secret_sharing::{Arithmetic as ArithmeticSecretSharing, SecretSharing},
+    secret_sharing::{Linear as LinearSecretSharing, SecretSharing},
 };
 use futures::future::try_join_all;
 
@@ -163,7 +163,7 @@ pub async fn check_everything<F, C, S>(
 where
     F: Field,
     C: Context,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let num_bits = record.len();
     let precomputed_combinations =

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, sort::check_everything, BasicProtocols, RecordId},
-    secret_sharing::Arithmetic as ArithmeticSecretSharing,
+    secret_sharing::Linear as LinearSecretSharing,
 };
 use futures::future::try_join_all;
 use std::iter::repeat;
@@ -28,7 +28,7 @@ use std::iter::repeat;
 pub async fn multi_bit_permutation<
     'a,
     F: Field,
-    S: ArithmeticSecretSharing<F> + BasicProtocols<C, F>,
+    S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context,
 >(
     ctx: C,

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -12,7 +12,9 @@ use crate::{
         ipa::{ipa, IPAInputRow},
         BreakdownKey, MatchKey, Step,
     },
-    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Arithmetic},
+    secret_sharing::{
+        replicated::semi_honest::AdditiveShare as Replicated, Linear as LinearSecretSharing,
+    },
     task::JoinHandle,
 };
 use futures_util::StreamExt;
@@ -45,7 +47,7 @@ where
     }
 }
 
-impl<F: Field, T: Arithmetic<F>, BK: GaloisField> Result
+impl<F: Field, T: LinearSecretSharing<F>, BK: GaloisField> Result
     for Vec<MCAggregateCreditOutputRow<F, T, BK>>
 where
     T: Serializable,

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -5,7 +5,7 @@ mod scheme;
 
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 pub use into_shares::IntoShares;
-pub use scheme::{Arithmetic, Boolean, SecretSharing};
+pub use scheme::{Bitwise, Linear, SecretSharing};
 
 use crate::ff::{ArithmeticOps, Serializable};
 use std::fmt::Debug;

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare,
-        Arithmetic as ArithmeticSecretSharing, SecretSharing, SharedValue,
+        Linear as LinearSecretSharing, SecretSharing, SharedValue,
     },
 };
 use async_trait::async_trait;
@@ -32,7 +32,7 @@ impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
     const ZERO: Self = AdditiveShare::ZERO;
 }
 
-impl<V: SharedValue> ArithmeticSecretSharing<V> for AdditiveShare<V> {}
+impl<V: SharedValue> LinearSecretSharing<V> for AdditiveShare<V> {}
 
 /// A trait that is implemented for various collections of `replicated::malicious::AdditiveShare`.
 /// This allows a protocol to downgrade to ordinary `replicated::semi_honest::AdditiveShare`

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -1,7 +1,7 @@
 use crate::{
     ff::Serializable,
     secret_sharing::{
-        replicated::ReplicatedSecretSharing, Arithmetic as ArithmeticSecretSharing, SecretSharing,
+        replicated::ReplicatedSecretSharing, Linear as LinearSecretSharing, SecretSharing,
         SharedValue,
     },
 };
@@ -19,7 +19,7 @@ impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
     const ZERO: Self = AdditiveShare::ZERO;
 }
 
-impl<V: SharedValue> ArithmeticSecretSharing<V> for AdditiveShare<V> {}
+impl<V: SharedValue> LinearSecretSharing<V> for AdditiveShare<V> {}
 
 impl<V: SharedValue + Debug> Debug for AdditiveShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -1,7 +1,7 @@
 use crate::{
     ff::{GaloisField, Serializable},
     secret_sharing::{
-        replicated::ReplicatedSecretSharing, Boolean as BooleanSecretSharing, SecretSharing,
+        replicated::ReplicatedSecretSharing, Bitwise as BitwiseSecretSharing, SecretSharing,
     },
 };
 use aes::cipher::generic_array::GenericArray;
@@ -21,7 +21,7 @@ impl<V: GaloisField> SecretSharing<V> for XorShare<V> {
     const ZERO: Self = XorShare::ZERO;
 }
 
-impl<V: GaloisField> BooleanSecretSharing<V> for XorShare<V> {}
+impl<V: GaloisField> BitwiseSecretSharing<V> for XorShare<V> {}
 
 impl<V: GaloisField + Debug> Debug for XorShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -8,7 +8,7 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 }
 
 /// Secret share of a secret that has additive and multiplicative properties.
-pub trait Arithmetic<V: SharedValue>: SecretSharing<V> + ArithmeticRefOps<V> {}
+pub trait Linear<V: SharedValue>: SecretSharing<V> + ArithmeticRefOps<V> {}
 
-/// Secret share of a secret with bit operations
-pub trait Boolean<V: GaloisField>: SecretSharing<V> + BooleanRefOps {}
+/// Secret share of a secret in bits. It has additive and multiplicative properties.
+pub trait Bitwise<V: GaloisField>: SecretSharing<V> + BooleanRefOps {}


### PR DESCRIPTION
`trait Arithmetic` -> `trait Linear`
`trait Boolean` -> `trait Bitwise`

This PR only renames all references. `Bitwise` should be bound to `Linear`, but it'll need `Mul` implementation, so I'll do that in the next diff.