### PR TITLE
Add bytes.sent metric to count bytes sent between helpers

### DIFF
--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -851,15 +851,19 @@ pub mod tests {
 
         /// empirical value as of Mar 24, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 14517;
+        const BYTES_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 48780;
 
         /// empirical value as of Mar 24, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 36543;
+        const BYTES_SENT_MALICIOUS_BASELINE_CAP_3: u64 = 136_884;
 
         /// empirical value as of Mar 24, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 10848;
+        const BYTES_SENT_SEMI_HONEST_BASELINE_CAP_1: u64 = 34104;
 
         /// empirical value as of Mar 24, 2023.
         const RECORDS_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 27189;
+        const BYTES_SENT_MALICIOUS_BASELINE_CAP_1: u64 = 99468;
 
         let records: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = ipa_test_input!(
             [
@@ -899,16 +903,16 @@ pub mod tests {
             let (records_baseline, bytes_baseline) = if per_user_cap == 1 {
                 (
                     RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1,
-                    FIELD_SIZE * RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1,
+                    BYTES_SENT_SEMI_HONEST_BASELINE_CAP_1,
                 )
             } else {
                 (
                     RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3,
-                    FIELD_SIZE * RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3,
+                    BYTES_SENT_SEMI_HONEST_BASELINE_CAP_3,
                 )
             };
             assert_baselines(
-                "semi-honest IPA (cap = {per_user_cap})",
+                &format!("semi-honest IPA (cap = {per_user_cap})"),
                 &snapshot,
                 [
                     (RECORDS_SENT, records_baseline),
@@ -937,16 +941,16 @@ pub mod tests {
             let (records_baseline, bytes_baseline) = if per_user_cap == 1 {
                 (
                     RECORDS_SENT_MALICIOUS_BASELINE_CAP_1,
-                    FIELD_SIZE * RECORDS_SENT_MALICIOUS_BASELINE_CAP_1,
+                    BYTES_SENT_MALICIOUS_BASELINE_CAP_1,
                 )
             } else {
                 (
                     RECORDS_SENT_MALICIOUS_BASELINE_CAP_3,
-                    FIELD_SIZE * RECORDS_SENT_MALICIOUS_BASELINE_CAP_3,
+                    BYTES_SENT_MALICIOUS_BASELINE_CAP_3,
                 )
             };
             assert_baselines(
-                "malicious IPA (cap = {per_user_cap})",
+                &format!("malicious IPA (cap = {per_user_cap})"),
                 &snapshot,
                 [
                     (RECORDS_SENT, records_baseline),
@@ -967,7 +971,7 @@ pub mod tests {
                     "{metric_name} baseline for {name} has DEGRADED! Expected {baseline}, got {actual}.");
 
             if actual < baseline {
-                tracing::warn!("{metric_name} baseline for {name} has improved! Expected {baseline}, got {actual}.\
+                tracing::warn!("{metric_name} baseline for {name} has improved! Expected {baseline}, got {actual}. \
                 Strongly consider adjusting the baseline, so the gains won't be accidentally offset by a regression.");
             }
         }

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -477,7 +477,10 @@ pub mod tests {
         ipa_test_input,
         protocol::{BreakdownKey, MatchKey},
         secret_sharing::IntoShares,
-        telemetry::metrics::RECORDS_SENT,
+        telemetry::{
+            metrics::{BYTES_SENT, RECORDS_SENT},
+            stats::Metrics,
+        },
         test_fixture::{
             input::GenericReportTestInput,
             ipa::{
@@ -812,6 +815,7 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
         const NUM_MULTI_BITS: u32 = 3;
+        const FIELD_SIZE: u64 = <Fp32BitPrime as Serializable>::Size::U64;
 
         /// empirical value as of Mar 8, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 15453;
@@ -860,19 +864,25 @@ pub mod tests {
                 .reconstruct();
 
             let snapshot = world.metrics_snapshot();
-            let records_sent = snapshot.get_counter(RECORDS_SENT);
-            let semi_honest_baseline = if per_user_cap == 1 {
-                RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1
+            let (records_baseline, bytes_baseline) = if per_user_cap == 1 {
+                (
+                    RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1,
+                    FIELD_SIZE * RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_1,
+                )
             } else {
-                RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3
+                (
+                    RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3,
+                    FIELD_SIZE * RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3,
+                )
             };
-            assert!(records_sent <= semi_honest_baseline,
-                "Baseline for semi-honest IPA (cap = {per_user_cap}) has DEGRADED! Expected {semi_honest_baseline}, got {records_sent}.");
-
-            if records_sent < semi_honest_baseline {
-                tracing::warn!("Baseline for semi-honest IPA (cap = {per_user_cap}) has improved! Expected {semi_honest_baseline}, got {records_sent}. \
-                                Consider adjusting the baseline, so the gains won't be accidentally offset by a regression.");
-            }
+            assert_baselines(
+                "semi-honest IPA (cap = {per_user_cap})",
+                &snapshot,
+                [
+                    (RECORDS_SENT, records_baseline),
+                    (BYTES_SENT, bytes_baseline),
+                ],
+            );
 
             let world = TestWorld::new_with(TestWorldConfig::default().enable_metrics());
 
@@ -892,20 +902,42 @@ pub mod tests {
                 .await;
 
             let snapshot = world.metrics_snapshot();
-            let records_sent = snapshot.get_counter(RECORDS_SENT);
-            let malicious_baseline = if per_user_cap == 1 {
-                RECORDS_SENT_MALICIOUS_BASELINE_CAP_1
+            let (records_baseline, bytes_baseline) = if per_user_cap == 1 {
+                (
+                    RECORDS_SENT_MALICIOUS_BASELINE_CAP_1,
+                    FIELD_SIZE * RECORDS_SENT_MALICIOUS_BASELINE_CAP_1,
+                )
             } else {
-                RECORDS_SENT_MALICIOUS_BASELINE_CAP_3
+                (
+                    RECORDS_SENT_MALICIOUS_BASELINE_CAP_3,
+                    FIELD_SIZE * RECORDS_SENT_MALICIOUS_BASELINE_CAP_3,
+                )
             };
+            assert_baselines(
+                "malicious IPA (cap = {per_user_cap})",
+                &snapshot,
+                [
+                    (RECORDS_SENT, records_baseline),
+                    (BYTES_SENT, bytes_baseline),
+                ],
+            );
+        }
+    }
 
-            if records_sent < malicious_baseline {
-                tracing::warn!("Baseline for malicious IPA (cap = {per_user_cap}) has improved! Expected {malicious_baseline}, got {records_sent}.\
+    fn assert_baselines<const N: usize>(
+        name: &str,
+        snapshot: &Metrics,
+        baselines: [(&'static str, u64); N],
+    ) {
+        for (metric_name, baseline) in baselines {
+            let actual = snapshot.get_counter(metric_name);
+            assert!(actual <= baseline,
+                    "{metric_name} baseline for {name} has DEGRADED! Expected {baseline}, got {actual}.");
+
+            if actual < baseline {
+                tracing::warn!("{metric_name} baseline for {name} has improved! Expected {baseline}, got {actual}.\
                 Strongly consider adjusting the baseline, so the gains won't be accidentally offset by a regression.");
             }
-
-            assert!(records_sent <= malicious_baseline,
-                "Baseline for malicious IPA (cap = {per_user_cap}) has DEGRADED! Expected {malicious_baseline}, got {records_sent}.");
         }
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -13,6 +13,7 @@ pub mod metrics {
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
     pub const RECORDS_SENT: &str = "records.sent";
+    pub const BYTES_SENT: &str = "bytes.sent";
     pub const INDEXED_PRSS_GENERATED: &str = "i.prss.gen";
     pub const SEQUENTIAL_PRSS_GENERATED: &str = "s.prss.gen";
 
@@ -83,6 +84,12 @@ pub mod metrics {
             RECORDS_SENT,
             Unit::Count,
             "Number of unique records sent from the infrastructure layer to the network"
+        );
+
+        describe_counter!(
+            BYTES_SENT,
+            Unit::Count,
+            "Bytes sent from the infrastructure layer to the network"
         );
 
         describe_counter!(

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -3,7 +3,7 @@
 
 use crate::telemetry::{
     labels,
-    metrics::{BYTES_SENT, INDEXED_PRSS_GENERATED, SEQUENTIAL_PRSS_GENERATED},
+    metrics::{BYTES_SENT, INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED},
     stats::Metrics,
 };
 use std::{
@@ -11,7 +11,6 @@ use std::{
     io,
     io::{Error, Write},
 };
-use crate::telemetry::metrics::RECORDS_SENT;
 
 pub trait CsvExporter {
     /// Writes the serialized version of this instance into the provided writer in CSV format.
@@ -36,7 +35,10 @@ impl CsvExporter for Metrics {
         // then dump them to the provided Write interface
         // TODO: include role dimension. That requires rethinking `Metrics` implementation
         // because it does not allow such breakdown atm.
-        writeln!(w, "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS")?;
+        writeln!(
+            w,
+            "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS"
+        )?;
         for (step, stats) in steps_stats.all_steps() {
             writeln!(
                 w,

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -11,6 +11,7 @@ use std::{
     io,
     io::{Error, Write},
 };
+use crate::telemetry::metrics::RECORDS_SENT;
 
 pub trait CsvExporter {
     /// Writes the serialized version of this instance into the provided writer in CSV format.
@@ -35,12 +36,13 @@ impl CsvExporter for Metrics {
         // then dump them to the provided Write interface
         // TODO: include role dimension. That requires rethinking `Metrics` implementation
         // because it does not allow such breakdown atm.
-        writeln!(w, "Step,Bytes sent,Indexed PRSS,Sequential PRSS")?;
+        writeln!(w, "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS")?;
         for (step, stats) in steps_stats.all_steps() {
             writeln!(
                 w,
-                "{},{},{},{}",
+                "{},{},{},{},{}",
                 step,
+                stats.get(RECORDS_SENT),
                 stats.get(BYTES_SENT),
                 stats.get(INDEXED_PRSS_GENERATED),
                 stats.get(SEQUENTIAL_PRSS_GENERATED)

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -3,7 +3,7 @@
 
 use crate::telemetry::{
     labels,
-    metrics::{INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED},
+    metrics::{BYTES_SENT, INDEXED_PRSS_GENERATED, SEQUENTIAL_PRSS_GENERATED},
     stats::Metrics,
 };
 use std::{
@@ -35,13 +35,13 @@ impl CsvExporter for Metrics {
         // then dump them to the provided Write interface
         // TODO: include role dimension. That requires rethinking `Metrics` implementation
         // because it does not allow such breakdown atm.
-        writeln!(w, "Step,Records Sent,Indexed PRSS,Sequential PRSS")?;
+        writeln!(w, "Step,Bytes sent,Indexed PRSS,Sequential PRSS")?;
         for (step, stats) in steps_stats.all_steps() {
             writeln!(
                 w,
                 "{},{},{},{}",
                 step,
-                stats.get(RECORDS_SENT),
+                stats.get(BYTES_SENT),
                 stats.get(INDEXED_PRSS_GENERATED),
                 stats.get(SEQUENTIAL_PRSS_GENERATED)
             )?;


### PR DESCRIPTION
A companion to `records.sent` that measures the total communication in bytes between helpers. With recent developments in IPA, the total number of records may stay the same, but size of messages sent is reduced. `records.sent` does not capture it, so we would rely on `bytes.sent` to check those improvements.