### PR TITLE
Remove test-fixture dependency from CLI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run Tests
         run: cargo test
 
+      - name: Run Web Tests
+        run: cargo test --no-default-features features = "web-app real-world-infra"
+
   extra:
     name: Additional Builds and Concurrency Tests
     env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,7 @@ jobs:
         run: cargo test
 
       - name: Run Web Tests
-        run: cargo test --no-default-features features = "web-app real-world-infra"
+        run: cargo test --no-default-features --features "web-app real-world-infra"
 
   extra:
     name: Additional Builds and Concurrency Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 default = ["web-app", "tracing/max_level_trace", "tracing/release_max_level_info"]
 # TODO: it feels wrong that CLI uses test-fixture module, but untangling `IntoShares`/`Reconstruct` and inputs
 # from other test components wasn't easy.
-cli = ["comfy-table", "clap", "test-fixture"]
+cli = ["comfy-table", "clap"]
 enable-serde = ["serde", "serde_json"]
 protocol-perf-testing = ["no-prss"]
 no-prss = []
@@ -109,7 +109,7 @@ bench = false
 
 [[bin]]
 name = "test_mpc"
-required-features = ["cli", "web-app"]
+required-features = ["cli", "web-app", "test-fixture"]
 bench = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ bench = false
 
 [[bin]]
 name = "helper"
-required-features = ["cli", "web-app"]
+required-features = ["cli", "web-app", "real-world-infra"]
 bench = false
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 
 [features]
 # by default remove all TRACE, DEBUG spans from release builds
-default = ["web-app", "tracing/max_level_trace", "tracing/release_max_level_info"]
-# TODO: it feels wrong that CLI uses test-fixture module, but untangling `IntoShares`/`Reconstruct` and inputs
-# from other test components wasn't easy.
+default = ["web-app", "in-memory-infra", "tracing/max_level_trace", "tracing/release_max_level_info"]
 cli = ["comfy-table", "clap"]
 enable-serde = ["serde", "serde_json"]
 protocol-perf-testing = ["no-prss"]
@@ -17,15 +15,16 @@ no-prss = []
 # TODO Consider moving out benches as well
 web-app = ["axum", "axum-server", "enable-serde", "hex", "hyper", "hyper-tls", "tower", "tower-http"]
 self-signed-certs = ["hyper-tls"]
