### PR TITLE
Switch to jemalloc allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 typenum = "1.16.0"
 x25519-dalek = "2.0.0-pre.1"
 
+[target.'cfg(all(target_arch = "x86_64", not(target_env = "msvc")))'.dependencies]
+tikv-jemallocator = "0.5.0"
+
 [dev-dependencies]
 permutation = "0.4.1"
 proptest = "1.0.0"

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -14,6 +14,10 @@ use ipa::{
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use std::{num::NonZeroUsize, time::Instant};
 
+#[cfg(all(target_arch = "x86_64", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// A benchmark for the full IPA protocol.
 #[derive(Parser)]
 #[command(about, long_about = None)]

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -2,6 +2,10 @@ use clap::Parser;
 use hyper::http::uri::Scheme;
 use ipa::cli::Verbosity;
 
+#[cfg(all(target_arch = "x86_64", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[derive(Debug, Parser)]
 #[clap(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
 struct Args {


### PR DESCRIPTION
This cut about 25% off the running time of a test, but it only works reliably on x86_64.