### PR TITLE
Use type aliases for Gateway and ReceivingEnd

### DIFF
--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -2,32 +2,48 @@ mod receive;
 mod send;
 mod transport;
 
-pub use receive::ReceivingEnd;
 pub use send::SendingEnd;
 
 use std::{fmt::Debug, num::NonZeroUsize};
 
 use crate::{
-    helpers::{transport::TransportImpl, ChannelId, Message, Role, RoleAssignment, TotalRecords},
+    helpers::{ChannelId, Message, Role, RoleAssignment, TotalRecords},
     protocol::QueryId,
 };
 
 use crate::{
     ff::Field,
-    helpers::gateway::{
-        receive::GatewayReceivers, send::GatewaySenders, transport::RoleResolvingTransport,
+    helpers::{
+        gateway::{
+            receive::{GatewayReceivers, ReceivingEnd as ReceivingEndBase},
+            send::GatewaySenders,
+            transport::RoleResolvingTransport,
+        },
+        Transport,
     },
 };
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;
 use typenum::Unsigned;
 
-/// Gateway into IPA Infrastructure systems. This object allows sending and receiving messages
-pub struct Gateway {
+#[cfg(any(feature = "test-fixture", test))]
+type TransportImpl = std::sync::Weak<crate::test_fixture::network::InMemoryTransport>;
+#[cfg(not(any(feature = "test-fixture", test)))]
+type TransportImpl = crate::helpers::transport::DummyTransport;
+
+pub type Gateway = GatewayBase<TransportImpl>;
+pub type ReceivingEnd<M> = ReceivingEndBase<TransportImpl, M>;
+
+/// Gateway into IPA Infrastructure systems. This object allows sending and receiving messages.
+/// As it is generic over network/transport layer implementation, type alias [`Gateway`] should be
+/// used to avoid carrying `T` over.
+///
+/// [`Gateway`]: crate::helpers::Gateway
+pub struct GatewayBase<T: Transport> {
     config: GatewayConfig,
-    transport: RoleResolvingTransport<TransportImpl>,
+    transport: RoleResolvingTransport<T>,
     senders: GatewaySenders,
-    receivers: GatewayReceivers<TransportImpl>,
+    receivers: GatewayReceivers<T>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -38,13 +54,13 @@ pub struct GatewayConfig {
     pub recv_outstanding: NonZeroUsize,
 }
 
-impl Gateway {
+impl<T: Transport> GatewayBase<T> {
     #[must_use]
     pub fn new(
         query_id: QueryId,
         config: GatewayConfig,
         roles: RoleAssignment,
-        transport: TransportImpl,
+        transport: T,
     ) -> Self {
         Self {
             config,
@@ -92,8 +108,8 @@ impl Gateway {
     }
 
     #[must_use]
-    pub fn get_receiver<M: Message>(&self, channel_id: &ChannelId) -> ReceivingEnd<M> {
-        ReceivingEnd::new(
+    pub fn get_receiver<M: Message>(&self, channel_id: &ChannelId) -> ReceivingEndBase<T, M> {
+        ReceivingEndBase::new(
             self.receivers
                 .get_or_create::<M, _>(channel_id, || self.transport.receive(channel_id)),
         )

--- a/src/helpers/gateway/receive.rs
+++ b/src/helpers/gateway/receive.rs
@@ -1,5 +1,5 @@
 use crate::{
-    helpers::{buffers::UnorderedReceiver, ChannelId, Error, Message, Transport, TransportImpl},
+    helpers::{buffers::UnorderedReceiver, ChannelId, Error, Message, Transport},
     protocol::RecordId,
 };
 use dashmap::DashMap;
@@ -7,8 +7,8 @@ use futures::Stream;
 use std::marker::PhantomData;
 
 /// Receiving end end of the gateway channel.
-pub struct ReceivingEnd<M: Message> {
-    unordered_rx: UR<TransportImpl>,
+pub struct ReceivingEnd<T: Transport, M: Message> {
+    unordered_rx: UR<T>,
     _phantom: PhantomData<M>,
 }
 
@@ -22,8 +22,8 @@ pub(super) type UR<T> = UnorderedReceiver<
     <<T as Transport>::RecordsStream as Stream>::Item,
 >;
 
-impl<M: Message> ReceivingEnd<M> {
-    pub(super) fn new(rx: UR<TransportImpl>) -> Self {
+impl<T: Transport, M: Message> ReceivingEnd<T, M> {
+    pub(super) fn new(rx: UR<T>) -> Self {
         Self {
             unordered_rx: rx,
             _phantom: PhantomData,

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -11,11 +11,14 @@ mod time;
 mod transport;
 
 pub use error::{Error, Result};
-pub use gateway::{Gateway, GatewayConfig, ReceivingEnd, SendingEnd};
+pub use gateway::{GatewayConfig, ReceivingEnd, SendingEnd};
+
+pub use gateway::Gateway;
+
 pub use prss_protocol::negotiate as negotiate_prss;
 pub use transport::{
     AlignedByteArrStream, ByteArrStream, NoResourceIdentifier, QueryIdBinding, RouteId,
-    RouteParams, StepBinding, Transport, TransportImpl,
+    RouteParams, StepBinding, Transport,
 };
 
 pub use transport::query;

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -23,7 +23,7 @@ use std::io::stdout;
 use std::{fmt::Debug, iter::zip, num::NonZeroUsize};
 
 use crate::{
-    helpers::{RoleAssignment, TransportImpl},
+    helpers::RoleAssignment,
     protocol::{QueryId, Substep},
     secret_sharing::IntoShares,
     sync::Arc,
@@ -109,7 +109,7 @@ impl TestWorld {
                 QueryId,
                 config.gateway_config,
                 role_assignment,
-                TransportImpl::InMemory(Arc::downgrade(transport)),
+                Arc::downgrade(transport),
             );
             let role = gateway.role();
             gateways[role] = Some(gateway);


### PR DESCRIPTION
Builds on top of #573 

It turns out the enum dispatch for the transport layer
implemented in `TransportImpl` is unusable with multiple transport implementations.

It does not allow decorators/wrappers to be used without adding another enum variant
which is horrible in my opinion. Testing `QueryProcessor` requires use of specialized
transports (`DelayedTransport`) and I couldn't just make it work even when I use the
atrocious downcasting `Transport` -> `InMemoryTransport`.

We still want `Gateway` to be generic free, but it is just not flexible for the infrastructure
layer tests. So I thought that I could maybe make it work if I lift type aliases one level above:
i.e. instead of using type aliases for transport implementations, I could use them to provide
different `Gateway` definitions depending on what underlying transport is used.

That turns out to cover my needs on the infra side and requires no change on MPC side. I can now
instantiate `Gateway` with whatever `Transport` implementation I have handy and the horrible `TransportImpl`
is gone now, which is another win imo.