### PR TITLE
Revert gateway send buffer capacity back from bytes to units

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -49,8 +49,7 @@ async fn main() -> Result<(), Error> {
 
     let prep_time = Instant::now();
     let mut config = TestWorldConfig::default();
-    config.gateway_config =
-        GatewayConfig::symmetric_buffers::<BenchField>(args.query_size.clamp(16, 1024));
+    config.gateway_config = GatewayConfig::symmetric_buffers(args.query_size.clamp(16, 1024));
 
     let seed = args.random_seed.unwrap_or_else(|| thread_rng().gen());
     println!(

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -21,8 +21,7 @@ async fn main() -> Result<(), Error> {
     type BenchField = Fp32BitPrime;
 
     let mut config = TestWorldConfig::default();
-    config.gateway_config =
-        GatewayConfig::symmetric_buffers::<BenchField>(BATCHSIZE.clamp(4, 1024));
+    config.gateway_config = GatewayConfig::symmetric_buffers(BATCHSIZE.clamp(4, 1024));
     let world = TestWorld::new_with(config);
     let [ctx0, ctx1, ctx2] = world.contexts();
     let mut rng = rand::thread_rng();

--- a/src/helpers/gateway/send.rs
+++ b/src/helpers/gateway/send.rs
@@ -7,6 +7,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+use typenum::Unsigned;
 
 use crate::{
     helpers::{buffers::OrderingSender, ChannelId, Error, Message, Role, TotalRecords},
@@ -97,8 +98,6 @@ impl<M: Message> SendingEnd<M> {
     ///
     /// [`set_total_records`]: crate::protocol::context::Context::set_total_records
     pub async fn send(&self, record_id: RecordId, msg: M) -> Result<(), Error> {
-        use typenum::Unsigned;
-
         let r = self.inner.send(record_id, msg).await;
         metrics::increment_counter!(RECORDS_SENT,
             STEP => self.channel_id.step.as_ref().to_string(),
@@ -135,7 +134,14 @@ impl GatewaySenders {
             let write_size = if total_records.is_indeterminate() {
                 NonZeroUsize::new(1).unwrap()
             } else {
+                // capacity is defined in terms of number of elements, while sender wants bytes
+                // so perform the conversion here
                 capacity
+                    .checked_mul(
+                        NonZeroUsize::new(M::Size::USIZE)
+                            .expect("Message size should be greater than 0"),
+                    )
+                    .expect("capacity should not overflow")
             };
 
             let sender = Arc::new(GatewaySender::new(

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -763,9 +763,7 @@ pub mod tests {
         // This is part of the IPA spec. Callers should do this before sending a batch of records in for processing.
         raw_data.sort_unstable_by(|a, b| a.timestamp.cmp(&b.timestamp));
         let config = TestWorldConfig {
-            gateway_config: GatewayConfig::symmetric_buffers::<TestField>(
-                raw_data.len().clamp(4, 1024),
-            ),
+            gateway_config: GatewayConfig::symmetric_buffers(raw_data.len().clamp(4, 1024)),
             ..Default::default()
         };
 

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -61,7 +61,7 @@ impl Default for TestWorldConfig {
     fn default() -> Self {
         Self {
             gateway_config: GatewayConfig {
-                send_outstanding_bytes: NonZeroUsize::new(16).unwrap(),
+                send_outstanding: NonZeroUsize::new(16).unwrap(),
                 recv_outstanding: NonZeroUsize::new(16).unwrap(),
             },
             // Disable metrics by default because `logging` only enables `Level::INFO` spans.

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -19,7 +19,7 @@ fn send_receive_sequential() {
             shuttle::future::block_on(async {
                 let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                 let config = TestWorldConfig {
-                    gateway_config: GatewayConfig::symmetric_buffers::<TestField>(input.len()),
+                    gateway_config: GatewayConfig::symmetric_buffers(input.len()),
                     ..Default::default()
                 };
                 let world = TestWorld::new_with(config);
@@ -74,7 +74,7 @@ fn send_receive_parallel() {
             shuttle::future::block_on(async {
                 let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                 let config = TestWorldConfig {
-                    gateway_config: GatewayConfig::symmetric_buffers::<TestField>(input.len()),
+                    gateway_config: GatewayConfig::symmetric_buffers(input.len()),
                     ..Default::default()
                 };
                 let world = TestWorld::new_with(config);


### PR DESCRIPTION
Recent [change](https://github.com/private-attribution/ipa/pull/566) made it possible for IPA to send different field values, so send buffer capacity must be adjusted to that. Setting up raw bytes capacity no longer works and here is why:

assume we set send buffer capacity to 1024 bytes. That would mean that it could keep up to 256 `Fp32BitPrime` values or 1024 `Gf2` values. Given that we are moving towards defining a sliding window of records we process in parallel (see @martinthomson's efforts to implement [`seq_try_join_all`](https://github.com/private-attribution/ipa/commit/bfc7a09b46bfb4f3de18693882192424d83addff)) we no longer can rely on universal send buffer capacity.

The proposed fix includes defining send buffer capacity in terms of items to process and adjusting byte capacity by calculating the size of one message (field value) and multiplying it by number of concurrent items it needs to hold.

Using the example above: if send buffer capacity is 1024 items, then `Gf2` buffer capacity will be set to 1024 bytes and `Fp32BitPrime` buffer capacity will be 4096 bytes. Note that if we want to optimize the network utilization, we would rather set `Gf2` buffer capacity to 4096 items while keeping `Fp32BitPrime` at 1024 items, but I don't think it is possible with `seq_try_join_all` API that uses number of records.

To explain why it wouldn't work: if `seq_try_join_all` processes up to 4096 items in parallel, it may underutilize send buffer for `Gf2` if it is ever set to be more than 1024 items, while being perfectly capable of using less than 25% of send buffer capacity for `Fp32BitPrime`.

Overall, it feels easier to use the same units across the system, currently it seems the number of records prevails, so lets use it everywhere then.