### PR TITLE
make PrimeField and GaloisField subtypes of Field

### DIFF
--- a/src/cli/playbook/ipa.rs
+++ b/src/cli/playbook/ipa.rs
@@ -7,7 +7,7 @@ use crate::{
     net::MpcHelperClient,
     protocol::{attribution::input::MCAggregateCreditOutputRow, ipa::IPAInputRow, QueryId},
     secret_sharing::{
-        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        replicated::semi_honest::AdditiveShare as Replicated,
         IntoShares,
     },
     test_fixture::input::GenericReportTestInput,
@@ -28,8 +28,8 @@ pub async fn semi_honest<F, MK, BK>(
 ) -> [Vec<impl Send + Debug>; 3]
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
     IPAInputRow<F, MK, BK>: Serializable,
     Replicated<F>: Serializable,

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,9 +1,9 @@
-use crate::{ff::Serializable, secret_sharing::SharedValue};
-use generic_array::{ArrayLength, GenericArray};
+use crate::{secret_sharing::SharedValue};
+use generic_array::ArrayLength;
 use std::fmt::Debug;
 
 // Trait for primitive integer types used to represent the underlying type for field values
-pub trait Int: Sized + Copy + Debug + Into<u128> {
+pub trait Int: Sized + Copy + Debug /* + Into<u128> */ {
     const BITS: u32;
 }
 
@@ -19,32 +19,10 @@ pub trait Field: SharedValue + From<u128> + Into<Self::Integer> {
     type Integer: Int;
     type Size: ArrayLength<u8>;
 
-    const PRIME: Self::Integer;
     /// Multiplicative identity element
     const ONE: Self;
 
-    /// Blanket implementation to represent the instance of this trait as 16 byte integer.
-    /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`
-    fn as_u128(&self) -> u128 {
-        let int: Self::Integer = (*self).into();
-        int.into()
-    }
-}
-
-impl<F: Field> Serializable for F {
-    type Size = <F as Field>::Size;
-
-    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
-        let raw = &self.as_u128().to_le_bytes()[..buf.len()];
-        buf.copy_from_slice(raw);
-    }
-
-    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Self {
-        let mut buf_to = [0u8; 16];
-        buf_to[..buf.len()].copy_from_slice(buf);
-
-        Self::from(u128::from_le_bytes(buf_to))
-    }
+    fn as_u128(&self) -> u128;
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -8,7 +8,7 @@ mod prime_field;
 
 pub use field::{Field, FieldType, Int};
 pub use galois_field::{Gf40Bit, Gf8Bit};
-pub use prime_field::{Fp31, Fp32BitPrime};
+pub use prime_field::{PrimeField, Fp31, Fp32BitPrime};
 
 use crate::secret_sharing::SharedValue;
 use generic_array::{ArrayLength, GenericArray};
@@ -69,7 +69,7 @@ where
 /// Trait for data types storing arbitrary number of bits.
 // TODO: Implement `Message`
 pub trait GaloisField:
-    SharedValue + TryFrom<u128> + Into<u128> + Index<usize, Output = bool> + Index<u32, Output = bool>
+    Field + TryFrom<u128> + Into<u128> + Index<usize, Output = bool> + Index<u32, Output = bool>
 {
     const POLYNOMIAL: u128;
 

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -1,5 +1,28 @@
 use super::Field;
-use crate::secret_sharing::SharedValue;
+use crate::{secret_sharing::SharedValue, ff::Serializable};
+use generic_array::GenericArray;
+
+pub trait PrimeField: Field {
+    type PrimeInteger: Into<u128>;
+
+    const PRIME: Self::PrimeInteger;
+}
+
+impl<F: PrimeField> Serializable for F {
+    type Size = <F as Field>::Size;
+
+    fn serialize(self, buf: &mut GenericArray<u8, Self::Size>) {
+        let raw = &self.as_u128().to_le_bytes()[..buf.len()];
+        buf.copy_from_slice(raw);
+    }
+
+    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Self {
+        let mut buf_to = [0u8; 16];
+        buf_to[..buf.len()].copy_from_slice(buf);
+
+        Self::from(u128::from_le_bytes(buf_to))
+    }
+}
 
 macro_rules! field_impl {
     ( $field:ident, $int:ty, $prime:expr, $arraylen:ty ) => {
@@ -12,8 +35,17 @@ macro_rules! field_impl {
         impl Field for $field {
             type Integer = $int;
             type Size = $arraylen;
-            const PRIME: Self::Integer = $prime;
             const ONE: Self = $field(1);
+
+            fn as_u128(&self) -> u128 {
+                let int: Self::Integer = (*self).into();
+                int.into()
+            }
+        }
+
+        impl PrimeField for $field {
+            type PrimeInteger = Self::Integer;
+            const PRIME: Self::PrimeInteger = $prime;
         }
 
         impl SharedValue for $field {

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -12,7 +12,7 @@ mod registry;
 
 use crate::{
     ff::{Gf40Bit, Serializable},
-    secret_sharing::replicated::semi_honest::XorShare,
+    secret_sharing::replicated::semi_honest::AdditiveShare,
 };
 pub use info::Info;
 pub use registry::KeyRegistry;
@@ -27,7 +27,7 @@ pub type KeyIdentifier = u8;
 /// Right now we assume the match keys to be 40 bits long. If it is not the case, the decryption
 /// will fail. This assumption allows to keep the bitstrings on the stack, for dynamically sized
 /// match keys we would have to heap allocate.
-type XorReplicated = XorShare<Gf40Bit>;
+type XorReplicated = AdditiveShare<Gf40Bit>;
 
 /// Event epoch as described [`ipa-spec`]
 /// For the purposes of this module, epochs are used to authenticate match key encryption. As

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator, RandomBits},
         context::Context,
@@ -28,7 +28,7 @@ async fn apply_attribution_window<F, C, T>(
     attribution_window_seconds: u32,
 ) -> Result<impl Iterator<Item = MCApplyAttributionWindowOutputRow<F, T>> + '_, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -129,7 +129,7 @@ async fn zero_out_expired_trigger_values<F, C, T>(
     cap: u32,
 ) -> Result<Vec<T>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{
         basics::SecureMul,
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator, RandomBits},
@@ -28,7 +28,7 @@ pub async fn credit_capping<F, C, T>(
     cap: u32,
 ) -> Result<Vec<MCCreditCappingOutputRow<F, T>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -224,7 +224,7 @@ async fn is_credit_larger_than_cap<F, C, T>(
     cap: u32,
 ) -> Result<Vec<T>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {

--- a/src/protocol/attribution/input.rs
+++ b/src/protocol/attribution/input.rs
@@ -9,7 +9,7 @@ use crate::{
                 AdditiveShare as MaliciousReplicated, DowngradeMalicious,
                 ThisCodeIsAuthorizedToDowngradeFromMalicious, UnauthorizedDowngradeWrapper,
             },
-            semi_honest::{AdditiveShare as Replicated, AdditiveShare, XorShare},
+            semi_honest::{AdditiveShare as Replicated, AdditiveShare},
         },
         Linear as LinearSecretSharing,
     },
@@ -28,7 +28,7 @@ pub struct ApplyAttributionWindowInputRow<F: Field, BK: GaloisField> {
     pub timestamp: AdditiveShare<F>,
     pub is_trigger_report: AdditiveShare<F>,
     pub helper_bit: AdditiveShare<F>,
-    pub breakdown_key: XorShare<BK>,
+    pub breakdown_key: AdditiveShare<BK>,
     pub trigger_value: AdditiveShare<F>,
 }
 
@@ -70,7 +70,7 @@ pub type MCApplyAttributionWindowOutputRow<F, T> = MCAccumulateCreditInputRow<F,
 pub struct AccumulateCreditInputRow<F: Field, BK: GaloisField> {
     pub is_trigger_report: AdditiveShare<F>,
     pub helper_bit: AdditiveShare<F>,
-    pub breakdown_key: XorShare<BK>,
+    pub breakdown_key: AdditiveShare<BK>,
     pub trigger_value: AdditiveShare<F>,
 }
 
@@ -166,7 +166,7 @@ where
 
 #[derive(Debug)]
 pub struct AggregateCreditInputRow<F: Field, BK: GaloisField> {
-    pub breakdown_key: XorShare<BK>,
+    pub breakdown_key: AdditiveShare<BK>,
     pub credit: AdditiveShare<F>,
 }
 

--- a/src/protocol/attribution/malicious.rs
+++ b/src/protocol/attribution/malicious.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Serializable},
+    ff::{PrimeField, GaloisField, Serializable},
     protocol::{
         boolean::bitwise_equal::bitwise_equal,
         context::{Context, SemiHonestContext},
@@ -34,7 +34,7 @@ pub async fn secure_attribution<'a, F, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, SemiHonestAdditiveShare<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     BK: GaloisField,
     AdditiveShare<F>: Serializable,
     SemiHonestAdditiveShare<F>: Serializable,

--- a/src/protocol/attribution/semi_honest.rs
+++ b/src/protocol/attribution/semi_honest.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Serializable},
+    ff::{PrimeField, GaloisField, Serializable},
     protocol::{
         boolean::bitwise_equal::bitwise_equal,
         context::{Context, SemiHonestContext},
@@ -30,7 +30,7 @@ pub async fn secure_attribution<F, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, AdditiveShare<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     BK: GaloisField,
     AdditiveShare<F>: Serializable,
 {

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -77,7 +77,7 @@ pub async fn check_zero<F: Field>(
 mod tests {
     use crate::{
         error::Error,
-        ff::{Field, Fp31},
+        ff::{Fp31, PrimeField},
         protocol::{basics::check_zero, context::Context, RecordId},
         rand::thread_rng,
         secret_sharing::{IntoShares, SharedValue},

--- a/src/protocol/basics/share_known_value.rs
+++ b/src/protocol/basics/share_known_value.rs
@@ -1,11 +1,11 @@
 use crate::{
-    ff::{Field, GaloisField},
+    ff::Field,
     helpers::Role,
     protocol::context::{Context, MaliciousContext, SemiHonestContext},
     secret_sharing::{
         replicated::{
             malicious::AdditiveShare as MaliciousReplicated,
-            semi_honest::{AdditiveShare as Replicated, XorShare},
+            semi_honest::AdditiveShare as Replicated,
             ReplicatedSecretSharing,
         },
         SharedValue,
@@ -22,16 +22,6 @@ impl<'a, F: Field> ShareKnownValue<SemiHonestContext<'a>, F> for Replicated<F> {
             Role::H1 => Self::new(value, F::ZERO),
             Role::H2 => Self::new(F::ZERO, F::ZERO),
             Role::H3 => Self::new(F::ZERO, value),
-        }
-    }
-}
-
-impl<'a, V: GaloisField> ShareKnownValue<SemiHonestContext<'a>, V> for XorShare<V> {
-    fn share_known_value(ctx: &SemiHonestContext<'a>, value: V) -> Self {
-        match ctx.role() {
-            Role::H1 => Self::new(value, V::ZERO),
-            Role::H2 => Self::new(V::ZERO, V::ZERO),
-            Role::H3 => Self::new(V::ZERO, value),
         }
     }
 }

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{basics::SecureMul, context::Context, BasicProtocols, BitOpStep, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -128,7 +128,7 @@ pub async fn maybe_add_constant_mod2l<F, C, S>(
     maybe: &S,
 ) -> Result<Vec<S>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
 {
@@ -202,7 +202,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::add_constant::{add_constant, maybe_add_constant_mod2l},
             context::Context,
@@ -214,7 +214,7 @@ mod tests {
     use bitvec::macros::internal::funty::Fundamental;
     use rand::{distributions::Standard, prelude::Distribution};
 
-    async fn add<F: Field>(world: &TestWorld, a: F, b: u128) -> Vec<F>
+    async fn add<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> Vec<F>
     where
         Standard: Distribution<F>,
     {
@@ -242,7 +242,7 @@ mod tests {
         result
     }
 
-    async fn maybe_add<F: Field>(world: &TestWorld, a: F, b: u128, maybe: F) -> Vec<F>
+    async fn maybe_add<F: PrimeField>(world: &TestWorld, a: F, b: u128, maybe: F) -> Vec<F>
     where
         Standard: Distribution<F>,
     {

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -34,7 +34,7 @@ impl BitDecomposition {
         a_p: &S,
     ) -> Result<Vec<S>, Error>
     where
-        F: Field,
+        F: PrimeField,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
         C: Context + RandomBits<F, Share = S>,
     {
@@ -100,7 +100,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitDecomposition;
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -120,7 +120,7 @@ mod tests {
 
     async fn bit_decomposition<F>(world: &TestWorld, a: F) -> Vec<F>
     where
-        F: Field + Sized,
+        F: PrimeField + Sized,
         Standard: Distribution<F>,
     {
         let result = world

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -1,7 +1,7 @@
 use super::{any_ones, or::or};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         boolean::multiply_all_shares, context::Context, BasicProtocols, BitOpStep, RecordId,
     },
@@ -26,7 +26,7 @@ pub struct BitwiseLessThanPrime {}
 impl BitwiseLessThanPrime {
     pub async fn less_than_prime<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -41,7 +41,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -91,7 +91,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -148,7 +148,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -201,7 +201,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitwiseLessThanPrime;
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{context::Context, RecordId},
         secret_sharing::SharedValue,
         test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
@@ -283,7 +283,7 @@ mod tests {
 
     async fn bitwise_less_than_prime<F>(a: u32, num_bits: u32) -> F
     where
-        F: Field + Sized,
+        F: PrimeField + Sized,
         Standard: Distribution<F>,
     {
         let world = TestWorld::new().await;

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -1,7 +1,7 @@
 use super::or::or;
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         boolean::{random_bits_generator::RandomBitsGenerator, RandomBits},
         context::Context,
@@ -67,7 +67,7 @@ pub async fn greater_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -181,7 +181,7 @@ pub async fn bitwise_greater_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -213,7 +213,7 @@ pub async fn bitwise_less_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -243,7 +243,7 @@ async fn first_differing_bit<F, C, S>(
     b: u128,
 ) -> Result<Vec<S>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -322,7 +322,7 @@ mod tests {
         greater_than_constant,
     };
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{PrimeField, Fp31, Fp32BitPrime, Field},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -333,7 +333,7 @@ mod tests {
     use proptest::proptest;
     use rand::{distributions::Standard, prelude::Distribution, Rng};
 
-    async fn bitwise_lt<F: Field>(world: &TestWorld, a: F, b: u128) -> F
+    async fn bitwise_lt<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,
@@ -363,7 +363,7 @@ mod tests {
         result
     }
 
-    async fn bitwise_gt<F: Field>(world: &TestWorld, a: F, b: u128) -> F
+    async fn bitwise_gt<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,
@@ -403,7 +403,7 @@ mod tests {
         result
     }
 
-    async fn gt<F: Field>(world: &TestWorld, lhs: F, rhs: u128) -> F
+    async fn gt<F: PrimeField>(world: &TestWorld, lhs: F, rhs: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -1,7 +1,7 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         context::{Context, MaliciousContext},
         BitOpStep, RecordId,
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 
 #[async_trait]
-impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
+impl<F: PrimeField> RandomBits<F> for MaliciousContext<'_, F> {
     type Share = MaliciousReplicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf40Bit},
+    ff::{Field, GaloisField, Gf40Bit, PrimeField},
     protocol::{
         basics::SecureMul,
         context::Context,
@@ -9,10 +9,8 @@ use crate::{
         BitOpStep, RecordId,
     },
     secret_sharing::{
-        replicated::{
-            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
-            ReplicatedSecretSharing,
-        },
+        replicated::semi_honest::AdditiveShare as Replicated,
+        replicated::ReplicatedSecretSharing,
         Linear as LinearSecretSharing, SecretSharing, SharedValue,
     },
 };
@@ -34,7 +32,7 @@ fn random_bits_triples<F, C>(
     record_id: RecordId,
 ) -> Vec<BitConversionTriple<Replicated<F>>>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
 {
     // Calculate the number of bits we need to form a random number that
@@ -46,7 +44,7 @@ where
     let (b_bits_left, b_bits_right) = ctx.prss().generate_values(record_id);
 
     // Same here. For now, 256-bit is enough for our F_p
-    let xor_share = XorReplicated::new(
+    let xor_share = Replicated::new(
         Gf40Bit::truncate_from(b_bits_left),
         Gf40Bit::truncate_from(b_bits_right),
     );

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -1,7 +1,7 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         context::{Context, SemiHonestContext},
         RecordId,
@@ -11,7 +11,7 @@ use crate::{
 use async_trait::async_trait;
 
 #[async_trait]
-impl<F: Field> RandomBits<F> for SemiHonestContext<'_> {
+impl<F: PrimeField> RandomBits<F> for SemiHonestContext<'_> {
     type Share = Replicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -2,7 +2,7 @@ use futures::future::try_join_all;
 
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{basics::SecureMul, BasicProtocols},
     secret_sharing::{Linear as LinearSecretSharing, SecretSharing},
 };
@@ -31,7 +31,7 @@ pub use xor::{xor, xor_sparse};
 /// local replicated share.
 pub fn local_secret_shared_bits<F, C, S>(ctx: &C, x: u128) -> Vec<S>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: SecretSharing<F> + ShareKnownValue<C, F>,
 {

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     helpers::messaging::TotalRecords,
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
@@ -30,7 +30,7 @@ pub struct RandomBitsGenerator<F, S, C> {
 
 impl<F, S, C> RandomBitsGenerator<F, S, C>
 where
-    F: Field,
+    F: PrimeField,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,7 +1,7 @@
 use super::{bitwise_less_than_prime::BitwiseLessThanPrime, RandomBits};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::{
         replicated::malicious::{
@@ -76,7 +76,7 @@ pub async fn solved_bits<F, S, C>(
     record_id: RecordId,
 ) -> Result<Option<RandomBitsShare<F, S>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {
@@ -115,7 +115,7 @@ where
 
 async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Result<bool, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -150,7 +150,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{boolean::solved_bits::solved_bits, context::Context, RecordId},
         secret_sharing::SharedValue,
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
@@ -161,7 +161,7 @@ mod tests {
     /// Execute `solved_bits` `COUNT` times for `F`. The count should be chosen
     /// such that the probability of that many consecutive failures in `F` is
     /// negligible (less than 2^-100).
-    async fn random_bits<F: Field, const COUNT: usize>()
+    async fn random_bits<F: PrimeField, const COUNT: usize>()
     where
         Standard: Distribution<F>,
     {

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::{
-            semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+            semi_honest::AdditiveShare as Replicated,
             ReplicatedSecretSharing,
         },
         Linear as LinearSecretSharing,
@@ -68,7 +68,7 @@ pub struct BitConversionTriple<S>(pub(crate) [S; 3]);
 pub fn convert_bit_local<F: Field, B: GaloisField>(
     helper_role: Role,
     bit_index: u32,
-    input: &XorReplicated<B>,
+    input: &Replicated<B>,
 ) -> BitConversionTriple<Replicated<F>> {
     let left = u128::from(input.left()[bit_index]);
     let right = u128::from(input.right()[bit_index]);
@@ -94,7 +94,7 @@ pub fn convert_bit_local<F: Field, B: GaloisField>(
 #[must_use]
 pub fn convert_all_bits_local<F: Field, B: GaloisField>(
     helper_role: Role,
-    input: impl Iterator<Item = XorReplicated<B>>,
+    input: impl Iterator<Item = Replicated<B>>,
 ) -> Vec<Vec<BitConversionTriple<Replicated<F>>>> {
     input
         .map(move |record| {

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -58,7 +58,7 @@ mod tests {
             MatchKey,
         },
         rand::{thread_rng, Rng},
-        secret_sharing::{replicated::semi_honest::XorShare, SharedValue},
+        secret_sharing::{SharedValue, replicated::semi_honest::AdditiveShare},
         test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
     };
 
@@ -96,7 +96,7 @@ mod tests {
                 (match_keys, sidecar),
                 |ctx,
                  (mk_shares, secret): (
-                    Vec<XorShare<MatchKey>>,
+                    Vec<AdditiveShare<MatchKey>>,
                     Vec<AccumulateCreditInputRow<Fp32BitPrime, BreakdownKey>>,
                 )| async move {
                     let local_lists =

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ff::{Field, FieldType, Fp31, GaloisField, Serializable},
+    ff::{Field, FieldType, Fp31, GaloisField, Serializable, PrimeField},
     helpers::{
         messaging::{Gateway, TotalRecords},
         negotiate_prss,
@@ -101,7 +101,7 @@ where
     results
 }
 
-async fn execute_ipa<F: Field, MK: GaloisField, BK: GaloisField>(
+async fn execute_ipa<F: PrimeField, MK: GaloisField, BK: GaloisField>(
     ctx: SemiHonestContext<'_>,
     query_config: IpaQueryConfig,
     mut input: AlignedByteArrStream,

--- a/src/secret_sharing/into_shares.rs
+++ b/src/secret_sharing/into_shares.rs
@@ -1,8 +1,7 @@
 use super::{replicated::ReplicatedSecretSharing, SharedValue};
 use crate::{
-    ff::GaloisField,
     rand::{thread_rng, Rng},
-    secret_sharing::replicated::semi_honest::{AdditiveShare, XorShare},
+    secret_sharing::replicated::semi_honest::AdditiveShare,
 };
 use rand::distributions::{Distribution, Standard};
 
@@ -27,23 +26,6 @@ where
             AdditiveShare::new(x1, x2),
             AdditiveShare::new(x2, x3),
             AdditiveShare::new(x3, x1),
-        ]
-    }
-}
-
-impl<V> IntoShares<XorShare<V>> for V
-where
-    V: GaloisField,
-    Standard: Distribution<V>,
-{
-    fn share_with<R: Rng>(self, rng: &mut R) -> [XorShare<V>; 3] {
-        let s0 = rng.gen::<V>();
-        let s1 = rng.gen::<V>();
-        let s2 = self - (s0 + s1);
-        [
-            XorShare::new(s0, s1),
-            XorShare::new(s1, s2),
-            XorShare::new(s2, s0),
         ]
     }
 }

--- a/src/secret_sharing/replicated/semi_honest/mod.rs
+++ b/src/secret_sharing/replicated/semi_honest/mod.rs
@@ -1,5 +1,5 @@
 mod additive_share;
-mod xor_share;
+//mod xor_share;
 
 pub use additive_share::AdditiveShare;
-pub use xor_share::XorShare;
+//pub use xor_share::XorShare;

--- a/src/test_fixture/input/mod.rs
+++ b/src/test_fixture/input/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     ff::{Field, GaloisField},
-    secret_sharing::replicated::semi_honest::{AdditiveShare, XorShare},
+    secret_sharing::replicated::semi_honest::AdditiveShare,
 };
 
 pub mod sharing;
@@ -8,11 +8,11 @@ pub mod sharing;
 // Struct that holds all possible fields of the input to IPA. Used for tests only.
 #[derive(Debug)]
 pub struct GenericReportShare<F: Field, MK: GaloisField, BK: GaloisField> {
-    pub match_key: Option<XorShare<MK>>,
+    pub match_key: Option<AdditiveShare<MK>>,
     pub attribution_constraint_id: Option<AdditiveShare<F>>,
     pub timestamp: Option<AdditiveShare<F>>,
     pub is_trigger_report: Option<AdditiveShare<F>>,
-    pub breakdown_key: XorShare<BK>,
+    pub breakdown_key: AdditiveShare<BK>,
     pub trigger_value: AdditiveShare<F>,
     pub helper_bit: Option<AdditiveShare<F>>,
     pub aggregation_bit: Option<AdditiveShare<F>>,

--- a/src/test_fixture/input/sharing.rs
+++ b/src/test_fixture/input/sharing.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     rand::Rng,
     secret_sharing::{
-        replicated::semi_honest::{AdditiveShare as Replicated, XorShare as XorReplicated},
+        replicated::semi_honest::AdditiveShare as Replicated,
         IntoShares,
     },
     test_fixture::Reconstruct,
@@ -20,8 +20,8 @@ use rand::{distributions::Standard, prelude::Distribution};
 impl<F, MK, BK> IntoShares<GenericReportShare<F, MK, BK>> for GenericReportTestInput<F, MK, BK>
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [GenericReportShare<F, MK, BK>; 3] {
@@ -83,8 +83,8 @@ impl<F, MK, BK> IntoShares<ApplyAttributionWindowInputRow<F, BK>>
     for GenericReportTestInput<F, MK, BK>
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [ApplyAttributionWindowInputRow<F, BK>; 3] {
@@ -119,8 +119,8 @@ where
 impl<F, MK, BK> IntoShares<AccumulateCreditInputRow<F, BK>> for GenericReportTestInput<F, MK, BK>
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [AccumulateCreditInputRow<F, BK>; 3] {
@@ -152,8 +152,8 @@ where
 impl<F, MK, BK> IntoShares<AggregateCreditInputRow<F, BK>> for GenericReportTestInput<F, MK, BK>
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [AggregateCreditInputRow<F, BK>; 3] {
@@ -179,8 +179,8 @@ where
 impl<F, MK, BK> IntoShares<IPAInputRow<F, MK, BK>> for GenericReportTestInput<F, MK, BK>
 where
     F: Field + IntoShares<Replicated<F>>,
-    MK: GaloisField + IntoShares<XorReplicated<MK>>,
-    BK: GaloisField + IntoShares<XorReplicated<BK>>,
+    MK: GaloisField + IntoShares<Replicated<MK>>,
+    BK: GaloisField + IntoShares<Replicated<BK>>,
     Standard: Distribution<F>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [IPAInputRow<F, MK, BK>; 3] {


### PR DESCRIPTION
@benjaminsavage @taikiy Prompted by the concerns in the description of #543, I did this as something of a lark to see how bad it would be and I think the conclusion is not trivial, but not too bad. There are some things that would need to be cleaned up, especially around the conversions between field types and u128.

I think with this in place, we could generalize malicious `AdditiveShare` to something like:

```
pub struct AdditiveShare<V: SharedValue, U: SharedValue + FieldExtension<V> = V> {
    x: SemiHonestAdditiveShare<V>,
    rx: SemiHonestAdditiveShare<U>,
}
```

Note the second type parameter has a default, so that `AdditiveShare<V>` as it is used today would still work and mean exactly the same thing.

That's not 100% of what we want, since the representation of `V` (`Gf1Bit`?) presumably ends up using at least one byte on the wire, so we only get 75% of the theoretical savings we're going for. For maximum savings we'd have to do something like:
```
struct PackedAdditiveShare<V: SharedValue, U: SharedValue + FieldExtension<V>> {
    x: SemiHonestAdditiveShare<V>,
    rx: Vec<SemiHonestAdditiveShare<U>>,
}
```
Here `V` would be `Gf40Bit`, `U` is `Gf32Bit` or whatever the security parameter dictates, and the `Vec` has length 40.

On the other hand, if the idea that I had tossed out the other day works, then I don't think we'd need to change malicious `AdditiveShare` at all. In fact, most of the necessary infrastructure may already be here? With these changes, reshare of malicious `AdditiveShare<Gf40Bit>` is supported.