### PR TITLE
Fix sequential prss metrics in IPA

### DIFF
--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -81,6 +81,7 @@ mod tests {
         telemetry::metrics::{
             BYTES_SENT, INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED,
         },
+        test_fixture::{Reconstruct, Runner, TestWorld, TestWorldConfig},
     };
     use futures_util::{future::join_all, try_join};
     use rand::{
@@ -91,7 +92,6 @@ mod tests {
     use typenum::Unsigned;
 
     use super::*;
-    use crate::test_fixture::{Reconstruct, Runner, TestWorld, TestWorldConfig};
 
     trait AsReplicatedTestOnly<F: Field> {
         fn l(&self) -> F;
@@ -141,7 +141,10 @@ mod tests {
         let (seq_l, seq_r) = {
             let ctx = ctx.narrow(&format!("seq-prss-{index}"));
             let (mut left_rng, mut right_rng) = ctx.prss_rng();
-            (left_rng.gen::<F>(), right_rng.gen::<F>())
+            (
+                left_rng.gen::<F>() + F::truncate_from(left_rng.gen::<u32>()),
+                right_rng.gen::<F>() + F::truncate_from(right_rng.gen::<u32>()),
+            )
         };
 
         let send_channel = ctx.send_channel(left_peer);
@@ -202,17 +205,18 @@ mod tests {
             .total(3 * input_size * field_size)
             .per_step(&metrics_step, 3 * input_size * field_size);
 
-        // each helper generates 2 128 bit values resuling in 4 calls to rng::<gen>() per input row
+        // each helper generates 2 128 bit values and 2 u32 values
+        // resulting in 6 calls to rng::<gen>() per input row
         let seq_prss_assert = snapshot
             .assert_metric(SEQUENTIAL_PRSS_GENERATED)
-            .total(4 * 3 * input_size)
-            .per_step(&metrics_step.narrow("seq-prss-0"), 4 * 3);
+            .total(6 * 3 * input_size)
+            .per_step(&metrics_step.narrow("seq-prss-0"), 6 * 3);
 
         for role in Role::all() {
             records_sent_assert.per_helper(role, input_size);
             bytes_sent_assert.per_helper(role, field_size * input_size);
             indexed_prss_assert.per_helper(role, input_size);
-            seq_prss_assert.per_helper(role, 4 * input_size);
+            seq_prss_assert.per_helper(role, 6 * input_size);
         }
     }
 
@@ -281,14 +285,14 @@ mod tests {
         // see semi-honest test for explanation
         let seq_prss_assert = snapshot
             .assert_metric(SEQUENTIAL_PRSS_GENERATED)
-            .total(4 * 3 * input_size)
-            .per_step(&metrics_step.narrow("seq-prss-0"), 4 * 3);
+            .total(6 * 3 * input_size)
+            .per_step(&metrics_step.narrow("seq-prss-0"), 6 * 3);
 
         for role in Role::all() {
             records_sent_assert.per_helper(role, comm_factor(input_size));
             bytes_sent_assert.per_helper(role, comm_factor(input_size) * field_size);
             indexed_prss_assert.per_helper(role, prss_factor(input_size));
-            seq_prss_assert.per_helper(role, 4 * input_size);
+            seq_prss_assert.per_helper(role, 6 * input_size);
         }
     }
 

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -141,6 +141,11 @@ mod tests {
         let (seq_l, seq_r) = {
             let ctx = ctx.narrow(&format!("seq-prss-{index}"));
             let (mut left_rng, mut right_rng) = ctx.prss_rng();
+
+            // exercise both methods of `RngCore` trait
+            // generating a field value involves calling `next_u64` and 32 bit integer values
+            // have special constructor method for them: `next_u32`. Sequential randomness must
+            // record metrics for both calls.
             (
                 left_rng.gen::<F>() + F::truncate_from(left_rng.gen::<u32>()),
                 right_rng.gen::<F>() + F::truncate_from(right_rng.gen::<u32>()),

--- a/src/protocol/context/prss.rs
+++ b/src/protocol/context/prss.rs
@@ -62,8 +62,9 @@ impl<'a> InstrumentedSequentialSharedRandomness<'a> {
 }
 
 impl RngCore for InstrumentedSequentialSharedRandomness<'_> {
+    #[allow(clippy::cast_possible_truncation)]
     fn next_u32(&mut self) -> u32 {
-        self.inner.next_u32()
+        self.next_u64() as u32
     }
 
     fn next_u64(&mut self) -> u64 {

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -267,7 +267,7 @@ pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{
         ff::{Field, Fp31},
-        protocol::{prss::SharedRandomness, Step},
+        protocol::{prss::SharedRandomness, prss::Endpoint, Step},
         rand::{thread_rng, Rng},
         secret_sharing::SharedValue,
         test_fixture::make_participants,
@@ -283,6 +283,10 @@ pub mod test {
         let (pk1, pk2) = (x1.public_key(), x2.public_key());
         let (f1, f2) = (x1.key_exchange(&pk2), x2.key_exchange(&pk1));
         (f1.generator(CONTEXT), f2.generator(CONTEXT))
+    }
+
+    fn participants() -> [Endpoint; 3] {
+        make_participants(&mut thread_rng())
     }
 
     /// When inputs are the same, outputs are the same.
@@ -327,7 +331,7 @@ pub mod test {
     #[test]
     fn three_party_values() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let (r1_l, r1_r) = p1.indexed(&step).generate_values(IDX);
@@ -345,7 +349,7 @@ pub mod test {
     #[test]
     fn three_party_zero_u128() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let z1 = p1.indexed(&step).zero_u128(IDX);
@@ -358,7 +362,7 @@ pub mod test {
     #[test]
     fn three_party_xor_zero() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let z1 = p1.indexed(&step).zero_xor(IDX);
@@ -372,7 +376,7 @@ pub mod test {
     fn three_party_random_u128() {
         const IDX1: u128 = 7;
         const IDX2: u128 = 21362;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let r1 = p1.indexed(&step).random_u128(IDX1);
@@ -393,7 +397,7 @@ pub mod test {
     #[test]
     fn three_party_fields() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         // These tests do not check that left != right because
         // the field might not be large enough.
@@ -410,7 +414,7 @@ pub mod test {
     #[test]
     fn three_party_zero() {
         const IDX: u128 = 72;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let z1: Fp31 = p1.indexed(&step).zero(IDX);
@@ -424,7 +428,7 @@ pub mod test {
     fn three_party_random() {
         const IDX1: u128 = 74;
         const IDX2: u128 = 12634;
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
 
         let step = Step::default();
         let s1 = p1.indexed(&step);
@@ -461,7 +465,7 @@ pub mod test {
             assert_eq!(a.gen_bool(0.3), b.gen_bool(0.3));
         }
 
-        let [p1, p2, p3] = make_participants(&mut thread_rng());
+        let [p1, p2, p3] = participants();
         let step = Step::default();
         let (rng1_l, rng1_r) = p1.sequential(&step);
         let (rng2_l, rng2_r) = p2.sequential(&step);
@@ -474,7 +478,7 @@ pub mod test {
 
     #[test]
     fn indexed_and_sequential() {
-        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
+        let [p1, _p2, _p3] = participants();
 
         let base = Step::default();
         let idx = p1.indexed(&base.narrow("indexed"));
@@ -493,7 +497,7 @@ pub mod test {
     #[test]
     #[should_panic]
     fn indexed_then_sequential() {
-        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
+        let [p1, _p2, _p3] = participants();
 
         let step = Step::default().narrow("test");
         drop(p1.indexed(&step));
@@ -503,7 +507,7 @@ pub mod test {
     #[test]
     #[should_panic]
     fn sequential_then_indexed() {
-        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
+        let [p1, _p2, _p3] = participants();
 
         let step = Step::default().narrow("test");
         let _: (_, _) = p1.sequential(&step);
@@ -512,7 +516,7 @@ pub mod test {
 
     #[test]
     fn indexed_accepts_unique_index() {
-        let [_, p2, _p3] = make_participants(&mut thread_rng());
+        let [_, p2, _p3] = participants();
         let step = Step::default().narrow("test");
         let mut indices = (1..100_u128).collect::<Vec<_>>();
         indices.shuffle(&mut thread_rng());
@@ -527,7 +531,7 @@ pub mod test {
     #[cfg(debug_assertions)]
     #[should_panic]
     fn indexed_rejects_the_same_index() {
-        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
+        let [p1, _p2, _p3] = participants();
         let step = Step::default().narrow("test");
 
         let _: u128 = p1.indexed(&step).random_u128(100_u128);

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -327,7 +327,7 @@ pub mod test {
     #[test]
     fn three_party_values() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let (r1_l, r1_r) = p1.indexed(&step).generate_values(IDX);
@@ -345,7 +345,7 @@ pub mod test {
     #[test]
     fn three_party_zero_u128() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let z1 = p1.indexed(&step).zero_u128(IDX);
@@ -358,7 +358,7 @@ pub mod test {
     #[test]
     fn three_party_xor_zero() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let z1 = p1.indexed(&step).zero_xor(IDX);
@@ -372,7 +372,7 @@ pub mod test {
     fn three_party_random_u128() {
         const IDX1: u128 = 7;
         const IDX2: u128 = 21362;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let r1 = p1.indexed(&step).random_u128(IDX1);
@@ -393,7 +393,7 @@ pub mod test {
     #[test]
     fn three_party_fields() {
         const IDX: u128 = 7;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         // These tests do not check that left != right because
         // the field might not be large enough.
@@ -410,7 +410,7 @@ pub mod test {
     #[test]
     fn three_party_zero() {
         const IDX: u128 = 72;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let z1: Fp31 = p1.indexed(&step).zero(IDX);
@@ -424,7 +424,7 @@ pub mod test {
     fn three_party_random() {
         const IDX1: u128 = 74;
         const IDX2: u128 = 12634;
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
 
         let step = Step::default();
         let s1 = p1.indexed(&step);
@@ -461,7 +461,7 @@ pub mod test {
             assert_eq!(a.gen_bool(0.3), b.gen_bool(0.3));
         }
 
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
         let step = Step::default();
         let (rng1_l, rng1_r) = p1.sequential(&step);
         let (rng2_l, rng2_r) = p2.sequential(&step);
@@ -474,7 +474,7 @@ pub mod test {
 
     #[test]
     fn indexed_and_sequential() {
-        let [p1, _p2, _p3] = make_participants();
+        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
 
         let base = Step::default();
         let idx = p1.indexed(&base.narrow("indexed"));
@@ -493,7 +493,7 @@ pub mod test {
     #[test]
     #[should_panic]
     fn indexed_then_sequential() {
-        let [p1, _p2, _p3] = make_participants();
+        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
 
         let step = Step::default().narrow("test");
         drop(p1.indexed(&step));
@@ -503,7 +503,7 @@ pub mod test {
     #[test]
     #[should_panic]
     fn sequential_then_indexed() {
-        let [p1, _p2, _p3] = make_participants();
+        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
 
         let step = Step::default().narrow("test");
         let _: (_, _) = p1.sequential(&step);
@@ -512,7 +512,7 @@ pub mod test {
 
     #[test]
     fn indexed_accepts_unique_index() {
-        let [_, p2, _p3] = make_participants();
+        let [_, p2, _p3] = make_participants(&mut thread_rng());
         let step = Step::default().narrow("test");
         let mut indices = (1..100_u128).collect::<Vec<_>>();
         indices.shuffle(&mut thread_rng());
@@ -527,7 +527,7 @@ pub mod test {
     #[cfg(debug_assertions)]
     #[should_panic]
     fn indexed_rejects_the_same_index() {
-        let [p1, _p2, _p3] = make_participants();
+        let [p1, _p2, _p3] = make_participants(&mut thread_rng());
         let step = Step::default().narrow("test");
 
         let _: u128 = p1.indexed(&step).random_u128(100_u128);

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -267,7 +267,10 @@ pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{
         ff::{Field, Fp31},
-        protocol::{prss::SharedRandomness, prss::Endpoint, Step},
+        protocol::{
+            prss::{Endpoint, SharedRandomness},
+            Step,
+        },
         rand::{thread_rng, Rng},
         secret_sharing::SharedValue,
         test_fixture::make_participants,

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -167,17 +167,17 @@ pub async fn unshuffle_shares<F: Field, S: SecretSharing<F> + Reshare<C, RecordI
 
 #[cfg(all(test, not(feature = "shuttle")))]
 mod tests {
-
     use crate::{
         protocol::{sort::shuffle::get_two_of_three_random_permutations, Step},
         test_fixture::{make_participants, permutation_valid},
     };
+    use rand::thread_rng;
 
     #[test]
     fn random_sequence_generated() {
         const BATCH_SIZE: u32 = 10000;
 
-        let [p1, p2, p3] = make_participants();
+        let [p1, p2, p3] = make_participants(&mut thread_rng());
         let step = Step::default();
         let perm1 = get_two_of_three_random_permutations(BATCH_SIZE, p1.sequential(&step));
         let perm2 = get_two_of_three_random_permutations(BATCH_SIZE, p2.sequential(&step));

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -169,9 +169,9 @@ pub async fn unshuffle_shares<F: Field, S: SecretSharing<F> + Reshare<C, RecordI
 mod tests {
     use crate::{
         protocol::{sort::shuffle::get_two_of_three_random_permutations, Step},
+        rand::thread_rng,
         test_fixture::{make_participants, permutation_valid},
     };
-    use rand::thread_rng;
 
     #[test]
     fn random_sequence_generated() {

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -44,7 +44,6 @@ pub fn narrow_contexts<C: Context>(contexts: &[C; 3], step: &impl Substep) -> [C
 /// p1 is left of p2, p2 is left of p3, p3 is left of p1...
 #[must_use]
 pub fn make_participants<R: RngCore + CryptoRng>(r: &mut R) -> [PrssEndpoint; 3] {
-    // let mut r = thread_rng();
     let setup1 = PrssEndpoint::prepare(r);
     let setup2 = PrssEndpoint::prepare(r);
     let setup3 = PrssEndpoint::prepare(r);

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -13,12 +13,12 @@ pub mod network;
 use crate::{
     ff::{Field, Fp31},
     protocol::{context::Context, prss::Endpoint as PrssEndpoint, Substep},
-    rand::thread_rng,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
 };
 pub use app::TestApp;
 use futures::TryFuture;
 use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
+use rand_core::{CryptoRng, RngCore};
 pub use sharing::{get_bits, into_bits, Reconstruct};
 use std::fmt::Debug;
 pub use world::{Runner, TestWorld, TestWorldConfig};
@@ -43,11 +43,11 @@ pub fn narrow_contexts<C: Context>(contexts: &[C; 3], step: &impl Substep) -> [C
 /// Generate three participants.
 /// p1 is left of p2, p2 is left of p3, p3 is left of p1...
 #[must_use]
-pub fn make_participants() -> [PrssEndpoint; 3] {
-    let mut r = thread_rng();
-    let setup1 = PrssEndpoint::prepare(&mut r);
-    let setup2 = PrssEndpoint::prepare(&mut r);
-    let setup3 = PrssEndpoint::prepare(&mut r);
+pub fn make_participants<R: RngCore + CryptoRng>(r: &mut R) -> [PrssEndpoint; 3] {
+    // let mut r = thread_rng();
+    let setup1 = PrssEndpoint::prepare(r);
+    let setup2 = PrssEndpoint::prepare(r);
+    let setup3 = PrssEndpoint::prepare(r);
     let (pk1_l, pk1_r) = setup1.public_keys();
     let (pk2_l, pk2_r) = setup2.public_keys();
     let (pk3_l, pk3_r) = setup3.public_keys();

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -24,7 +24,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::{future::join_all, Future};
-use rand::{distributions::Standard, prelude::Distribution};
+use rand::{distributions::Standard, prelude::Distribution, rngs::StdRng};
+use rand_core::{RngCore, SeedableRng};
 use std::{fmt::Debug, io::stdout, iter::zip};
 use tracing::Level;
 
@@ -49,6 +50,8 @@ pub struct TestWorldConfig {
     pub metrics_level: Level,
     /// Assignment of roles to helpers. If `None`, a default assignment will be used.
     pub role_assignment: Option<RoleAssignment>,
+    /// Seed for random generators used in PRSS
+    pub seed: u64,
 }
 
 impl Default for TestWorldConfig {
@@ -60,6 +63,7 @@ impl Default for TestWorldConfig {
             // Can be overridden by setting `RUST_LOG` environment variable to match this level.
             metrics_level: Level::DEBUG,
             role_assignment: None,
+            seed: thread_rng().next_u64(),
         }
     }
 }
@@ -68,6 +72,12 @@ impl TestWorldConfig {
     #[must_use]
     pub fn enable_metrics(mut self) -> Self {
         self.metrics_level = Level::INFO;
+        self
+    }
+
+    #[must_use]
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
         self
     }
 }
@@ -87,7 +97,7 @@ impl TestWorld {
         logging::setup();
 
         let metrics_handle = MetricsHandle::new(config.metrics_level);
-        let participants = make_participants();
+        let participants = make_participants(&mut StdRng::seed_from_u64(config.seed));
         let network = InMemoryNetwork::default();
         let role_assignment = config
             .role_assignment


### PR DESCRIPTION
I realized that we no longer print/emit sequential randomness metrics

```bash
RUST_LOG=ipa=DEBUG cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches debug-trace" -- -n 10 | cut -d',' -f5 | sort -nr | head -n10
Sequential PRSS
0
0
0
0
0
0
0
0
0
```

after some debugging, it seems that shuffle now calls `next_u32` method instead of `next_u64`. I think it happened because we switched from `usize` to `u32` in `get_two_of_three_random_permutations`. Static dispatch does not call instrumented `next_u64` and here we are.

Unit tests did not catch that because they use a different protocol that never hit that path. Now it is changed to generate `u32` values too.

It also feels bad that we don't test PRSS metrics for IPA, so I changed the `communication_baseline` test. That required some fiddling with test infrastructure because Sequential PRSS calls are not deterministic: there is a loop inside `gen_range` method that calls `next_u32` several times depending on initial seed value. So baseline tests must use the same seed to correctly estimate the calls to sequential PRSS.

I also got annoyed by the size of baseline test, so I split it in two.