### PR TITLE
Allow disallowed methods in tests

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
 disallowed-methods = [
   { path = "futures::future::join_all", reason = "We don't have a replacement for this method yet. Consider extending `SeqJoin` trait." },
-  { path = "futures::future::try_join_all", reason = "Use Context.join instead." },
+  { path = "futures::future::try_join_all", reason = "Use Context.try_join instead." },
 ]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
 disallowed-methods = [
-  "futures::future::join_all",
-  "futures::future::try_join_all",
+  { path = "futures::future::join_all", reason = "We don't have a replacement for this method yet. Consider extending `SeqJoin` trait." },
+  { path = "futures::future::try_join_all", reason = "Use Context.join instead." },
 ]

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,4 @@
+# A list of methods that are discouraged to use in production code. It is still possible to use them in tests
 disallowed-methods = [
   { path = "futures::future::join_all", reason = "We don't have a replacement for this method yet. Consider extending `SeqJoin` trait." },
   { path = "futures::future::try_join_all", reason = "Use Context.try_join instead." },

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -271,7 +271,6 @@ impl OrderingMpscEnd {
 
 #[cfg(test)]
 mod fixture {
-    #![allow(clippy::disallowed_methods)] // It's a test without a context to use.
     use crate::{
         ff::{Fp32BitPrime, Serializable},
         helpers::buffers::ordering_mpsc::{

--- a/src/helpers/buffers/ordering_sender.rs
+++ b/src/helpers/buffers/ordering_sender.rs
@@ -385,7 +385,6 @@ impl<B: Borrow<OrderingSender> + Unpin> Stream for OrderedStream<B> {
 
 #[cfg(test)]
 mod test {
-    #![allow(clippy::disallowed_methods)] // It's a test without a context to use.
     use super::OrderingSender;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Serializable},

--- a/src/helpers/buffers/unordered_receiver.rs
+++ b/src/helpers/buffers/unordered_receiver.rs
@@ -298,8 +298,6 @@ where
 
 #[cfg(test)]
 mod test {
-    #![allow(clippy::disallowed_methods)] // A parallel join is needed to test without a context.
-
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Serializable},
         helpers::buffers::unordered_receiver::UnorderedReceiver,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 // code with allow annotations. Disabling them once per project here
 #![allow(clippy::similar_names)]
 #![allow(clippy::module_name_repetitions)]
+// In unit tests, it is ok to use methods discouraged to use in prod code. Most of the time it is
+// because of performance implications which shouldn't be a concern for unit testing.
+#![cfg_attr(test, allow(clippy::disallowed_methods))]
 
 pub mod chunkscan;
 #[cfg(feature = "cli")]

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -51,7 +51,7 @@ where
         .narrow(&Step::MemoizeIsTriggerBitTimesHelperBit)
         .set_total_records(num_rows - 1);
     let credits = ctx
-        .join(input.iter().skip(1).enumerate().map(|(i, x)| {
+        .try_join(input.iter().skip(1).enumerate().map(|(i, x)| {
             let c = memoize_context.clone();
             let record_id = RecordId::from(i);
             async move {
@@ -110,7 +110,7 @@ where
         .narrow(&Step::MemoizeIsTriggerBitTimesHelperBit)
         .set_total_records(num_rows - 1);
     let helper_bits = ctx
-        .join(input.iter().skip(1).enumerate().map(|(i, x)| {
+        .try_join(input.iter().skip(1).enumerate().map(|(i, x)| {
             let c = memoize_context.clone();
             let record_id = RecordId::from(i);
             let is_trigger_bit = &x.is_trigger_report;

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -265,7 +265,7 @@ where
         .set_total_records(inputs.len());
 
     let increments = ctx
-        .join(
+        .try_join(
             inputs
                 .iter()
                 .enumerate()
@@ -275,7 +275,7 @@ where
                     async move {
                         let equality_checks =
                             check_everything(c1.clone(), i, breakdown_key_bits).await?;
-                        c1.join(equality_checks.iter().take(to_take).enumerate().map(
+                        c1.try_join(equality_checks.iter().take(to_take).enumerate().map(
                             |(check_idx, check)| {
                                 let step = BitOpStep::from(check_idx);
                                 let c = c2.narrow(&step);

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -70,7 +70,7 @@ where
         .set_total_records(num_rows - 1);
     // `empty().chain()` keeps `try_join_all().await?` as iterator. Is there a better way of doing this?
     let stop_bits = std::iter::empty().chain(
-        ctx.join(input.iter().skip(1).enumerate().map(|(i, x)| {
+        ctx.try_join(input.iter().skip(1).enumerate().map(|(i, x)| {
             let c = stop_bit_context.clone();
             let record_id = RecordId::from(i);
             async move {
@@ -90,7 +90,7 @@ where
         .set_total_records(num_rows - 1);
     let mut t_delta = std::iter::once(T::ZERO)
         .chain(
-            ctx.join(
+            ctx.try_join(
                 zip(input.iter(), input.iter().skip(1))
                     .zip(stop_bits.clone())
                     .enumerate()
@@ -141,7 +141,7 @@ where
 
     // Compare the accumulated timestamp deltas with the specified attribution window
     // cap value, and zero-out trigger event values that exceed the cap.
-    ctx.join(
+    ctx.try_join(
         zip(input, time_delta)
             .zip(repeat(T::share_known_value(&ctx, F::ONE)))
             .enumerate()

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -127,7 +127,7 @@ where
         .narrow(&Step::PrefixOrTimesHelperBit)
         .set_total_records(input.len() - 1);
     let ever_any_subsequent_credit = ctx
-        .join(prefix_ors.iter().zip(helper_bits.iter()).enumerate().map(
+        .try_join(prefix_ors.iter().zip(helper_bits.iter()).enumerate().map(
             |(i, (prefix_or, helper_bit))| {
                 let record_id = RecordId::from(i);
                 let c = prefix_or_times_helper_bit_ctx.clone();
@@ -140,7 +140,7 @@ where
         .narrow(&Step::IfCurrentExceedsCapOrElse)
         .set_total_records(input.len() - 1);
     let capped_credits = ctx
-        .join(
+        .try_join(
             uncapped_credits
                 .iter()
                 .zip(ever_any_subsequent_credit.iter())
@@ -179,7 +179,7 @@ where
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
 {
-    ctx.join(
+    ctx.try_join(
         input
             .iter()
             .zip(zip(

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -135,8 +135,8 @@ where
         }
 
         let (stop_bit_updates, credit_updates) = try_join(
-            assert_send(ctx.join(stop_bit_futures)),
-            assert_send(ctx.join(credit_update_futures)),
+            assert_send(ctx.try_join(stop_bit_futures)),
+            assert_send(ctx.try_join(credit_update_futures)),
         )
         .await?;
 
@@ -219,8 +219,8 @@ where
         }
 
         let (stop_bit_updates, value_updates) = try_join(
-            assert_send(ctx.join(stop_bit_futures)),
-            assert_send(ctx.join(value_update_futures)),
+            assert_send(ctx.try_join(stop_bit_futures)),
+            assert_send(ctx.try_join(value_update_futures)),
         )
         .await?;
 
@@ -252,7 +252,7 @@ where
         .narrow(&Step::ComputeHelperBits)
         .set_total_records(sorted_match_keys.len() - 1);
 
-    ctx.join(sorted_match_keys.windows(2).enumerate().map(|(i, rows)| {
+    ctx.try_join(sorted_match_keys.windows(2).enumerate().map(|(i, rows)| {
         let c = narrowed_ctx.clone();
         let record_id = RecordId::from(i);
         async move { bitwise_equal_gf2(c, record_id, &rows[0], &rows[1]).await }
@@ -272,7 +272,7 @@ where
         .set_total_records(semi_honest_helper_bits_gf2.len());
 
     sh_ctx
-        .join(
+        .try_join(
             semi_honest_helper_bits_gf2
                 .iter()
                 .enumerate()

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -139,7 +139,7 @@ mod test {
         let expected: Vec<_> = zip(a.iter(), b.iter()).map(|(&a, &b)| a * b).collect();
         let results = world
             .semi_honest((a, b), |ctx, (a_shares, b_shares)| async move {
-                ctx.join(
+                ctx.try_join(
                     zip(
                         repeat(ctx.set_total_records(COUNT)),
                         zip(a_shares, b_shares),

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -208,7 +208,7 @@ where
     where
         C: 'fut,
     {
-        ctx.join(
+        ctx.try_join(
             zip(repeat(ctx.set_total_records(self.len())), self.iter())
                 .enumerate()
                 .map(|(i, (c, x))| async move { x.reshare(c, RecordId::from(i), to_helper).await }),

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -140,7 +140,7 @@ where
         let ctx_ref = &ctx;
         let ctx = ctx.set_total_records(self.perm.len());
         let revealed_permutation = ctx_ref
-            .join(zip(repeat(ctx), self.perm.iter()).enumerate().map(
+            .try_join(zip(repeat(ctx), self.perm.iter()).enumerate().map(
                 |(index, (ctx, value))| async move {
                     let reveal_value = value.reveal(ctx, RecordId::from(index)).await;
 

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -95,7 +95,6 @@ where
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    #![allow(clippy::disallowed_methods)]
     use super::RandomBitsGenerator;
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -168,7 +168,7 @@ mod tests {
         let world = TestWorld::default();
         let [rv0, rv1, rv2] = world
             .semi_honest((), |ctx, ()| async move {
-                ctx.join(
+                ctx.try_join(
                     repeat(ctx.set_total_records(COUNT))
                         .take(COUNT)
                         .enumerate()

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -613,7 +613,7 @@ where
     async fn upgrade(self, input: Vec<T>) -> Result<Vec<M>, Error> {
         let ctx = self.ctx.set_total_records(input.len());
         let ctx_ref = &ctx;
-        ctx.join(input.into_iter().enumerate().map(|(i, share)| async move {
+        ctx.try_join(input.into_iter().enumerate().map(|(i, share)| async move {
             // TODO: make it a bit more ergonomic to call with record id bound
             UpgradeContext {
                 ctx: ctx_ref.clone(),
@@ -648,7 +648,7 @@ where
         let all_ctx = (0..num_columns).map(|idx| ctx.narrow(&Upgrade2DVectors::V(idx)));
 
         ctx_ref
-            .join(zip(repeat(all_ctx), input.into_iter()).enumerate().map(
+            .try_join(zip(repeat(all_ctx), input.into_iter()).enumerate().map(
                 |(record_idx, (all_ctx, one_input))| async move {
                     // This inner join is truly concurrent.
                     ctx_ref

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -65,7 +65,6 @@ pub trait Context: Clone + Send + Sync + SeqJoin {
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-    #![allow(clippy::disallowed_methods)] // It's a test with a toy implementation.
     use crate::{
         ff::{Field, Fp31, Serializable},
         helpers::Direction,

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -456,7 +456,7 @@ mod tests {
                 let m_input = m_ctx.upgrade(input_shares).await.unwrap();
 
                 let m_results = m_ctx
-                    .join(
+                    .try_join(
                         zip(
                             repeat(m_ctx.set_total_records(COUNT - 1)).enumerate(),
                             zip(m_input.iter(), m_input.iter().skip(1)),

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -154,7 +154,7 @@ where
     // The outer loop is concurrent; the inner is fully sequential.
     ctx.parallel_join(all_bits.chunks(num_multi_bits as usize).map(|chunk| {
         assert_send(
-            ctx.join(
+            ctx.try_join(
                 zip(locally_converted_bits, repeat(ctx.clone()))
                     .enumerate()
                     .map(move |(idx, (record, ctx))| async move {

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -57,7 +57,7 @@ pub async fn bit_permutation<
                 let record_id = RecordId::from(i);
                 x.multiply(&sum, ctx, record_id).await
             });
-    let mut mult_output = ctx_ref.join(async_multiply).await?;
+    let mut mult_output = ctx_ref.try_join(async_multiply).await?;
 
     debug_assert!(mult_output.len() == input.len() * 2);
     // Generate permutation location

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -44,7 +44,7 @@ pub async fn multi_bit_permutation<
     let share_of_one = S::share_known_value(&ctx, F::ONE);
     // Equality bit checker: this checks if each secret shared record is equal to any of numbers between 0 and num_possible_bit_values
     let equality_checks = ctx
-        .join(
+        .try_join(
             input
                 .iter()
                 .zip(repeat(ctx.set_total_records(num_records)))
@@ -68,7 +68,7 @@ pub async fn multi_bit_permutation<
 
     // Take sum of products of output of equality check and accumulated sum
     let mut one_off_permutation = ctx
-        .join(
+        .try_join(
             equality_checks
                 .into_iter()
                 .zip(prefix_sum.into_iter())
@@ -151,7 +151,7 @@ mod tests {
                 for (i, record) in m_shares.iter().enumerate() {
                     equality_check_futures.push(check_everything(ctx.clone(), i, record));
                 }
-                ctx.join(equality_check_futures).await.unwrap()
+                ctx.try_join(equality_check_futures).await.unwrap()
             })
             .await;
         let reconstructs: Vec<Vec<Fp31>> = result.reconstruct();

--- a/src/seq_join.rs
+++ b/src/seq_join.rs
@@ -77,7 +77,7 @@ pub trait SeqJoin {
     /// [`active_work`]: Self::active_work
     /// [`parallel_join`]: Self::parallel_join
     /// [`join3`]: futures::future::join3
-    fn join<I, F, O, E>(&self, iterable: I) -> TryCollect<SeqTryJoinAll<I, F>, Vec<O>>
+    fn try_join<I, F, O, E>(&self, iterable: I) -> TryCollect<SeqTryJoinAll<I, F>, Vec<O>>
     where
         I: IntoIterator<Item = F> + Send,
         I::IntoIter: Send,

--- a/src/tests/infra.rs
+++ b/src/tests/infra.rs
@@ -97,7 +97,11 @@ fn send_receive_parallel() {
                             futures.push(left_channel.send(record_id, share.left()));
                             futures.push(right_channel.send(record_id, share.right()));
                         }
-                        ctx.join(futures).await.unwrap().into_iter().for_each(drop);
+                        ctx.try_join(futures)
+                            .await
+                            .unwrap()
+                            .into_iter()
+                            .for_each(drop);
 
                         // receive all shares from the left peer in parallel
                         let left_channel = left_ctx.recv_channel::<Fp32BitPrime>(left_peer);
@@ -111,7 +115,7 @@ fn send_receive_parallel() {
                             ));
                         }
 
-                        let result = ctx.join(futures).await.unwrap();
+                        let result = ctx.try_join(futures).await.unwrap();
 
                         result.into_iter().map(Replicated::from).collect::<Vec<_>>()
                     })


### PR DESCRIPTION
Allow array joins in tests

Follow up on #585 - relax this requirement to avoid array joins in prod code only
Also this change proposes to rename `join` to `try_join` - see commit message for details why.

 
## Testing

* removed lint suppression in prod code and verified that clippy is angry about it

```bash
cargo clippy
    Checking num-traits v0.2.15
    Checking byteorder v1.4.3
    Checking curve25519-dalek v3.2.0
    Checking ordered-float v2.10.0
    Checking x25519-dalek v2.0.0-pre.1
    Checking metrics-util v0.14.0
    Checking hpke v0.10.0
    Checking metrics-tracing-context v0.12.0
    Checking ipa v0.1.0 (/Users/koshelev/workspace/raw-ipa)
warning: use of a disallowed method `futures::future::join_all`
   --> src/secret_sharing/replicated/malicious/additive_share.rs:294:22
    |
294 |           let result = join_all(
    |  ______________________^
295 | |             self.into_iter()
296 | |                 .map(|v| async move { v.downgrade().await.access_without_downgrade() }),
297 | |         );
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_methods
    = note: `#[warn(clippy::disallowed_methods)]` on by default
```