### PR TITLE
Add a query config parameter for the attribution window

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -16,6 +16,7 @@ async fn main() -> Result<(), Error> {
     const MAX_QUERY_SIZE: usize = 1000;
     const NUM_USERS: usize = 300;
     const MAX_RECORDS_PER_USER: usize = 10;
+    const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
 
     let mut config = TestWorldConfig::default();
     config.gateway_config =
@@ -54,7 +55,12 @@ async fn main() -> Result<(), Error> {
     let mut expected_results = vec![0_u32; MAX_BREAKDOWN_KEY.try_into().unwrap()];
 
     for records_for_user in &random_user_records {
-        update_expected_output_for_user(records_for_user, &mut expected_results, per_user_cap);
+        update_expected_output_for_user(
+            records_for_user,
+            &mut expected_results,
+            per_user_cap,
+            ATTRIBUTION_WINDOW_SECONDS,
+        );
     }
     let world = TestWorld::new_with(config.clone());
 
@@ -64,6 +70,7 @@ async fn main() -> Result<(), Error> {
         &expected_results,
         per_user_cap,
         MAX_BREAKDOWN_KEY,
+        ATTRIBUTION_WINDOW_SECONDS,
         IpaSecurityModel::Malicious,
     )
     .await;

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -113,6 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         per_user_credit_cap: 3,
                         max_breakdown_key: 3,
                         num_multi_bits: 3,
+                        attribution_window_seconds: 0,
                     }),
                 };
                 let query_id = clients[0].create_query(query_config).await.unwrap();

--- a/src/helpers/transport/query.rs
+++ b/src/helpers/transport/query.rs
@@ -115,6 +115,7 @@ impl Substep for QueryType {}
 pub struct IpaQueryConfig {
     pub per_user_credit_cap: u32,
     pub max_breakdown_key: u32,
+    pub attribution_window_seconds: u32,
     pub num_multi_bits: u32,
 }
 

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -124,17 +124,20 @@ pub mod query {
                     struct IPAQueryConfigParam {
                         per_user_credit_cap: u32,
                         max_breakdown_key: u32,
+                        attribution_window_seconds: u32,
                         num_multi_bits: u32,
                     }
                     let Query(IPAQueryConfigParam {
                         per_user_credit_cap,
                         max_breakdown_key,
+                        attribution_window_seconds,
                         num_multi_bits,
                     }) = req.extract().await?;
 
                     Ok(QueryType::IPA(IpaQueryConfig {
                         per_user_credit_cap,
                         max_breakdown_key,
+                        attribution_window_seconds,
                         num_multi_bits,
                     }))
                 }
@@ -155,10 +158,11 @@ pub mod query {
                 QueryType::TestMultiply => write!(f, "query_type={}", QueryType::TEST_MULTIPLY_STR),
                 QueryType::IPA(config) => write!(
                     f,
-                    "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&num_multi_bits={}",
+                    "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&attribution_window_seconds={}&num_multi_bits={}",
                     QueryType::IPA_STR,
                     config.per_user_credit_cap,
                     config.max_breakdown_key,
+                    config.attribution_window_seconds,
                     config.num_multi_bits,
                 ),
             }

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -81,6 +81,7 @@ mod tests {
             query_type: QueryType::IPA(IpaQueryConfig {
                 per_user_credit_cap: 1,
                 max_breakdown_key: 1,
+                attribution_window_seconds: 0,
                 num_multi_bits: 3,
             }),
         })
@@ -154,6 +155,7 @@ mod tests {
         query_type: String,
         per_user_credit_cap: String,
         max_breakdown_key: String,
+        attribution_window_seconds: String,
         num_multi_bits: String,
     }
 
@@ -162,10 +164,11 @@ mod tests {
             OverrideReq {
                 field_type: self.field_type,
                 query_type_params: format!(
-                    "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&num_multi_bits={}",
+                    "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&attribution_window_seconds={}&num_multi_bits={}",
                     self.query_type,
                     self.per_user_credit_cap,
                     self.max_breakdown_key,
+                    self.attribution_window_seconds,
                     self.num_multi_bits
                 ),
             }
@@ -180,6 +183,7 @@ mod tests {
                 query_type: QueryType::IPA_STR.to_string(),
                 per_user_credit_cap: "1".into(),
                 max_breakdown_key: "1".into(),
+                attribution_window_seconds: "0".into(),
                 num_multi_bits: "3".into(),
             }
         }
