### PR TITLE
Exclude bytearrstream tests from Shuttle

### DIFF
--- a/src/helpers/transport/bytearrstream/aligned.rs
+++ b/src/helpers/transport/bytearrstream/aligned.rs
@@ -148,7 +148,7 @@ impl Debug for ByteArrStream {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "shuttle")))]
 mod test {
     use super::*;
     use crate::{ff, helpers::transport::ByteArrStream as UnalignedByteArrStream};


### PR DESCRIPTION
They are not supposed to be executed under Shuttle's scheduler.
