### PR TITLE
Implement TryFrom<u128> for Field subtypes

### DIFF
--- a/proptest-regressions/protocol/ipa/mod.txt
+++ b/proptest-regressions/protocol/ipa/mod.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 911c81f506632492b8681501b77f1e1c441e4269b1c37cf6fbeed919e254efd0 # shrinks to match_key = 0, trigger_bit = 0, breakdown_key = 0, trigger_value = 256, seed = 0

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     Serde(#[from] serde_json::Error),
     #[error("Infrastructure error: {0}")]
     InfraError(#[from] crate::helpers::Error),
+    #[error("Value truncation error: {0}")]
+    FieldValueTruncation(String),
 }
 
 impl Error {

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,4 +1,7 @@
-use crate::secret_sharing::{Block, SharedValue};
+use crate::{
+    error,
+    secret_sharing::{Block, SharedValue},
+};
 use std::fmt::Debug;
 use typenum::{U1, U4};
 
@@ -12,9 +15,14 @@ impl Block for u32 {
     const VALID_BIT_LENGTH: u32 = u32::BITS;
 }
 
-pub trait Field: SharedValue + From<u128> + Into<Self::Storage> {
+pub trait Field: SharedValue + TryFrom<u128, Error = error::Error> + Into<Self::Storage> {
     /// Multiplicative identity element
     const ONE: Self;
+
+    /// Truncates the higher-order bits larger than `Self::BITS`, and converts
+    /// into this data type. This conversion is lossy. Callers are encouraged
+    /// to use `try_from` if the input is not known in advance.
+    fn truncate_from<T: Into<u128>>(v: T) -> Self;
 
     /// Blanket implementation to represent the instance of this trait as 16 byte integer.
     /// Uses the fact that such conversion already exists via `Self` -> `Self::Integer` -> `Into<u128>`

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -295,9 +295,12 @@ mod fixture {
     #[async_trait]
     impl TestSender for OrderingMpscSender<Fp32BitPrime> {
         async fn send_test(&self, i: usize) {
-            self.send(i, Fp32BitPrime::from(u128::try_from(i).unwrap()))
-                .await
-                .unwrap();
+            self.send(
+                i,
+                Fp32BitPrime::try_from(u128::try_from(i).unwrap()).unwrap(),
+            )
+            .await
+            .unwrap();
         }
     }
 
@@ -356,7 +359,7 @@ mod fixture {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod unit {
     use crate::{
-        ff::{Fp31, Serializable},
+        ff::{Field, Fp31, Serializable},
         helpers::buffers::ordering_mpsc::{
             fixture::{TestSender, FP32BIT_SIZE},
             ordering_mpsc,
@@ -369,7 +372,7 @@ mod unit {
     /// Test that a single value can be sent and received successfully.
     #[tokio::test]
     async fn in_and_out() {
-        let input = Fp31::from(7_u128);
+        let input = Fp31::truncate_from(7_u128);
         let (tx, mut rx) = ordering_mpsc("test", NonZeroUsize::new(3).unwrap());
         let tx_a = tx.clone();
         let send = async move {

--- a/src/helpers/buffers/ordering_sender.rs
+++ b/src/helpers/buffers/ordering_sender.rs
@@ -382,7 +382,7 @@ impl<'s> Deref for OrderedStream<'s> {
 mod test {
     use super::OrderingSender;
     use crate::{
-        ff::{Fp31, Fp32BitPrime, Serializable},
+        ff::{Field, Fp31, Fp32BitPrime, Serializable},
         rand::thread_rng,
     };
     use futures::{
@@ -425,7 +425,7 @@ mod test {
     #[test]
     fn send_recv() {
         run(|| async {
-            let input = Fp31::from(7_u128);
+            let input = Fp31::truncate_from(7_u128);
             let sender = sender();
             sender.send(0, input).await;
             assert!(sender.as_stream().next().now_or_never().is_none());
@@ -436,7 +436,7 @@ mod test {
     #[test]
     fn send_close_recv() {
         run(|| async {
-            let input = Fp31::from(7_u128);
+            let input = Fp31::truncate_from(7_u128);
             let sender = sender();
             let send = sender.send(0, input);
             let close = sender.close(1);
@@ -452,7 +452,7 @@ mod test {
     #[test]
     fn close_send_recv() {
         run(|| async {
-            let input = Fp31::from(7_u128);
+            let input = Fp31::truncate_from(7_u128);
             let sender = sender();
             let close = sender.close(1);
             let send = sender.send(0, input);
@@ -469,8 +469,9 @@ mod test {
     fn double_send() {
         run(|| async {
             let sender = sender();
-            let send_many = join_all((0..3_u8).map(|i| sender.send(usize::from(i), Fp31::from(i))));
-            let send_again = sender.send(2, Fp31::from(2_u128));
+            let send_many =
+                join_all((0..3_u8).map(|i| sender.send(usize::from(i), Fp31::truncate_from(i))));
+            let send_again = sender.send(2, Fp31::truncate_from(2_u128));
             join(send_many, send_again).await;
         });
     }
@@ -480,7 +481,8 @@ mod test {
     fn close_over_send() {
         run(|| async {
             let sender = sender();
-            let send_many = join_all((0..3_u8).map(|i| sender.send(usize::from(i), Fp31::from(i))));
+            let send_many =
+                join_all((0..3_u8).map(|i| sender.send(usize::from(i), Fp31::truncate_from(i))));
             let close_it = sender.close(2);
             join(send_many, close_it).await;
         });
@@ -494,7 +496,7 @@ mod test {
             // We can't use `join()` here because the close task won't bother to
             // wake the send task if the send is polled first.
             sender.close(0).await;
-            sender.send(1, Fp31::from(1_u128)).await;
+            sender.send(1, Fp31::truncate_from(1_u128)).await;
         });
     }
 
@@ -502,8 +504,8 @@ mod test {
     #[test]
     fn mixed_size() {
         run(|| async {
-            let small = Fp31::from(7_u128);
-            let large = Fp32BitPrime::from(5_108_u128);
+            let small = Fp31::truncate_from(7_u128);
+            let large = Fp32BitPrime::truncate_from(5_108_u128);
             let sender = sender();
             let send_small = sender.send(0, small);
             let send_large = sender.send(1, large);

--- a/src/helpers/buffers/unordered_receiver.rs
+++ b/src/helpers/buffers/unordered_receiver.rs
@@ -301,7 +301,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        ff::{Fp31, Fp32BitPrime, Serializable},
+        ff::{Field, Fp31, Fp32BitPrime, Serializable},
         helpers::buffers::unordered_receiver::UnorderedReceiver,
     };
     use futures::{
@@ -388,7 +388,7 @@ mod test {
                 let recv = recv.clone();
                 async move {
                     let f: Fp32BitPrime = recv.recv(1_usize).await.unwrap();
-                    assert_eq!(f, Fp32BitPrime::try_from(0x0100_020c).unwrap());
+                    assert_eq!(f, Fp32BitPrime::truncate_from(0x0100_020c_u128));
                 }
             }),
         )

--- a/src/helpers/buffers/unordered_receiver.rs
+++ b/src/helpers/buffers/unordered_receiver.rs
@@ -363,7 +363,7 @@ mod test {
                         let recv = recv.clone();
                         async move {
                             let f: Fp31 = recv.recv(i).await.unwrap();
-                            assert_eq!(f, Fp31::from(u128::from(v)));
+                            assert_eq!(f, Fp31::try_from(u128::from(v)).unwrap());
                         }
                     })
                 }))
@@ -381,14 +381,14 @@ mod test {
                 let recv = recv.clone();
                 async move {
                     let f: Fp31 = recv.recv(0_usize).await.unwrap();
-                    assert_eq!(f, Fp31::from(18_u128));
+                    assert_eq!(f, Fp31::try_from(18).unwrap());
                 }
             }),
             spawn({
                 let recv = recv.clone();
                 async move {
                     let f: Fp32BitPrime = recv.recv(1_usize).await.unwrap();
-                    assert_eq!(f, Fp32BitPrime::from(0x0100_020c_u128));
+                    assert_eq!(f, Fp32BitPrime::try_from(0x0100_020c).unwrap());
                 }
             }),
         )
@@ -480,7 +480,7 @@ mod test {
         assert!(recv.recv::<Fp31, _>(1_usize).now_or_never().is_none());
         for (i, &v) in DATA.iter().enumerate() {
             let f: Fp31 = recv.recv(i).now_or_never().unwrap().unwrap();
-            assert_eq!(f, Fp31::from(u128::from(v)));
+            assert_eq!(f, Fp31::try_from(u128::from(v)).unwrap());
         }
     }
 
@@ -498,7 +498,7 @@ mod test {
                         let recv = recv.clone();
                         async move {
                             let f: Fp31 = recv.recv(i).await.unwrap();
-                            assert_eq!(f, Fp31::from(u128::from(v)));
+                            assert_eq!(f, Fp31::try_from(u128::from(v)).unwrap());
                         }
                     })
                 }))

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -113,7 +113,7 @@ impl GatewayConfig {
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::Fp31,
+        ff::{Field, Fp31},
         helpers::Role,
         protocol::{context::Context, RecordId},
         test_fixture::{TestWorld, TestWorldConfig},
@@ -137,11 +137,11 @@ mod tests {
         tokio::spawn(async move {
             let channel = sender_ctx.send_channel(Role::H2);
             channel
-                .send(RecordId::from(1), Fp31::from(1_u128))
+                .send(RecordId::from(1), Fp31::truncate_from(1_u128))
                 .await
                 .unwrap();
             channel
-                .send(RecordId::from(0), Fp31::from(0_u128))
+                .send(RecordId::from(0), Fp31::truncate_from(0_u128))
                 .await
                 .unwrap();
         });
@@ -154,6 +154,9 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!((Fp31::from(1u128), Fp31::from(0u128)), result);
+        assert_eq!(
+            (Fp31::truncate_from(1u128), Fp31::truncate_from(0u128)),
+            result
+        );
     }
 }

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -267,7 +267,7 @@ where
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let num_rows = input.len();
-    let cap = T::share_known_value(&ctx, F::from(cap.into()));
+    let cap = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());
     let mut final_credits = original_credits.to_vec();
 
     // This method implements the logic below:

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -77,7 +77,7 @@ pub async fn check_zero<F: Field>(
 mod tests {
     use crate::{
         error::Error,
-        ff::{Fp31, PrimeField},
+        ff::{Field, Fp31, PrimeField},
         protocol::{basics::check_zero, context::Context, RecordId},
         rand::thread_rng,
         secret_sharing::{IntoShares, SharedValue},
@@ -93,7 +93,7 @@ mod tests {
         let mut counter = 0_u32;
 
         for v in 0..u32::from(Fp31::PRIME) {
-            let v = Fp31::from(v);
+            let v = Fp31::truncate_from(v);
             let mut num_false_positives = 0;
             for _ in 0..10 {
                 let v_shares = v.share_with(&mut rng);

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -162,8 +162,8 @@ mod test {
         (F, F): Sized,
         Standard: Distribution<F>,
     {
-        let a = F::from(a);
-        let b = F::from(b);
+        let a = F::try_from(a).unwrap();
+        let b = F::try_from(b).unwrap();
 
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -138,8 +138,8 @@ mod test {
         F: Field,
         (F, F): Sized,
     {
-        let a: Vec<_> = a.iter().map(|x| Fp31::from(*x)).collect();
-        let b: Vec<_> = b.iter().map(|x| Fp31::from(*x)).collect();
+        let a: Vec<_> = a.iter().map(|x| Fp31::try_from(*x).unwrap()).collect();
+        let b: Vec<_> = b.iter().map(|x| Fp31::try_from(*x).unwrap()).collect();
 
         let result = world
             .semi_honest((a, b), |ctx, (a, b)| async move {

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -100,7 +100,7 @@ impl AsRef<str> for Step {
 mod tests {
     use super::BitDecomposition;
     use crate::{
-        ff::{Fp31, Fp32BitPrime, PrimeField},
+        ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
             boolean::random_bits_generator::RandomBitsGenerator, context::Context, RecordId,
         },
@@ -147,7 +147,7 @@ mod tests {
     #[tokio::test]
     pub async fn fp31() {
         let world = TestWorld::default();
-        let c = Fp31::from;
+        let c = Fp31::truncate_from;
         assert_eq!(0, bits_to_value(&bit_decomposition(&world, c(0_u32)).await));
         assert_eq!(1, bits_to_value(&bit_decomposition(&world, c(1)).await));
         assert_eq!(15, bits_to_value(&bit_decomposition(&world, c(15)).await));
@@ -161,7 +161,7 @@ mod tests {
     #[tokio::test]
     pub async fn fp32_bit_prime() {
         let world = TestWorld::default();
-        let c = Fp32BitPrime::from;
+        let c = Fp32BitPrime::truncate_from;
         let u16_max: u32 = u16::MAX.into();
         assert_eq!(0, bits_to_value(&bit_decomposition(&world, c(0_u32)).await));
         assert_eq!(1, bits_to_value(&bit_decomposition(&world, c(1)).await));

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -445,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn gt_fp31() {
-        let c = Fp31::from;
+        let c = Fp31::truncate_from;
         let zero = Fp31::ZERO;
         let one = Fp31::ONE;
         let world = TestWorld::default();
@@ -464,7 +464,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn bw_gt_fp31() {
-        let c = Fp31::from;
+        let c = Fp31::truncate_from;
         let zero = Fp31::ZERO;
         let one = Fp31::ONE;
         let world = TestWorld::default();
@@ -484,7 +484,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn bw_lt_fp31() {
-        let c = Fp31::from;
+        let c = Fp31::truncate_from;
         let zero = Fp31::ZERO;
         let one = Fp31::ONE;
         let world = TestWorld::default();
@@ -504,7 +504,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn bw_gt_fp_32bit_prime() {
-        let c = Fp32BitPrime::from;
+        let c = Fp32BitPrime::truncate_from;
         let zero = Fp32BitPrime::ZERO;
         let one = Fp32BitPrime::ONE;
         let u16_max: u32 = u16::MAX.into();
@@ -547,7 +547,7 @@ mod tests {
         fn gt_fp31_proptest(a in 0..Fp31::PRIME, c in 0..Fp31::PRIME) {
             type F = Fp31;
             let r = thread_rng().gen::<F>();
-            let b = F::from(a) + r;
+            let b = F::truncate_from(a) + r;
             assert_eq!(a > c, compute_r_bounds(b.as_u128(), c.into(), F::PRIME.into()).evaluate(r.as_u128()));
         }
 
@@ -555,7 +555,7 @@ mod tests {
         fn gt_fp_32bit_prime_proptest(a in 0..Fp32BitPrime::PRIME, c in 0..Fp32BitPrime::PRIME) {
             type F = Fp32BitPrime;
             let r = thread_rng().gen::<F>();
-            let b = F::from(a) + r;
+            let b = F::truncate_from(a) + r;
             assert_eq!(a > c, compute_r_bounds(b.as_u128(), c.into(), F::PRIME.into()).evaluate(r.as_u128()));
         }
     }
@@ -570,7 +570,7 @@ mod tests {
             let a = rand.gen::<Fp32BitPrime>();
             let b = rand.gen::<Fp32BitPrime>();
             assert_eq!(
-                Fp32BitPrime::from(a.as_u128() > b.as_u128()),
+                Fp32BitPrime::truncate_from(a.as_u128() > b.as_u128()),
                 bitwise_gt(&world, a, b.as_u128()).await
             );
         }
@@ -584,8 +584,8 @@ mod tests {
         for a in 0..Fp31::PRIME {
             for b in 0..Fp31::PRIME {
                 assert_eq!(
-                    Fp31::from(a > b),
-                    bitwise_gt(&world, Fp31::from(a), b.into()).await
+                    Fp31::truncate_from(a > b),
+                    bitwise_gt(&world, Fp31::truncate_from(a), b.into()).await
                 );
             }
         }

--- a/src/protocol/boolean/generate_random_bits/mod.rs
+++ b/src/protocol/boolean/generate_random_bits/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf40Bit, PrimeField},
+    ff::{Field, Gf40Bit, PrimeField},
     protocol::{
         basics::SecureMul,
         context::Context,

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -101,10 +101,9 @@ where
     //
     // if success, then compute `[b_p]` by `Σ 2^i * [b_i]_B`
     #[allow(clippy::cast_possible_truncation)]
-    let b_p: S = b_b
-        .iter()
-        .enumerate()
-        .fold(S::ZERO, |acc, (i, x)| acc + &(x.clone() * F::from(1 << i)));
+    let b_p: S = b_b.iter().enumerate().fold(S::ZERO, |acc, (i, x)| {
+        acc + &(x.clone() * F::try_from(1 << i).unwrap())
+    });
 
     Ok(Some(RandomBitsShare {
         b_b,

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -38,7 +38,7 @@ where
     S: LinearSecretSharing<F> + SecureMul<C>,
 {
     let ab = a.multiply_sparse(b, ctx, record_id, zeros_at).await?;
-    Ok(-(ab * F::from(2)) + a + b)
+    Ok(-(ab * F::truncate_from(2_u128)) + a + b)
 }
 
 #[cfg(all(test, not(feature = "shuttle")))]
@@ -112,8 +112,8 @@ mod tests {
     async fn run_sparse(world: &TestWorld, a: bool, b: bool, zeros: MultiplyZeroPositions) -> bool {
         type F = Fp31;
 
-        let a = SparseField::<F>::new(F::from(u128::from(a)), zeros.0);
-        let b = SparseField::<F>::new(F::from(u128::from(b)), zeros.1);
+        let a = SparseField::<F>::new(F::truncate_from(u128::from(a)), zeros.0);
+        let b = SparseField::<F>::new(F::truncate_from(u128::from(b)), zeros.1);
         let result = world
             .semi_honest((a, b), |ctx, (a_share, b_share)| async move {
                 xor_sparse(

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -151,7 +151,7 @@ mod tests {
     #[tokio::test]
     async fn semi_honest_metrics() {
         let world = TestWorld::new_with(TestWorldConfig::default().enable_metrics());
-        let input = (0..10u128).map(Fp31::from).collect::<Vec<_>>();
+        let input = (0..10u128).map(Fp31::truncate_from).collect::<Vec<_>>();
         let input_len = input.len();
 
         let result = world
@@ -205,7 +205,7 @@ mod tests {
     #[tokio::test]
     async fn malicious_metrics() {
         let world = TestWorld::new_with(TestWorldConfig::default().enable_metrics());
-        let input = vec![Fp31::from(0u128), Fp31::from(1u128)];
+        let input = vec![Fp31::truncate_from(0u128), Fp31::truncate_from(1u128)];
         let input_len = input.len();
 
         let _result = world

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -24,7 +24,7 @@ pub trait SharedRandomness {
     #[must_use]
     fn generate_fields<F: Field, I: Into<u128>>(&self, index: I) -> (F, F) {
         let (l, r) = self.generate_values(index);
-        (F::from(l), F::from(r))
+        (F::truncate_from(l), F::truncate_from(r))
     }
 
     /// Generate two sequences of random Fp2 bits.

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -266,7 +266,7 @@ impl EndpointSetup {
 pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{
-        ff::Fp31,
+        ff::{Field, Fp31},
         protocol::{prss::SharedRandomness, Step},
         rand::{thread_rng, Rng},
         test_fixture::make_participants,
@@ -416,7 +416,7 @@ pub mod test {
         let z2: Fp31 = p2.indexed(&step).zero(IDX);
         let z3: Fp31 = p3.indexed(&step).zero(IDX);
 
-        assert_eq!(Fp31::from(0_u8), z1 + z2 + z3);
+        assert_eq!(Fp31::truncate_from(0_u8), z1 + z2 + z3);
     }
 
     #[test]
@@ -437,7 +437,7 @@ pub mod test {
 
         // There isn't enough entropy in this field (~5 bits) to be sure that the test will pass.
         // So run a few rounds (~21 -> ~100 bits) looking for a mismatch.
-        let mut v2 = Fp31::from(0_u8);
+        let mut v2 = Fp31::truncate_from(0_u8);
         for i in IDX2..(IDX2 + 21) {
             let r1: Fp31 = s1.random(i);
             let r2 = s2.random(i);

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -269,6 +269,7 @@ pub mod test {
         ff::{Field, Fp31},
         protocol::{prss::SharedRandomness, Step},
         rand::{thread_rng, Rng},
+        secret_sharing::SharedValue,
         test_fixture::make_participants,
     };
     use rand::prelude::SliceRandom;
@@ -416,7 +417,7 @@ pub mod test {
         let z2: Fp31 = p2.indexed(&step).zero(IDX);
         let z3: Fp31 = p3.indexed(&step).zero(IDX);
 
-        assert_eq!(Fp31::truncate_from(0_u8), z1 + z2 + z3);
+        assert_eq!(<Fp31 as SharedValue>::ZERO, z1 + z2 + z3);
     }
 
     #[test]

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -77,7 +77,7 @@ pub async fn bit_permutation<
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::Fp31,
+        ff::{Field, Fp31},
         protocol::sort::bit_permutation::bit_permutation,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
@@ -91,7 +91,7 @@ mod tests {
     pub async fn semi_honest() {
         let world = TestWorld::default();
 
-        let input: Vec<_> = INPUT.iter().map(|x| Fp31::from(*x)).collect();
+        let input: Vec<_> = INPUT.iter().map(|x| Fp31::truncate_from(*x)).collect();
         let result = world
             .semi_honest(input, |ctx, m_shares| async move {
                 bit_permutation(ctx, &m_shares).await.unwrap()
@@ -105,7 +105,7 @@ mod tests {
     pub async fn malicious() {
         let world = TestWorld::default();
 
-        let input: Vec<_> = INPUT.iter().map(|x| Fp31::from(*x)).collect();
+        let input: Vec<_> = INPUT.iter().map(|x| Fp31::truncate_from(*x)).collect();
         let result = world
             .malicious(input, |ctx, m_shares| async move {
                 bit_permutation(ctx, &m_shares).await.unwrap()

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -51,7 +51,7 @@ pub async fn compose<F: Field, S: SecretSharing<F> + Reshare<C, RecordId>, C: Co
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use crate::{
-        ff::Fp31,
+        ff::{Field, Fp31},
         protocol::{
             context::Context,
             sort::{
@@ -83,8 +83,8 @@ mod tests {
         let result = world
             .semi_honest(
                 (
-                    sigma.into_iter().map(u128::from).map(Fp31::from),
-                    rho.into_iter().map(Fp31::from),
+                    sigma.into_iter().map(u128::from).map(Fp31::truncate_from),
+                    rho.into_iter().map(Fp31::truncate_from),
                 ),
                 |ctx, (m_sigma_shares, m_rho_shares)| async move {
                     let sigma_and_randoms = shuffle_and_reveal_permutation(

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -122,7 +122,7 @@ mod tests {
 
         let input: Vec<Vec<_>> = INPUT
             .into_iter()
-            .map(|v| v.iter().map(|x| Fp31::from(*x)).collect())
+            .map(|v| v.iter().map(|x| Fp31::truncate_from(*x)).collect())
             .collect();
         let result = world
             .semi_honest(input, |ctx, m_shares| async move {
@@ -139,7 +139,7 @@ mod tests {
 
         let input: Vec<Vec<_>> = INPUT
             .into_iter()
-            .map(|v| v.iter().map(|x| Fp31::from(*x)).collect())
+            .map(|v| v.iter().map(|x| Fp31::truncate_from(*x)).collect())
             .collect();
 
         let num_records = INPUT.len();

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -28,7 +28,7 @@ mod tests {
         use rand::seq::SliceRandom;
 
         use crate::{
-            ff::Fp31,
+            ff::{Field, Fp31},
             protocol::{
                 context::Context,
                 sort::{
@@ -62,7 +62,10 @@ mod tests {
             // Applying permutation on the input in clear to get the expected result
             apply_inv(&permutation, &mut expected_result);
 
-            let permutation_iter = permutation.into_iter().map(u128::from).map(Fp31::from);
+            let permutation_iter = permutation
+                .into_iter()
+                .map(u128::from)
+                .map(Fp31::truncate_from);
 
             let result = world
                 .semi_honest(

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -200,7 +200,7 @@ mod tests {
 
     mod semi_honest {
         use crate::{
-            ff::Fp31,
+            ff::{Field, Fp31},
             protocol::{
                 context::Context,
                 sort::shuffle::{
@@ -221,7 +221,11 @@ mod tests {
 
             let result = world
                 .semi_honest(
-                    input.clone().into_iter().map(u128::from).map(Fp31::from),
+                    input
+                        .clone()
+                        .into_iter()
+                        .map(u128::from)
+                        .map(Fp31::truncate_from),
                     |ctx, m_shares| async move {
                         let perms =
                             get_two_of_three_random_permutations(BATCHSIZE.into(), ctx.prss_rng());
@@ -259,7 +263,7 @@ mod tests {
 
             let result = world
                 .semi_honest(
-                    input.clone().into_iter().map(Fp31::from),
+                    input.clone().into_iter().map(Fp31::truncate_from),
                     |ctx, m_shares| async move {
                         let perms = get_two_of_three_random_permutations(
                             BATCHSIZE.try_into().unwrap(),
@@ -290,7 +294,7 @@ mod tests {
 
     mod malicious {
         use crate::{
-            ff::Fp31,
+            ff::{Field, Fp31},
             protocol::{
                 context::Context,
                 sort::shuffle::{
@@ -313,7 +317,7 @@ mod tests {
 
             let result = world
                 .malicious(
-                    input_u128.clone().into_iter().map(Fp31::from),
+                    input_u128.clone().into_iter().map(Fp31::truncate_from),
                     |ctx, m_shares| async move {
                         let perms =
                             get_two_of_three_random_permutations(BATCHSIZE.into(), ctx.prss_rng());
@@ -351,7 +355,7 @@ mod tests {
 
             let result = world
                 .malicious(
-                    input.clone().into_iter().map(Fp31::from),
+                    input.clone().into_iter().map(Fp31::truncate_from),
                     |ctx, m_shares| async move {
                         let perms = get_two_of_three_random_permutations(
                             BATCHSIZE.try_into().unwrap(),

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -190,8 +190,8 @@ mod tests {
         let contexts = world
             .contexts()
             .map(|ctx| ctx.set_total_records(TotalRecords::Indeterminate));
-        let a = [Fp31::from(4u128), Fp31::from(5u128)];
-        let b = [Fp31::from(3u128), Fp31::from(6u128)];
+        let a = [Fp31::truncate_from(4u128), Fp31::truncate_from(5u128)];
+        let b = [Fp31::truncate_from(3u128), Fp31::truncate_from(6u128)];
 
         let helper_shares = (a, b).share().map(|(a, b)| {
             const SIZE: usize = <Replicated<Fp31> as Serializable>::Size::USIZE;
@@ -222,7 +222,10 @@ mod tests {
 
         let results = results.reconstruct();
 
-        assert_eq!(vec![Fp31::from(12u128), Fp31::from(30u128)], results);
+        assert_eq!(
+            vec![Fp31::truncate_from(12u128), Fp31::truncate_from(30u128)],
+            results
+        );
     }
 
     #[tokio::test]
@@ -289,7 +292,10 @@ mod tests {
 
     #[test]
     fn serialize_result() {
-        let [input, ..] = (0u128..=3).map(Fp31::from).collect::<Vec<_>>().share();
+        let [input, ..] = (0u128..=3)
+            .map(Fp31::truncate_from)
+            .collect::<Vec<_>>()
+            .share();
         let expected = input.clone();
         let bytes = Box::new(input).into_bytes();
         assert_eq!(

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -328,15 +328,15 @@ mod tests {
             let malicious_a_plus_b = malicious_a + &malicious_b;
             let malicious_c_minus_d = malicious_c - &malicious_d;
             let malicious_1_minus_e = malicious_one - &malicious_e;
-            let malicious_2f = malicious_f * Fp31::from(2_u128);
+            let malicious_2f = malicious_f * Fp31::truncate_from(2_u128);
 
             let mut temp = -malicious_a_plus_b - &malicious_c_minus_d - &malicious_1_minus_e;
-            temp = temp * Fp31::from(6_u128);
+            temp = temp * Fp31::truncate_from(6_u128);
             results.push(temp + &malicious_2f);
         }
 
-        let correct =
-            (-(a + b) - (c - d) - (Fp31::ONE - e)) * Fp31::from(6_u128) + Fp31::from(2_u128) * f;
+        let correct = (-(a + b) - (c - d) - (Fp31::ONE - e)) * Fp31::truncate_from(6_u128)
+            + Fp31::truncate_from(2_u128) * f;
 
         assert_eq!(
             [

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -165,7 +165,10 @@ where
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
     use super::AdditiveShare;
-    use crate::{ff::Fp31, secret_sharing::replicated::ReplicatedSecretSharing};
+    use crate::{
+        ff::{Field, Fp31},
+        secret_sharing::replicated::ReplicatedSecretSharing,
+    };
 
     fn secret_share(
         a: u8,
@@ -177,9 +180,9 @@ mod tests {
         AdditiveShare<Fp31>,
     ) {
         (
-            AdditiveShare::new(Fp31::from(a), Fp31::from(b)),
-            AdditiveShare::new(Fp31::from(b), Fp31::from(c)),
-            AdditiveShare::new(Fp31::from(c), Fp31::from(a)),
+            AdditiveShare::new(Fp31::truncate_from(a), Fp31::truncate_from(b)),
+            AdditiveShare::new(Fp31::truncate_from(b), Fp31::truncate_from(c)),
+            AdditiveShare::new(Fp31::truncate_from(c), Fp31::truncate_from(a)),
         )
     }
 
@@ -199,8 +202,8 @@ mod tests {
         a3: &AdditiveShare<Fp31>,
         expected_value: u128,
     ) {
-        assert_eq!(a1.0 + a2.0 + a3.0, Fp31::from(expected_value));
-        assert_eq!(a1.1 + a2.1 + a3.1, Fp31::from(expected_value));
+        assert_eq!(a1.0 + a2.0 + a3.0, Fp31::truncate_from(expected_value));
+        assert_eq!(a1.1 + a2.1 + a3.1, Fp31::truncate_from(expected_value));
     }
 
     fn addition_test_case(a: (u8, u8, u8), b: (u8, u8, u8), expected_output: u128) {
@@ -286,9 +289,9 @@ mod tests {
     fn mult_by_constant_test_case(a: (u8, u8, u8), c: u8, expected_output: u128) {
         let (a1, a2, a3) = secret_share(a.0, a.1, a.2);
 
-        let res1 = a1 * Fp31::from(c);
-        let res2 = a2 * Fp31::from(c);
-        let res3 = a3 * Fp31::from(c);
+        let res1 = a1 * Fp31::truncate_from(c);
+        let res2 = a2 * Fp31::truncate_from(c);
+        let res3 = a3 * Fp31::truncate_from(c);
 
         assert_valid_secret_sharing(&res1, &res2, &res3);
         assert_secret_shared_value(&res1, &res2, &res3, expected_output);

--- a/src/secret_sharing/replicated/semi_honest/xor_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/xor_share.rs
@@ -156,7 +156,7 @@ where
 mod tests {
     use super::XorShare;
     use crate::{
-        ff::{GaloisField, Gf40Bit, Serializable},
+        ff::{Field, Gf40Bit, Serializable},
         secret_sharing::replicated::ReplicatedSecretSharing,
     };
 

--- a/src/test_fixture/input/mod.rs
+++ b/src/test_fixture/input/mod.rs
@@ -34,12 +34,12 @@ pub struct GenericReportTestInput<F: Field, MK: GaloisField, BK: GaloisField> {
 macro_rules! ipa_test_input {
     ( { match_key: $mk:expr, is_trigger_report: $itr:expr, breakdown_key: $bk:expr, trigger_value: $tv:expr $(,)? }; ($field:tt, $mk_bit_array:tt, $bk_bit_array:tt) ) => {
         GenericReportTestInput {
-            match_key: Some(<$mk_bit_array as $crate::ff::GaloisField>::truncate_from(u128::try_from($mk).unwrap())),
+            match_key: Some(<$mk_bit_array as $crate::ff::Field>::truncate_from(u128::try_from($mk).unwrap())),
             attribution_constraint_id: None,
             timestamp: None,
-            is_trigger_report: Some($field::from(u128::try_from($itr).unwrap())),
-            breakdown_key: <$bk_bit_array as $crate::ff::GaloisField>::truncate_from(u128::try_from($bk).unwrap()),
-            trigger_value: $field::from(u128::try_from($tv).unwrap()),
+            is_trigger_report: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($itr).unwrap())),
+            breakdown_key: <$bk_bit_array as $crate::ff::Field>::truncate_from(u128::try_from($bk).unwrap()),
+            trigger_value: <$field as $crate::ff::Field>::truncate_from(u128::try_from($tv).unwrap()),
             helper_bit: None,
             aggregation_bit: None,
         }
@@ -58,11 +58,11 @@ macro_rules! attribution_window_test_input {
         GenericReportTestInput {
             match_key: None,
             attribution_constraint_id: None,
-            timestamp: Some($field::from(u128::try_from($ts).unwrap())),
-            is_trigger_report: Some($field::from(u128::try_from($itr).unwrap())),
-            breakdown_key: <$bk_bit_array as $crate::ff::GaloisField>::truncate_from(u128::try_from($bk).unwrap()),
-            trigger_value: $field::from(u128::try_from($cdt).unwrap()),
-            helper_bit: Some($field::from(u128::try_from($hb).unwrap())),
+            timestamp: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($ts).unwrap())),
+            is_trigger_report: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($itr).unwrap())),
+            breakdown_key: <$bk_bit_array as $crate::ff::Field>::truncate_from(u128::try_from($bk).unwrap()),
+            trigger_value: <$field as $crate::ff::Field>::truncate_from(u128::try_from($cdt).unwrap()),
+            helper_bit: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($hb).unwrap())),
             aggregation_bit: None,
         }
     };
@@ -81,10 +81,10 @@ macro_rules! accumulation_test_input {
             match_key: None,
             attribution_constraint_id: None,
             timestamp: None,
-            is_trigger_report: Some($field::from(u128::try_from($itr).unwrap())),
-            breakdown_key: <$bk_bit_array as $crate::ff::GaloisField>::truncate_from(u128::try_from($bk).unwrap()),
-            trigger_value: $field::from(u128::try_from($cdt).unwrap()),
-            helper_bit: Some($field::from(u128::try_from($hb).unwrap())),
+            is_trigger_report: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($itr).unwrap())),
+            breakdown_key: <$bk_bit_array as $crate::ff::Field>::truncate_from(u128::try_from($bk).unwrap()),
+            trigger_value: <$field as $crate::ff::Field>::truncate_from(u128::try_from($cdt).unwrap()),
+            helper_bit: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($hb).unwrap())),
             aggregation_bit: None,
         }
     };
@@ -104,9 +104,9 @@ macro_rules! aggregation_test_input {
             attribution_constraint_id: None,
             timestamp: None,
             is_trigger_report: None,
-            breakdown_key: <$bk_bit_array as $crate::ff::GaloisField>::truncate_from(u128::try_from($bk).unwrap()),
-            trigger_value: $field::from(u128::try_from($cdt).unwrap()),
-            helper_bit: Some($field::from(u128::try_from($hb).unwrap())),
+            breakdown_key: <$bk_bit_array as $crate::ff::Field>::truncate_from(u128::try_from($bk).unwrap()),
+            trigger_value: <$field as $crate::ff::Field>::truncate_from(u128::try_from($cdt).unwrap()),
+            helper_bit: Some(<$field as $crate::ff::Field>::truncate_from(u128::try_from($hb).unwrap())),
             aggregation_bit: None
         }
     };

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -63,7 +63,10 @@ pub fn make_participants() -> [PrssEndpoint; 3] {
 
 pub type ReplicatedShares<T> = [Vec<Replicated<T>>; 3];
 
-// Generate vector shares from vector of inputs for three participant
+/// Generate vector shares from vector of inputs for three participant
+///
+/// # Panics
+/// If the input cannot be converted into the given field `F` without truncation.
 #[must_use]
 pub fn generate_shares<F: Field>(input: &[u128]) -> ReplicatedShares<F>
 where
@@ -77,7 +80,7 @@ where
     let mut shares2 = Vec::with_capacity(len);
 
     for i in input {
-        let [s0, s1, s2] = F::from(*i).share_with(&mut rand);
+        let [s0, s1, s2] = F::try_from(*i).unwrap().share_with(&mut rand);
         shares0.push(s0);
         shares1.push(s1);
         shares2.push(s2);
@@ -140,6 +143,9 @@ pub fn bits_to_value<F: Field>(x: &[F]) -> u128 {
 }
 
 /// Take a slice of bits in `{0,1} ⊆ F_p`, and reconstruct the integer in `F_p`
+///
+/// # Panics
+/// If the input cannot be converted into the given field `F` without truncation.
 pub fn bits_to_field<F: Field>(x: &[F]) -> F {
-    F::from(bits_to_value(x))
+    F::try_from(bits_to_value(x)).unwrap()
 }

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -15,7 +15,7 @@ use std::{borrow::Borrow, iter::zip};
 /// Deconstructs a field value into N values, one for each bit.
 pub fn into_bits<F: PrimeField>(v: F) -> Vec<F> {
     (0..(u128::BITS - F::PRIME.into().leading_zeros()))
-        .map(|i| F::from((v.as_u128() >> i) & 1))
+        .map(|i| F::truncate_from((v.as_u128() >> i) & 1))
         .collect::<Vec<_>>()
 }
 
@@ -25,7 +25,7 @@ pub fn into_bits<F: PrimeField>(v: F) -> Vec<F> {
 #[must_use]
 pub fn get_bits<F: Field>(x: u32, num_bits: u32) -> Vec<F> {
     (0..num_bits.try_into().unwrap())
-        .map(|i| F::from(((x >> i) & 1).into()))
+        .map(|i| F::try_from(((x >> i) & 1).into()).unwrap())
         .collect::<Vec<_>>()
 }
 
@@ -137,7 +137,7 @@ where
             zip(self[1].b_b.iter(), self[2].b_b.iter()),
         )
         .enumerate()
-        .map(|(i, (b0, (b1, b2)))| [b0, b1, b2].reconstruct() * F::from(1 << i))
+        .map(|(i, (b0, (b1, b2)))| [b0, b1, b2].reconstruct() * F::try_from(1 << i).unwrap())
         .fold(F::ZERO, |a, b| a + b);
         let value = [&self[0].b_p, &self[1].b_p, &self[2].b_p].reconstruct();
         assert_eq!(bits, value);

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -25,7 +25,7 @@ pub fn into_bits<F: PrimeField>(v: F) -> Vec<F> {
 #[must_use]
 pub fn get_bits<F: Field>(x: u32, num_bits: u32) -> Vec<F> {
     (0..num_bits.try_into().unwrap())
-        .map(|i| F::try_from(((x >> i) & 1).into()).unwrap())
+        .map(|i| F::truncate_from((x >> i) & 1))
         .collect::<Vec<_>>()
 }
 

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "shuttle", test))]
 
 use crate::{
-    ff::Fp32BitPrime,
+    ff::{Field, Fp32BitPrime},
     helpers::{Direction, GatewayConfig},
     protocol::{context::Context, RecordId},
     secret_sharing::replicated::{
@@ -16,7 +16,9 @@ fn send_receive_sequential() {
     shuttle::check_random(
         || {
             shuttle::future::block_on(async {
-                let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
+                let input = (0u32..11)
+                    .map(Fp32BitPrime::truncate_from)
+                    .collect::<Vec<_>>();
                 let config = TestWorldConfig {
                     gateway_config: GatewayConfig::symmetric_buffers(input.len()),
                     ..Default::default()
@@ -70,7 +72,9 @@ fn send_receive_parallel() {
     shuttle::check_random(
         || {
             shuttle::future::block_on(async {
-                let input = (0u32..11).map(Fp32BitPrime::from).collect::<Vec<_>>();
+                let input = (0u32..11)
+                    .map(Fp32BitPrime::truncate_from)
+                    .collect::<Vec<_>>();
                 let config = TestWorldConfig {
                     gateway_config: GatewayConfig::symmetric_buffers(input.len()),
                     ..Default::default()


### PR DESCRIPTION
I removed TryFrom temporarily in #547 to separate changes. This PR brings back the fallible conversion for the `GaloisField`. As a part of the change, I moved `TryFrom<u128>` bound up to `Field`, so `PrimeField` also needs to implement `TryFrom`. I think it's a good practice to use `try_from()` as a caution if the input is unknown. If the code is guaranteed or we explicitly allow truncating the input, then we can use `truncate_from()`.