-# The test-http and test-fixture features are mutually incompatible, and the
-# code doesn't support building tests without test-fixture. So if you want to
-# run the tests enabled by test-http, you unfortunately need to do something
-# like `s/cfg(any(test,/cfg(any(never, test/`.
-test-http = []
 test-fixture = ["enable-serde"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
-enable-benches = ["cli", "test-fixture", "criterion", "iai"]
+# TODO: we may want to use in-memory-bench and real-world-bench some time after
+enable-benches = ["cli", "in-memory-infra", "test-fixture", "criterion", "iai"]
+
+# The following two features are mutually exclusive. In-memory should be enabled by default as the vast majority
+# of unit tests use it. Real world infra uses HTTP implementation and is suitable for integration/e2e tests
+in-memory-infra = []
+real-world-infra = []
 
 [dependencies]
 aes = "0.8"

--- a/pre-commit
+++ b/pre-commit
@@ -76,6 +76,8 @@ cargo clippy --tests --features shuttle -- -D warnings || error "Clippy concurre
 
 cargo test || error "Test failures"
 
+cargo test --no-default-features --features "web-app real-world-infra" || error "Web test failures"
+
 cargo test --release --features shuttle || error "Concurrency test failures"
 
 cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches" -- -n 100 || error "Failed to run IPA benchmark"

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -1,75 +1,49 @@
-//! Ideally, this binary would only be built when:
-//!  * the `web-app` feature is active, AND
-//!  * the `test-fixture` feature is not active.
-//!
-//! Unfortunately, that is not possible to specify in Cargo.toml, so it is (somewhat awkwardly)
-//! written to build and fail at runtime when both features are active.
-//!
-//! See `TransportImpl` for further discussion.
+use clap::Parser;
+use hyper::http::uri::Scheme;
+use ipa::{
+    cli::Verbosity,
+    config::{NetworkConfig, ServerConfig},
+    helpers::HelperIdentity,
+    net::{BindTarget, HttpTransport, MpcHelperClient},
+    AppSetup,
+};
+use std::{error::Error, sync::Arc};
 
-use std::error::Error;
+use tracing::info;
 
-#[cfg(all(feature = "test-fixture", feature = "web-app"))]
-mod stub {
-    use std::error::Error;
+#[cfg(all(target_arch = "x86_64", not(target_env = "msvc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-    pub async fn main() -> Result<(), Box<dyn Error>> {
-        Err(format!(
-            "{} is not available when both the test-fixture and web-app features are enabled",
-            env!("CARGO_BIN_NAME"),
-        )
-        .into())
-    }
+#[derive(Debug, Parser)]
+#[clap(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
+struct Args {
+    /// Configure logging.
+    #[clap(flatten)]
+    logging: Verbosity,
+
+    /// Indicates which identity this helper has
+    #[arg(short, long)]
+    identity: usize,
+
+    /// Port to listen. If not specified, will ask Kernel to assign the port
+    #[arg(short, long)]
+    port: Option<u16>,
+
+    /// Indicates whether to start HTTP or HTTPS endpoint
+    #[arg(short, long, default_value = "http")]
+    scheme: Scheme,
 }
 
-#[cfg(not(all(feature = "test-fixture", feature = "web-app")))]
-mod real {
-    use clap::Parser;
-    use hyper::http::uri::Scheme;
-    use ipa::{
-        cli::Verbosity,
-        config::{NetworkConfig, ServerConfig},
-        helpers::HelperIdentity,
-        net::{BindTarget, HttpTransport, MpcHelperClient},
-        AppSetup,
+fn config(identity: HelperIdentity) -> (NetworkConfig, ServerConfig) {
+    let port = match identity {
+        HelperIdentity::ONE => 3000,
+        HelperIdentity::TWO => 3001,
+        HelperIdentity::THREE => 3002,
+        _ => panic!("invalid helper identity {:?}", identity),
     };
-    use std::{error::Error, sync::Arc};
 
-    use tracing::info;
-
-    #[cfg(all(target_arch = "x86_64", not(target_env = "msvc")))]
-    #[global_allocator]
-    static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-    #[derive(Debug, Parser)]
-    #[clap(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
-    struct Args {
-        /// Configure logging.
-        #[clap(flatten)]
-        logging: Verbosity,
-
-        /// Indicates which identity this helper has
-        #[arg(short, long)]
-        identity: usize,
-
-        /// Port to listen. If not specified, will ask Kernel to assign the port
-        #[arg(short, long)]
-        port: Option<u16>,
-
-        /// Indicates whether to start HTTP or HTTPS endpoint
-        #[arg(short, long, default_value = "http")]
-        scheme: Scheme,
-    }
-
-    fn config(identity: HelperIdentity) -> (NetworkConfig, ServerConfig) {
-        let port = match identity {
-            HelperIdentity::ONE => 3000,
-            HelperIdentity::TWO => 3001,
-            HelperIdentity::THREE => 3002,
-            _ => panic!("invalid helper identity {:?}", identity),
-        };
-
-        let config_str = r#"
+    let config_str = r#"
 # H1
 [[peers]]
 origin = "http://localhost:3000"
@@ -92,66 +66,54 @@ origin = "http://localhost:3002"
 public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
 "#;
 
-        let network = NetworkConfig::from_toml_str(&config_str).unwrap();
-        let server = ServerConfig::with_http_and_port(port);
+    let network = NetworkConfig::from_toml_str(&config_str).unwrap();
+    let server = ServerConfig::with_http_and_port(port);
 
-        (network, server)
-    }
-
-    pub async fn main() -> Result<(), Box<dyn Error>> {
-        let args = Args::parse();
-        let _handle = args.logging.setup_logging();
-
-        let my_identity = HelperIdentity::try_from(args.identity).unwrap();
-        info!("configured with identity {:?}", my_identity);
-
-        // TODO(596): the config should be loaded from a file, possibly with some values merged from the
-        // command line arguments.
-        let (network_config, server_config) = config(my_identity);
-
-        let (setup, callbacks) = AppSetup::new();
-
-        let clients = MpcHelperClient::from_conf(&network_config);
-
-        let (transport, server) = HttpTransport::new(
-            my_identity,
-            //server_config,
-            clients,
-            callbacks,
-        );
-
-        let _app = setup.connect(transport.clone());
-
-        // TODO(596): Bind target was moved here from `HttpTransport::bind()`. It needs to come
-        // from a config file. Probably, the config should be stored in the server when
-        // constructed, and the argument to server.bind() should go away.
-        let (addr, server_handle) = server
-            .bind(BindTarget::Http(
-                format!("0.0.0.0:{}", server_config.port.unwrap())
-                    .parse()
-                    .unwrap(),
-            ))
-            .await;
-
-        info!(
-            "listening to {}://{}, press Enter to quit",
-            args.scheme, addr
-        );
-        let _ = std::io::stdin().read_line(&mut String::new())?;
-        server_handle.abort();
-
-        Ok(())
-    }
+    (network, server)
 }
 
-#[cfg(all(feature = "test-fixture", feature = "web-app"))]
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    stub::main().await
-}
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let _handle = args.logging.setup_logging();
 
-#[cfg(not(all(feature = "test-fixture", feature = "web-app")))]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    real::main().await
+    let my_identity = HelperIdentity::try_from(args.identity).unwrap();
+    info!("configured with identity {:?}", my_identity);
+
+    // TODO(596): the config should be loaded from a file, possibly with some values merged from the
+    // command line arguments.
+    let (network_config, server_config) = config(my_identity);
+
+    let (setup, callbacks) = AppSetup::new();
+
+    let clients = MpcHelperClient::from_conf(&network_config);
+
+    let (transport, server) = HttpTransport::new(
+        my_identity,
+        //server_config,
+        clients,
+        callbacks,
+    );
+
+    let _app = setup.connect(transport.clone());
+
+    // TODO(596): Bind target was moved here from `HttpTransport::bind()`. It needs to come
+    // from a config file. Probably, the config should be stored in the server when
+    // constructed, and the argument to server.bind() should go away.
+    let (addr, server_handle) = server
+        .bind(BindTarget::Http(
+            format!("0.0.0.0:{}", server_config.port.unwrap())
+                .parse()
+                .unwrap(),
+        ))
+        .await;
+
+    info!(
+        "listening to {}://{}, press Enter to quit",
+        args.scheme, addr
+    );
+    let _ = std::io::stdin().read_line(&mut String::new())?;
+    server_handle.abort();
+
+    Ok(())
 }

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -7,7 +7,7 @@ use ipa::{
     net::{BindTarget, HttpTransport, MpcHelperClient},
     AppSetup,
 };
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 
 use tracing::info;
 

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -167,7 +167,7 @@ fn add_event_timestamps(rhs: EventTimestamp, lhs: EventTimestamp) -> EventTimest
     EventTimestamp::new((epoch % (c(Epoch::MAX) + 1)) as Epoch, offset)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::{gen_reports, generate_events, EventTimestamp, GenericReport};
     use crate::{gen_events::add_event_timestamps, models::Epoch, sample::Sample};

--- a/src/bin/ipa_bench/models.rs
+++ b/src/bin/ipa_bench/models.rs
@@ -316,7 +316,7 @@ impl Debug for TriggerFanoutQuery {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::models::Epoch;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,5 @@
 mod metric_collector;
-#[cfg(feature = "web-app")]
+#[cfg(all(feature = "test-fixture", feature = "web-app"))]
 pub mod playbook;
 mod verbosity;
 

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -109,7 +109,7 @@ impl BufRead for InputSource {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         cli::playbook::input::InputItem,

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,7 +99,7 @@ impl ServerConfig {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{helpers::HelperIdentity, test_fixture::config::TestConfigBuilder};
     use hyper::Uri;

--- a/src/ff/galois_field.rs
+++ b/src/ff/galois_field.rs
@@ -326,7 +326,7 @@ macro_rules! bit_array_impl {
                 }
             }
 
-            #[cfg(all(test, not(feature = "shuttle")))]
+            #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
             mod tests {
                 use super::*;
                 use crate::{ff::GaloisField, secret_sharing::SharedValue};

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -179,7 +179,7 @@ macro_rules! field_impl {
             }
         }
 
-        #[cfg(all(test, not(feature = "shuttle")))]
+        #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
         mod common_tests {
             use super::*;
             use crate::ff::Serializable;
@@ -224,7 +224,7 @@ macro_rules! field_impl {
 mod fp31 {
     field_impl! { Fp31, u8, 8, 31 }
 
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
     mod specialized_tests {
         use super::*;
 
@@ -247,7 +247,7 @@ mod fp31 {
 mod fp32bit {
     field_impl! { Fp32BitPrime, u32, 32, 4_294_967_291 }
 
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
     mod specialized_tests {
         use super::*;
 

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -355,7 +355,7 @@ mod fixture {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod unit {
     use crate::{
         ff::{Field, Fp31, Serializable},
@@ -487,7 +487,7 @@ mod concurrency {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod proptests {
     use crate::helpers::buffers::ordering_mpsc::fixture::{shuffle_indices, shuffled_send_recv};
 

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -19,21 +19,10 @@ use crate::{
 use shuttle::future as tokio;
 use std::{fmt::Debug, num::NonZeroUsize};
 
-// /// Alias for the currently configured transport.
-// ///
-// /// To avoid proliferation of type parameters, most code references this concrete type alias, rather
-// /// than a type parameter `T: Transport`. Where this gets tricky is code enabled by the `web-app`
-// /// feature, which may want to reference `HttpTransport` even when `TransportImpl` is referring to
-// /// `InMemoryTransport`. Although it is not possible to produce a functioning web server compiled
-// /// with both the `web-app` and `test-fixture` features, it is important that the code compile that
-// /// way, for tests of `web-app` functionality. When the result of this is nonsensical (in
-// /// particular, the `helper` binary, which references this comment), such a build will fail at
-// /// runtime.
-// #[cfg(all(any(test, feature = "test-fixture"), feature = "in-memory-infra"))]
-// pub type TransportImpl = crate::test_fixture::network::InMemoryTransport;
-// #[cfg(all(not(feature = "test-fixture"), feature = "real-world-infra"))]
-// pub type TransportImpl = std::sync::Arc<crate::net::HttpTransport>;
-
+/// Alias for the currently configured transport.
+///
+/// To avoid proliferation of type parameters, most code references this concrete type alias, rather
+/// than a type parameter `T: Transport`.
 #[cfg(feature = "in-memory-infra")]
 pub type TransportImpl = super::transport::InMemoryTransport;
 

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -19,20 +19,26 @@ use crate::{
 use shuttle::future as tokio;
 use std::{fmt::Debug, num::NonZeroUsize};
 
-/// Alias for the currently configured transport.
-///
-/// To avoid proliferation of type parameters, most code references this concrete type alias, rather
-/// than a type parameter `T: Transport`. Where this gets tricky is code enabled by the `web-app`
-/// feature, which may want to reference `HttpTransport` even when `TransportImpl` is referring to
-/// `InMemoryTransport`. Although it is not possible to produce a functioning web server compiled
-/// with both the `web-app` and `test-fixture` features, it is important that the code compile that
-/// way, for tests of `web-app` functionality. When the result of this is nonsensical (in
-/// particular, the `helper` binary, which references this comment), such a build will fail at
-/// runtime.
-#[cfg(all(any(feature = "test-fixture", test), not(feature = "test-http")))]
-pub type TransportImpl = crate::test_fixture::network::InMemoryTransport;
-#[cfg(not(all(any(feature = "test-fixture", test), not(feature = "test-http"))))]
-pub type TransportImpl = std::sync::Arc<crate::net::HttpTransport>;
+// /// Alias for the currently configured transport.
+// ///
+// /// To avoid proliferation of type parameters, most code references this concrete type alias, rather
+// /// than a type parameter `T: Transport`. Where this gets tricky is code enabled by the `web-app`
+// /// feature, which may want to reference `HttpTransport` even when `TransportImpl` is referring to
+// /// `InMemoryTransport`. Although it is not possible to produce a functioning web server compiled
+// /// with both the `web-app` and `test-fixture` features, it is important that the code compile that
+// /// way, for tests of `web-app` functionality. When the result of this is nonsensical (in
+// /// particular, the `helper` binary, which references this comment), such a build will fail at
+// /// runtime.
+// #[cfg(all(any(test, feature = "test-fixture"), feature = "in-memory-infra"))]
+// pub type TransportImpl = crate::test_fixture::network::InMemoryTransport;
+// #[cfg(all(not(feature = "test-fixture"), feature = "real-world-infra"))]
+// pub type TransportImpl = std::sync::Arc<crate::net::HttpTransport>;
+
+#[cfg(feature = "in-memory-infra")]
+pub type TransportImpl = super::transport::InMemoryTransport;
+
+#[cfg(feature = "real-world-infra")]
+pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
 
 pub type TransportError = <TransportImpl as Transport>::Error;
 pub type ReceivingEnd<M> = ReceivingEndBase<TransportImpl, M>;
@@ -147,7 +153,7 @@ impl GatewayConfig {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -22,6 +22,9 @@ pub use transport::{
     ReceiveRecords, RouteId, RouteParams, StepBinding, StreamCollection, StreamKey, Transport,
 };
 
+#[cfg(feature = "in-memory-infra")]
+pub use transport::{InMemoryNetwork, InMemoryTransport};
+
 pub use transport::query;
 
 /// to validate that transport can actually send streams of this type
@@ -130,7 +133,7 @@ impl HelperIdentity {
     }
 }
 
-#[cfg(any(test, feature = "test-fixture"))]
+#[cfg(any(test, feature = "test-fixture", feature = "in-memory-infra"))]
 impl HelperIdentity {
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
@@ -478,7 +481,7 @@ impl From<usize> for TotalRecords {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
 

--- a/src/helpers/transport/callbacks.rs
+++ b/src/helpers/transport/callbacks.rs
@@ -66,7 +66,7 @@ pub struct TransportCallbacks<T> {
     pub complete_query: Box<dyn CompleteQueryCallback<T>>,
 }
 
-#[cfg(any(test, feature = "test-fixture"))]
+#[cfg(any(test, feature = "test-fixture", feature = "in-memory-infra"))]
 impl<T> Default for TransportCallbacks<T> {
     fn default() -> Self {
         // `TransportCallbacks::default()` is commonly used with struct update syntax

--- a/src/helpers/transport/in_memory/mod.rs
+++ b/src/helpers/transport/in_memory/mod.rs
@@ -1,11 +1,10 @@
 mod transport;
 
 use crate::{
-    helpers::HelperIdentity,
+    helpers::{HelperIdentity, TransportCallbacks},
     sync::{Arc, Weak},
 };
 
-use crate::helpers::TransportCallbacks;
 pub use transport::Setup;
 
 pub type InMemoryTransport = Weak<transport::InMemoryTransport>;
@@ -26,6 +25,7 @@ impl Default for InMemoryNetwork {
     }
 }
 
+#[allow(dead_code)]
 impl InMemoryNetwork {
     #[must_use]
     pub fn new(callbacks: [TransportCallbacks<InMemoryTransport>; 3]) -> Self {

--- a/src/helpers/transport/in_memory/transport.rs
+++ b/src/helpers/transport/in_memory/transport.rs
@@ -208,7 +208,7 @@ pub struct InMemoryStream {
 }
 
 impl InMemoryStream {
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
     fn empty() -> Self {
         Self::from_iter(std::iter::empty())
     }
@@ -219,7 +219,7 @@ impl InMemoryStream {
         }
     }
 
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
     fn from_iter<I>(input: I) -> Self
     where
         I: IntoIterator<Item = StreamItem>,
@@ -286,7 +286,7 @@ impl Addr {
         serde_json::from_str(&self.params).unwrap()
     }
 
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
     fn records(from: HelperIdentity, query_id: QueryId, step: Step) -> Self {
         Self {
             route: RouteId::Records,
@@ -366,9 +366,10 @@ mod tests {
     use super::*;
     use crate::{
         ff::{FieldType, Fp31},
-        helpers::{query::QueryType, HelperIdentity, OrderingSender},
+        helpers::{
+            query::QueryType, transport::in_memory::InMemoryNetwork, HelperIdentity, OrderingSender,
+        },
         protocol::Step,
-        test_fixture::network::InMemoryNetwork,
     };
     use futures_util::{stream::poll_immediate, FutureExt, StreamExt};
     use std::{io::ErrorKind, num::NonZeroUsize, panic::AssertUnwindSafe, sync::Mutex};

--- a/src/helpers/transport/mod.rs
+++ b/src/helpers/transport/mod.rs
@@ -8,11 +8,15 @@ use std::borrow::Borrow;
 
 mod bytearrstream;
 pub mod callbacks;
+#[cfg(feature = "in-memory-infra")]
+mod in_memory;
 pub mod query;
 mod receive;
 mod stream;
 
 pub use bytearrstream::{AlignedByteArrStream, ByteArrStream};
+#[cfg(feature = "in-memory-infra")]
+pub use in_memory::{InMemoryNetwork, InMemoryTransport};
 pub use receive::ReceiveRecords;
 pub use stream::{StreamCollection, StreamKey};
 

--- a/src/helpers/transport/receive.rs
+++ b/src/helpers/transport/receive.rs
@@ -1,9 +1,8 @@
 use crate::helpers::transport::stream::{StreamCollection, StreamKey};
 use futures::Stream;
 use futures_util::StreamExt;
-#[cfg(any(not(feature = "web-app"), feature = "test-fixture", test))]
-use std::convert::identity;
 use std::{
+    convert::identity,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -20,8 +19,7 @@ where
 }
 
 impl<S> ReceiveRecords<S, S, fn(S) -> S> {
-    #[cfg(any(not(feature = "web-app"), feature = "test-fixture", test))]
-    pub(crate) fn new(key: StreamKey, coll: StreamCollection<S>) -> Self {
+    pub fn new(key: StreamKey, coll: StreamCollection<S>) -> Self {
         Self {
             inner: ReceiveRecordsInner::Pending(key, coll, Some(identity)),
         }

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -160,7 +160,7 @@ pub fn open_in_place<'a>(
 /// Represents an encrypted share of single match key.
 #[derive(Clone)]
 // temporarily to appease clippy while we don't have actual consumers of this struct
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 struct MatchKeyEncryption<'a> {
     /// Encapsulated key as defined in [`url`] specification.
     /// Key size depends on the AEAD type used in HPKE, in current setting IPA uses [`aead`] type.
@@ -178,7 +178,7 @@ struct MatchKeyEncryption<'a> {
     info: Info<'a>,
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use generic_array::GenericArray;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,6 @@ pub(crate) mod task {
 pub(crate) mod task {
     pub use tokio::task::JoinHandle;
 }
+
+#[cfg(all(feature = "in-memory-infra", feature = "real-world-infra"))]
+compile_error!("feature \"in-memory-infra\" and feature \"real-world-infra\" cannot be enabled at the same time");

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -195,7 +195,7 @@ impl MpcHelperClient {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]
 pub(crate) mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/echo.rs
+++ b/src/net/server/handlers/echo.rs
@@ -10,7 +10,7 @@ pub fn router() -> Router {
     Router::new().route(http_serde::echo::AXUM_PATH, get(handler))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -29,7 +29,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/query/input.rs
+++ b/src/net/server/handlers/query/input.rs
@@ -23,7 +23,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/query/mod.rs
+++ b/src/net/server/handlers/query/mod.rs
@@ -32,7 +32,7 @@ pub fn h2h_router(transport: Arc<HttpTransport>) -> Router {
         .merge(step::router(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 pub mod test_helpers {
     use crate::net::test::TestServer;
     use futures_util::future::poll_immediate;

--- a/src/net/server/handlers/query/prepare.rs
+++ b/src/net/server/handlers/query/prepare.rs
@@ -28,7 +28,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::future::ready;
 

--- a/src/net/server/handlers/query/results.rs
+++ b/src/net/server/handlers/query/results.rs
@@ -26,7 +26,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::future::ready;
 

--- a/src/net/server/handlers/query/step.rs
+++ b/src/net/server/handlers/query/step.rs
@@ -21,7 +21,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::{future::ready, task::Poll};
 

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -116,7 +116,7 @@ impl MpcHelperServer {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod e2e_tests {
     use super::*;
     use crate::{

--- a/src/net/test.rs
+++ b/src/net/test.rs
@@ -95,6 +95,7 @@ impl TestServerBuilder {
         self
     }
 
+    #[allow(dead_code)] // TODO: fix when TLS is enabled
     pub fn https(mut self) -> Self {
         self.https = true;
         self
@@ -166,7 +167,6 @@ pub struct TestClientsBuilder {
 }
 
 impl TestClientsBuilder {
-    #[cfg(feature = "test-http")]
     pub fn with_network_config(mut self, network_config: NetworkConfig) -> Self {
         self.network_config = Some(network_config);
         self

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -165,18 +165,27 @@ impl Transport for Arc<HttpTransport> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]
 mod e2e_tests {
     use super::*;
     use crate::{
-        net::test::{body_stream, TestServer},
+        config::{NetworkConfig, PeerConfig, ServerConfig},
+        ff::{FieldType, Fp31, Serializable},
+        helpers::{query::QueryType, ByteArrStream},
+        net::test::{body_stream, TestClients, TestServer},
         protocol::Step,
+        secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
+        test_fixture::{config::TestConfigBuilder, Reconstruct},
+        AppSetup, HelperApp,
     };
     use futures::stream::{poll_immediate, StreamExt};
+    use futures_util::future::{join_all, try_join_all};
+    use generic_array::GenericArray;
     use once_cell::sync::Lazy;
-    use std::task::Poll;
+    use std::{iter::zip, net::TcpListener, task::Poll};
     use tokio::sync::mpsc::channel;
     use tokio_stream::wrappers::ReceiverStream;
+    use typenum::Unsigned;
 
     static STEP: Lazy<Step> = Lazy::new(|| Step::from("http-transport"));
 
@@ -222,7 +231,6 @@ mod e2e_tests {
 
     // TODO: write a test for an error while reading the body (after error handling is finalized)
 
-    #[cfg(feature = "test-http")]
     async fn make_helpers(
         ids: [HelperIdentity; 3],
         sockets: [TcpListener; 3],
@@ -232,13 +240,13 @@ mod e2e_tests {
         use crate::net::BindTarget;
 
         join_all(zip(ids, zip(sockets, server_config)).map(
-            |(id, (socket, server_conf))| async move {
+            |(id, (socket, _server_conf))| async move {
                 let (setup, callbacks) = AppSetup::new();
                 let client_config = network_config.clone();
                 let clients = TestClients::builder()
                     .with_network_config(client_config)
                     .build();
-                let (transport, server) = HttpTransport::new(id, clients, callbacks);
+                let (transport, server) = HttpTransport::new(id, clients.0, callbacks);
                 server.bind(BindTarget::HttpListener(socket)).await;
                 let app = setup.connect(transport);
                 app
@@ -250,7 +258,6 @@ mod e2e_tests {
         .unwrap()
     }
 
-    #[cfg(feature = "test-http")]
     fn make_clients(confs: &[PeerConfig; 3]) -> [MpcHelperClient; 3] {
         confs
             .iter()
@@ -260,10 +267,9 @@ mod e2e_tests {
             .unwrap()
     }
 
-    #[cfg(feature = "test-http")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn happy_case() {
-        const SZ: usize = <Replicated<Fp31> as Serializable>::Size::USIZE;
+        const SZ: usize = <AdditiveShare<Fp31> as Serializable>::Size::USIZE;
         let mut conf = TestConfigBuilder::with_open_ports().build();
         let ids = HelperIdentity::make_three();
         let clients = make_clients(conf.network.peers());
@@ -308,12 +314,11 @@ mod e2e_tests {
 
         let result: [_; 3] = join_all(clients.map(|client| async move {
             let r = client.query_results(query_id).await.unwrap();
-            Replicated::<Fp31>::from_byte_slice(&r).collect::<Vec<_>>()
+            AdditiveShare::<Fp31>::from_byte_slice(&r).collect::<Vec<_>>()
         }))
         .await
         .try_into()
         .unwrap();
-
         let res = result.reconstruct();
         assert_eq!(Fp31::try_from(20u128).unwrap(), res[0]);
     }

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -156,7 +156,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::iter;
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -540,7 +540,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
 
     use super::aggregate_credit;

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -194,7 +194,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         attribution_window_test_input,

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -484,7 +484,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         credit_capping_test_input,

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -73,7 +73,7 @@ pub async fn check_zero<F: Field>(
     Ok(rv == F::ZERO)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         error::Error,

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -120,7 +120,7 @@ where
     Ok(malicious_ab)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod test {
     use crate::{
         ff::Fp31,

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -80,7 +80,7 @@ where
     Ok(Replicated::new(lhs, rhs))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod test {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -185,7 +185,7 @@ impl MultiplyWork for MultiplyZeroPositions {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 pub(in crate::protocol) mod test {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -240,7 +240,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     mod semi_honest {
         use crate::{

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -155,7 +155,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         rand::{thread_rng, Rng},

--- a/src/protocol/basics/share_known_value.rs
+++ b/src/protocol/basics/share_known_value.rs
@@ -34,7 +34,7 @@ impl<'a, F: Field + ExtendableField> ShareKnownValue<MaliciousContext<'a, F>, F>
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::ShareKnownValue;
     use crate::{

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -155,7 +155,7 @@ where
     Ok(malicious_ab)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod test {
     use super::sum_of_products;
     use crate::{

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -69,7 +69,7 @@ where
     Ok(Replicated::new(lhs, rhs))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod test {
     use super::sum_of_products;
     use crate::{

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -200,7 +200,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -96,7 +96,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::BitDecomposition;
     use crate::{

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -121,7 +121,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -197,7 +197,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::BitwiseLessThanPrime;
     use crate::{

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -110,7 +110,7 @@ struct RBounds {
     invert: bool,
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 impl RBounds {
     // This is used for the proptest. It must match the actual implementation!
     fn evaluate(&self, r: u128) -> bool {
@@ -315,7 +315,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::{
         bitwise_greater_than_constant, bitwise_less_than_constant, compute_r_bounds,

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -20,7 +20,7 @@ pub async fn or<F: Field, C: Context, S: LinearSecretSharing<F> + SecureMul<C>>(
     Ok(-ab + a + b)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::or;
     use crate::{

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -93,7 +93,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::RandomBitsGenerator;
     use crate::{

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -146,7 +146,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -41,7 +41,7 @@ where
     Ok(-(ab * F::truncate_from(2_u128)) + a + b)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::xor;
     use crate::{

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -63,7 +63,7 @@ pub trait Context: Clone + Send + Sync + SeqJoin {
     fn recv_channel<M: Message>(&self, role: Role) -> ReceivingEnd<M>;
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Serializable},

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -522,7 +522,7 @@ where
         .collect::<Vec<_>>()
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 pub mod tests {
     use super::{ipa, ipa_malicious, IPAInputRow};
     use crate::{

--- a/src/protocol/malicious.rs
+++ b/src/protocol/malicious.rs
@@ -282,7 +282,7 @@ impl<F: Field + ExtendableField> Debug for MaliciousValidator<'_, F> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::iter::{repeat, zip};
 

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -203,7 +203,7 @@ where
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         error::Error,

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -262,7 +262,7 @@ impl EndpointSetup {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -46,7 +46,7 @@ pub fn apply_inv<T>(permutation: &[u32], values: &mut [T]) {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::{apply, apply_inv};
     use crate::rand::thread_rng;

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -40,7 +40,7 @@ where
     Ok(shuffled_objects)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         accumulation_test_input,

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -109,7 +109,7 @@ where
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
 
     mod semi_honest {

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -72,7 +72,7 @@ pub async fn bit_permutation<
     Ok(mult_output)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -48,7 +48,7 @@ pub async fn compose<F: Field, S: SecretSharing<F> + Reshare<C, RecordId>, C: Co
     Ok(unshuffled_rho)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -158,7 +158,7 @@ pub async fn malicious_generate_permutation_and_reveal_shuffled<F: Field + Exten
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use std::iter::zip;
 

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -216,7 +216,7 @@ where
     ))
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, GaloisField, Gf40Bit},

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -93,7 +93,7 @@ pub async fn multi_bit_permutation<
     Ok(one_off_permutation)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::multi_bit_permutation;
     use crate::{

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -22,7 +22,7 @@ pub async fn secureapplyinv_multi<C: Context, I: Reshare<C, RecordId> + Send + S
     Ok(shuffled_input)
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     mod semi_honest {
         use rand::seq::SliceRandom;

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -165,7 +165,7 @@ pub async fn unshuffle_shares<F: Field, S: SecretSharing<F> + Reshare<C, RecordI
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use crate::{
         protocol::{sort::shuffle::get_two_of_three_random_permutations, Step},

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -168,7 +168,7 @@ pub fn start_query(
     })
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -261,13 +261,15 @@ impl Processor {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::*;
     use crate::{
         ff::FieldType,
-        helpers::{query::QueryType, HelperIdentity, PrepareQueryCallback, TransportCallbacks},
-        test_fixture::network::InMemoryNetwork,
+        helpers::{
+            query::QueryType, HelperIdentity, InMemoryNetwork, PrepareQueryCallback,
+            TransportCallbacks,
+        },
     };
     use futures::pin_mut;
     use futures_util::future::poll_immediate;

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -305,7 +305,7 @@ impl<T> ThisCodeIsAuthorizedToDowngradeFromMalicious<T> for UnauthorizedDowngrad
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::{
         AdditiveShare, Downgrade, ExtendableField, ThisCodeIsAuthorizedToDowngradeFromMalicious,

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -162,7 +162,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
     use super::AdditiveShare;
     use crate::{

--- a/src/test_fixture/app.rs
+++ b/src/test_fixture/app.rs
@@ -6,11 +6,11 @@ use crate::{
         ByteArrStream,
     },
     secret_sharing::IntoShares,
-    test_fixture::network::{InMemoryNetwork, InMemoryTransport},
     AppSetup, HelperApp,
 };
 use std::iter::zip;
 
+use crate::helpers::{InMemoryNetwork, InMemoryTransport};
 use generic_array::GenericArray;
 use typenum::Unsigned;
 

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -1,10 +1,10 @@
 use crate::{
-    ff::Field,
+    ff::{Field, Fp31},
     helpers::TotalRecords,
     protocol::{basics::SecureMul, context::Context, RecordId},
     rand::thread_rng,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
-    test_fixture::{narrow_contexts, Fp31, Reconstruct, TestWorld},
+    test_fixture::{narrow_contexts, Reconstruct, TestWorld},
 };
 use futures_util::future::join_all;
 

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -1,26 +1,34 @@
 pub mod input;
 mod sharing;
+#[cfg(feature = "in-memory-infra")]
 mod world;
 
+// `test-fixture` module is enabled for all tests, but app makes sense only for tests that use
+// in-memory infra.
+#[cfg(feature = "in-memory-infra")]
 mod app;
+
+#[cfg(feature = "in-memory-infra")]
 pub mod circuit;
 pub mod config;
+#[cfg(feature = "in-memory-infra")]
 pub mod ipa;
 pub mod logging;
 pub mod metrics;
-pub mod network;
 
 use crate::{
-    ff::{Field, Fp31},
+    ff::Field,
     protocol::{context::Context, prss::Endpoint as PrssEndpoint, Substep},
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
 };
+#[cfg(feature = "in-memory-infra")]
 pub use app::TestApp;
 use futures::TryFuture;
 use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
 use rand_core::{CryptoRng, RngCore};
 pub use sharing::{get_bits, into_bits, Reconstruct};
 use std::fmt::Debug;
+#[cfg(feature = "in-memory-infra")]
 pub use world::{Runner, TestWorld, TestWorldConfig};
 
 /// Narrows a set of contexts all at once.

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -1,7 +1,7 @@
 use super::{sharing::ValidateMalicious, Reconstruct};
 use crate::{
     ff::Field,
-    helpers::{Gateway, GatewayConfig, Role, RoleAssignment},
+    helpers::{Gateway, GatewayConfig, InMemoryNetwork, Role, RoleAssignment},
     protocol::{
         context::{
             Context, MaliciousContext, SemiHonestContext, UpgradeContext, UpgradeToMalicious,
@@ -20,7 +20,7 @@ use crate::{
         Arc,
     },
     telemetry::{stats::Metrics, StepStatsCsvExporter},
-    test_fixture::{logging, make_participants, metrics::MetricsHandle, network::InMemoryNetwork},
+    test_fixture::{logging, make_participants, metrics::MetricsHandle},
 };
 use async_trait::async_trait;
 use futures::{future::join_all, Future};


### PR DESCRIPTION
As @andyleiserson mentioned, we have an issue now where `web-app` and `test-fixture` features are mutually incompatible because of different `Transport` implementations. That bubbles up to the top-level feature `cli` that we use to start HTTP server and to run test circuits. 

Here is what I am proposing to do to resolve this:

* [This PR] Not every CLI needs to depend on `test-fixture`, only those that we use to test IPA. `Reconstruct`/`IntoShares` are two examples. So removing `test-fixture` dependency from `cli` feature and adding it to `test_mpc` should keep our CLI dependency tree clean.
* [Pending] `test_mpc` still needs some of the web components (client) to communicate with IPA helpers. I suggest that we add another feature `web-client` and use it to build `MpcHelperClient` struct and its friends. That feature does not need to depend on transport because it should only build client package.

After making those two changes, I believe we should no longer have issues with `cli` and `web-app`.