### PR TITLE
Remove VALID_BIT_LENGTH from Block trait

### DIFF
--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -7,12 +7,10 @@ use typenum::{U1, U4};
 
 impl Block for u8 {
     type Size = U1;
-    const VALID_BIT_LENGTH: u32 = u8::BITS;
 }
 
 impl Block for u32 {
     type Size = U4;
-    const VALID_BIT_LENGTH: u32 = u32::BITS;
 }
 
 pub trait Field: SharedValue + TryFrom<u128, Error = error::Error> + Into<Self::Storage> {

--- a/src/ff/galois_field.rs
+++ b/src/ff/galois_field.rs
@@ -25,17 +25,14 @@ type U8_5 = BitArr!(for 40, in u8, Lsb0);
 
 impl Block for U8_1 {
     type Size = U1;
-    const VALID_BIT_LENGTH: u32 = 8;
 }
 
 impl Block for U8_4 {
     type Size = U4;
-    const VALID_BIT_LENGTH: u32 = 32;
 }
 
 impl Block for U8_5 {
     type Size = U5;
-    const VALID_BIT_LENGTH: u32 = 40;
 }
 
 /// The implementation below cannot be constrained without breaking Rust's
@@ -46,7 +43,7 @@ fn assert_copy<C: Copy>(c: C) -> C {
 }
 
 macro_rules! bit_array_impl {
-    ( $modname:ident, $name:ident, $store:ty, $one:expr, $polynomial:expr ) => {
+    ( $modname:ident, $name:ident, $store:ty, $bits:expr, $one:expr, $polynomial:expr ) => {
         #[allow(clippy::suspicious_arithmetic_impl)]
         #[allow(clippy::suspicious_op_assign_impl)]
         mod $modname {
@@ -62,7 +59,7 @@ macro_rules! bit_array_impl {
 
             impl SharedValue for $name {
                 type Storage = $store;
-                const BITS: u32 = <$store as Block>::VALID_BIT_LENGTH;
+                const BITS: u32 = $bits;
                 const ZERO: Self = Self(<$store>::ZERO);
             }
 
@@ -459,6 +456,7 @@ bit_array_impl!(
     bit_array_40,
     Gf40Bit,
     U8_5,
+    40,
     bitarr!(const u8, Lsb0; 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
     // x^40 + x^5 + x^3 + x^2 + 1
     0b1_0000_0000_0000_0000_0000_0000_0000_0000_0010_1101_u128
@@ -468,6 +466,7 @@ bit_array_impl!(
     bit_array_32,
     Gf32Bit,
     U8_4,
+    32,
     bitarr!(const u8, Lsb0; 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
     // x^32 + x^7 + x^3 + x^2 + 1
     0b1_0000_0000_0000_0000_0000_0000_1000_1101_u128
@@ -477,6 +476,7 @@ bit_array_impl!(
     bit_array_8,
     Gf8Bit,
     U8_1,
+    8,
     bitarr!(const u8, Lsb0; 1, 0, 0, 0, 0, 0, 0, 0),
     // x^8 + x^4 + x^3 + x + 1
     0b1_0001_1011_u128

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -28,7 +28,7 @@ impl<F: PrimeField> Serializable for F {
 }
 
 macro_rules! field_impl {
-    ( $field:ident, $store:ty, $prime:expr ) => {
+    ( $field:ident, $store:ty, $bits:expr, $prime:expr ) => {
         use super::*;
         use crate::ff::FieldType;
 
@@ -37,7 +37,7 @@ macro_rules! field_impl {
 
         impl SharedValue for $field {
             type Storage = $store;
-            const BITS: u32 = <$store as Block>::VALID_BIT_LENGTH;
+            const BITS: u32 = $bits;
             const ZERO: Self = $field(0);
         }
 
@@ -222,7 +222,7 @@ macro_rules! field_impl {
 }
 
 mod fp31 {
-    field_impl! { Fp31, u8, 31 }
+    field_impl! { Fp31, u8, 8, 31 }
 
     #[cfg(all(test, not(feature = "shuttle")))]
     mod specialized_tests {
@@ -245,7 +245,7 @@ mod fp31 {
 }
 
 mod fp32bit {
-    field_impl! { Fp32BitPrime, u32, 4_294_967_291 }
+    field_impl! { Fp32BitPrime, u32, 32, 4_294_967_291 }
 
     #[cfg(all(test, not(feature = "shuttle")))]
     mod specialized_tests {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -15,9 +15,6 @@ use std::fmt::Debug;
 pub trait Block: Sized + Copy + Debug {
     /// Size of a block in bytes big enough to hold the shared value. `Size * 8 >= VALID_BIT_LENGTH`.
     type Size: ArrayLength<u8>;
-
-    /// Minimum number of bits needed to represent the shared value.
-    const VALID_BIT_LENGTH: u32;
 }
 
 pub trait SharedValue:


### PR DESCRIPTION
We want to create a new type `Gf2` as in #552, which is basically a field of 2 elements {0, 1}. We use the `BitArr!` to define an internal struct to store the bits for `GaloisFields` like this:

`type U8_1 = BitArr!(for 8, in u8, Lsb0);`

For Gf2, it's tempting to do something like `type U8_0 = BitArr!(for 1, in u8, Lsb0);`, but this macro just generates an array long enough to fit the number of bits (`for 1`) in the underlying primitive type (`in u8`), so both `U8_1` and `U8_0` here are `[u8; 1]`.

This is a problem because we want to implement `Block` for these storage types, but type aliases are just short names for the given type; not new types.

Specifying a trait for type aliases is in [nightly build](https://rust-lang.github.io/impl-trait-initiative/explainer/tait.html), but until that becomes available, we'll either need use the newtype pattern, or do it a dumb way by explicitly specifying the bit length.