### PR TITLE
Fix the memory spike

### DIFF
--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -236,10 +236,8 @@ where
         RandomBitsGenerator::new(ctx.narrow(&Step::RandomBitsForComparison));
     let rbg = &random_bits_generator;
 
-    // TODO: This can't use a sequential join because `greater_than_constant` uses
-    // a `RandomBitsGenerator`.  We need to fix that.
     ctx_ref
-        .parallel_join(
+        .try_join(
             prefix_summed_credits
                 .iter()
                 .zip(zip(repeat(ctx), repeat(cap)))


### PR DESCRIPTION
We're still far too exposed to memory allocations, but this should fix the spike we're seeing about 2/3 - 3/4 through a run.

This is safe because the comparison ends with sequential operations, even if earlier operations (RBG) are not.

IPA for 50000 records took 568.861833105s compared to 843.574458344s without this change (same baseline; not rebased).