### PR TITLE
WIP: using field extension to drop IPA communications

### DIFF
--- a/src/protocol/attribution/malicious.rs
+++ b/src/protocol/attribution/malicious.rs
@@ -1,32 +1,32 @@
 use super::{
     accumulate_credit::accumulate_credit,
     aggregate_credit::malicious_aggregate_credit,
+    compute_helper_bits_gf2,
     credit_capping::credit_capping,
     input::{MCAccumulateCreditInputRow, MCAggregateCreditOutputRow},
+    mod_conv_helper_bits,
 };
 use crate::{
     error::Error,
     ff::{GaloisField, Gf2, PrimeField, Serializable},
     protocol::{
-        boolean::bitwise_equal::bitwise_equal_gf2,
         context::{Context, SemiHonestContext},
         ipa::IPAModulusConvertedInputRow,
         malicious::MaliciousValidator,
-        modulus_conversion::{convert_bit, convert_bit_local},
-        RecordId, Substep,
+        Substep,
     },
     secret_sharing::replicated::{
         malicious::{AdditiveShare, ExtendableField},
         semi_honest::AdditiveShare as SemiHonestAdditiveShare,
     },
 };
-use futures::future::try_join_all;
-use std::iter::{repeat, zip};
+use std::iter::zip;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///
 /// # Errors
 /// propagates errors from multiplications
+#[allow(clippy::too_many_arguments)]
 pub async fn secure_attribution<'a, F, BK>(
     sh_ctx: SemiHonestContext<'a>,
     malicious_validator: MaliciousValidator<'a, F>,
@@ -47,40 +47,13 @@ where
     let m_ctx = malicious_validator.context();
     let m_binary_ctx = binary_malicious_validator.context();
 
-    let futures = zip(
-        repeat(
-            m_binary_ctx
-                .narrow(&Step::ComputeHelperBits)
-                .set_total_records(sorted_match_keys.len() - 1),
-        ),
-        sorted_match_keys.iter(),
-    )
-    .zip(sorted_match_keys.iter().skip(1))
-    .enumerate()
-    .map(|(i, ((c, row), next_row))| {
-        let record_id = RecordId::from(i);
-        async move { bitwise_equal_gf2(c, record_id, &row, &next_row).await }
-    });
-    let helper_bits_gf2 = try_join_all(futures).await?;
-
+    let helper_bits_gf2 = compute_helper_bits_gf2(m_binary_ctx, &sorted_match_keys).await?;
     let validated_helper_bits_gf2 = binary_malicious_validator.validate(helper_bits_gf2).await?;
-
-    let hb_mod_conv_ctx = sh_ctx
-        .narrow(&Step::ModConvHelperBits)
-        .set_total_records(sorted_match_keys.len() - 1);
-    let semi_honest_helper_bits = try_join_all(validated_helper_bits_gf2.iter().enumerate().map(
-        |(i, gf2_bit)| {
-            let bit_triple = convert_bit_local::<F, Gf2>(sh_ctx.role(), 0, gf2_bit);
-            let record_id = RecordId::from(i);
-            let c = hb_mod_conv_ctx.clone();
-            async move { convert_bit(c, record_id, &bit_triple).await }
-        },
-    ))
-    .await?;
-
+    let semi_honest_fp_helper_bits =
+        mod_conv_helper_bits(sh_ctx.clone(), &validated_helper_bits_gf2).await?;
     let helper_bits = Some(AdditiveShare::ZERO)
         .into_iter()
