### PR TITLE
Fix send gateway buffer capacity

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -1,6 +1,7 @@
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use raw_ipa::{
     error::Error,
+    ff::Fp32BitPrime,
     helpers::GatewayConfig,
     test_fixture::{
         generate_random_user_records_in_reverse_chronological_order, test_ipa,
@@ -16,10 +17,12 @@ async fn main() -> Result<(), Error> {
     const MAX_QUERY_SIZE: usize = 1000;
     const NUM_USERS: usize = 300;
     const MAX_RECORDS_PER_USER: usize = 10;
+    type BenchField = Fp32BitPrime;
 
     let mut config = TestWorldConfig::default();
-    config.gateway_config =
-        GatewayConfig::symmetric_buffers((NUM_USERS * MAX_RECORDS_PER_USER).clamp(16, 1024));
+    config.gateway_config = GatewayConfig::symmetric_buffers::<BenchField>(
+        (NUM_USERS * MAX_RECORDS_PER_USER).clamp(16, 1024),
+    );
 
     let random_seed = thread_rng().gen();
     println!("Using random seed: {random_seed}");
@@ -58,7 +61,7 @@ async fn main() -> Result<(), Error> {
     }
     let world = TestWorld::new_with(config.clone());
 
-    test_ipa(
+    test_ipa::<BenchField>(
         &world,
         &raw_data,
         &expected_results,

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -18,9 +18,11 @@ use std::time::Instant;
 async fn main() -> Result<(), Error> {
     const BATCHSIZE: usize = 100;
     const NUM_MULTI_BITS: u32 = 3;
+    type BenchField = Fp32BitPrime;
 
     let mut config = TestWorldConfig::default();
-    config.gateway_config = GatewayConfig::symmetric_buffers(BATCHSIZE.clamp(4, 1024));
+    config.gateway_config =
+        GatewayConfig::symmetric_buffers::<BenchField>(BATCHSIZE.clamp(4, 1024));
     let world = TestWorld::new_with(config);
     let [ctx0, ctx1, ctx2] = world.contexts();
     let mut rng = rand::thread_rng();
@@ -33,7 +35,7 @@ async fn main() -> Result<(), Error> {
 
     let converted_shares = world
         .semi_honest(match_keys.clone(), |ctx, match_key| async move {
-            convert_all_bits::<Fp32BitPrime, _, _>(
+            convert_all_bits::<BenchField, _, _>(
                 &ctx,
                 &convert_all_bits_local(ctx.role(), match_key.into_iter()),
                 Gf40Bit::BITS,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -693,6 +693,7 @@ pub mod tests {
         const NUM_USERS: usize = 8;
         const MAX_RECORDS_PER_USER: usize = 8;
         const NUM_MULTI_BITS: u32 = 3;
+        type TestField = Fp32BitPrime;
 
         let random_seed = thread_rng().gen();
         println!("Using random seed: {random_seed}");
@@ -714,7 +715,9 @@ pub mod tests {
         // This is part of the IPA spec. Callers should do this before sending a batch of records in for processing.
         raw_data.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
         let config = TestWorldConfig {
-            gateway_config: GatewayConfig::symmetric_buffers(raw_data.len().clamp(4, 1024)),
+            gateway_config: GatewayConfig::symmetric_buffers::<TestField>(
+                raw_data.len().clamp(4, 1024),
+            ),
             ..Default::default()
         };
 
@@ -731,7 +734,7 @@ pub mod tests {
                 );
             }
 
-            test_ipa(
+            test_ipa::<TestField>(
                 &world,
                 &raw_data,
                 &expected_results,

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -61,7 +61,7 @@ impl Default for TestWorldConfig {
     fn default() -> Self {
         Self {
             gateway_config: GatewayConfig {
-                send_outstanding: NonZeroUsize::new(16).unwrap(),
+                send_outstanding_bytes: NonZeroUsize::new(16).unwrap(),
                 recv_outstanding: NonZeroUsize::new(16).unwrap(),
             },
             // Disable metrics by default because `logging` only enables `Level::INFO` spans.

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -13,14 +13,13 @@ use futures_util::future::{try_join, try_join_all};
 
 #[test]
 fn send_receive_sequential() {
+    type TestField = Fp32BitPrime;
     shuttle::check_random(
         || {
             shuttle::future::block_on(async {
-                let input = (0u32..11)
-                    .map(Fp32BitPrime::truncate_from)
-                    .collect::<Vec<_>>();
+                let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                 let config = TestWorldConfig {
-                    gateway_config: GatewayConfig::symmetric_buffers(input.len()),
+                    gateway_config: GatewayConfig::symmetric_buffers::<TestField>(input.len()),
                     ..Default::default()
                 };
                 let world = TestWorld::new_with(config);
@@ -69,14 +68,13 @@ fn send_receive_sequential() {
 
 #[test]
 fn send_receive_parallel() {
+    type TestField = Fp32BitPrime;
     shuttle::check_random(
         || {
             shuttle::future::block_on(async {
-                let input = (0u32..11)
-                    .map(Fp32BitPrime::truncate_from)
-                    .collect::<Vec<_>>();
+                let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                 let config = TestWorldConfig {
-                    gateway_config: GatewayConfig::symmetric_buffers(input.len()),
+                    gateway_config: GatewayConfig::symmetric_buffers::<TestField>(input.len()),
                     ..Default::default()
                 };
                 let world = TestWorld::new_with(config);


### PR DESCRIPTION
As Martin predicted, send capacity was destined to be broken because of the bad config name. So we ended up with send buffer capacity that is 4 times smaller than we wanted.

I thought it might be a good idea to align buffer capacity with the field size as it should work for the majority of the channels. That required making sure IPA uses the same field, so I had to plug in a generic argument to it