### PR TITLE
Bring back test_mpc CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 [features]
 # by default remove all TRACE, DEBUG spans from release builds
 default = ["web-app", "tracing/max_level_trace", "tracing/release_max_level_info"]
-cli = ["comfy-table", "clap"]
+# TODO: it feels wrong that CLI uses test-fixture module, but untangling `IntoShares`/`Reconstruct` and inputs
+# from other test components wasn't easy.
+cli = ["comfy-table", "clap", "test-fixture"]
 enable-serde = ["serde", "serde_json"]
 protocol-perf-testing = ["no-prss"]
 no-prss = []

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -1,6 +1,17 @@
 use clap::{Parser, Subcommand, ValueEnum};
-use ipa::cli::Verbosity;
-use std::{fmt::Debug, path::PathBuf};
+use comfy_table::Table;
+use ipa::{
+    cli::{
+        playbook::{secure_mul, semi_honest, InputSource},
+        Verbosity,
+    },
+    ff::{FieldType, Fp31},
+    helpers::query::{IpaQueryConfig, QueryConfig, QueryType},
+    net::MpcHelperClient,
+    protocol::{BreakdownKey, MatchKey},
+    test_fixture::config::TestConfigBuilder,
+};
+use std::{error::Error, fmt::Debug, path::PathBuf};
 
 #[derive(Debug, Parser)]
 #[clap(
@@ -31,7 +42,6 @@ pub struct CommandInput {
     input_type: InputType,
 }
 
-#[cfg(never)]
 impl From<&CommandInput> for InputSource {
     fn from(source: &CommandInput) -> Self {
         if let Some(ref file_name) = source.input_file {
@@ -56,13 +66,7 @@ enum TestAction {
     SemiHonestIPA,
 }
 
-#[cfg(not(never))]
-fn main() {
-    println!("Hello, world");
-}
-
 #[tokio::main]
-#[cfg(never)]
 async fn main() -> Result<(), Box<dyn Error>> {
     fn print_output<O: Debug>(values: &[Vec<O>; 3]) {
         let mut shares_table = Table::new();
@@ -109,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             InputType::Fp31 => {
                 let query_config = QueryConfig {
                     field_type: FieldType::Fp31,
-                    query_type: QueryType::IPA(IpaQueryConfig {
+                    query_type: QueryType::Ipa(IpaQueryConfig {
                         per_user_credit_cap: 3,
                         max_breakdown_key: 3,
                         num_multi_bits: 3,

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -16,7 +16,7 @@ pub trait InputItem {
 impl<F: Field> InputItem for F {
     fn from_str(s: &str) -> Self {
         let int_v = s.parse::<u128>().unwrap();
-        F::from(int_v)
+        F::truncate_from(int_v)
     }
 }
 
@@ -28,21 +28,18 @@ impl InputItem for u64 {
 
 impl<F: Field, MK: GaloisField, BK: GaloisField> InputItem for GenericReportTestInput<F, MK, BK> {
     fn from_str(s: &str) -> Self {
-        if let [match_key, is_trigger_bit, breakdown_key, trigger_value] =
-            s.splitn(4, ',').collect::<Vec<_>>()[..]
+        if let [ts, match_key, is_trigger_bit, breakdown_key, trigger_value] =
+            s.splitn(5, ',').collect::<Vec<_>>()[..]
         {
-            let records: Vec<GenericReportTestInput<F, MK, BK>> = ipa_test_input!(
-                [
-                    {
-                        match_key: match_key.parse::<u128>().unwrap(),
-                        is_trigger_report: is_trigger_bit.parse::<u128>().unwrap(),
-                        breakdown_key: breakdown_key.parse::<u128>().unwrap(),
-                        trigger_value: trigger_value.parse::<u128>().unwrap()
-                    },
-                ];
+            ipa_test_input!({
+                    timestamp: ts.parse::<u128>().unwrap(),
+                    match_key: match_key.parse::<u128>().unwrap(),
+                    is_trigger_report: is_trigger_bit.parse::<u128>().unwrap(),
+                    breakdown_key: breakdown_key.parse::<u128>().unwrap(),
+                    trigger_value: trigger_value.parse::<u128>().unwrap()
+                };
                 (F, MK, BK)
-            );
-            records[0]
+            )
         } else {
             panic!("{s} is not a valid IPAInputTestRow")
         }

--- a/src/cli/playbook/mod.rs
+++ b/src/cli/playbook/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(never)] // TODO: remove when HTTP layer can work with channelled transport
-
 mod input;
 mod ipa;
 mod multiply;

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -3,7 +3,7 @@
 use crate::{
     cli::playbook::InputSource,
     ff::{Field, Serializable},
-    helpers::{query::QueryInput, transport::ByteArrStream},
+    helpers::{query::QueryInput, ByteArrStream},
     net::MpcHelperClient,
     protocol::QueryId,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},


### PR DESCRIPTION
It compiles and runs, but obviously needs HTTP servers to stand

```bash
cargo run --bin test_mpc --features=cli --features=web-app -- --input-type fp31 multiply
    Finished dev [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/test_mpc --input-type fp31 multiply`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: HyperPassthrough(hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })))', src/bin/test_mpc.rs:100:76
```