-        .chain(m_ctx.upgrade(semi_honest_helper_bits).await?);
+        .chain(m_ctx.upgrade(semi_honest_fp_helper_bits).await?);
 
     let attribution_input_rows = zip(sorted_rows, helper_bits)
         .map(|(row, hb)| {
@@ -122,11 +95,9 @@ where
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Step {
-    ComputeHelperBits,
     AccumulateCredit,
     PerformUserCapping,
     AggregateCredit,
-    ModConvHelperBits,
 }
 
 impl Substep for Step {}
@@ -134,11 +105,9 @@ impl Substep for Step {}
 impl AsRef<str> for Step {
     fn as_ref(&self) -> &str {
         match self {
-            Self::ComputeHelperBits => "compute_helper_bits",
             Self::AccumulateCredit => "accumulate_credit",
             Self::PerformUserCapping => "user_capping",
             Self::AggregateCredit => "aggregate_credit",
-            Self::ModConvHelperBits => "mod_conv_helper_bits",
         }
     }
 }

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -251,17 +251,11 @@ where
         .narrow(&Step::ComputeHelperBits)
         .set_total_records(sorted_match_keys.len() - 1);
 
-    try_join_all(
-        sorted_match_keys
-            .iter()
-            .zip(sorted_match_keys.iter().skip(1))
-            .enumerate()
-            .map(|(i, (row, next_row))| {
-                let c = narrowed_ctx.clone();
-                let record_id = RecordId::from(i);
-                async move { bitwise_equal_gf2(c, record_id, row, next_row).await }
-            }),
-    )
+    try_join_all(sorted_match_keys.windows(2).enumerate().map(|(i, rows)| {
+        let c = narrowed_ctx.clone();
+        let record_id = RecordId::from(i);
+        async move { bitwise_equal_gf2(c, record_id, &rows[0], &rows[1]).await }
+    }))
     .await
 }
 

--- a/src/protocol/attribution/semi_honest.rs
+++ b/src/protocol/attribution/semi_honest.rs
@@ -6,11 +6,12 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{GaloisField, PrimeField, Serializable},
+    ff::{GaloisField, Gf2, PrimeField, Serializable},
     protocol::{
-        boolean::bitwise_equal::bitwise_equal,
+        boolean::bitwise_equal::bitwise_equal_gf2,
         context::{Context, SemiHonestContext},
         ipa::IPAModulusConvertedInputRow,
+        modulus_conversion::{convert_bit, convert_bit_local},
         RecordId, Substep,
     },
     secret_sharing::replicated::semi_honest::AdditiveShare,
@@ -24,6 +25,7 @@ use std::iter::{repeat, zip};
 /// propagates errors from multiplications
 pub async fn secure_attribution<F, BK>(
     ctx: SemiHonestContext<'_>,
+    sorted_match_keys: Vec<Vec<AdditiveShare<Gf2>>>,
     sorted_rows: Vec<IPAModulusConvertedInputRow<F, AdditiveShare<F>>>,
     per_user_credit_cap: u32,
     max_breakdown_key: u32,
@@ -38,19 +40,33 @@ where
     let futures = zip(
         repeat(
             ctx.narrow(&Step::ComputeHelperBits)
-                .set_total_records(sorted_rows.len() - 1),
+                .set_total_records(sorted_match_keys.len() - 1),
         ),
-        sorted_rows.iter(),
+        sorted_match_keys.iter(),
     )
-    .zip(sorted_rows.iter().skip(1))
+    .zip(sorted_match_keys.iter().skip(1))
     .enumerate()
-    .map(|(i, ((ctx, row), next_row))| {
+    .map(|(i, ((c, row), next_row))| {
         let record_id = RecordId::from(i);
-        async move { bitwise_equal(ctx, record_id, &row.mk_shares, &next_row.mk_shares).await }
+        async move { bitwise_equal_gf2(c, record_id, &row, &next_row).await }
     });
+    let helper_bits_gf2 = try_join_all(futures).await?;
+
+    let hb_mod_conv_ctx = ctx
+        .narrow(&Step::ModConvHelperBits)
+        .set_total_records(sorted_match_keys.len() - 1);
+    let semi_honest_helper_bits =
+        try_join_all(helper_bits_gf2.iter().enumerate().map(|(i, gf2_bit)| {
+            let bit_triple = convert_bit_local::<F, Gf2>(ctx.role(), 0, gf2_bit);
+            let record_id = RecordId::from(i);
+            let c = hb_mod_conv_ctx.clone();
+            async move { convert_bit(c, record_id, &bit_triple).await }
+        }))
+        .await?;
+
     let helper_bits = Some(AdditiveShare::ZERO)
         .into_iter()
-        .chain(try_join_all(futures).await?);
+        .chain(semi_honest_helper_bits);
 
     let attribution_input_rows = zip(sorted_rows, helper_bits)
         .map(|(row, hb)| {
@@ -92,6 +108,7 @@ pub enum Step {
     AccumulateCredit,
     PerformUserCapping,
     AggregateCredit,
+    ModConvHelperBits,
 }
 
 impl Substep for Step {}
@@ -103,6 +120,7 @@ impl AsRef<str> for Step {
             Self::AccumulateCredit => "accumulate_credit",
             Self::PerformUserCapping => "user_capping",
             Self::AggregateCredit => "aggregate_credit",
+            Self::ModConvHelperBits => "mod_conv_helper_bits",
         }
     }
 }

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -1,7 +1,7 @@
 use super::xor;
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, Gf2},
     protocol::{
         basics::SecureMul, boolean::no_ones, context::Context, BasicProtocols, BitOpStep, RecordId,
     },
@@ -44,6 +44,26 @@ where
         })
         .collect::<Vec<_>>();
     no_ones(ctx, record_id, &xored_bits).await
+}
+
+pub async fn bitwise_equal_gf2<C, S>(
+    ctx: C,
+    record_id: RecordId,
+    a: &[S],
+    b: &[S],
+) -> Result<S, Error>
+where
+    C: Context,
+    S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    debug_assert!(a.len() == b.len());
+    let c = a
+        .iter()
+        .zip(b.iter())
+        .map(|(a_bit, b_bit)| a_bit.clone() - b_bit)
+        .collect::<Vec<_>>();
+
+    no_ones(ctx, record_id, &c).await
 }
 
 /// # Errors

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -3,7 +3,8 @@ use crate::{
     error::Error,
     ff::{Field, Gf2},
     protocol::{
-        basics::SecureMul, boolean::no_ones, context::Context, BasicProtocols, BitOpStep, RecordId,
+        basics::SecureMul, boolean::all_zeroes, context::Context, BasicProtocols, BitOpStep,
+        RecordId,
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -43,9 +44,13 @@ where
             }
         })
         .collect::<Vec<_>>();
