### PR TITLE
DHAT for memory profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ test-fixture = ["enable-serde"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 enable-benches = ["cli", "test-fixture", "criterion", "iai"]
-dhat-heap = ["cli", "test-fixture", "disable-metrics"]
+dhat-heap = ["cli", "test-fixture"]
 
 [dependencies]
 aes = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cli = ["comfy-table", "clap"]
 enable-serde = ["serde", "serde_json"]
 protocol-perf-testing = ["no-prss"]
 no-prss = []
+disable-metrics = []
 # TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
 # TODO Consider moving out benches as well
 web-app = ["axum", "axum-server", "enable-serde", "hex", "hyper", "hyper-tls", "tower", "tower-http"]
@@ -19,6 +20,7 @@ test-fixture = ["enable-serde"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 enable-benches = ["cli", "test-fixture", "criterion", "iai"]
+dhat-heap = ["cli", "test-fixture", "disable-metrics"]
 
 [dependencies]
 aes = "0.8"
@@ -69,6 +71,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 typenum = "1.16.0"
 x25519-dalek = "2.0.0-pre.1"
+dhat = "0.3.2"
 
 [target.'cfg(all(target_arch = "x86_64", not(target_env = "msvc")))'.dependencies]
 tikv-jemallocator = "0.5.0"
@@ -83,6 +86,12 @@ lto = "thin"
 
 [profile.bench]
 debug-assertions = true
+
+[profile.bench-dhat]
+inherits = "bench"
+incremental = true
+lto = "thin"
+debug = 1
 
 [lib]
 name = "ipa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ debug-assertions = true
 
 [profile.bench-dhat]
 inherits = "bench"
+debug-assertions = false
 incremental = true
 lto = "thin"
 debug = 1

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,8 +1,8 @@
 ## Benchmarks
 
-This folder contains benchmarks for various components of IPA implementation. It will include end-to-end benchmark eventually as well. There are two different micro benchmarking frameworks used: [criterion](https://github.com/bheisler/criterion.rs) (multiplatform) and [iai](https://github.com/bheisler/iai) (Linux only). 
+This folder contains benchmarks for various components of IPA implementation. It will include end-to-end benchmark eventually as well. There are two different micro benchmarking frameworks used: [criterion](https://github.com/bheisler/criterion.rs) (multiplatform) and [iai](https://github.com/bheisler/iai) (Linux only).
 
-By convention, Criterion benchmarks have prefix `ct`, iai benchmark names start with `iai`. 
+By convention, Criterion benchmarks have prefix `ct`, iai benchmark names start with `iai`.
 
 To execute a benchmark, run
 
@@ -13,10 +13,10 @@ cargo bench -F enable-benches --bench <benchmark_name>
 Oneshot benchmarks are simply Rust programs that often share the benchmark logic with Criterion/iai benchmarks. They make it easier to produce and interpret flamegraphs. They may also read their input from stdin
 
 ```bash
-CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --root --bench oneshot_arithmetic --features="enable-benches" -- --depth=64 --width=1000000       
+CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --root --bench oneshot_arithmetic --features="enable-benches" -- --depth=64 --width=1000000
 ```
 
-Note: make sure you've installed `cargo-flamegraph` by running 
+Note: make sure you've installed `cargo-flamegraph` by running
 
 ```bash
 cargo add flamegraph
@@ -27,9 +27,8 @@ cargo add flamegraph
 It is possible to print communication/crypto metrics with per-step breakdown. That requires default features to be turned
 off.
 
-
 Run the following command to print step-level metrics at the end of benchmarks. Note that debug traces impact program
-performance. It is not recommended to profile IPA in this mode. 
+performance. It is not recommended to profile IPA in this mode.
 
 Execute the following command to enable step-level metrics. It is possible to use different bench as long as it uses
 `TestWorld` to set up the environment.
@@ -61,3 +60,30 @@ cat -p /tmp/steps.log | cut -d',' -f2 | awk '{s+=$1}END{print s}'
 189900
 ```
 
+## Memory Profiling
+
+It is possible to profile the heap usage of IPA. We reuse `oneshot/ipa` benchmark for profiling, but any tests/executables can be profiled by enabling the global allocator. If you want more details, see DHAT [documentation](https://docs.rs/dhat/latest/dhat/).
+
+The following command will run a benchmark and produce a profiling result.
+
+```bash
+cargo bench --bench oneshot_ipa --profile=bench-dhat --features="dhat-heap enable-benches" --no-default-features -- -n 100
+```
+
+The output will look similar to this:
+
+```
+Using random seed: 9907163113946974138 for 100 records
+Preparation complete in 2.358458ms
+Malicious IPA for 100 records took 96.743081542s
+dhat: Total:     1,667,896,432 bytes in 11,399,291 blocks
+dhat: At t-gmax: 97,081,304 bytes in 275,872 blocks
+dhat: At t-end:  1,656,860 bytes in 6,836 blocks
+dhat: The data has been saved to dhat-heap.json, and is viewable with dhat/dh_view.html
+```
+
+- **Total**: The total number of blocks allocated during the execution. Highly useful for evaluating heap churn; reducing the number of calls to the allocator can significantly speed up a program. This is the default sort metric.
+- **At t-gmax**: This shows the breakdown of memory at the point of peak heap memory usage. Highly useful for reducing peak memory usage.
+- **At t-end**: This shows the breakdown of memory at program termination. Highly useful for identifying process-lifetime leaks.
+
+DHAT generates a file `dhat-heap.json` in the current directory. To view the results, go to https://nnethercote.github.io/dh_view/dh_view.html and upload the file.

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -18,6 +18,10 @@ use std::{num::NonZeroUsize, time::Instant};
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 /// A benchmark for the full IPA protocol.
 #[derive(Parser)]
 #[command(about, long_about = None)]
@@ -68,6 +72,9 @@ impl Args {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), Error> {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     type BenchField = Fp32BitPrime;
 
     let args = Args::parse();

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -14,7 +14,11 @@ use ipa::{
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 use std::{num::NonZeroUsize, time::Instant};
 
-#[cfg(all(target_arch = "x86_64", not(target_env = "msvc")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(target_env = "msvc"),
+    not(feature = "dhat-heap")
+))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/protocol/context/prss.rs
+++ b/src/protocol/context/prss.rs
@@ -34,16 +34,11 @@ impl<'a> InstrumentedIndexedSharedRandomness<'a> {
 
 impl SharedRandomness for InstrumentedIndexedSharedRandomness<'_> {
     fn generate_values<I: Into<u128>>(&self, index: I) -> (u128, u128) {
-        #[cfg(not(feature = "disable-metrics"))]
-        {
-            // This string cloning consumes ~11% of the total heap usage. It doesn't affect the peak
-            // heap usage, but skipping this code path improves the performance.
-            let step = self.step.as_ref().to_string();
-            // TODO: what we really want here is a gauge indicating the maximum index used to generate
-            // PRSS. Gauge infrastructure is not supported yet, `Metrics` struct needs to be able to
-            // handle gauges
-            metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.role.as_static_str());
-        }
+        let step = self.step.as_ref().to_string();
+        // TODO: what we really want here is a gauge indicating the maximum index used to generate
+        // PRSS. Gauge infrastructure is not supported yet, `Metrics` struct needs to be able to
+        // handle gauges
+        metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.role.as_static_str());
         self.inner.generate_values(index)
     }
 }

--- a/src/protocol/context/prss.rs
+++ b/src/protocol/context/prss.rs
@@ -34,11 +34,16 @@ impl<'a> InstrumentedIndexedSharedRandomness<'a> {
 
 impl SharedRandomness for InstrumentedIndexedSharedRandomness<'_> {
     fn generate_values<I: Into<u128>>(&self, index: I) -> (u128, u128) {
-        let step = self.step.as_ref().to_string();
-        // TODO: what we really want here is a gauge indicating the maximum index used to generate
-        // PRSS. Gauge infrastructure is not supported yet, `Metrics` struct needs to be able to
-        // handle gauges
-        metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.role.as_static_str());
+        #[cfg(not(feature = "disable-metrics"))]
+        {
+            // This string cloning consumes ~11% of the total heap usage. It doesn't affect the peak
+            // heap usage, but skipping this code path improves the performance.
+            let step = self.step.as_ref().to_string();
+            // TODO: what we really want here is a gauge indicating the maximum index used to generate
+            // PRSS. Gauge infrastructure is not supported yet, `Metrics` struct needs to be able to
+            // handle gauges
+            metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.role.as_static_str());
+        }
         self.inner.generate_values(index)
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -53,11 +53,6 @@ pub mod metrics {
     /// ## Panics
     /// Panic if there is no recorder installed
     pub fn register() {
-        assert!(
-            matches!(metrics::try_recorder(), Some(_)),
-            "metrics recorder must be installed before metrics can be described"
-        );
-
         describe_counter!(
             REQUESTS_RECEIVED,
             Unit::Count,

--- a/src/test_fixture/metrics.rs
+++ b/src/test_fixture/metrics.rs
@@ -25,6 +25,8 @@ fn setup() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
         let recorder = Box::leak(Box::new(TracingContextLayer::all().layer(recorder)));
+
+        #[cfg(not(feature = "disable-metrics"))]
         metrics::set_recorder(recorder).unwrap();
 
         // register metrics


### PR DESCRIPTION
[DHAT](https://docs.rs/dhat/latest/dhat/)

This PR enables DHAT for memory profiling. Only `oneshot/ipa` is supported for now. To run the profiling, execute the following command.

```
cargo bench --bench oneshot_ipa --profile=bench-dhat --features="dhat-heap enable-benches" --no-default-features -- -n 100
```

For more detail, refer to README.md included in this PR.