@@ -216,6 +220,15 @@ mod tests {
     async fn malformed_max_breakdown_key_ipa() {
         let req = OverrideIPAReq {
             max_breakdown_key: "-1".into(),
+            ..Default::default()
+        };
+        assert_req_fails_with(req, StatusCode::UNPROCESSABLE_ENTITY).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_attribution_window_seconds_ipa() {
+        let req = OverrideIPAReq {
+            attribution_window_seconds: "-1".into(),
             ..Default::default()
         };
         assert_req_fails_with(req, StatusCode::UNPROCESSABLE_ENTITY).await;

--- a/src/protocol/attribution/malicious.rs
+++ b/src/protocol/attribution/malicious.rs
@@ -31,6 +31,7 @@ pub async fn secure_attribution<'a, F, BK>(
     sorted_rows: Vec<IPAModulusConvertedInputRow<F, AdditiveShare<F>>>,
     per_user_credit_cap: u32,
     max_breakdown_key: u32,
+    _attribution_window_seconds: u32, // TODO(taikiy): compute the output with the attribution window
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, SemiHonestAdditiveShare<F>, BK>>, Error>
 where

--- a/src/protocol/attribution/semi_honest.rs
+++ b/src/protocol/attribution/semi_honest.rs
@@ -27,6 +27,7 @@ pub async fn secure_attribution<F, BK>(
     sorted_rows: Vec<IPAModulusConvertedInputRow<F, AdditiveShare<F>>>,
     per_user_credit_cap: u32,
     max_breakdown_key: u32,
+    _attribution_window_seconds: u32, // TODO(taikiy): compute the output with the attribution window
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, AdditiveShare<F>, BK>>, Error>
 where

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -269,6 +269,7 @@ pub async fn ipa<F, MK, BK>(
     input_rows: &[IPAInputRow<F, MK, BK>],
     per_user_credit_cap: u32,
     max_breakdown_key: u32,
+    attribution_window_seconds: u32,
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
@@ -341,6 +342,7 @@ where
         sorted_rows,
         per_user_credit_cap,
         max_breakdown_key,
+        attribution_window_seconds,
         num_multi_bits,
     )
     .await
@@ -358,6 +360,7 @@ pub async fn ipa_malicious<'a, F, MK, BK>(
     input_rows: &[IPAInputRow<F, MK, BK>],
     per_user_credit_cap: u32,
     max_breakdown_key: u32,
+    attribution_window_seconds: u32,
     num_multi_bits: u32,
 ) -> Result<Vec<MCAggregateCreditOutputRow<F, Replicated<F>, BK>>, Error>
 where
@@ -458,6 +461,7 @@ where
         sorted_rows,
         per_user_credit_cap,
         max_breakdown_key,
+        attribution_window_seconds,
         num_multi_bits,
     )
     .await
@@ -507,6 +511,7 @@ pub mod tests {
             [7, 0],
         ];
         const MAX_BREAKDOWN_KEY: u32 = 8;
+        const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::default();
@@ -529,6 +534,7 @@ pub mod tests {
                     &input_rows,
                     PER_USER_CAP,
                     MAX_BREAKDOWN_KEY,
+                    ATTRIBUTION_WINDOW_SECONDS,
                     NUM_MULTI_BITS,
                 )
                 .await
@@ -556,6 +562,7 @@ pub mod tests {
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 2], [2, 3]];
         const MAX_BREAKDOWN_KEY: u32 = 3;
+        const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::default();
@@ -578,6 +585,7 @@ pub mod tests {
                     &input_rows,
                     PER_USER_CAP,
                     MAX_BREAKDOWN_KEY,
+                    ATTRIBUTION_WINDOW_SECONDS,
                     NUM_MULTI_BITS,
                 )
                 .await
@@ -603,6 +611,7 @@ pub mod tests {
         const PER_USER_CAP: u32 = 1;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 1], [2, 0], [3, 0], [4, 0], [5, 1], [6, 1]];
         const MAX_BREAKDOWN_KEY: u32 = 7;
+        const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
         const NUM_MULTI_BITS: u32 = 3;
 
         let world = TestWorld::default();
@@ -637,6 +646,7 @@ pub mod tests {
                     &input_rows,
                     PER_USER_CAP,
                     MAX_BREAKDOWN_KEY,
+                    ATTRIBUTION_WINDOW_SECONDS,
                     NUM_MULTI_BITS,
                 )
                 .await
@@ -664,6 +674,7 @@ pub mod tests {
                     &input_rows,
                     PER_USER_CAP,
                     MAX_BREAKDOWN_KEY,
+                    ATTRIBUTION_WINDOW_SECONDS,
                     NUM_MULTI_BITS,
                 )
                 .await
@@ -693,6 +704,7 @@ pub mod tests {
         const NUM_USERS: usize = 8;
         const MAX_RECORDS_PER_USER: usize = 8;
         const NUM_MULTI_BITS: u32 = 3;
+        const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
 
         let random_seed = thread_rng().gen();
         println!("Using random seed: {random_seed}");
@@ -728,6 +740,7 @@ pub mod tests {
                     records_for_user,
                     &mut expected_results,
                     per_user_cap,
+                    ATTRIBUTION_WINDOW_SECONDS,
                 );
             }
 
@@ -737,6 +750,7 @@ pub mod tests {
                 &expected_results,
                 per_user_cap,
                 MAX_BREAKDOWN_KEY,
+                ATTRIBUTION_WINDOW_SECONDS,
                 IpaSecurityModel::SemiHonest,
             )
             .await;