-    no_ones(ctx, record_id, &xored_bits).await
+    all_zeroes(ctx, record_id, &xored_bits).await
 }
 
+///
+/// # Errors
+/// Propagates errors from multiplications
+///
 pub async fn bitwise_equal_gf2<C, S>(
     ctx: C,
     record_id: RecordId,
@@ -57,13 +62,11 @@ where
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
 {
     debug_assert!(a.len() == b.len());
-    let c = a
-        .iter()
-        .zip(b.iter())
+    let c = zip(a.iter(), b.iter())
         .map(|(a_bit, b_bit)| a_bit.clone() - b_bit)
         .collect::<Vec<_>>();
 
-    no_ones(ctx, record_id, &c).await
+    all_zeroes(ctx, record_id, &c).await
 }
 
 /// # Errors
@@ -82,7 +85,7 @@ where
 {
     debug_assert!(a.len() == b.len());
     let xored_bits = xor_all_the_bits(ctx.narrow(&Step::XORAllTheBits), record_id, a, b).await?;
-    no_ones(ctx, record_id, &xored_bits).await
+    all_zeroes(ctx, record_id, &xored_bits).await
 }
 
 async fn xor_all_the_bits<F, C, S>(

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -101,11 +101,11 @@ where
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
     let one = S::share_known_value(&ctx, F::ONE);
-    let res = no_ones(ctx, record_id, x).await?;
+    let res = all_zeroes(ctx, record_id, x).await?;
     Ok(one - &res)
 }
 
-pub(crate) async fn no_ones<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Result<S, Error>
+pub(crate) async fn all_zeroes<F, C, S>(ctx: C, record_id: RecordId, x: &[S]) -> Result<S, Error>
 where
     F: Field,
     C: Context,

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures::future::{try_join, try_join3, try_join_all};
+use futures::future::{try_join, try_join_all};
 
 use crate::{
     error::Error,
@@ -307,7 +307,6 @@ impl AsRef<str> for UpgradeTripleStep {
 }
 
 enum UpgradeModConvStep {
-    V0(usize),
     V1,
     V2,
 }
@@ -316,10 +315,7 @@ impl crate::protocol::Substep for UpgradeModConvStep {}
 
 impl AsRef<str> for UpgradeModConvStep {
     fn as_ref(&self) -> &str {
-        const UPGRADE_MOD_CONV0: [&str; 64] = repeat64str!["upgrade_mod_conv0"];
-
         match self {
-            Self::V0(i) => UPGRADE_MOD_CONV0[*i],
             Self::V1 => "upgrade_mod_conv1",
             Self::V2 => "upgrade_mod_conv2",
         }
@@ -359,16 +355,7 @@ impl<'a, F: Field + ExtendableField>
         self,
         input: IPAModulusConvertedInputRowWrapper<F, Replicated<F>>,
     ) -> Result<IPAModulusConvertedInputRowWrapper<F, MaliciousReplicated<F>>, Error> {
-        let ctx_ref = &self.ctx;
-        let (mk_shares, is_trigger_bit, trigger_value) = try_join3(
-            try_join_all(input.mk_shares.into_iter().enumerate().map(
-                |(idx, mk_share)| async move {
-                    ctx_ref
-                        .narrow(&UpgradeModConvStep::V0(idx))
-                        .upgrade_one(self.record_binding, mk_share, ZeroPositions::Pvvv)
-                        .await
-                },
-            )),
+        let (is_trigger_bit, trigger_value) = try_join(
             self.ctx.narrow(&UpgradeModConvStep::V1).upgrade_one(
                 self.record_binding,
                 input.is_trigger_bit,
@@ -383,7 +370,6 @@ impl<'a, F: Field + ExtendableField>
         .await?;
 
         Ok(IPAModulusConvertedInputRowWrapper::new(
-            mk_shares,
             is_trigger_bit,
             trigger_value,
         ))
@@ -391,16 +377,14 @@ impl<'a, F: Field + ExtendableField>
 }
 
 pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: LinearSecretSharing<F>> {
-    pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub trigger_value: T,
     _marker: PhantomData<F>,
 }
 
 impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRowWrapper<F, T> {
-    pub fn new(mk_shares: Vec<T>, is_trigger_bit: T, trigger_value: T) -> Self {
+    pub fn new(is_trigger_bit: T, trigger_value: T) -> Self {
         Self {
-            mk_shares,
             is_trigger_bit,
             trigger_value,
             _marker: PhantomData,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, PrimeField, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
     helpers::Role,
     protocol::{
         attribution::{input::MCAggregateCreditOutputRow, malicious, semi_honest},
@@ -10,7 +10,7 @@ use crate::{
             SemiHonestContext,
         },
         malicious::MaliciousValidator,
-        modulus_conversion::{combine_slices, convert_all_bits, convert_all_bits_local},
+        modulus_conversion::{convert_all_bits, convert_all_bits_local},
         sort::{
             apply_sort::apply_sort_permutation,
             generate_permutation::{
@@ -24,13 +24,14 @@ use crate::{
         replicated::{
             malicious::{AdditiveShare as MaliciousReplicated, ExtendableField},
             semi_honest::AdditiveShare as Replicated,
+            ReplicatedSecretSharing,
         },
         Linear as LinearSecretSharing,
     },
 };
 
 use async_trait::async_trait;
-use futures::future::{try_join, try_join3};
+use futures::future::try_join3;
 use generic_array::{ArrayLength, GenericArray};
 use std::{marker::PhantomData, ops::Add};
 use typenum::Unsigned;
@@ -41,7 +42,9 @@ pub enum Step {
     ModulusConversionForBreakdownKeys,
     GenSortPermutationFromMatchKeys,
     ApplySortPermutation,
+    ApplySortPermutationToMatchKeys,
     AfterConvertAllBits,
+    BinaryValidator,
 }
 
 impl Substep for Step {}
@@ -53,7 +56,9 @@ impl AsRef<str> for Step {
             Self::ModulusConversionForBreakdownKeys => "mod_conv_breakdown_key",
             Self::GenSortPermutationFromMatchKeys => "gen_sort_permutation_from_match_keys",
             Self::ApplySortPermutation => "apply_sort_permutation",
+            Self::ApplySortPermutationToMatchKeys => "apply_sort_permutation_to_match_keys",
             Self::AfterConvertAllBits => "after_convert_all_bits",
+            Self::BinaryValidator => "binary_validator",
         }
     }
 }
@@ -183,7 +188,6 @@ where
 }
 
 pub struct IPAModulusConvertedInputRow<F: Field, T: LinearSecretSharing<F>> {
-    pub mk_shares: Vec<T>,
     pub is_trigger_bit: T,
     pub breakdown_key: Vec<T>,
     pub trigger_value: T,
@@ -191,14 +195,8 @@ pub struct IPAModulusConvertedInputRow<F: Field, T: LinearSecretSharing<F>> {
 }
 
 impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRow<F, T> {
-    pub fn new(
-        mk_shares: Vec<T>,
-        is_trigger_bit: T,
-        breakdown_key: Vec<T>,
-        trigger_value: T,
-    ) -> Self {
+    pub fn new(is_trigger_bit: T, breakdown_key: Vec<T>, trigger_value: T) -> Self {
         Self {
-            mk_shares,
             is_trigger_bit,
             breakdown_key,
             trigger_value,
@@ -223,11 +221,11 @@ where
     where
         C: 'fut,
     {
-        let f_mk_shares = self.mk_shares.reshare(
-            ctx.narrow(&IPAInputRowResharableStep::MatchKeyShares),
-            record_id,
-            to_helper,
-        );
+        // let f_mk_shares = self.mk_shares.reshare(
+        //     ctx.narrow(&IPAInputRowResharableStep::MatchKeyShares),
+        //     record_id,
+        //     to_helper,
+        // );
         let f_is_trigger_bit = self.is_trigger_bit.reshare(
             ctx.narrow(&IPAInputRowResharableStep::TriggerBit),
             record_id,
@@ -244,15 +242,10 @@ where
             to_helper,
         );
 
-        let (mk_shares, breakdown_key, (is_trigger_bit, trigger_value)) = try_join3(
-            f_mk_shares,
-            f_breakdown_key,
-            try_join(f_is_trigger_bit, f_trigger_value),
-        )
-        .await?;
+        let (breakdown_key, is_trigger_bit, trigger_value) =
+            try_join3(f_breakdown_key, f_is_trigger_bit, f_trigger_value).await?;
 
         Ok(IPAModulusConvertedInputRow::new(
-            mk_shares,
             is_trigger_bit,
             breakdown_key,
             trigger_value,
@@ -300,7 +293,7 @@ where
     // Match key modulus conversion, and then sort
     let converted_mk_shares = convert_all_bits(
         &ctx.narrow(&Step::ModulusConversionForMatchKeys),
-        &convert_all_bits_local(ctx.role(), mk_shares.into_iter()),
+        &convert_all_bits_local::<F, MK>(ctx.role(), mk_shares.into_iter()),
         MK::BITS,
         num_multi_bits,
     )
@@ -314,20 +307,31 @@ where
     .await
     .unwrap();
 
-    let converted_mk_shares = combine_slices(&converted_mk_shares, MK::BITS);
+    let match_key_bitwise_sharings = input_rows
+        .iter()
+        .map(|row| {
+            (0..MK::BITS)
+                .map(|i| {
+                    Replicated::new(
+                        Gf2::truncate_from(row.mk_shares.left()[i]),
+                        Gf2::truncate_from(row.mk_shares.right()[i]),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
 
-    let combined_match_keys_and_sidecar_data =
-        std::iter::zip(converted_mk_shares, converted_bk_shares)
-            .zip(input_rows)
-            .map(|((mk_shares, bk_shares), input_row)| {
-                IPAModulusConvertedInputRow::new(
-                    mk_shares,
-                    input_row.is_trigger_bit.clone(),
-                    bk_shares,
-                    input_row.trigger_value.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
+    let combined_match_keys_and_sidecar_data = converted_bk_shares
+        .into_iter()
+        .zip(input_rows)
+        .map(|(bk_shares, input_row)| {
+            IPAModulusConvertedInputRow::new(
+                input_row.is_trigger_bit.clone(),
+                bk_shares,
+                input_row.trigger_value.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
 
     let sorted_rows = apply_sort_permutation(
         ctx.narrow(&Step::ApplySortPermutation),
@@ -337,8 +341,17 @@ where
     .await
     .unwrap();
 
+    let sorted_match_keys = apply_sort_permutation(
+        ctx.narrow(&Step::ApplySortPermutationToMatchKeys),
+        match_key_bitwise_sharings,
+        &sort_permutation,
+    )
+    .await
+    .unwrap();
+
     semi_honest::secure_attribution(
         ctx,
+        sorted_match_keys,
         sorted_rows,
         per_user_credit_cap,
         max_breakdown_key,
@@ -404,7 +417,29 @@ where
         MaliciousValidator::<F>::new(sh_ctx.narrow(&Step::AfterConvertAllBits));
     let m_ctx = malicious_validator.context();
 
-    let converted_mk_shares = combine_slices(&converted_mk_shares, MK::BITS);
+    //
+    //New stuff
+    //  let converted_mk_shares = combine_slices(&converted_mk_shares, MK::BITS);
+    //
+    let match_key_bitwise_sharings = input_rows
+        .iter()
+        .map(|row| {
+            (0..MK::BITS)
+                .map(|i| {
+                    Replicated::new(
+                        Gf2::truncate_from(row.mk_shares.left()[i]),
+                        Gf2::truncate_from(row.mk_shares.right()[i]),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    let binary_validator = MaliciousValidator::<Gf2>::new(sh_ctx.narrow(&Step::BinaryValidator));
+    let binary_m_ctx = binary_validator.context();
+
+    let upgraded_match_key_bitwise_sharings =
+        binary_m_ctx.upgrade(match_key_bitwise_sharings).await?;
 
     // Breakdown key modulus conversion
     let mut converted_bk_shares = convert_all_bits(
@@ -421,11 +456,10 @@ where
 
     let converted_bk_shares = converted_bk_shares.pop().unwrap();
 
-    let intermediate = converted_mk_shares
-        .zip(input_rows)
-        .map(|(mk_shares, input_row)| {
+    let intermediate = input_rows
+        .iter()
+        .map(|input_row| {
             IPAModulusConvertedInputRowWrapper::new(
-                mk_shares,
                 input_row.is_trigger_bit.clone(),
                 input_row.trigger_value.clone(),
             )
@@ -433,13 +467,12 @@ where
         .collect::<Vec<_>>();
 
     let intermediate = m_ctx.upgrade(intermediate).await?;
-
+    println!("Before combining stuff");
     let combined_match_keys_and_sidecar_data = intermediate
         .into_iter()
         .zip(converted_bk_shares)
         .map(
             |(one_row, bk_shares)| IPAModulusConvertedInputRow::<F, MaliciousReplicated<F>> {
-                mk_shares: one_row.mk_shares,
                 is_trigger_bit: one_row.is_trigger_bit,
                 trigger_value: one_row.trigger_value,
                 breakdown_key: bk_shares,
@@ -447,7 +480,7 @@ where
             },
         )
         .collect::<Vec<_>>();
-
+    println!("Before apply sort permutation to stuff");
     let sorted_rows = apply_sort_permutation(
         m_ctx.narrow(&Step::ApplySortPermutation),
         combined_match_keys_and_sidecar_data,
@@ -455,10 +488,20 @@ where
     )
     .await
     .unwrap();
-
+    println!("Before apply sort permutation to match keys");
+    let sorted_match_keys = apply_sort_permutation(
+        binary_m_ctx.narrow(&Step::ApplySortPermutation),
+        upgraded_match_key_bitwise_sharings,
+        &sort_permutation,
+    )
+    .await
+    .unwrap();
+    println!("Before secure attribution");
     malicious::secure_attribution(
         sh_ctx,
         malicious_validator,
+        binary_validator,
+        sorted_match_keys,
         sorted_rows,
         per_user_credit_cap,
         max_breakdown_key,
@@ -811,16 +854,16 @@ pub mod tests {
         const NUM_MULTI_BITS: u32 = 3;
 
         /// empirical value as of Mar 8, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 15453;
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 14517;
 
         /// empirical value as of Mar 8, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 38400;
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 36543;
 
-        /// empirical value as of Feb 27, 2023.
-        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 11784;
+        /// empirical value as of Mar 23, 2023.
+        const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 10848;
 
         /// empirical value as of Feb 28, 2023.
-        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 29046;
+        const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 27189;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [


### PR DESCRIPTION
This PR is stacked on top of #552 - and makes use of that new functionality to save communication overhead in IPA.

This uses a *binary field* for the bits of the match key, and while in malicious mode, the `rx` component is still a 4-byte value, the `x` part is just a single bit. For the moment, this results in 1-byte of communication - but we can address that later.