### PR TITLE
MaliciousContext::narrow must narrow the inner context as well

### DIFF
--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -130,7 +130,13 @@ impl<'a, F: Field> Context for MaliciousContext<'a, F> {
 
     fn narrow<S: Substep + ?Sized>(&self, step: &S) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
+            // todo: it is inefficient, we only need to change the context, but end up
+            // cloning everything from inner
+            inner: ContextInner::new(
+                self.inner.upgrade_ctx.narrow(step),
+                self.inner.accumulator.clone(),
+                self.inner.r_share.clone(),
+            ),
             step: self.step.narrow(step),
             total_records: self.total_records,
         }


### PR DESCRIPTION
Found this issue while working on #549 - narrowing malicious context did not change the step for upgrade.

root -> substep1 -> substep2 -> upgrade
  -> another_substep1 -> another_substep2 -> upgrade

Before this change, both upgrades will use the same step `upgrade_inputs/...` and the second will fail because of record_id re-use.

I stared at this for some time and initially I did not like the idea of narrowing the internal context - it can lead to step explosion. However, `RandomBitsGenerator` after #549 needs to do exactly that - call malicious upgrade with the same record id twice (one through regular channel and sometimes again via the fallback). So I don't really have a better option now, but open for suggestions if there is a better way