@@ -792,6 +806,7 @@ pub mod tests {
     #[tokio::test]
     pub async fn communication_baseline() {
         const MAX_BREAKDOWN_KEY: u32 = 3;
+        const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
         const NUM_MULTI_BITS: u32 = 3;
 
         /// empirical value as of Mar 8, 2023.
@@ -831,6 +846,7 @@ pub mod tests {
                         &input_rows,
                         per_user_cap,
                         MAX_BREAKDOWN_KEY,
+                        ATTRIBUTION_WINDOW_SECONDS,
                         NUM_MULTI_BITS,
                     )
                     .await
@@ -863,6 +879,7 @@ pub mod tests {
                         &input_rows,
                         per_user_cap,
                         MAX_BREAKDOWN_KEY,
+                        ATTRIBUTION_WINDOW_SECONDS,
                         NUM_MULTI_BITS,
                     )
                     .await

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -119,6 +119,7 @@ where
         input_vec.as_slice(),
         query_config.per_user_credit_cap,
         query_config.max_breakdown_key,
+        query_config.attribution_window_seconds,
         query_config.num_multi_bits,
     )
     .await
@@ -267,6 +268,7 @@ mod tests {
             let query_config = IpaQueryConfig {
                 num_multi_bits: 3,
                 per_user_credit_cap: 3,
+                attribution_window_seconds: 0,
                 max_breakdown_key: 3,
             };
             let input = ByteArrStream::from(shares)

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -562,6 +562,7 @@ mod tests {
                         num_multi_bits: 3,
                         per_user_credit_cap: 3,
                         max_breakdown_key: 3,
+                        attribution_window_seconds: 0,
                     }
                     .into(),
                 },

--- a/src/test_fixture/ipa.rs
+++ b/src/test_fixture/ipa.rs
@@ -73,6 +73,7 @@ pub fn update_expected_output_for_user(
     records_for_user: &[TestRawDataRecord],
     expected_results: &mut [u32],
     per_user_cap: u32,
+    _attribution_window_seconds: u32, // TODO(taikiy): compute the output with the attribution window
 ) {
     let mut pending_trigger_value = 0;
     let mut total_contribution = 0;
@@ -102,6 +103,7 @@ pub async fn test_ipa(
     expected_results: &[u32],
     per_user_cap: u32,
     max_breakdown_key: u32,
+    attribution_window_seconds: u32,
     security_model: IpaSecurityModel,
 ) {
     const NUM_MULTI_BITS: u32 = 3;
@@ -130,6 +132,7 @@ pub async fn test_ipa(
                         &input_rows,
                         per_user_cap,
                         max_breakdown_key,
+                        attribution_window_seconds,
                         NUM_MULTI_BITS,
                     )
                     .await
@@ -144,6 +147,7 @@ pub async fn test_ipa(
                         &input_rows,
                         per_user_cap,
                         max_breakdown_key,
+                        attribution_window_seconds,
                         NUM_MULTI_BITS,
                     )
                     .await

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -20,6 +20,7 @@ fn semi_honest_ipa() {
                 const PER_USER_CAP: u32 = 10;
                 const MAX_BREAKDOWN_KEY: u32 = 8;
                 const MAX_TRIGGER_VALUE: u32 = 5;
+                const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
                 const NUM_MULTI_BITS: u32 = 3;
                 const MAX_MATCH_KEY: u128 = 3;
 
@@ -48,6 +49,7 @@ fn semi_honest_ipa() {
                                 &input_rows,
                                 PER_USER_CAP,
                                 MAX_BREAKDOWN_KEY,
+                                ATTRIBUTION_WINDOW_SECONDS,
                                 NUM_MULTI_BITS,
                             )
                             .await
@@ -71,6 +73,7 @@ fn malicious_ipa() {
                 const BATCHSIZE: usize = 5;
                 const PER_USER_CAP: u32 = 10;
                 const MAX_BREAKDOWN_KEY: u32 = 8;
+                const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
                 const MAX_TRIGGER_VALUE: u32 = 5;
                 const NUM_MULTI_BITS: u32 = 3;
                 const MAX_MATCH_KEY: u128 = 3;
@@ -100,6 +103,7 @@ fn malicious_ipa() {
                                 &input_rows,
                                 PER_USER_CAP,
                                 MAX_BREAKDOWN_KEY,
+                                ATTRIBUTION_WINDOW_SECONDS,
                                 NUM_MULTI_BITS,
                             )
                             .await


### PR DESCRIPTION
Look-back window protocol is landed, but not enabled yet. This PR adds a new query config parameter to specify the window in seconds. My current suggestion is to keep it simple by making this as a required parameter like every other parameters, and skip computing the look-back window when we see the value 0 (which should be a rare case anyway).

This PR only adds the new parameter. The actual code to enable the look-back window protocol will be in the next diff.