### PR TITLE
PrimeField trait

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,9 +1,9 @@
-use crate::{ff::Serializable, secret_sharing::SharedValue};
-use generic_array::{ArrayLength, GenericArray};
+use crate::secret_sharing::SharedValue;
+use generic_array::ArrayLength;
 use std::fmt::Debug;
 
 // Trait for primitive integer types used to represent the underlying type for field values
-pub trait Int: Sized + Copy + Debug + Into<u128> {
+pub trait Int: Sized + Copy + Debug {
     const BITS: u32;
 }
 
@@ -19,32 +19,12 @@ pub trait Field: SharedValue + From<u128> + Into<Self::Integer> {
     type Integer: Int;
     type Size: ArrayLength<u8>;
 
-    const PRIME: Self::Integer;
     /// Multiplicative identity element
     const ONE: Self;
 
     /// Blanket implementation to represent the instance of this trait as 16 byte integer.
     /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`
-    fn as_u128(&self) -> u128 {
-        let int: Self::Integer = (*self).into();
-        int.into()
-    }
-}
-
-impl<F: Field> Serializable for F {
-    type Size = <F as Field>::Size;
-
-    fn serialize(&self, buf: &mut GenericArray<u8, Self::Size>) {
-        let raw = &self.as_u128().to_le_bytes()[..buf.len()];
-        buf.copy_from_slice(raw);
-    }
-
-    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Self {
-        let mut buf_to = [0u8; 16];
-        buf_to[..buf.len()].copy_from_slice(buf);
-
-        Self::from(u128::from_le_bytes(buf_to))
-    }
+    fn as_u128(&self) -> u128;
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -8,7 +8,7 @@ mod prime_field;
 
 pub use field::{Field, FieldType, Int};
 pub use galois_field::{Gf40Bit, Gf8Bit};
-pub use prime_field::{Fp31, Fp32BitPrime};
+pub use prime_field::{Fp31, Fp32BitPrime, PrimeField};
 
 use crate::secret_sharing::SharedValue;
 use generic_array::{ArrayLength, GenericArray};

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator, RandomBits},
         context::Context,
@@ -28,7 +28,7 @@ async fn apply_attribution_window<F, C, T>(
     attribution_window_seconds: u32,
 ) -> Result<impl Iterator<Item = MCApplyAttributionWindowOutputRow<F, T>> + '_, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -129,7 +129,7 @@ async fn zero_out_expired_trigger_values<F, C, T>(
     cap: u32,
 ) -> Result<Vec<T>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{
         basics::SecureMul,
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator, RandomBits},
@@ -28,7 +28,7 @@ pub async fn credit_capping<F, C, T>(
     cap: u32,
 ) -> Result<Vec<MCCreditCappingOutputRow<F, T>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -224,7 +224,7 @@ async fn is_credit_larger_than_cap<F, C, T>(
     cap: u32,
 ) -> Result<Vec<T>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = T>,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {

--- a/src/protocol/attribution/malicious.rs
+++ b/src/protocol/attribution/malicious.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Serializable},
+    ff::{GaloisField, PrimeField, Serializable},
     protocol::{
         boolean::bitwise_equal::bitwise_equal,
         context::{Context, SemiHonestContext},
@@ -34,7 +34,7 @@ pub async fn secure_attribution<'a, F, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, SemiHonestAdditiveShare<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     BK: GaloisField,
     AdditiveShare<F>: Serializable,
     SemiHonestAdditiveShare<F>: Serializable,

--- a/src/protocol/attribution/semi_honest.rs
+++ b/src/protocol/attribution/semi_honest.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Serializable},
+    ff::{GaloisField, PrimeField, Serializable},
     protocol::{
         boolean::bitwise_equal::bitwise_equal,
         context::{Context, SemiHonestContext},
@@ -30,7 +30,7 @@ pub async fn secure_attribution<F, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, AdditiveShare<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     BK: GaloisField,
     AdditiveShare<F>: Serializable,
 {

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -77,7 +77,7 @@ pub async fn check_zero<F: Field>(
 mod tests {
     use crate::{
         error::Error,
-        ff::{Field, Fp31},
+        ff::{Fp31, PrimeField},
         protocol::{basics::check_zero, context::Context, RecordId},
         rand::thread_rng,
         secret_sharing::{IntoShares, SharedValue},

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{basics::SecureMul, context::Context, BasicProtocols, BitOpStep, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -128,7 +128,7 @@ pub async fn maybe_add_constant_mod2l<F, C, S>(
     maybe: &S,
 ) -> Result<Vec<S>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
 {
@@ -202,7 +202,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::add_constant::{add_constant, maybe_add_constant_mod2l},
             context::Context,
@@ -214,7 +214,7 @@ mod tests {
     use bitvec::macros::internal::funty::Fundamental;
     use rand::{distributions::Standard, prelude::Distribution};
 
-    async fn add<F: Field>(world: &TestWorld, a: F, b: u128) -> Vec<F>
+    async fn add<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> Vec<F>
     where
         Standard: Distribution<F>,
     {
@@ -242,7 +242,7 @@ mod tests {
         result
     }
 
-    async fn maybe_add<F: Field>(world: &TestWorld, a: F, b: u128, maybe: F) -> Vec<F>
+    async fn maybe_add<F: PrimeField>(world: &TestWorld, a: F, b: u128, maybe: F) -> Vec<F>
     where
         Standard: Distribution<F>,
     {

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -34,7 +34,7 @@ impl BitDecomposition {
         a_p: &S,
     ) -> Result<Vec<S>, Error>
     where
-        F: Field,
+        F: PrimeField,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
         C: Context + RandomBits<F, Share = S>,
     {
@@ -100,7 +100,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitDecomposition;
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -120,7 +120,7 @@ mod tests {
 
     async fn bit_decomposition<F>(world: &TestWorld, a: F) -> Vec<F>
     where
-        F: Field + Sized,
+        F: PrimeField + Sized,
         Standard: Distribution<F>,
     {
         let result = world

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -1,7 +1,7 @@
 use super::{any_ones, or::or};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         boolean::multiply_all_shares, context::Context, BasicProtocols, BitOpStep, RecordId,
     },
@@ -26,7 +26,7 @@ pub struct BitwiseLessThanPrime {}
 impl BitwiseLessThanPrime {
     pub async fn less_than_prime<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -41,7 +41,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -91,7 +91,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -148,7 +148,7 @@ impl BitwiseLessThanPrime {
         x: &[S],
     ) -> Result<S, Error>
     where
-        F: Field,
+        F: PrimeField,
         C: Context,
         S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     {
@@ -201,7 +201,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitwiseLessThanPrime;
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{context::Context, RecordId},
         secret_sharing::SharedValue,
         test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
@@ -283,7 +283,7 @@ mod tests {
 
     async fn bitwise_less_than_prime<F>(a: u32, num_bits: u32) -> F
     where
-        F: Field + Sized,
+        F: PrimeField + Sized,
         Standard: Distribution<F>,
     {
         let world = TestWorld::default();

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -1,7 +1,7 @@
 use super::or::or;
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         boolean::{random_bits_generator::RandomBitsGenerator, RandomBits},
         context::Context,
@@ -67,7 +67,7 @@ pub async fn greater_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context + RandomBits<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -181,7 +181,7 @@ pub async fn bitwise_greater_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -213,7 +213,7 @@ pub async fn bitwise_less_than_constant<F, C, S>(
     c: u128,
 ) -> Result<S, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -243,7 +243,7 @@ async fn first_differing_bit<F, C, S>(
     b: u128,
 ) -> Result<Vec<S>, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -322,7 +322,7 @@ mod tests {
         greater_than_constant,
     };
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -333,7 +333,7 @@ mod tests {
     use proptest::proptest;
     use rand::{distributions::Standard, prelude::Distribution, Rng};
 
-    async fn bitwise_lt<F: Field>(world: &TestWorld, a: F, b: u128) -> F
+    async fn bitwise_lt<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,
@@ -363,7 +363,7 @@ mod tests {
         result
     }
 
-    async fn bitwise_gt<F: Field>(world: &TestWorld, a: F, b: u128) -> F
+    async fn bitwise_gt<F: PrimeField>(world: &TestWorld, a: F, b: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,
@@ -403,7 +403,7 @@ mod tests {
         result
     }
 
-    async fn gt<F: Field>(world: &TestWorld, lhs: F, rhs: u128) -> F
+    async fn gt<F: PrimeField>(world: &TestWorld, lhs: F, rhs: u128) -> F
     where
         (F, F): Sized,
         Standard: Distribution<F>,

--- a/src/protocol/boolean/generate_random_bits/malicious.rs
+++ b/src/protocol/boolean/generate_random_bits/malicious.rs
@@ -1,7 +1,7 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         context::{Context, MaliciousContext},
         BitOpStep, RecordId,
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use futures::future::try_join_all;
 
 #[async_trait]
-impl<F: Field> RandomBits<F> for MaliciousContext<'_, F> {
+impl<F: PrimeField> RandomBits<F> for MaliciousContext<'_, F> {
     type Share = MaliciousReplicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf40Bit},
+    ff::{Field, GaloisField, Gf40Bit, PrimeField},
     protocol::{
         basics::SecureMul,
         context::Context,
@@ -34,7 +34,7 @@ fn random_bits_triples<F, C>(
     record_id: RecordId,
 ) -> Vec<BitConversionTriple<Replicated<F>>>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
 {
     // Calculate the number of bits we need to form a random number that

--- a/src/protocol/boolean/generate_random_bits/semi_honest.rs
+++ b/src/protocol/boolean/generate_random_bits/semi_honest.rs
@@ -1,7 +1,7 @@
 use super::{convert_triples_to_shares, random_bits_triples, RandomBits, Step};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     protocol::{
         context::{Context, SemiHonestContext},
         RecordId,
@@ -11,7 +11,7 @@ use crate::{
 use async_trait::async_trait;
 
 #[async_trait]
-impl<F: Field> RandomBits<F> for SemiHonestContext<'_> {
+impl<F: PrimeField> RandomBits<F> for SemiHonestContext<'_> {
     type Share = Replicated<F>;
 
     /// Generates a sequence of `l` random bit sharings in the target field `F`.

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -2,7 +2,7 @@ use futures::future::try_join_all;
 
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{basics::SecureMul, BasicProtocols},
     secret_sharing::{Linear as LinearSecretSharing, SecretSharing},
 };
@@ -31,7 +31,7 @@ pub use xor::{xor, xor_sparse};
 /// local replicated share.
 pub fn local_secret_shared_bits<F, C, S>(ctx: &C, x: u128) -> Vec<S>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: SecretSharing<F> + ShareKnownValue<C, F>,
 {

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::Field,
+    ff::PrimeField,
     helpers::TotalRecords,
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
@@ -30,7 +30,7 @@ pub struct RandomBitsGenerator<F, S, C> {
 
 impl<F, S, C> RandomBitsGenerator<F, S, C>
 where
-    F: Field,
+    F: PrimeField,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,7 +1,7 @@
 use super::{bitwise_less_than_prime::BitwiseLessThanPrime, RandomBits};
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, PrimeField},
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::{
         replicated::malicious::{
@@ -76,7 +76,7 @@ pub async fn solved_bits<F, S, C>(
     record_id: RecordId,
 ) -> Result<Option<RandomBitsShare<F, S>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
     C: Context + RandomBits<F, Share = S>,
 {
@@ -115,7 +115,7 @@ where
 
 async fn is_less_than_p<F, C, S>(ctx: C, record_id: RecordId, b_b: &[S]) -> Result<bool, Error>
 where
-    F: Field,
+    F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
@@ -150,7 +150,7 @@ impl AsRef<str> for Step {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::{Field, Fp31, Fp32BitPrime},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{boolean::solved_bits::solved_bits, context::Context, RecordId},
         secret_sharing::SharedValue,
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
@@ -161,7 +161,7 @@ mod tests {
     /// Execute `solved_bits` `COUNT` times for `F`. The count should be chosen
     /// such that the probability of that many consecutive failures in `F` is
     /// negligible (less than 2^-100).
-    async fn random_bits<F: Field, const COUNT: usize>()
+    async fn random_bits<F: PrimeField, const COUNT: usize>()
     where
         Standard: Distribution<F>,
     {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Serializable},
+    ff::{Field, GaloisField, PrimeField, Serializable},
     helpers::Role,
     protocol::{
         attribution::{input::MCAggregateCreditOutputRow, malicious, semi_honest},
@@ -272,7 +272,7 @@ pub async fn ipa<F, MK, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     MK: GaloisField,
     BK: GaloisField,
     Replicated<F>: Serializable,
@@ -361,7 +361,7 @@ pub async fn ipa_malicious<'a, F, MK, BK>(
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
-    F: Field,
+    F: PrimeField,
     MK: GaloisField,
     BK: GaloisField,
     MaliciousReplicated<F>: Serializable + BasicProtocols<MaliciousContext<'a, F>, F>,

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ff::{Field, FieldType, Fp31, GaloisField, Serializable},
+    ff::{Field, FieldType, Fp31, GaloisField, PrimeField, Serializable},
     helpers::{
         negotiate_prss,
         query::{IpaQueryConfig, QueryConfig, QueryType},
@@ -100,7 +100,7 @@ where
     results
 }
 
-async fn execute_ipa<F: Field, MK: GaloisField, BK: GaloisField>(
+async fn execute_ipa<F: PrimeField, MK: GaloisField, BK: GaloisField>(
     ctx: SemiHonestContext<'_>,
     query_config: IpaQueryConfig,
     mut input: AlignedByteArrStream,

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ff::{Field, GaloisField},
+    ff::{Field, GaloisField, PrimeField},
     protocol::boolean::RandomBitsShare,
     secret_sharing::{
         replicated::{
@@ -13,7 +13,7 @@ use crate::{
 use std::{borrow::Borrow, iter::zip};
 
 /// Deconstructs a field value into N values, one for each bit.
-pub fn into_bits<F: Field>(v: F) -> Vec<F> {
+pub fn into_bits<F: PrimeField>(v: F) -> Vec<F> {
     (0..(u128::BITS - F::PRIME.into().leading_zeros()))
         .map(|i| F::from((v.as_u128() >> i) & 1))
         .collect::<Vec<_>>()


### PR DESCRIPTION
This extracts `PrimeField` piece from @andyleiserson's PR https://github.com/private-attribution/ipa/pull/545.

Current hierarchy of secret shared value types are:

```SharedValue -> Field```

where `Field` was really prime fields defined in prime_field.rs. Now that we have Galois Fields, this diff creates a new trait `PrimeField` that all current prime fields (i.e., Fp32BitPrime) implement. This allows us to Galois Field to be the sub-type of `Field`.

```
SharedValue -> Field -> PrimeField
                     \-> GaloisField
```