### PR TITLE
Upgrade to Rust 1.69

### DIFF
--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -105,7 +105,7 @@ impl<T: Transport> Gateway<T> {
     pub fn get_receiver<M: Message>(&self, channel_id: &ChannelId) -> ReceivingEndBase<T, M> {
         ReceivingEndBase::new(
             self.receivers
-                .get_or_create::<M, _>(channel_id, || self.transport.receive(channel_id)),
+                .get_or_create(channel_id, || self.transport.receive(channel_id)),
         )
     }
 }

--- a/src/helpers/gateway/receive.rs
+++ b/src/helpers/gateway/receive.rs
@@ -55,11 +55,7 @@ impl<T: Transport> Default for GatewayReceivers<T> {
 }
 
 impl<T: Transport> GatewayReceivers<T> {
-    pub fn get_or_create<M: Message, F: FnOnce() -> UR<T>>(
-        &self,
-        channel_id: &ChannelId,
-        ctr: F,
-    ) -> UR<T> {
+    pub fn get_or_create<F: FnOnce() -> UR<T>>(&self, channel_id: &ChannelId, ctr: F) -> UR<T> {
         let receivers = &self.inner;
         if let Some(recv) = receivers.get(channel_id) {
             recv.clone()

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -324,7 +324,7 @@ mod tests {
         let enc = suite.seal(0, EventType::Source, &match_key);
         suite.advance_epoch();
 
-        let _ = suite.open(0, EventType::Source, enc).unwrap_err();
+        let _: DecryptionError = suite.open(0, EventType::Source, enc).unwrap_err();
     }
 
     #[test]
@@ -333,7 +333,7 @@ mod tests {
         let mut suite = EncryptionSuite::new(10, rng);
         let match_key = new_share(1u64 << 39, 1u64 << 20);
         let enc = suite.seal(0, EventType::Source, &match_key);
-        let _ = suite.open(1, EventType::Source, enc).unwrap_err();
+        let _: DecryptionError = suite.open(1, EventType::Source, enc).unwrap_err();
     }
 
     #[test]
@@ -363,7 +363,7 @@ mod tests {
                 let mut encryption = suite.seal(0, EventType::Source, &new_share(0, 0));
 
                 encryption.ct.as_mut()[bad_byte] ^= 1 << bad_bit;
-                let _ = suite.open(0, EventType::Source, encryption).unwrap_err();
+                suite.open(0, EventType::Source, encryption).unwrap_err();
             }
         }
 
@@ -376,7 +376,7 @@ mod tests {
                 let mut encryption = suite.seal(0, EventType::Source, &new_share(0, 0));
 
                 encryption.enc.as_mut()[bad_byte] ^= 1 << bad_bit;
-                let _ = suite.open(0, EventType::Source, encryption).unwrap_err();
+                suite.open(0, EventType::Source, encryption).unwrap_err();
             }
         }
 
@@ -467,7 +467,7 @@ mod tests {
                     _ => panic!("bad test setup: only 6 fields can be corrupted, asked to corrupt: {corrupted_info_field}")
                 };
 
-                let _ = open_in_place(&suite.registry, &encryption.enc, &mut encryption.ct, info).unwrap_err();
+                open_in_place(&suite.registry, &encryption.enc, &mut encryption.ct, info).unwrap_err();
             }
         }
     }

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -83,17 +83,14 @@ mod test {
     #[tokio::test]
     async fn basic() {
         let world = TestWorld::default();
-        assert_eq!(11, sop_sync::<Fp31>(&world, &[7], &[6]).await);
-        assert_eq!(3, sop_sync::<Fp31>(&world, &[6, 2], &[5, 2]).await);
-        assert_eq!(28, sop_sync::<Fp31>(&world, &[5, 3], &[5, 1]).await);
-        assert_eq!(16, sop_sync::<Fp31>(&world, &[7, 1, 4], &[1, 1, 2]).await);
-        assert_eq!(
-            13,
-            sop_sync::<Fp31>(&world, &[0, 4, 7, 2], &[14, 0, 6, 1]).await
-        );
+        assert_eq!(11, sop_sync(&world, &[7], &[6]).await);
+        assert_eq!(3, sop_sync(&world, &[6, 2], &[5, 2]).await);
+        assert_eq!(28, sop_sync(&world, &[5, 3], &[5, 1]).await);
+        assert_eq!(16, sop_sync(&world, &[7, 1, 4], &[1, 1, 2]).await);
+        assert_eq!(13, sop_sync(&world, &[0, 4, 7, 2], &[14, 0, 6, 1]).await);
         assert_eq!(
             15,
-            sop_sync::<Fp31>(&world, &[7, 5, 4, 2, 1], &[10, 3, 2, 3, 9]).await
+            sop_sync(&world, &[7, 5, 4, 2, 1], &[10, 3, 2, 3, 9]).await
         );
     }
 
@@ -133,11 +130,7 @@ mod test {
         assert_eq!(expected, res.reconstruct());
     }
 
-    async fn sop_sync<F>(world: &TestWorld, a: &[u128], b: &[u128]) -> u128
-    where
-        F: Field,
-        (F, F): Sized,
-    {
+    async fn sop_sync(world: &TestWorld, a: &[u128], b: &[u128]) -> u128 {
         let a: Vec<_> = a.iter().map(|x| Fp31::try_from(*x).unwrap()).collect();
         let b: Vec<_> = b.iter().map(|x| Fp31::try_from(*x).unwrap()).collect();
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -68,7 +68,7 @@ where
     for (bit_index, bit) in a.iter().enumerate().skip(1) {
         let mult_result = if last_carry_known_to_be_zero {
             // TODO: this makes me sad
-            let _ = S::ZERO
+            S::ZERO
                 .multiply(&S::ZERO, ctx.narrow(&BitOpStep::from(bit_index)), record_id) // this is stupid
                 .await?;
 

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -556,7 +556,6 @@ pub mod tests {
     #[tokio::test]
     #[allow(clippy::missing_panics_doc)]
     pub async fn semi_honest() {
-        const COUNT: usize = 7;
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[
             [0, 0],
@@ -618,7 +617,6 @@ pub mod tests {
 
     #[tokio::test]
     async fn malicious() {
-        const COUNT: usize = 5;
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 2], [2, 3]];
         const MAX_BREAKDOWN_KEY: u32 = 3;
@@ -670,7 +668,6 @@ pub mod tests {
 
     #[tokio::test]
     async fn semi_honest_with_attribution_window() {
-        const COUNT: usize = 7;
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[
             [0, 0],
@@ -732,7 +729,6 @@ pub mod tests {
 
     #[tokio::test]
     async fn malicious_with_attribution_window() {
-        const COUNT: usize = 5;
         const PER_USER_CAP: u32 = 3;
         const EXPECTED: &[[u128; 2]] = &[[0, 0], [1, 0], [2, 3]];
         const MAX_BREAKDOWN_KEY: u32 = 3;
@@ -1153,7 +1149,6 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: u32 = 600;
         const NUM_MULTI_BITS: u32 = 3;
-        const FIELD_SIZE: u64 = <Fp32BitPrime as Serializable>::Size::U64;
 
         /// empirical value as of Apr 13, 2023.
         const RECORDS_SENT_SEMI_HONEST_BASELINE_CAP_3: u64 = 21_936;
@@ -1230,7 +1225,7 @@ pub mod tests {
 
             let world = TestWorld::new_with(TestWorldConfig::default().enable_metrics());
 
-            let _ = world
+            world
                 .semi_honest(records.clone(), |ctx, input_rows| async move {
                     ipa_malicious::<Fp32BitPrime, MatchKey, BreakdownKey>(
                         ctx,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -245,7 +245,7 @@ pub struct QueryId;
 impl Display for QueryId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // fail when query id becomes meaningful and change the display implementation
-        let _ = QueryId;
+        let _: QueryId = QueryId;
         write!(f, "{self:?}")
     }
 }

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -497,7 +497,7 @@ pub mod test {
 
         let step = Step::default().narrow("test");
         drop(p1.indexed(&step));
-        let _ = p1.sequential(&step);
+        let _: (_, _) = p1.sequential(&step);
     }
 
     #[test]
@@ -506,7 +506,7 @@ pub mod test {
         let [p1, _p2, _p3] = make_participants();
 
         let step = Step::default().narrow("test");
-        let _ = p1.sequential(&step);
+        let _: (_, _) = p1.sequential(&step);
         drop(p1.indexed(&step));
     }
 
@@ -519,7 +519,7 @@ pub mod test {
         let indexed_prss = p2.indexed(&step);
 
         for index in indices {
-            let _ = indexed_prss.random_u128(index);
+            let _: u128 = indexed_prss.random_u128(index);
         }
     }
 
@@ -530,7 +530,7 @@ pub mod test {
         let [p1, _p2, _p3] = make_participants();
         let step = Step::default().narrow("test");
 
-        let _ = p1.indexed(&step).random_u128(100_u128);
-        let _ = p1.indexed(&step).random_u128(100_u128);
+        let _: u128 = p1.indexed(&step).random_u128(100_u128);
+        let _: u128 = p1.indexed(&step).random_u128(100_u128);
     }
 }

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -144,7 +144,6 @@ mod tests {
 
         #[tokio::test]
         async fn shuffle_attribution_input_row() {
-            const NUM_MULTI_BITS: u32 = 3;
             const BATCHSIZE: u8 = 25;
             let world = TestWorld::default();
             let mut rng = thread_rng();


### PR DESCRIPTION
Fix new clippy warnings - it is pretty cool that clippy can now detect unused type parameter and constants