### PR TITLE
Format code using group_imports=StdExternalCrate setting

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Check formatting
-        run: cargo fmt --all -- --check --config imports_granularity=Crate
+        run: cargo fmt --all -- --check --config "imports_granularity=Crate,group_imports=StdExternalCrate"
 
       - name: Clippy
         if: ${{ success() || failure() }}

--- a/benches/oneshot/arithmetic_circuit.rs
+++ b/benches/oneshot/arithmetic_circuit.rs
@@ -1,6 +1,7 @@
+use std::time::Instant;
+
 use clap::Parser;
 use ipa::{ff::Fp31, secret_sharing::SharedValue, test_fixture::circuit};
-use std::time::Instant;
 
 #[derive(Debug, Parser)]
 pub struct CircuitArgs {

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -1,3 +1,8 @@
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    time::Instant,
+};
+
 use clap::Parser;
 use ipa::{
     error::Error,
@@ -9,10 +14,6 @@ use ipa::{
     },
 };
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
-use std::{
-    num::{NonZeroU32, NonZeroUsize},
-    time::Instant,
-};
 use tokio::runtime::Builder;
 
 #[cfg(all(not(target_env = "msvc"), not(feature = "dhat-heap")))]

--- a/benches/oneshot/sort.rs
+++ b/benches/oneshot/sort.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use futures::stream::iter as stream_iter;
 use ipa::{
     error::Error,
@@ -14,7 +16,6 @@ use ipa::{
     test_fixture::{join3, Reconstruct, TestWorld, TestWorldConfig},
 };
 use rand::Rng;
-use std::time::Instant;
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 3)]
 async fn main() -> Result<(), Error> {

--- a/ipa-macros/src/derive_gate/mod.rs
+++ b/ipa-macros/src/derive_gate/mod.rs
@@ -1,7 +1,8 @@
-use crate::parser::{group_by_modules, ipa_state_transition_map, module_string_to_ast};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
+
+use crate::parser::{group_by_modules, ipa_state_transition_map, module_string_to_ast};
 
 // Procedural macro to derive the Step and StepNarrow traits and generate a memory-efficient gate.
 //

--- a/ipa-macros/src/parser.rs
+++ b/ipa-macros/src/parser.rs
@@ -1,10 +1,12 @@
-use crate::tree::Node;
-use quote::format_ident;
 use std::{
     collections::{HashMap, VecDeque},
     io::Read,
     path::PathBuf,
 };
+
+use quote::format_ident;
+
+use crate::tree::Node;
 
 const TARGET_CRATE: &str = "ipa";
 const STEPS_FILE_PATH: &str = "/../src/protocol/step/";

--- a/ipa-macros/src/tree.rs
+++ b/ipa-macros/src/tree.rs
@@ -83,8 +83,9 @@ impl<T> Deref for InnerNode<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tree::Node;
     use std::rc::{Rc, Weak};
+
+    use crate::tree::Node;
 
     #[derive(Debug)]
     struct TestData(u8);

--- a/pre-commit
+++ b/pre-commit
@@ -53,9 +53,11 @@ stashfile=$(mktemp .pre-commit.stashXXXXXX)
 trap 'set +e;git stash pop -q; rm -f "$stashfile"; restore_merge_files' EXIT
 save_merge_files
 git stash push -k -u -q -m "pre-commit stash"
-if ! errors=($(cargo fmt -- --check --config imports_granularity=Crate -l)); then
+
+fmtconfig="imports_granularity=Crate,group_imports=StdExternalCrate"
+if ! errors=($(cargo fmt --all -- --check --config "$fmtconfig" -l)); then
     echo "Formatting errors found."
-    echo "Run \`cargo fmt -- --config imports_granularity=Crate\` to fix the following files:"
+    echo "Run \`cargo fmt --all -- --config \"$fmtconfig\"\` to fix the following files:"
     for err in "${errors[@]}"; do
         echo "  $err"
     done

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -1,3 +1,11 @@
+use std::{
+    fs,
+    net::TcpListener,
+    os::fd::{FromRawFd, RawFd},
+    path::{Path, PathBuf},
+    process,
+};
+
 use clap::{self, Parser, Subcommand};
 use hyper::http::uri::Scheme;
 use ipa::{
@@ -9,13 +17,6 @@ use ipa::{
     helpers::HelperIdentity,
     net::{ClientIdentity, HttpTransport, MpcHelperClient},
     AppSetup,
-};
-use std::{
-    fs,
-    net::TcpListener,
-    os::fd::{FromRawFd, RawFd},
-    path::{Path, PathBuf},
-    process,
 };
 use tracing::{error, info};
 

--- a/src/bin/ipa_bench/cmd.rs
+++ b/src/bin/ipa_bench/cmd.rs
@@ -1,14 +1,16 @@
-use crate::{gen_events::generate_events, sample::Sample};
-use clap::Parser;
-use ipa::cli::Verbosity;
-use rand::{rngs::StdRng, SeedableRng};
 use std::{
     fs::File,
     io,
     path::{Path, PathBuf},
     process,
 };
+
+use clap::Parser;
+use ipa::cli::Verbosity;
+use rand::{rngs::StdRng, SeedableRng};
 use tracing::{debug, error, info};
+
+use crate::{gen_events::generate_events, sample::Sample};
 
 const DEFAULT_EVENT_GEN_COUNT: u32 = 100_000;
 

--- a/src/bin/ipa_bench/config.rs
+++ b/src/bin/ipa_bench/config.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::ops::Range;
+
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "enable-serde")]
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -1,14 +1,16 @@
-use crate::{
-    models::{Epoch, Event, EventTimestamp, GenericReport, MatchKey, Number},
-    sample::Sample,
-};
+use std::io;
+
 use bitvec::view::BitViewSized;
 use rand::{
     distributions::{Bernoulli, Distribution},
     CryptoRng, Rng, RngCore,
 };
-use std::io;
 use tracing::{debug, info, trace};
+
+use crate::{
+    models::{Epoch, Event, EventTimestamp, GenericReport, MatchKey, Number},
+    sample::Sample,
+};
 
 // 0x1E. https://datatracker.ietf.org/doc/html/rfc7464
 const RECORD_SEPARATOR: u8 = 30;
@@ -170,13 +172,15 @@ fn add_event_timestamps(rhs: EventTimestamp, lhs: EventTimestamp) -> EventTimest
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::{gen_reports, generate_events, EventTimestamp, GenericReport};
-    use crate::{gen_events::add_event_timestamps, models::Epoch, sample::Sample};
-    use rand::{rngs::StdRng, SeedableRng};
     use std::{
         cmp::Ordering,
         io::{Cursor, Write},
     };
+
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use super::{gen_reports, generate_events, EventTimestamp, GenericReport};
+    use crate::{gen_events::add_event_timestamps, models::Epoch, sample::Sample};
 
     const DATA: &str = r#"
       {

--- a/src/bin/ipa_bench/models.rs
+++ b/src/bin/ipa_bench/models.rs
@@ -1,10 +1,11 @@
-use rand::{CryptoRng, Rng, RngCore};
-use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Debug, Formatter},
     io::{Error as IoError, ErrorKind as IoErrorKind},
     ops::Range,
 };
+
+use rand::{CryptoRng, Rng, RngCore};
+use serde::{Deserialize, Serialize};
 
 // Type aliases to indicate whether the parameter should be encrypted, secret shared, etc.
 // Underlying types are temporalily assigned for PoC.
@@ -318,9 +319,8 @@ impl Debug for TriggerFanoutQuery {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use crate::models::Epoch;
-
     use super::EventTimestamp;
+    use crate::models::Epoch;
 
     #[test]
     fn event_timestamp_new() {

--- a/src/bin/ipa_bench/sample.rs
+++ b/src/bin/ipa_bench/sample.rs
@@ -1,9 +1,11 @@
-use crate::config::Config;
+use std::time::Duration;
+
 use rand::{
     distributions::{Distribution, WeightedIndex},
     CryptoRng, Rng, RngCore,
 };
-use std::time::Duration;
+
+use crate::config::Config;
 
 pub struct Sample<'a> {
     config: &'a Config,

--- a/src/bin/report_collector.rs
+++ b/src/bin/report_collector.rs
@@ -1,33 +1,3 @@
-use clap::{Parser, Subcommand};
-use hyper::http::uri::Scheme;
-use ipa::{
-    cli::{
-        playbook::{make_clients, playbook_ipa, validate, InputSource},
-        Verbosity,
-    },
-    config::NetworkConfig,
-    ff::{FieldType, Fp32BitPrime},
-    helpers::query::{IpaQueryConfig, QueryConfig, QueryType},
-    hpke::{KeyRegistry, PublicKeyOnly},
-    net::MpcHelperClient,
-    protocol::{BreakdownKey, MatchKey},
-    report::{KeyIdentifier, DEFAULT_KEY_ID},
-    test_fixture::{
-        ipa::{ipa_in_the_clear, IpaSecurityModel, TestRawDataRecord},
-        EventGenerator, EventGeneratorConfig,
-    },
-};
-
-use comfy_table::{Cell, Table};
-use ipa::{
-    cli::{
-        noise::{apply, ApplyDpArgs},
-        CsvSerializer, IpaQueryResult,
-    },
-    helpers::query::QuerySize,
-};
-use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng};
-use rand_core::SeedableRng;
 use std::{
     borrow::Cow,
     error::Error,
@@ -38,6 +8,30 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
 };
+
+use clap::{Parser, Subcommand};
+use comfy_table::{Cell, Table};
+use hyper::http::uri::Scheme;
+use ipa::{
+    cli::{
+        noise::{apply, ApplyDpArgs},
+        playbook::{make_clients, playbook_ipa, validate, InputSource},
+        CsvSerializer, IpaQueryResult, Verbosity,
+    },
+    config::NetworkConfig,
+    ff::{FieldType, Fp32BitPrime},
+    helpers::query::{IpaQueryConfig, QueryConfig, QuerySize, QueryType},
+    hpke::{KeyRegistry, PublicKeyOnly},
+    net::MpcHelperClient,
+    protocol::{BreakdownKey, MatchKey},
+    report::{KeyIdentifier, DEFAULT_KEY_ID},
+    test_fixture::{
+        ipa::{ipa_in_the_clear, IpaSecurityModel, TestRawDataRecord},
+        EventGenerator, EventGeneratorConfig,
+    },
+};
+use rand::{distributions::Alphanumeric, rngs::StdRng, thread_rng, Rng};
+use rand_core::SeedableRng;
 
 #[derive(Debug, Parser)]
 #[clap(name = "rc", about = "Report Collector CLI")]

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, fmt::Debug, ops::Add, path::PathBuf};
+
 use clap::{Parser, Subcommand};
 use generic_array::ArrayLength;
 use hyper::http::uri::Scheme;
@@ -11,7 +13,6 @@ use ipa::{
     net::MpcHelperClient,
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
 };
-use std::{error::Error, fmt::Debug, ops::Add, path::PathBuf};
 
 #[derive(Debug, Parser)]
 #[clap(

--- a/src/chunkscan.rs
+++ b/src/chunkscan.rs
@@ -1,13 +1,15 @@
-use crate::error::BoxError;
-use futures::{ready, Stream};
-use pin_project::pin_project;
 use std::{
     future::Future,
     mem,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{ready, Stream};
+use pin_project::pin_project;
 use tracing::error;
+
+use crate::error::BoxError;
 
 /// A variant of stream transform that combines semantic of `StreamExt::chunks` and `StreamExt::scan`.
 /// Consumes the input stream and keeps accumulating items in the internal buffer until it reaches

--- a/src/cli/clientconf.rs
+++ b/src/cli/clientconf.rs
@@ -1,13 +1,15 @@
+use std::{fs, fs::File, io::Write, iter::zip, path::PathBuf};
+
+use clap::Args;
+use config::Map;
+use hpke::Serializable as _;
+use toml::{Table, Value};
+
 use crate::{
     cli::paths::PathExt,
     config::{ClientConfig, HpkeClientConfig, NetworkConfig, PeerConfig},
     error::BoxError,
 };
-use clap::Args;
-use config::Map;
-use hpke::Serializable as _;
-use std::{fs, fs::File, io::Write, iter::zip, path::PathBuf};
-use toml::{Table, Value};
 
 #[derive(Debug, Args)]
 #[clap(about = "Generate client config for 3 MPC helper parties")]

--- a/src/cli/ipa_output.rs
+++ b/src/cli/ipa_output.rs
@@ -1,5 +1,6 @@
-use crate::helpers::query::{IpaQueryConfig, QuerySize};
 use std::time::Duration;
+
+use crate::helpers::query::{IpaQueryConfig, QuerySize};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/cli/keygen.rs
+++ b/src/cli/keygen.rs
@@ -1,4 +1,9 @@
-use crate::{error::BoxError, hpke::KeyPair};
+use std::{
+    fs::File,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
 use clap::Args;
 use rand::{thread_rng, Rng};
 use rand_core::CryptoRng;
@@ -6,12 +11,9 @@ use rcgen::{
     Certificate, CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa,
     KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
 };
-use std::{
-    fs::File,
-    io::{self, Write},
-    path::{Path, PathBuf},
-};
 use time::{Duration, OffsetDateTime};
+
+use crate::{error::BoxError, hpke::KeyPair};
 
 #[derive(Debug, Args)]
 #[clap(

--- a/src/cli/metric_collector.rs
+++ b/src/cli/metric_collector.rs
@@ -1,10 +1,12 @@
-use crate::telemetry::stats::Metrics;
+use std::{io::stderr, thread};
+
 use metrics_tracing_context::TracingContextLayer;
 use metrics_util::{
     debugging::{DebuggingRecorder, Snapshotter},
     layers::Layer,
 };
-use std::{io::stderr, thread};
+
+use crate::telemetry::stats::Metrics;
 
 /// Collects metrics using `DebuggingRecorder` and dumps them to `stderr` when dropped.
 pub struct CollectorHandle {

--- a/src/cli/noise.rs
+++ b/src/cli/noise.rs
@@ -1,12 +1,13 @@
-use clap::Args;
-use rand::rngs::StdRng;
 use std::{
     collections::BTreeMap,
     fmt::{Debug, Display, Formatter},
 };
 
-use crate::protocol::dp::InsecureDiscreteDp;
+use clap::Args;
+use rand::rngs::StdRng;
 use rand_core::SeedableRng;
+
+use crate::protocol::dp::InsecureDiscreteDp;
 
 #[derive(Debug, Args)]
 #[clap(about = "Apply differential privacy noise to the given input")]

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -1,18 +1,16 @@
-use crate::ff::Field;
-
 use std::{
     any::type_name,
     fs::File,
     io,
     io::{stdin, BufRead, BufReader, Read},
+    path::PathBuf,
 };
 
 use crate::{
-    ff::GaloisField,
+    ff::{Field, GaloisField},
     ipa_test_input,
     test_fixture::{input::GenericReportTestInput, ipa::TestRawDataRecord},
 };
-use std::path::PathBuf;
 
 pub trait InputItem {
     fn from_str(s: &str) -> Self;

--- a/src/cli/playbook/ipa.rs
+++ b/src/cli/playbook/ipa.rs
@@ -1,4 +1,17 @@
 #![cfg(all(feature = "web-app", feature = "cli"))]
+use std::{
+    cmp::min,
+    iter::zip,
+    time::{Duration, Instant},
+};
+
+use futures_util::future::try_join_all;
+use generic_array::GenericArray;
+use rand::{distributions::Standard, prelude::Distribution, rngs::StdRng};
+use rand_core::SeedableRng;
+use tokio::time::sleep;
+use typenum::Unsigned;
+
 use crate::{
     cli::IpaQueryResult,
     ff::{PrimeField, Serializable},
@@ -15,17 +28,6 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
     test_fixture::{input::GenericReportTestInput, ipa::TestRawDataRecord, Reconstruct},
 };
-use futures_util::future::try_join_all;
-use generic_array::GenericArray;
-use rand::{distributions::Standard, prelude::Distribution, rngs::StdRng};
-use rand_core::SeedableRng;
-use std::{
-    cmp::min,
-    iter::zip,
-    time::{Duration, Instant},
-};
-use tokio::time::sleep;
-use typenum::Unsigned;
 
 /// Semi-honest IPA protocol.
 /// Returns aggregated values per breakdown key represented as index in the returned vector

--- a/src/cli/playbook/mod.rs
+++ b/src/cli/playbook/mod.rs
@@ -2,18 +2,20 @@ mod input;
 mod ipa;
 mod multiply;
 
+use core::fmt::Debug;
+use std::{fs, path::Path, time::Duration};
+
+use comfy_table::{Cell, Color, Table};
+use hyper::http::uri::Scheme;
+pub use input::InputSource;
+pub use multiply::secure_mul;
+use tokio::time::sleep;
+
 pub use self::ipa::playbook_ipa;
 use crate::{
     config::{ClientConfig, NetworkConfig, PeerConfig},
     net::{ClientIdentity, MpcHelperClient},
 };
-use comfy_table::{Cell, Color, Table};
-use core::fmt::Debug;
-use hyper::http::uri::Scheme;
-pub use input::InputSource;
-pub use multiply::secure_mul;
-use std::{fs, path::Path, time::Duration};
-use tokio::time::sleep;
 
 pub fn validate<'a, I, S>(expected: I, actual: I)
 where

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -1,5 +1,11 @@
 #![cfg(feature = "web-app")]
 
+use std::ops::Add;
+
+use futures::future::try_join_all;
+use generic_array::{ArrayLength, GenericArray};
+use typenum::Unsigned;
+
 use crate::{
     ff::{Field, Serializable},
     helpers::{query::QueryInput, BodyStream},
@@ -8,10 +14,6 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::Reconstruct,
 };
-use futures::future::try_join_all;
-use generic_array::{ArrayLength, GenericArray};
-use std::ops::Add;
-use typenum::Unsigned;
 
 /// Secure multiplication. Each input must be a valid tuple of field values.
 /// `(a, b)` will produce `a` * `b`.

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -1,17 +1,19 @@
-use crate::{
-    cli::{keygen, KeygenArgs},
-    error::BoxError,
-};
-use clap::Args;
 use std::{
     fs::{DirBuilder, File},
     iter::zip,
     path::PathBuf,
 };
 
-use crate::cli::{
-    clientconf::{gen_client_config, HelperClientConf},
-    paths::PathExt,
+use clap::Args;
+
+use crate::{
+    cli::{
+        clientconf::{gen_client_config, HelperClientConf},
+        keygen,
+        paths::PathExt,
+        KeygenArgs,
+    },
+    error::BoxError,
 };
 
 #[derive(Debug, Args)]

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -1,13 +1,15 @@
-use crate::{
-    cli::{install_collector, metric_collector::CollectorHandle},
-    error::set_global_panic_hook,
-};
+use std::io::stderr;
+
 use clap::Parser;
 use metrics_tracing_context::MetricsLayer;
-use std::io::stderr;
 use tracing::{info, metadata::LevelFilter, Level};
 use tracing_subscriber::{
     fmt, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+use crate::{
+    cli::{install_collector, metric_collector::CollectorHandle},
+    error::set_global_panic_hook,
 };
 
 #[derive(Debug, Parser)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,3 @@
-use crate::{
-    error::BoxError,
-    helpers::HelperIdentity,
-    hpke::{
-        Deserializable as _, IpaPrivateKey, IpaPublicKey, KeyPair, KeyRegistry, Serializable as _,
-    },
-};
-
-use hyper::{client::Builder, http::uri::Scheme, Uri};
-use rustls_pemfile::Item;
-use serde::{Deserialize, Deserializer, Serialize};
-use tokio::fs;
-use tokio_rustls::rustls::Certificate;
-
 use std::{
     array,
     borrow::{Borrow, Cow},
@@ -20,6 +6,20 @@ use std::{
     path::PathBuf,
     slice,
     time::Duration,
+};
+
+use hyper::{client::Builder, http::uri::Scheme, Uri};
+use rustls_pemfile::Item;
+use serde::{Deserialize, Deserializer, Serialize};
+use tokio::fs;
+use tokio_rustls::rustls::Certificate;
+
+use crate::{
+    error::BoxError,
+    helpers::HelperIdentity,
+    hpke::{
+        Deserializable as _, IpaPrivateKey, IpaPublicKey, KeyPair, KeyRegistry, Serializable as _,
+    },
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -426,12 +426,13 @@ impl Debug for Http2Configurator {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
-    use crate::{config::HpkeClientConfig, helpers::HelperIdentity, net::test::TestConfigBuilder};
     use hpke::{kem::X25519HkdfSha256, Kem};
     use hyper::Uri;
     use rand::rngs::StdRng;
     use rand_core::SeedableRng;
+
+    use super::*;
+    use crate::{config::HpkeClientConfig, helpers::HelperIdentity, net::test::TestConfigBuilder};
 
     const URI_1: &str = "http://localhost:3000";
     const URI_2: &str = "http://localhost:3001";

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
-use crate::{report::InvalidReportError, task::JoinError};
 use std::{backtrace::Backtrace, fmt::Debug};
+
 use thiserror::Error;
+
+use crate::{report::InvalidReportError, task::JoinError};
 
 /// An error raised by the IPA protocol.
 ///

--- a/src/exact.rs
+++ b/src/exact.rs
@@ -1,9 +1,10 @@
-use futures::stream::Stream;
-use pin_project::pin_project;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::stream::Stream;
+use pin_project::pin_project;
 
 /// An analogue of [`ExactSizeIterator`] for [`Stream`].
 /// This behaves exactly as you might expect based on the documentation of
@@ -83,9 +84,10 @@ impl<S: Stream> ExactSizeStream for FixedLength<S> {}
 
 #[cfg(all(test, unit_test))]
 mod test {
-    use crate::exact::{ExactSizeStream, FixedLength};
     use futures::stream::iter;
     use futures_util::StreamExt;
+
+    use crate::exact::{ExactSizeStream, FixedLength};
 
     #[test]
     fn fixed_stream() {

--- a/src/ff/field.rs
+++ b/src/ff/field.rs
@@ -1,9 +1,11 @@
+use std::fmt::Debug;
+
+use typenum::{U1, U4};
+
 use crate::{
     error,
     secret_sharing::{Block, SharedValue},
 };
-use std::fmt::Debug;
-use typenum::{U1, U4};
 
 impl Block for u8 {
     type Size = U1;

--- a/src/ff/galois_field.rs
+++ b/src/ff/galois_field.rs
@@ -1,14 +1,16 @@
-use crate::{
-    ff::{Field, Serializable},
-    secret_sharing::{Block, SharedValue},
-};
-use bitvec::prelude::{bitarr, BitArr, Lsb0};
-use generic_array::GenericArray;
 use std::{
     fmt::{Debug, Formatter},
     ops::Index,
 };
+
+use bitvec::prelude::{bitarr, BitArr, Lsb0};
+use generic_array::GenericArray;
 use typenum::{Unsigned, U1, U4, U5};
+
+use crate::{
+    ff::{Field, Serializable},
+    secret_sharing::{Block, SharedValue},
+};
 
 /// Trait for data types storing arbitrary number of bits.
 pub trait GaloisField:

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -6,15 +6,16 @@ mod field;
 mod galois_field;
 mod prime_field;
 
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
 pub use field::{Field, FieldType};
 pub use galois_field::{GaloisField, Gf2, Gf32Bit, Gf40Bit, Gf8Bit};
+use generic_array::{ArrayLength, GenericArray};
 #[cfg(any(test, feature = "weak-field"))]
 pub use prime_field::Fp31;
 pub use prime_field::{Fp32BitPrime, PrimeField};
 
 use crate::secret_sharing::SharedValue;
-use generic_array::{ArrayLength, GenericArray};
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -1,9 +1,10 @@
+use generic_array::GenericArray;
+
 use super::Field;
 use crate::{
     ff::Serializable,
     secret_sharing::{Block, SharedValue},
 };
-use generic_array::GenericArray;
 
 pub trait PrimeField: Field {
     type PrimeInteger: Into<u128>;
@@ -181,10 +182,11 @@ macro_rules! field_impl {
 
         #[cfg(all(test, unit_test))]
         mod common_tests {
-            use super::*;
-            use crate::ff::Serializable;
             use generic_array::GenericArray;
             use proptest::proptest;
+
+            use super::*;
+            use crate::ff::Serializable;
 
             #[test]
             fn zero() {

--- a/src/helpers/buffers/mod.rs
+++ b/src/helpers/buffers/mod.rs
@@ -9,8 +9,9 @@ pub use unordered_receiver::UnorderedReceiver;
 #[cfg(debug_assertions)]
 #[allow(unused)] // todo(alex): make test world print the state again
 mod waiting {
-    use crate::helpers::ChannelId;
     use std::collections::HashMap;
+
+    use crate::helpers::ChannelId;
 
     pub(in crate::helpers) struct WaitingTasks<'a> {
         tasks: HashMap<&'a ChannelId, Vec<u32>>,

--- a/src/helpers/buffers/ordering_sender.rs
+++ b/src/helpers/buffers/ordering_sender.rs
@@ -1,17 +1,5 @@
 #![allow(dead_code)] // TODO remove
 
-use crate::{
-    helpers::Message,
-    sync::{
-        atomic::{
-            AtomicUsize,
-            Ordering::{AcqRel, Acquire},
-        },
-        Mutex, MutexGuard,
-    },
-};
-use futures::{task::Waker, Future, Stream};
-use generic_array::GenericArray;
 use std::{
     borrow::Borrow,
     cmp::Ordering,
@@ -22,7 +10,21 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+use futures::{task::Waker, Future, Stream};
+use generic_array::GenericArray;
 use typenum::Unsigned;
+
+use crate::{
+    helpers::Message,
+    sync::{
+        atomic::{
+            AtomicUsize,
+            Ordering::{AcqRel, Acquire},
+        },
+        Mutex, MutexGuard,
+    },
+};
 
 /// The operating state for an `OrderingSender`.
 struct State {
@@ -394,13 +396,8 @@ impl<B: Borrow<OrderingSender> + Unpin> Stream for OrderedStream<B> {
 
 #[cfg(all(test, any(unit_test, feature = "shuttle")))]
 mod test {
-    use super::OrderingSender;
-    use crate::{
-        ff::{Field, Fp31, Fp32BitPrime, Serializable},
-        rand::thread_rng,
-        sync::Arc,
-        test_executor::run,
-    };
+    use std::{iter::zip, num::NonZeroUsize};
+
     use futures::{
         future::{join, join3, join_all},
         stream::StreamExt,
@@ -408,8 +405,15 @@ mod test {
     };
     use generic_array::GenericArray;
     use rand::Rng;
-    use std::{iter::zip, num::NonZeroUsize};
     use typenum::Unsigned;
+
+    use super::OrderingSender;
+    use crate::{
+        ff::{Field, Fp31, Fp32BitPrime, Serializable},
+        rand::thread_rng,
+        sync::Arc,
+        test_executor::run,
+    };
 
     fn sender() -> Arc<OrderingSender> {
         Arc::new(OrderingSender::new(

--- a/src/helpers/buffers/unordered_receiver.rs
+++ b/src/helpers/buffers/unordered_receiver.rs
@@ -1,10 +1,3 @@
-use crate::{
-    helpers::{Error, Message},
-    protocol::RecordId,
-    sync::{Arc, Mutex},
-};
-use futures::{task::Waker, Future, Stream};
-use generic_array::GenericArray;
 use std::{
     marker::PhantomData,
     mem::take,
@@ -12,7 +5,16 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{task::Waker, Future, Stream};
+use generic_array::GenericArray;
 use typenum::Unsigned;
+
+use crate::{
+    helpers::{Error, Message},
+    protocol::RecordId,
+    sync::{Arc, Mutex},
+};
 
 /// A future for receiving item `i` from an `UnorderedReceiver`.
 pub struct Receiver<S, C, M>
@@ -298,10 +300,8 @@ where
 
 #[cfg(all(test, any(unit_test, feature = "shuttle")))]
 mod test {
-    use crate::{
-        ff::{Field, Fp31, Fp32BitPrime, Serializable},
-        helpers::buffers::unordered_receiver::UnorderedReceiver,
-    };
+    use std::num::NonZeroUsize;
+
     use futures::{
         future::{try_join, try_join_all},
         stream::iter,
@@ -311,10 +311,14 @@ mod test {
     use rand::Rng;
     #[cfg(feature = "shuttle")]
     use shuttle::future::spawn;
-    use std::num::NonZeroUsize;
     #[cfg(not(feature = "shuttle"))]
     use tokio::spawn;
     use typenum::Unsigned;
+
+    use crate::{
+        ff::{Field, Fp31, Fp32BitPrime, Serializable},
+        helpers::buffers::unordered_receiver::UnorderedReceiver,
+    };
 
     fn receiver<I, T>(it: I) -> UnorderedReceiver<impl Stream<Item = T>, T>
     where

--- a/src/helpers/error.rs
+++ b/src/helpers/error.rs
@@ -1,10 +1,11 @@
+use thiserror::Error;
+use tokio::sync::mpsc::error::SendError;
+
 use crate::{
     error::BoxError,
     helpers::{ChannelId, HelperIdentity, Message, Role, TotalRecords},
     protocol::{step::Gate, RecordId},
 };
-use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
 
 /// An error raised by the IPA supporting infrastructure.
 #[derive(Error, Debug)]

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -2,7 +2,11 @@ mod receive;
 mod send;
 mod transport;
 
+use std::{fmt::Debug, num::NonZeroUsize};
+
 pub use send::SendingEnd;
+#[cfg(all(feature = "shuttle", test))]
+use shuttle::future as tokio;
 
 use crate::{
     helpers::{
@@ -15,9 +19,6 @@ use crate::{
     },
     protocol::QueryId,
 };
-#[cfg(all(feature = "shuttle", test))]
-use shuttle::future as tokio;
-use std::{fmt::Debug, num::NonZeroUsize};
 
 /// Alias for the currently configured transport.
 ///
@@ -145,6 +146,8 @@ impl GatewayConfig {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use futures_util::future::{join, try_join};
+
     use super::*;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Gf2},
@@ -152,7 +155,6 @@ mod tests {
         protocol::{context::Context, RecordId},
         test_fixture::{Runner, TestWorld, TestWorldConfig},
     };
-    use futures_util::future::{join, try_join};
 
     /// Verifies that [`Gateway`] send buffer capacity is adjusted to the message size.
     /// IPA protocol opens many channels to send values from different fields, while message size

--- a/src/helpers/gateway/receive.rs
+++ b/src/helpers/gateway/receive.rs
@@ -1,10 +1,12 @@
+use std::marker::PhantomData;
+
+use dashmap::DashMap;
+use futures::Stream;
+
 use crate::{
     helpers::{buffers::UnorderedReceiver, ChannelId, Error, Message, Transport},
     protocol::RecordId,
 };
-use dashmap::DashMap;
-use futures::Stream;
-use std::marker::PhantomData;
 
 /// Receiving end end of the gateway channel.
 pub struct ReceivingEnd<T: Transport, M: Message> {

--- a/src/helpers/gateway/send.rs
+++ b/src/helpers/gateway/send.rs
@@ -1,17 +1,18 @@
-use crate::sync::Arc;
-use dashmap::DashMap;
-use futures::Stream;
 use std::{
     marker::PhantomData,
     num::NonZeroUsize,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use dashmap::DashMap;
+use futures::Stream;
 use typenum::Unsigned;
 
 use crate::{
     helpers::{buffers::OrderingSender, ChannelId, Error, Message, Role, TotalRecords},
     protocol::RecordId,
+    sync::Arc,
     telemetry::{
         labels::{ROLE, STEP},
         metrics::{BYTES_SENT, RECORDS_SENT},

--- a/src/helpers/prss_protocol.rs
+++ b/src/helpers/prss_protocol.rs
@@ -1,3 +1,7 @@
+use futures_util::future::try_join4;
+use rand_core::{CryptoRng, RngCore};
+use x25519_dalek::PublicKey;
+
 use crate::{
     helpers::{ChannelId, Direction, Error, Gateway, TotalRecords, Transport},
     protocol::{
@@ -6,11 +10,6 @@ use crate::{
         RecordId,
     },
 };
-use futures_util::future::try_join4;
-
-use rand_core::{CryptoRng, RngCore};
-
-use x25519_dalek::PublicKey;
 
 pub struct PrssExchangeStep;
 

--- a/src/helpers/transport/callbacks.rs
+++ b/src/helpers/transport/callbacks.rs
@@ -1,3 +1,5 @@
+use std::{future::Future, pin::Pin};
+
 use crate::{
     helpers::query::{PrepareQuery, QueryConfig, QueryInput},
     protocol::QueryId,
@@ -6,7 +8,6 @@ use crate::{
         QueryStatus, QueryStatusError,
     },
 };
-use std::{future::Future, pin::Pin};
 
 /// Macro for defining transport callbacks.
 ///

--- a/src/helpers/transport/in_memory/mod.rs
+++ b/src/helpers/transport/in_memory/mod.rs
@@ -1,11 +1,11 @@
 mod transport;
 
+pub use transport::Setup;
+
 use crate::{
     helpers::{HelperIdentity, TransportCallbacks},
     sync::{Arc, Weak},
 };
-
-pub use transport::Setup;
 
 pub type InMemoryTransport = Weak<transport::InMemoryTransport>;
 

--- a/src/helpers/transport/mod.rs
+++ b/src/helpers/transport/mod.rs
@@ -1,10 +1,12 @@
+use std::borrow::Borrow;
+
+use async_trait::async_trait;
+use futures::Stream;
+
 use crate::{
     helpers::HelperIdentity,
     protocol::{step::Gate, QueryId},
 };
-use async_trait::async_trait;
-use futures::Stream;
-use std::borrow::Borrow;
 
 pub mod callbacks;
 #[cfg(feature = "in-memory-infra")]

--- a/src/helpers/transport/query.rs
+++ b/src/helpers/transport/query.rs
@@ -1,3 +1,10 @@
+use std::{
+    fmt::{Debug, Display, Formatter},
+    num::NonZeroU32,
+};
+
+use serde::{Deserialize, Deserializer, Serialize};
+
 use crate::{
     ff::FieldType,
     helpers::{
@@ -5,11 +12,6 @@ use crate::{
         GatewayConfig, RoleAssignment, RouteId, RouteParams,
     },
     protocol::{step::Step, QueryId},
-};
-use serde::{Deserialize, Deserializer, Serialize};
-use std::{
-    fmt::{Debug, Display, Formatter},
-    num::NonZeroU32,
 };
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]

--- a/src/helpers/transport/receive.rs
+++ b/src/helpers/transport/receive.rs
@@ -1,14 +1,16 @@
-use crate::{
-    error::BoxError,
-    helpers::transport::stream::{StreamCollection, StreamKey},
-};
-use futures::Stream;
-use futures_util::StreamExt;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::Stream;
+use futures_util::StreamExt;
 use tracing::error;
+
+use crate::{
+    error::BoxError,
+    helpers::transport::stream::{StreamCollection, StreamKey},
+};
 
 /// Adapt a stream of `Result<T: Into<Vec<u8>>, Error>` to a stream of `Vec<u8>`.
 ///

--- a/src/helpers/transport/stream/axum_body.rs
+++ b/src/helpers/transport/stream/axum_body.rs
@@ -1,13 +1,14 @@
-use crate::error::BoxError;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use axum::extract::{BodyStream, FromRequest, RequestParts};
 use futures::{Stream, TryStreamExt};
 use hyper::Body;
 use pin_project::pin_project;
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-};
+
+use crate::error::BoxError;
 
 type AxumInner = futures::stream::MapErr<BodyStream, fn(axum::Error) -> crate::error::BoxError>;
 

--- a/src/helpers/transport/stream/box_body.rs
+++ b/src/helpers/transport/stream/box_body.rs
@@ -1,10 +1,11 @@
-use crate::helpers::transport::stream::BoxBytesStream;
-
-use futures::Stream;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::Stream;
+
+use crate::helpers::transport::stream::BoxBytesStream;
 
 pub struct WrappedBoxBodyStream(BoxBytesStream);
 

--- a/src/helpers/transport/stream/collection.rs
+++ b/src/helpers/transport/stream/collection.rs
@@ -1,13 +1,15 @@
-use crate::{
-    helpers::HelperIdentity,
-    protocol::{step::Gate, QueryId},
-    sync::{Arc, Mutex},
-};
-use futures::Stream;
 use std::{
     collections::{hash_map::Entry, HashMap},
     fmt::{Debug, Formatter},
     task::Waker,
+};
+
+use futures::Stream;
+
+use crate::{
+    helpers::HelperIdentity,
+    protocol::{step::Gate, QueryId},
+    sync::{Arc, Mutex},
 };
 
 /// Each stream is indexed by query id, the identity of helper where stream is originated from

--- a/src/helpers/transport/stream/input.rs
+++ b/src/helpers/transport/stream/input.rs
@@ -1,10 +1,3 @@
-use crate::{error::BoxError, ff::Serializable, helpers::BytesStream};
-use bytes::Bytes;
-use futures::{
-    stream::{iter, once, Fuse, FusedStream, Iter, Map, Once},
-    Stream, StreamExt,
-};
-use pin_project::pin_project;
 use std::{
     cmp::max,
     collections::VecDeque,
@@ -15,7 +8,16 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use bytes::Bytes;
+use futures::{
+    stream::{iter, once, Fuse, FusedStream, Iter, Map, Once},
+    Stream, StreamExt,
+};
+use pin_project::pin_project;
 use typenum::{Unsigned, U2};
+
+use crate::{error::BoxError, ff::Serializable, helpers::BytesStream};
 
 #[derive(Debug)]
 pub struct BufDeque {
@@ -448,13 +450,14 @@ mod test {
     use super::*;
 
     mod unit_test {
+        use futures::{StreamExt, TryStreamExt};
+        use generic_array::GenericArray;
+
         use super::*;
         use crate::{
             ff::{Fp31, Fp32BitPrime, Serializable},
             secret_sharing::replicated::semi_honest::AdditiveShare,
         };
-        use futures::{StreamExt, TryStreamExt};
-        use generic_array::GenericArray;
 
         #[tokio::test]
         async fn records_stream_fp31() {
@@ -578,8 +581,9 @@ mod test {
     }
 
     mod delimited {
-        use super::*;
         use futures::TryStreamExt;
+
+        use super::*;
 
         #[tokio::test]
         async fn basic() {
@@ -669,13 +673,13 @@ mod test {
     }
 
     mod prop_test {
-        use crate::ff::Fp32BitPrime;
-
-        use super::*;
         use futures::TryStreamExt;
         use generic_array::GenericArray;
         use proptest::prelude::*;
         use rand::{rngs::StdRng, SeedableRng};
+
+        use super::*;
+        use crate::ff::Fp32BitPrime;
 
         prop_compose! {
             fn arb_size_in_bytes(field_size: usize, max_multiplier: usize)
@@ -727,11 +731,12 @@ mod test {
     mod delimited_prop_test {
         use std::{mem::size_of, ops::Range};
 
-        use super::*;
         use bytes::BufMut;
         use futures::TryStreamExt;
         use proptest::prelude::*;
         use rand::{rngs::StdRng, SeedableRng};
+
+        use super::*;
 
         #[derive(Copy, Clone, Debug)]
         enum ItemSize {

--- a/src/helpers/transport/stream/mod.rs
+++ b/src/helpers/transport/stream/mod.rs
@@ -4,16 +4,17 @@ mod box_body;
 mod collection;
 mod input;
 
+use std::pin::Pin;
+
 #[cfg(feature = "web-app")]
 pub use axum_body::WrappedAxumBodyStream;
 pub use box_body::WrappedBoxBodyStream;
+use bytes::Bytes;
 pub use collection::{StreamCollection, StreamKey};
+use futures::Stream;
 pub use input::{LengthDelimitedStream, RecordsStream};
 
 use crate::error::BoxError;
-use bytes::Bytes;
-use futures::Stream;
-use std::pin::Pin;
 
 pub trait BytesStream: Stream<Item = Result<Bytes, BoxError>> + Send {
     /// Collects the entire stream into a vec; only intended for use in tests

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -2,25 +2,27 @@
 //!
 //! [`specification`]: https://github.com/patcg-individual-drafts/ipa/blob/main/details/encryption.md
 
+use std::{fmt::Debug, io, ops::Add};
+
 use generic_array::ArrayLength;
 use hpke::{
     aead::AeadTag, generic_array::typenum::Unsigned, single_shot_open_in_place_detached,
     single_shot_seal_in_place_detached, OpModeR, OpModeS,
 };
 use rand_core::{CryptoRng, RngCore};
-use std::{fmt::Debug, io, ops::Add};
 use typenum::U16;
 
 mod info;
 mod registry;
+
+pub use info::Info;
+pub use registry::{KeyPair, KeyRegistry, PublicKeyOnly, PublicKeyRegistry};
 
 use crate::{
     ff::{GaloisField, Gf40Bit, Serializable as IpaSerializable},
     report::KeyIdentifier,
     secret_sharing::replicated::semi_honest::AdditiveShare,
 };
-pub use info::Info;
-pub use registry::{KeyPair, KeyRegistry, PublicKeyOnly, PublicKeyRegistry};
 
 /// IPA ciphersuite
 type IpaKem = hpke::kem::X25519HkdfSha256;
@@ -188,16 +190,16 @@ struct MatchKeyEncryption<'a> {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
     use generic_array::GenericArray;
+    use rand::rngs::StdRng;
+    use rand_core::{CryptoRng, RngCore, SeedableRng};
 
+    use super::*;
     use crate::{
         ff::Serializable as IpaSerializable,
         report::{Epoch, EventType},
         secret_sharing::replicated::ReplicatedSecretSharing,
     };
-    use rand::rngs::StdRng;
-    use rand_core::{CryptoRng, RngCore, SeedableRng};
 
     struct EncryptionSuite<R: RngCore + CryptoRng> {
         registry: KeyRegistry<KeyPair>,
@@ -353,9 +355,10 @@ mod tests {
     }
 
     mod proptests {
-        use super::*;
         use proptest::prelude::ProptestConfig;
         use rand::{distributions::Alphanumeric, Rng};
+
+        use super::*;
 
         proptest::proptest! {
             #![proptest_config(ProptestConfig::with_cases(50))]

--- a/src/hpke/registry.rs
+++ b/src/hpke/registry.rs
@@ -1,6 +1,8 @@
-use super::{IpaPrivateKey, IpaPublicKey, KeyIdentifier};
-use hpke::Serializable;
 use std::ops::Deref;
+
+use hpke::Serializable;
+
+use super::{IpaPrivateKey, IpaPublicKey, KeyIdentifier};
 
 /// A pair of secret key and public key. Public keys used by UA to encrypt the data towards helpers
 /// secret keys used by helpers to open the ciphertexts. Each helper needs access to both
@@ -121,11 +123,12 @@ impl PublicKeyRegistry for KeyRegistry<PublicKeyOnly> {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
-    use crate::hpke::{IpaAead, IpaKdf, IpaKem};
     use hpke::{kem::EncappedKey, HpkeError, OpModeR, OpModeS};
     use rand::rngs::StdRng;
     use rand_core::{CryptoRng, RngCore, SeedableRng};
+
+    use super::*;
+    use crate::hpke::{IpaAead, IpaKdf, IpaKem};
 
     const INFO_STR: &[u8] = b"This is an INFO string.";
     const AAD: &[u8] = b"This is AAD.";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,10 @@ pub(crate) mod sync {
 
 #[cfg(all(feature = "shuttle", test))]
 pub(crate) mod rand {
-    pub use shuttle::rand::{thread_rng, Rng, RngCore};
-
     /// TODO: shuttle does not re-export `CryptoRng`. The only reason it works is because IPA uses
     /// the same version of `rand`.
     pub use rand::CryptoRng;
+    pub use shuttle::rand::{thread_rng, Rng, RngCore};
 }
 
 #[cfg(not(all(feature = "shuttle", test)))]

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -1,20 +1,3 @@
-use crate::{
-    config::{ClientConfig, HyperClientConfigurator, NetworkConfig, PeerConfig},
-    helpers::{
-        query::{PrepareQuery, QueryConfig, QueryInput},
-        HelperIdentity,
-    },
-    net::{http_serde, server::HTTP_CLIENT_ID_HEADER, Error},
-    protocol::{step::Gate, QueryId},
-};
-use axum::http::uri::{self, Parts, Scheme};
-use futures::{Stream, StreamExt};
-use hyper::{
-    body, client::HttpConnector, header::HeaderName, http::HeaderValue, Body, Client, Request,
-    Response, StatusCode, Uri,
-};
-use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
-use pin_project::pin_project;
 use std::{
     collections::HashMap,
     future::Future,
@@ -24,11 +7,30 @@ use std::{
     pin::Pin,
     task::{ready, Context, Poll},
 };
+
+use axum::http::uri::{self, Parts, Scheme};
+use futures::{Stream, StreamExt};
+use hyper::{
+    body, client::HttpConnector, header::HeaderName, http::HeaderValue, Body, Client, Request,
+    Response, StatusCode, Uri,
+};
+use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
+use pin_project::pin_project;
 use tokio_rustls::{
     rustls,
     rustls::{Certificate, PrivateKey, RootCertStore},
 };
 use tracing::error;
+
+use crate::{
+    config::{ClientConfig, HyperClientConfigurator, NetworkConfig, PeerConfig},
+    helpers::{
+        query::{PrepareQuery, QueryConfig, QueryInput},
+        HelperIdentity,
+    },
+    net::{http_serde, server::HTTP_CLIENT_ID_HEADER, Error},
+    protocol::{step::Gate, QueryId},
+};
 
 #[derive(Clone, Default)]
 pub enum ClientIdentity {
@@ -421,6 +423,15 @@ fn make_http_connector() -> HttpConnector {
 
 #[cfg(all(test, web_test))]
 pub(crate) mod tests {
+    use std::{
+        fmt::Debug,
+        future::{ready, Future},
+        iter::zip,
+        task::Poll,
+    };
+
+    use futures::stream::{once, poll_immediate};
+
     use super::*;
     use crate::{
         ff::{FieldType, Fp31},
@@ -433,13 +444,6 @@ pub(crate) mod tests {
         query::ProtocolResult,
         secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
         sync::Arc,
-    };
-    use futures::stream::{once, poll_immediate};
-    use std::{
-        fmt::Debug,
-        future::{ready, Future},
-        iter::zip,
-        task::Poll,
     };
 
     // This is a kludgy way of working around `TransportCallbacks` not being `Clone`, so

--- a/src/net/error.rs
+++ b/src/net/error.rs
@@ -1,8 +1,9 @@
-use crate::{error::BoxError, net::client::ResponseFromEndpoint, protocol::QueryId};
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+
+use crate::{error::BoxError, net::client::ResponseFromEndpoint, protocol::QueryId};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -4,11 +4,13 @@
 // to compose const strings at compile time is concat!()
 
 pub mod echo {
-    use crate::net::Error;
+    use std::collections::HashMap;
+
     use async_trait::async_trait;
     use axum::extract::{FromRequest, Query, RequestParts};
     use hyper::http::uri;
-    use std::collections::HashMap;
+
+    use crate::net::Error;
 
     #[derive(Debug, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
@@ -78,16 +80,18 @@ pub mod echo {
 }
 
 pub mod query {
+    use std::{
+        fmt::{Display, Formatter},
+        num::NonZeroU32,
+    };
+
+    use async_trait::async_trait;
+    use axum::extract::{FromRequest, Query, RequestParts};
+
     use crate::{
         ff::FieldType,
         helpers::query::{IpaQueryConfig, QueryConfig, QuerySize, QueryType},
         net::Error,
-    };
-    use async_trait::async_trait;
-    use axum::extract::{FromRequest, Query, RequestParts};
-    use std::{
-        fmt::{Display, Formatter},
-        num::NonZeroU32,
     };
 
     /// wrapper around [`QueryConfig`] to enable extraction from an `Axum` request. To be used with
@@ -209,6 +213,10 @@ pub mod query {
     pub const BASE_AXUM_PATH: &str = "/query";
 
     pub mod create {
+        use async_trait::async_trait;
+        use axum::extract::{FromRequest, RequestParts};
+        use hyper::http::uri;
+
         use crate::{
             helpers::query::QueryConfig,
             net::{
@@ -217,9 +225,6 @@ pub mod query {
             },
             protocol::QueryId,
         };
-        use async_trait::async_trait;
-        use axum::extract::{FromRequest, RequestParts};
-        use hyper::http::uri;
 
         #[derive(Debug, Clone)]
         pub struct Request {
@@ -268,13 +273,6 @@ pub mod query {
     }
 
     pub mod prepare {
-        use crate::{
-            helpers::{query::PrepareQuery, RoleAssignment},
-            net::{
-                http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
-                Error,
-            },
-        };
         use async_trait::async_trait;
         use axum::{
             extract::{FromRequest, Path, RequestParts},
@@ -282,6 +280,14 @@ pub mod query {
             Json,
         };
         use hyper::header::CONTENT_TYPE;
+
+        use crate::{
+            helpers::{query::PrepareQuery, RoleAssignment},
+            net::{
+                http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
+                Error,
+            },
+        };
 
         #[derive(Debug, Clone)]
         pub struct Request {
@@ -346,16 +352,17 @@ pub mod query {
     }
 
     pub mod input {
-        use crate::{
-            helpers::query::QueryInput,
-            net::{http_serde::query::BASE_AXUM_PATH, Error},
-        };
         use async_trait::async_trait;
         use axum::{
             extract::{FromRequest, Path, RequestParts},
             http::uri,
         };
         use hyper::{header::CONTENT_TYPE, Body};
+
+        use crate::{
+            helpers::query::QueryInput,
+            net::{http_serde::query::BASE_AXUM_PATH, Error},
+        };
 
         #[derive(Debug)]
         pub struct Request {
@@ -410,15 +417,16 @@ pub mod query {
     }
 
     pub mod step {
-        use crate::{
-            helpers::BodyStream,
-            net::{http_serde::query::BASE_AXUM_PATH, Error},
-            protocol::{step::Gate, QueryId},
-        };
         use async_trait::async_trait;
         use axum::{
             extract::{FromRequest, Path, RequestParts},
             http::uri,
+        };
+
+        use crate::{
+            helpers::BodyStream,
+            net::{http_serde::query::BASE_AXUM_PATH, Error},
+            protocol::{step::Gate, QueryId},
         };
 
         // When this type is used on the client side, `B` is `hyper::Body`. When this type
@@ -490,10 +498,11 @@ pub mod query {
     }
 
     pub mod status {
-        use crate::{net::Error, protocol::QueryId, query::QueryStatus};
         use async_trait::async_trait;
         use axum::extract::{FromRequest, Path, RequestParts};
         use serde::{Deserialize, Serialize};
+
+        use crate::{net::Error, protocol::QueryId, query::QueryStatus};
 
         #[derive(Debug, Clone)]
         pub struct Request {
@@ -544,9 +553,10 @@ pub mod query {
     }
 
     pub mod results {
-        use crate::{net::Error, protocol::QueryId};
         use async_trait::async_trait;
         use axum::extract::{FromRequest, Path, RequestParts};
+
+        use crate::{net::Error, protocol::QueryId};
 
         #[derive(Debug, Clone)]
         pub struct Request {

--- a/src/net/server/handlers/echo.rs
+++ b/src/net/server/handlers/echo.rs
@@ -1,5 +1,6 @@
-use crate::net::{http_serde, server::Error};
 use axum::{routing::get, Json, Router};
+
+use crate::net::{http_serde, server::Error};
 
 #[allow(clippy::unused_async)] // needs to be async for axum handler
 async fn handler(req: http_serde::echo::Request) -> Result<Json<http_serde::echo::Request>, Error> {
@@ -12,8 +13,9 @@ pub fn router() -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
+
+    use super::*;
 
     #[tokio::test]
     async fn happy_case() {

--- a/src/net/server/handlers/mod.rs
+++ b/src/net/server/handlers/mod.rs
@@ -1,11 +1,12 @@
 mod echo;
 mod query;
 
+use axum::Router;
+
 use crate::{
     net::{http_serde, HttpTransport},
     sync::Arc,
 };
-use axum::Router;
 
 pub fn router(transport: Arc<HttpTransport>) -> Router {
     echo::router().nest(

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -1,11 +1,12 @@
+use axum::{routing::post, Extension, Json, Router};
+use hyper::StatusCode;
+
 use crate::{
     helpers::Transport,
     net::{http_serde, Error, HttpTransport},
     query::NewQueryError,
     sync::Arc,
 };
-use axum::{routing::post, Extension, Json, Router};
-use hyper::StatusCode;
 
 /// Takes details from the HTTP request and creates a `[TransportCommand]::CreateQuery` that is sent
 /// to the [`HttpTransport`].
@@ -31,6 +32,14 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::{future::ready, num::NonZeroU32};
+
+    use axum::http::Request;
+    use hyper::{
+        http::uri::{Authority, Scheme},
+        Body, StatusCode,
+    };
+
     use super::*;
     use crate::{
         ff::FieldType,
@@ -44,13 +53,6 @@ mod tests {
         },
         protocol::QueryId,
     };
-    use axum::http::Request;
-
-    use hyper::{
-        http::uri::{Authority, Scheme},
-        Body, StatusCode,
-    };
-    use std::{future::ready, num::NonZeroU32};
 
     async fn create_test(expected_query_config: QueryConfig) {
         let cb = TransportCallbacks {

--- a/src/net/server/handlers/query/input.rs
+++ b/src/net/server/handlers/query/input.rs
@@ -1,10 +1,11 @@
+use axum::{routing::post, Extension, Router};
+use hyper::StatusCode;
+
 use crate::{
     helpers::Transport,
     net::{http_serde, Error, HttpTransport},
     sync::Arc,
 };
-use axum::{routing::post, Extension, Router};
-use hyper::StatusCode;
 
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
@@ -25,6 +26,9 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use axum::http::Request;
+    use hyper::{Body, StatusCode};
+
     use super::*;
     use crate::{
         helpers::{query::QueryInput, BytesStream, TransportCallbacks},
@@ -34,8 +38,6 @@ mod tests {
         },
         protocol::QueryId,
     };
-    use axum::http::Request;
-    use hyper::{Body, StatusCode};
 
     #[tokio::test]
     async fn input_test() {

--- a/src/net/server/handlers/query/mod.rs
+++ b/src/net/server/handlers/query/mod.rs
@@ -5,10 +5,8 @@ mod results;
 mod status;
 mod step;
 
-use crate::{
-    net::{server::ClientIdentity, HttpTransport},
-    sync::Arc,
-};
+use std::any::Any;
+
 use axum::{
     response::{IntoResponse, Response},
     Router,
@@ -18,8 +16,12 @@ use futures_util::{
     FutureExt,
 };
 use hyper::{http::request, Request, StatusCode};
-use std::any::Any;
 use tower::{layer::layer_fn, Service};
+
+use crate::{
+    net::{server::ClientIdentity, HttpTransport},
+    sync::Arc,
+};
 
 /// Construct router for IPA query web service
 ///
@@ -115,10 +117,11 @@ impl MaybeExtensionExt for request::Builder {
 
 #[cfg(all(test, unit_test))]
 pub mod test_helpers {
-    use crate::net::test::TestServer;
     use futures_util::future::poll_immediate;
     use hyper::{service::Service, StatusCode};
     use tower::ServiceExt;
+
+    use crate::net::test::TestServer;
 
     /// types that implement `IntoFailingReq` are intended to induce some failure in the process of
     /// axum routing. Pair with `assert_req_fails_with` to detect specific [`StatusCode`] failures.

--- a/src/net/server/handlers/query/prepare.rs
+++ b/src/net/server/handlers/query/prepare.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use axum::{response::IntoResponse, routing::post, Extension, Router};
+use hyper::StatusCode;
+
 use crate::{
     net::{http_serde, server::ClientIdentity, HttpTransport},
     query::PrepareQueryError,
 };
-use axum::{response::IntoResponse, routing::post, Extension, Router};
-use hyper::StatusCode;
 
 /// Called by whichever peer helper is the leader for an individual query, to initiatialize
 /// processing of that query.
@@ -33,6 +34,9 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::future::ready;
 
+    use axum::http::Request;
+    use hyper::{Body, StatusCode};
+
     use super::*;
     use crate::{
         ff::FieldType,
@@ -52,8 +56,6 @@ mod tests {
         },
         protocol::QueryId,
     };
-    use axum::http::Request;
-    use hyper::{Body, StatusCode};
 
     #[tokio::test]
     async fn prepare_test() {

--- a/src/net/server/handlers/query/results.rs
+++ b/src/net/server/handlers/query/results.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use axum::{routing::get, Extension, Router};
+use hyper::StatusCode;
+
 use crate::{
     helpers::Transport,
     net::{http_serde, server::Error, HttpTransport},
 };
-use axum::{routing::get, Extension, Router};
-use hyper::StatusCode;
 
 /// Handles the completion of the query by blocking the sender until query is completed.
 async fn handler(
@@ -30,6 +31,9 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::future::ready;
 
+    use axum::http::Request;
+    use hyper::StatusCode;
+
     use super::*;
     use crate::{
         ff::Fp31,
@@ -42,8 +46,6 @@ mod tests {
         query::ProtocolResult,
         secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
     };
-    use axum::http::Request;
-    use hyper::StatusCode;
 
     #[tokio::test]
     async fn results_test() {

--- a/src/net/server/handlers/query/status.rs
+++ b/src/net/server/handlers/query/status.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use axum::{routing::get, Extension, Json, Router};
+use hyper::StatusCode;
+
 use crate::{
     helpers::Transport,
     net::{http_serde::query::status, server::Error, HttpTransport},
 };
-use axum::{routing::get, Extension, Json, Router};
-use hyper::StatusCode;
 
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
@@ -28,6 +29,9 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::future::ready;
 
+    use axum::http::Request;
+    use hyper::StatusCode;
+
     use super::*;
     use crate::{
         helpers::TransportCallbacks,
@@ -39,8 +43,6 @@ mod tests {
         protocol::QueryId,
         query::QueryStatus,
     };
-    use axum::http::Request;
-    use hyper::StatusCode;
 
     #[tokio::test]
     async fn status_test() {

--- a/src/net/server/handlers/query/step.rs
+++ b/src/net/server/handlers/query/step.rs
@@ -1,3 +1,5 @@
+use axum::{routing::post, Extension, Router};
+
 use crate::{
     helpers::{BodyStream, Transport},
     net::{
@@ -7,7 +9,6 @@ use crate::{
     },
     sync::Arc,
 };
-use axum::{routing::post, Extension, Router};
 
 #[allow(clippy::unused_async)] // axum doesn't like synchronous handler
 async fn handler(
@@ -30,6 +31,10 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::task::Poll;
 
+    use axum::http::Request;
+    use futures::{stream::poll_immediate, StreamExt};
+    use hyper::{Body, StatusCode};
+
     use super::*;
     use crate::{
         helpers::{HelperIdentity, MESSAGE_PAYLOAD_SIZE_BYTES},
@@ -45,9 +50,6 @@ mod tests {
             QueryId,
         },
     };
-    use axum::http::Request;
-    use futures::{stream::poll_immediate, StreamExt};
-    use hyper::{Body, StatusCode};
 
     const DATA_LEN: usize = 3;
 

--- a/src/net/test.rs
+++ b/src/net/test.rs
@@ -9,6 +9,15 @@
 
 #![allow(clippy::missing_panics_doc)]
 
+use std::{
+    array,
+    net::{SocketAddr, TcpListener},
+};
+
+use once_cell::sync::Lazy;
+use tokio::task::JoinHandle;
+use tokio_rustls::rustls::Certificate;
+
 use crate::{
     config::{
         ClientConfig, HpkeClientConfig, HpkeServerConfig, NetworkConfig, PeerConfig, ServerConfig,
@@ -20,15 +29,6 @@ use crate::{
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
 };
-use once_cell::sync::Lazy;
-use std::{
-    array,
-    net::{SocketAddr, TcpListener},
-};
-
-use tokio::task::JoinHandle;
-
-use tokio_rustls::rustls::Certificate;
 
 pub const DEFAULT_TEST_PORTS: [u16; 3] = [3000, 3001, 3002];
 

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -1,3 +1,14 @@
+use std::{
+    borrow::Borrow,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::{Stream, TryFutureExt};
+
 use crate::{
     config::{NetworkConfig, ServerConfig},
     error::BoxError,
@@ -11,15 +22,6 @@ use crate::{
     net::{client::MpcHelperClient, error::Error, MpcHelperServer},
     protocol::{step::Gate, QueryId},
     sync::Arc,
-};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::{Stream, TryFutureExt};
-use std::{
-    borrow::Borrow,
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
 };
 
 type LogHttpErrors = LogErrors<BodyStream, Bytes, BoxError>;
@@ -185,6 +187,16 @@ impl Transport for Arc<HttpTransport> {
 
 #[cfg(all(test, web_test))]
 mod tests {
+    use std::{iter::zip, net::TcpListener, task::Poll};
+
+    use futures::stream::{poll_immediate, StreamExt};
+    use futures_util::future::{join_all, try_join_all};
+    use generic_array::GenericArray;
+    use once_cell::sync::Lazy;
+    use tokio::sync::mpsc::channel;
+    use tokio_stream::wrappers::ReceiverStream;
+    use typenum::Unsigned;
+
     use super::*;
     use crate::{
         config::{NetworkConfig, ServerConfig},
@@ -198,14 +210,6 @@ mod tests {
         test_fixture::Reconstruct,
         AppSetup, HelperApp,
     };
-    use futures::stream::{poll_immediate, StreamExt};
-    use futures_util::future::{join_all, try_join_all};
-    use generic_array::GenericArray;
-    use once_cell::sync::Lazy;
-    use std::{iter::zip, net::TcpListener, task::Poll};
-    use tokio::sync::mpsc::channel;
-    use tokio_stream::wrappers::ReceiverStream;
-    use typenum::Unsigned;
 
     static STEP: Lazy<Gate> = Lazy::new(|| Gate::from("http-transport"));
 

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -1,3 +1,8 @@
+use std::num::NonZeroU32;
+
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use super::{
     do_the_binary_tree_thing,
     input::{AccumulateCreditInputRow, AccumulateCreditOutputRow},
@@ -8,9 +13,6 @@ use crate::{
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use ipa_macros::step;
-use std::num::NonZeroU32;
-use strum::AsRefStr;
 
 ///
 /// When `PER_USER_CAP` is set to one, this function is called
@@ -146,6 +148,8 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::num::NonZeroU32;
+
     use crate::{
         accumulation_test_input,
         ff::Fp32BitPrime,
@@ -160,7 +164,6 @@ mod tests {
         secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
         test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
     };
-    use std::num::NonZeroU32;
 
     async fn accumulate_credit_test(
         input: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>>,

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -1,5 +1,9 @@
 extern crate ipa_macros;
 
+use futures::stream::{iter as stream_iter, StreamExt, TryStreamExt};
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::{Gf2, PrimeField, Serializable},
@@ -19,9 +23,6 @@ use crate::{
     },
     seq_join::seq_join,
 };
-use futures::stream::{iter as stream_iter, StreamExt, TryStreamExt};
-use ipa_macros::step;
-use strum::AsRefStr;
 
 /// This is the number of breakdown keys above which it is more efficient to SORT by breakdown key.
 /// Below this number, it's more efficient to just do a ton of equality checks.

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -1,3 +1,11 @@
+use std::{
+    iter::{repeat, zip},
+    num::NonZeroU32,
+};
+
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use super::{
     do_the_binary_tree_thing,
     input::{ApplyAttributionWindowInputRow, ApplyAttributionWindowOutputRow},
@@ -12,12 +20,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use ipa_macros::step;
-use std::{
-    iter::{repeat, zip},
-    num::NonZeroU32,
-};
-use strum::AsRefStr;
 
 /// This protocol applies the specified attribution window to trigger events. All trigger values of
 /// events that are outside the window will be replaced with 0, hence will not be attributed to
@@ -191,6 +193,8 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::{iter::zip, num::NonZeroU32};
+
     use crate::{
         attribution_window_test_input,
         ff::{Field, Fp32BitPrime},
@@ -206,7 +210,6 @@ mod tests {
         secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
         test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
     };
-    use std::{iter::zip, num::NonZeroU32};
 
     #[tokio::test]
     pub async fn attribution_window() {

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -1,3 +1,12 @@
+use std::iter::{repeat, zip};
+
+use futures::{
+    stream::{iter, once},
+    StreamExt, TryStreamExt,
+};
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use super::{do_the_binary_tree_thing, input::CreditCappingInputRow, prefix_or_binary_tree_style};
 use crate::{
     error::Error,
@@ -11,13 +20,6 @@ use crate::{
     secret_sharing::Linear as LinearSecretSharing,
     seq_join::seq_join,
 };
-use futures::{
-    stream::{iter, once},
-    StreamExt, TryStreamExt,
-};
-use ipa_macros::step;
-use std::iter::{repeat, zip};
-use strum::AsRefStr;
 
 /// User-level credit capping protocol.
 ///

--- a/src/protocol/attribution/input.rs
+++ b/src/protocol/attribution/input.rs
@@ -1,3 +1,10 @@
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use futures::future::try_join4;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -5,11 +12,6 @@ use crate::{
     protocol::{basics::Reshare, context::Context, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use async_trait::async_trait;
-use futures::future::try_join4;
-use ipa_macros::step;
-use std::marker::PhantomData;
-use strum::AsRefStr;
 
 //
 // `apply_attribution_window` protocol

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -4,6 +4,15 @@ pub mod apply_attribution_window;
 pub mod credit_capping;
 pub mod input;
 
+use std::iter::{once as iter_once, zip};
+
+use futures::{
+    future::try_join,
+    stream::{iter as stream_iter, TryStreamExt},
+};
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use self::{
     accumulate_credit::accumulate_credit, aggregate_credit::aggregate_credit,
     apply_attribution_window::apply_attribution_window, credit_capping::credit_capping,
@@ -32,13 +41,6 @@ use crate::{
     },
     seq_join::assert_send,
 };
-use futures::{
-    future::try_join,
-    stream::{iter as stream_iter, TryStreamExt},
-};
-use ipa_macros::step;
-use std::iter::{once as iter_once, zip};
-use strum::AsRefStr;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -1,3 +1,6 @@
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -9,8 +12,6 @@ use crate::{
     },
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use ipa_macros::step;
-use strum::AsRefStr;
 
 #[step]
 pub(crate) enum Step {
@@ -66,6 +67,8 @@ pub async fn check_zero<C: Context, F: Field>(
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use futures_util::future::try_join3;
+
     use crate::{
         error::Error,
         ff::{Field, Fp31, PrimeField},
@@ -74,7 +77,6 @@ mod tests {
         secret_sharing::{IntoShares, SharedValue},
         test_fixture::TestWorld,
     };
-    use futures_util::future::try_join3;
 
     #[tokio::test]
     async fn basic() -> Result<(), Error> {

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -1,3 +1,9 @@
+use std::fmt::Debug;
+
+use futures::future::try_join;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     protocol::{
@@ -11,10 +17,6 @@ use crate::{
         ReplicatedSecretSharing,
     },
 };
-use futures::future::try_join;
-use ipa_macros::step;
-use std::fmt::Debug;
-use strum::AsRefStr;
 
 #[step]
 pub(crate) enum Step {

--- a/src/protocol/basics/mul/mod.rs
+++ b/src/protocol/basics/mul/mod.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -10,7 +12,6 @@ use crate::{
         semi_honest::AdditiveShare as Replicated,
     },
 };
-use async_trait::async_trait;
 
 pub(crate) mod malicious;
 mod semi_honest;

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -83,6 +83,10 @@ where
 
 #[cfg(all(test, unit_test))]
 mod test {
+    use std::iter::{repeat, zip};
+
+    use rand::distributions::{Distribution, Standard};
+
     use crate::{
         ff::{Field, Fp31},
         protocol::{basics::SecureMul, context::Context, RecordId},
@@ -90,8 +94,6 @@ mod test {
         seq_join::SeqJoin,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use rand::distributions::{Distribution, Standard};
-    use std::iter::{repeat, zip};
 
     #[tokio::test]
     async fn basic() {

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -187,6 +187,11 @@ impl MultiplyWork for MultiplyZeroPositions {
 
 #[cfg(all(test, unit_test))]
 pub(in crate::protocol) mod test {
+    use std::{borrow::Borrow, iter::zip};
+
+    use futures::future::try_join;
+    use rand::distributions::{Distribution, Standard};
+
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         helpers::{
@@ -206,9 +211,6 @@ pub(in crate::protocol) mod test {
         },
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use futures::future::try_join;
-    use rand::distributions::{Distribution, Standard};
-    use std::{borrow::Borrow, iter::zip};
 
     #[derive(Clone, Copy)]
     pub struct SparseField<F> {

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -1,3 +1,9 @@
+use std::iter::{repeat, zip};
+
+use async_trait::async_trait;
+use embed_doc_image::embed_doc_image;
+use futures::future::try_join;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -20,10 +26,6 @@ use crate::{
         BitDecomposed,
     },
 };
-use async_trait::async_trait;
-use embed_doc_image::embed_doc_image;
-use futures::future::try_join;
-use std::iter::{repeat, zip};
 #[embed_doc_image("reshare", "images/sort/reshare.png")]
 /// Trait for reshare protocol to renew shares of a secret value for all 3 helpers.
 ///

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -1,5 +1,9 @@
 use std::iter::{repeat, zip};
 
+use async_trait::async_trait;
+use embed_doc_image::embed_doc_image;
+use futures::future::try_join;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -17,9 +21,6 @@ use crate::{
         SecretSharing,
     },
 };
-use async_trait::async_trait;
-use embed_doc_image::embed_doc_image;
-use futures::future::try_join;
 
 /// Trait for reveal protocol to open a shared secret to all helpers inside the MPC ring.
 #[async_trait]
@@ -153,14 +154,9 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use crate::{
-        protocol::context::{UpgradableContext, UpgradedContext, Validator},
-        rand::{thread_rng, Rng},
-        secret_sharing::replicated::malicious::ExtendableField,
-        test_fixture::Runner,
-    };
-    use futures::future::{try_join, try_join3};
     use std::iter::zip;
+
+    use futures::future::{try_join, try_join3};
 
     use crate::{
         error::Error,
@@ -168,16 +164,20 @@ mod tests {
         helpers::Direction,
         protocol::{
             basics::Reveal,
-            context::{Context, UpgradedMaliciousContext},
+            context::{
+                Context, UpgradableContext, UpgradedContext, UpgradedMaliciousContext, Validator,
+            },
             RecordId,
         },
+        rand::{thread_rng, Rng},
         secret_sharing::{
             replicated::malicious::{
-                AdditiveShare as MaliciousReplicated, ThisCodeIsAuthorizedToDowngradeFromMalicious,
+                AdditiveShare as MaliciousReplicated, ExtendableField,
+                ThisCodeIsAuthorizedToDowngradeFromMalicious,
             },
             IntoShares,
         },
-        test_fixture::{join3v, TestWorld},
+        test_fixture::{join3v, Runner, TestWorld},
     };
 
     #[tokio::test]

--- a/src/protocol/basics/share_known_value.rs
+++ b/src/protocol/basics/share_known_value.rs
@@ -36,6 +36,8 @@ impl<'a, F: ExtendableField> ShareKnownValue<UpgradedMaliciousContext<'a, F>, F>
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::Rng;
+
     use super::ShareKnownValue;
     use crate::{
         ff::Fp31,
@@ -45,7 +47,6 @@ mod tests {
         },
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use rand::Rng;
 
     #[tokio::test]
     pub async fn semi_honest_share_known_values() {

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -1,3 +1,9 @@
+use std::fmt::Debug;
+
+use futures::future::try_join;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     helpers::Direction,
@@ -12,10 +18,6 @@ use crate::{
         ReplicatedSecretSharing,
     },
 };
-use futures::future::try_join;
-use ipa_macros::step;
-use std::fmt::Debug;
-use strum::AsRefStr;
 
 #[step]
 pub(crate) enum Step {

--- a/src/protocol/basics/sum_of_product/mod.rs
+++ b/src/protocol/basics/sum_of_product/mod.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -10,7 +12,6 @@ use crate::{
         semi_honest::AdditiveShare as Replicated,
     },
 };
-use async_trait::async_trait;
 
 pub(crate) mod malicious;
 mod semi_honest;

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -211,6 +211,9 @@ impl AsRef<str> for Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use bitvec::macros::internal::funty::Fundamental;
+    use rand::{distributions::Standard, prelude::Distribution};
+
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
@@ -221,8 +224,6 @@ mod tests {
         secret_sharing::{replicated::malicious::ExtendableField, SharedValue},
         test_fixture::{into_bits, Reconstruct, Runner, TestWorld},
     };
-    use bitvec::macros::internal::funty::Fundamental;
-    use rand::{distributions::Standard, prelude::Distribution};
 
     async fn add<F>(world: &TestWorld, a: F, b: u128) -> Vec<F>
     where

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -1,3 +1,6 @@
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -12,8 +15,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use ipa_macros::step;
-use strum::AsRefStr;
 
 /// This is an implementation of "3. Bit-Decomposition" from I. Damgård et al..
 ///
@@ -89,6 +90,8 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::{distributions::Standard, prelude::Distribution};
+
     use super::BitDecomposition;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},
@@ -100,7 +103,6 @@ mod tests {
         secret_sharing::replicated::malicious::ExtendableField,
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
     };
-    use rand::{distributions::Standard, prelude::Distribution};
 
     async fn bit_decomposition<F>(world: &TestWorld, a: F) -> Vec<F>
     where

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -1,3 +1,8 @@
+use std::iter::zip;
+
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use super::xor;
 use crate::{
     error::Error,
@@ -8,9 +13,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use ipa_macros::step;
-use std::iter::zip;
-use strum::AsRefStr;
 
 /// Compares `[a]` and `c`, and returns 1 iff `a == c`
 ///
@@ -115,14 +117,13 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use super::{bitwise_equal, bitwise_equal_constant};
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
         protocol::{context::Context, RecordId},
         secret_sharing::BitDecomposed,
         test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
     };
-
-    use super::{bitwise_equal, bitwise_equal_constant};
 
     #[tokio::test]
     pub async fn simple() {

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -1,3 +1,9 @@
+use std::cmp::Ordering;
+
+use futures::future::try_join;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -9,10 +15,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use futures::future::try_join;
-use ipa_macros::step;
-use std::cmp::Ordering;
-use strum::AsRefStr;
 
 /// This is an implementation of Bitwise Less-Than on bitwise-shared numbers.
 ///
@@ -202,6 +204,8 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::{distributions::Standard, prelude::Distribution};
+
     use super::BitwiseLessThanPrime;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},
@@ -209,7 +213,6 @@ mod tests {
         secret_sharing::{replicated::malicious::ExtendableField, SharedValue},
         test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
     };
-    use rand::{distributions::Standard, prelude::Distribution};
 
     #[tokio::test]
     pub async fn fp31() {

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -1,3 +1,6 @@
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use super::or::or;
 use crate::{
     error::Error,
@@ -10,8 +13,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use ipa_macros::step;
-use strum::AsRefStr;
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
 //
@@ -296,6 +297,9 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use proptest::proptest;
+    use rand::{distributions::Standard, prelude::Distribution, Rng};
+
     use super::{
         bitwise_greater_than_constant, bitwise_less_than_constant, compute_r_bounds,
         greater_than_constant,
@@ -311,8 +315,6 @@ mod tests {
         secret_sharing::{replicated::malicious::ExtendableField, SharedValue},
         test_fixture::{into_bits, Reconstruct, Runner, TestWorld},
     };
-    use proptest::proptest;
-    use rand::{distributions::Standard, prelude::Distribution, Rng};
 
     async fn bitwise_lt<F>(world: &TestWorld, a: F, b: u128) -> F
     where

--- a/src/protocol/boolean/generate_random_bits.rs
+++ b/src/protocol/boolean/generate_random_bits.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use futures::stream::{iter as stream_iter, Stream, StreamExt};
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -17,7 +19,6 @@ use crate::{
         Linear as LinearSecretSharing,
     },
 };
-use futures::stream::{iter as stream_iter, Stream, StreamExt};
 
 #[derive(Debug)]
 struct RawRandomBits {

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -1,3 +1,5 @@
+use std::iter::repeat;
+
 use crate::{
     error::Error,
     ff::{Field, PrimeField},
@@ -9,7 +11,6 @@ use crate::{
     },
     secret_sharing::{Linear as LinearSecretSharing, SecretSharing},
 };
-use std::iter::repeat;
 
 pub mod add_constant;
 pub mod bit_decomposition;

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -22,6 +22,8 @@ pub async fn or<F: Field, C: Context, S: LinearSecretSharing<F> + SecureMul<C>>(
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::distributions::{Distribution, Standard};
+
     use super::or;
     use crate::{
         ff::{Field, Fp31},
@@ -29,7 +31,6 @@ mod tests {
         secret_sharing::{replicated::malicious::ExtendableField, SharedValue},
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use rand::distributions::{Distribution, Standard};
 
     async fn run<F>(world: &TestWorld, a: F, b: F) -> F
     where

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -1,3 +1,8 @@
+use std::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -9,10 +14,6 @@ use crate::{
         BasicProtocols, RecordId,
     },
     secret_sharing::Linear as LinearSecretSharing,
-};
-use std::{
-    marker::PhantomData,
-    sync::atomic::{AtomicU32, Ordering},
 };
 
 /// A struct that generates random sharings of bits from the
@@ -96,6 +97,10 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::iter::zip;
+
+    use futures::future::try_join_all;
+
     use super::RandomBitsGenerator;
     use crate::{
         ff::{Field, Fp31},
@@ -109,8 +114,6 @@ mod tests {
         },
         test_fixture::{join3, join3v, Reconstruct, Runner, TestWorld},
     };
-    use futures::future::try_join_all;
-    use std::iter::zip;
 
     #[tokio::test]
     pub async fn semi_honest() {

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -1,3 +1,9 @@
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::{Field, PrimeField},
@@ -16,10 +22,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing, SecretSharing,
     },
 };
-use async_trait::async_trait;
-use ipa_macros::step;
-use std::marker::PhantomData;
-use strum::AsRefStr;
 
 #[derive(Debug)]
 pub struct RandomBitsShare<F, S>
@@ -146,6 +148,10 @@ pub(crate) enum Step {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::iter::{repeat, zip};
+
+    use rand::{distributions::Standard, prelude::Distribution};
+
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},
         protocol::{
@@ -157,8 +163,6 @@ mod tests {
         seq_join::SeqJoin,
         test_fixture::{bits_to_value, Reconstruct, Runner, TestWorld},
     };
-    use rand::{distributions::Standard, prelude::Distribution};
-    use std::iter::{repeat, zip};
 
     /// Execute `solved_bits` `COUNT` times for `F`. The count should be chosen
     /// such that the probability of that many consecutive failures in `F` is

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -43,6 +43,8 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::distributions::{Distribution, Standard};
+
     use super::xor;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
@@ -55,7 +57,6 @@ mod tests {
         secret_sharing::{replicated::malicious::ExtendableField, SharedValue},
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use rand::distributions::{Distribution, Standard};
 
     async fn run<F>(world: &TestWorld, a: F, b: F) -> F
     where

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -1,3 +1,12 @@
+use std::{
+    any::type_name,
+    fmt::{Debug, Formatter},
+    num::NonZeroUsize,
+};
+
+use async_trait::async_trait;
+
+use super::{UpgradeContext, UpgradeToMalicious};
 use crate::{
     error::Error,
     helpers::{ChannelId, Gateway, Message, ReceivingEnd, Role, SendingEnd, TotalRecords},
@@ -24,14 +33,6 @@ use crate::{
     seq_join::SeqJoin,
     sync::Arc,
 };
-use async_trait::async_trait;
-use std::{
-    any::type_name,
-    fmt::{Debug, Formatter},
-    num::NonZeroUsize,
-};
-
-use super::{UpgradeContext, UpgradeToMalicious};
 
 #[derive(Clone)]
 pub struct Context<'a> {

--- a/src/protocol/context/prss.rs
+++ b/src/protocol/context/prss.rs
@@ -1,5 +1,7 @@
 //! Metric-aware PRSS decorators
 
+use rand_core::{Error, RngCore};
+
 use crate::{
     helpers::Role,
     protocol::{
@@ -12,7 +14,6 @@ use crate::{
         metrics::{INDEXED_PRSS_GENERATED, SEQUENTIAL_PRSS_GENERATED},
     },
 };
-use rand_core::{Error, RngCore};
 
 /// Wrapper around `IndexedSharedRandomness` that instrument calls to `generate_values`
 pub struct InstrumentedIndexedSharedRandomness<'a> {

--- a/src/protocol/context/semi_honest.rs
+++ b/src/protocol/context/semi_honest.rs
@@ -1,5 +1,13 @@
+use std::{
+    any::type_name,
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+    num::NonZeroUsize,
+};
+
 use async_trait::async_trait;
 
+use super::{Context as SuperContext, UpgradeContext, UpgradeToMalicious};
 use crate::{
     error::Error,
     helpers::{Gateway, Message, ReceivingEnd, Role, SendingEnd, TotalRecords},
@@ -19,14 +27,6 @@ use crate::{
     },
     seq_join::SeqJoin,
 };
-use std::{
-    any::type_name,
-    fmt::{Debug, Formatter},
-    marker::PhantomData,
-    num::NonZeroUsize,
-};
-
-use super::{Context as SuperContext, UpgradeContext, UpgradeToMalicious};
 
 #[derive(Clone)]
 pub struct Context<'a> {

--- a/src/protocol/context/upgrade.rs
+++ b/src/protocol/context/upgrade.rs
@@ -1,3 +1,10 @@
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use futures::future::{try_join, try_join3};
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -15,11 +22,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
 };
-use async_trait::async_trait;
-use futures::future::{try_join, try_join3};
-use ipa_macros::step;
-use std::marker::PhantomData;
-use strum::AsRefStr;
 
 /// Special context type used for malicious upgrades.
 ///

--- a/src/protocol/context/validator.rs
+++ b/src/protocol/context/validator.rs
@@ -1,3 +1,14 @@
+use std::{
+    any::type_name,
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+};
+
+use async_trait::async_trait;
+use futures::future::try_join;
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -18,15 +29,6 @@ use crate::{
     },
     sync::{Arc, Mutex, Weak},
 };
-use async_trait::async_trait;
-use futures::future::try_join;
-use ipa_macros::step;
-use std::{
-    any::type_name,
-    fmt::{Debug, Formatter},
-    marker::PhantomData,
-};
-use strum::AsRefStr;
 
 #[async_trait]
 pub trait Validator<B: UpgradableContext, F: ExtendableField> {
@@ -311,6 +313,8 @@ impl<F: ExtendableField> Debug for Malicious<'_, F> {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::iter::{repeat, zip};
+
     use crate::{
         error::Error,
         ff::{Field, Fp31, Fp32BitPrime},
@@ -331,7 +335,6 @@ mod tests {
         seq_join::SeqJoin,
         test_fixture::{join3v, Reconstruct, Runner, TestWorld},
     };
-    use std::iter::{repeat, zip};
 
     /// This is the simplest arithmetic circuit that allows us to test all of the pieces of this validator
     /// A -

--- a/src/protocol/dp/distributions.rs
+++ b/src/protocol/dp/distributions.rs
@@ -1,9 +1,9 @@
+use std::{f64::consts::PI, fmt::Debug};
+
 use rand::{
     distributions::{Distribution, Uniform},
     Rng,
 };
-
-use std::{f64::consts::PI, fmt::Debug};
 
 /// Returns `true` iff `a` and `b` are close to each other. `a` and `b` are considered close if
 /// |a-b| < 10^(-precision).
@@ -72,10 +72,12 @@ impl From<BoxMuller> for RoundedBoxMuller {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
+    use std::iter::repeat_with;
+
     use rand::{distributions::Distribution, thread_rng};
     use rand_core::RngCore;
-    use std::iter::repeat_with;
+
+    use super::*;
 
     #[test]
     fn dp_normal_distribution_sample_standard() {

--- a/src/protocol/dp/insecure.rs
+++ b/src/protocol/dp/insecure.rs
@@ -1,9 +1,11 @@
 #![allow(dead_code)]
 
-use crate::protocol::dp::distributions::{BoxMuller, RoundedBoxMuller};
+use std::f64;
+
 use rand::distributions::Distribution;
 use rand_core::{CryptoRng, RngCore};
-use std::f64;
+
+use crate::protocol::dp::distributions::{BoxMuller, RoundedBoxMuller};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -101,11 +103,12 @@ impl DiscreteDp {
 
 #[cfg(all(test, unit_test))]
 mod test {
-    use super::*;
-    use crate::protocol::dp::distributions::is_close;
     use proptest::{prelude::ProptestConfig, proptest};
     use rand::{rngs::StdRng, thread_rng, Rng};
     use rand_core::SeedableRng;
+
+    use super::*;
+    use crate::protocol::dp::distributions::is_close;
 
     #[test]
     fn dp_normal_distribution_generation_standard() {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -1,3 +1,15 @@
+use std::{iter::zip, marker::PhantomData, ops::Add};
+
+use async_trait::async_trait;
+use futures::{
+    future::{try_join, try_join3},
+    stream::iter as stream_iter,
+};
+use generic_array::{ArrayLength, GenericArray};
+use ipa_macros::step;
+use strum::AsRefStr;
+use typenum::Unsigned;
+
 use crate::{
     error::Error,
     ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
@@ -27,16 +39,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
 };
-use async_trait::async_trait;
-use futures::{
-    future::{try_join, try_join3},
-    stream::iter as stream_iter,
-};
-use generic_array::{ArrayLength, GenericArray};
-use ipa_macros::step;
-use std::{iter::zip, marker::PhantomData, ops::Add};
-use strum::AsRefStr;
-use typenum::Unsigned;
 
 #[step]
 pub(crate) enum Step {
@@ -449,6 +451,8 @@ where
 
 #[cfg(all(test, any(unit_test, feature = "shuttle")))]
 pub mod tests {
+    use std::num::NonZeroU32;
+
     use super::ipa;
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},
@@ -464,7 +468,6 @@ pub mod tests {
             TestWorldConfig,
         },
     };
-    use std::num::NonZeroU32;
 
     #[test]
     fn semi_honest() {
@@ -895,6 +898,14 @@ pub mod tests {
 
     #[cfg(all(test, unit_test))]
     mod serialization {
+        use generic_array::GenericArray;
+        use proptest::{
+            proptest,
+            test_runner::{RngAlgorithm, TestRng},
+        };
+        use rand::distributions::{Distribution, Standard};
+        use typenum::Unsigned;
+
         use crate::{
             ff::{Field, Fp31, PrimeField, Serializable},
             ipa_test_input,
@@ -905,13 +916,6 @@ pub mod tests {
             secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
             test_fixture::input::GenericReportTestInput,
         };
-        use generic_array::GenericArray;
-        use proptest::{
-            proptest,
-            test_runner::{RngAlgorithm, TestRng},
-        };
-        use rand::distributions::{Distribution, Standard};
-        use typenum::Unsigned;
 
         fn serde_internal<F>(
             timestamp: u128,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -9,10 +9,6 @@ pub mod prss;
 pub mod sort;
 pub mod step;
 
-use crate::{
-    error::Error,
-    ff::{Gf40Bit, Gf8Bit},
-};
 use std::{
     fmt::{Debug, Display, Formatter},
     hash::Hash,
@@ -20,6 +16,11 @@ use std::{
 };
 
 pub use basics::BasicProtocols;
+
+use crate::{
+    error::Error,
+    ff::{Gf40Bit, Gf8Bit},
+};
 
 pub type MatchKey = Gf40Bit;
 pub type BreakdownKey = Gf8Bit;

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -19,6 +19,17 @@
 //! we know the secret-shared values are all either 0, or 1. As such, the XOR operation
 //! is equivalent to fn xor(a, b) { a + b - 2*a*b }
 
+use std::{
+    iter::zip,
+    marker::PhantomData,
+    ops::Range,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::stream::{unfold, Stream, StreamExt};
+use pin_project::pin_project;
+
 use crate::{
     error::Error,
     exact::ExactSizeStream,
@@ -36,15 +47,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
     seq_join::seq_join,
-};
-use futures::stream::{unfold, Stream, StreamExt};
-use pin_project::pin_project;
-use std::{
-    iter::zip,
-    marker::PhantomData,
-    ops::Range,
-    pin::Pin,
-    task::{Context as TaskContext, Poll},
 };
 
 #[derive(PartialEq, Eq, Debug)]
@@ -318,6 +320,10 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::future::ready;
+
+    use futures::stream::{once, StreamExt, TryStreamExt};
+
     use crate::{
         error::Error,
         ff::{Field, Fp31, Fp32BitPrime},
@@ -333,8 +339,6 @@ mod tests {
         },
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use futures::stream::{once, StreamExt, TryStreamExt};
-    use std::future::ready;
 
     #[tokio::test]
     pub async fn one_bit() {

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -1,9 +1,3 @@
-use crate::{
-    ff::{Field, GaloisField},
-    secret_sharing::replicated::{
-        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
-    },
-};
 use aes::{
     cipher::{generic_array::GenericArray, BlockEncrypt, KeyInit},
     Aes256,
@@ -12,6 +6,13 @@ use hkdf::Hkdf;
 use rand::{CryptoRng, RngCore};
 use sha2::Sha256;
 use x25519_dalek::{EphemeralSecret, PublicKey};
+
+use crate::{
+    ff::{Field, GaloisField},
+    secret_sharing::replicated::{
+        semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing,
+    },
+};
 
 pub trait SharedRandomness {
     /// Generate two random values, one that is known to the left helper

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -1,16 +1,16 @@
 mod crypto;
+use std::{collections::HashMap, fmt::Debug};
+#[cfg(debug_assertions)]
+use std::{collections::HashSet, fmt::Formatter};
+
+pub use crypto::{Generator, GeneratorFactory, KeyExchange, SharedRandomness};
+use x25519_dalek::PublicKey;
+
 use super::step::Gate;
 use crate::{
     rand::{CryptoRng, RngCore},
     sync::{Arc, Mutex},
 };
-use std::{collections::HashMap, fmt::Debug};
-use x25519_dalek::PublicKey;
-
-#[cfg(debug_assertions)]
-use std::{collections::HashSet, fmt::Formatter};
-
-pub use crypto::{Generator, GeneratorFactory, KeyExchange, SharedRandomness};
 
 /// Keeps track of all indices used to generate shared randomness inside `IndexedSharedRandomness`.
 /// Any two indices provided to `IndexesSharedRandomness::generate_values` must be unique.
@@ -256,6 +256,10 @@ impl EndpointSetup {
 
 #[cfg(all(test, unit_test))]
 pub mod test {
+    use std::mem::drop;
+
+    use rand::prelude::SliceRandom;
+
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{
         ff::{Field, Fp31},
@@ -267,8 +271,6 @@ pub mod test {
         secret_sharing::SharedValue,
         test_fixture::make_participants,
     };
-    use rand::prelude::SliceRandom;
-    use std::mem::drop;
 
     fn make() -> (Generator, Generator) {
         const CONTEXT: &[u8] = b"test generator";

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -48,9 +48,10 @@ pub fn apply_inv<T>(permutation: &[u32], values: &mut [T]) {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::seq::SliceRandom;
+
     use super::{apply, apply_inv};
     use crate::rand::thread_rng;
-    use rand::seq::SliceRandom;
 
     #[test]
     fn apply_just_one_cycle() {

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -43,6 +43,8 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use futures::stream::iter as stream_iter;
+
     use crate::{
         accumulation_test_input,
         ff::{Fp32BitPrime, GaloisField},
@@ -59,7 +61,6 @@ mod tests {
         secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SharedValue},
         test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
     };
-    use futures::stream::iter as stream_iter;
 
     #[tokio::test]
     pub async fn semi_honest() {

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -1,3 +1,5 @@
+use embed_doc_image::embed_doc_image;
+
 use crate::{
     error::Error,
     helpers::Direction,
@@ -13,7 +15,6 @@ use crate::{
     },
     repeat64str,
 };
-use embed_doc_image::embed_doc_image;
 
 pub struct InnerVectorElementStep(usize);
 
@@ -114,6 +115,8 @@ where
 mod tests {
 
     mod semi_honest {
+        use std::collections::HashSet;
+
         use crate::{
             accumulation_test_input,
             ff::{Fp31, Fp32BitPrime},
@@ -136,7 +139,6 @@ mod tests {
                 TestWorld,
             },
         };
-        use std::collections::HashSet;
 
         #[tokio::test]
         async fn shuffle_attribution_input_row() {

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -1,11 +1,13 @@
+use std::iter::{repeat, zip};
+
+use embed_doc_image::embed_doc_image;
+
 use crate::{
     error::Error,
     ff::Field,
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use embed_doc_image::embed_doc_image;
-use std::iter::{repeat, zip};
 
 #[embed_doc_image("bit_permutation", "images/sort/bit_permutations.png")]
 /// This is an implementation of `GenBitPerm` (Algorithm 3) described in:

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -1,3 +1,5 @@
+use embed_doc_image::embed_doc_image;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -9,7 +11,6 @@ use crate::{
     },
     secret_sharing::SecretSharing,
 };
-use embed_doc_image::embed_doc_image;
 
 #[embed_doc_image("compose", "images/sort/compose.png")]
 /// This is an implementation of Compose (Algorithm 5) found in the paper:
@@ -53,6 +54,8 @@ pub async fn compose<F: Field, S: SecretSharing<F> + Reshare<C, RecordId>, C: Co
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use rand::seq::SliceRandom;
+
     use crate::{
         ff::{Field, Fp31},
         protocol::{
@@ -65,7 +68,6 @@ mod tests {
         rand::thread_rng,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-    use rand::seq::SliceRandom;
 
     #[tokio::test]
     pub async fn semi_honest() {

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -1,3 +1,6 @@
+use async_trait::async_trait;
+use futures::stream::Stream;
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -26,8 +29,6 @@ use crate::{
         Linear as LinearSecretSharing, SecretSharing,
     },
 };
-use async_trait::async_trait;
-use futures::stream::Stream;
 
 #[derive(Debug)]
 /// This object contains the output of `shuffle_and_reveal_permutation`
@@ -173,6 +174,11 @@ impl<'a, F: ExtendableField> DowngradeMalicious
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::iter::zip;
+
+    use futures::stream::iter as stream_iter;
+    use rand::seq::SliceRandom;
+
     use crate::{
         ff::{Field, Fp31, GaloisField},
         protocol::{
@@ -187,9 +193,6 @@ mod tests {
         secret_sharing::SharedValue,
         test_fixture::{generate_shares, join3, Reconstruct, Runner, TestWorld},
     };
-    use futures::stream::iter as stream_iter;
-    use rand::seq::SliceRandom;
-    use std::iter::zip;
 
     #[tokio::test]
     pub async fn semi_honest() {

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -1,3 +1,8 @@
+use std::cmp::min;
+
+use embed_doc_image::embed_doc_image;
+use futures::stream::{iter as stream_iter, Stream, StreamExt, TryStreamExt};
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -28,9 +33,6 @@ use crate::{
         Linear as LinearSecretSharing,
     },
 };
-use embed_doc_image::embed_doc_image;
-use futures::stream::{iter as stream_iter, Stream, StreamExt, TryStreamExt};
-use std::cmp::min;
 
 #[embed_doc_image("semi_honest_sort", "images/sort/semi-honest-sort.png")]
 #[embed_doc_image("malicious_sort", "images/sort/malicious-sort.png")]
@@ -194,6 +196,10 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::iter::zip;
+
+    use futures::stream::iter as stream_iter;
+
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, GaloisField},
         protocol::{
@@ -205,8 +211,6 @@ mod tests {
         secret_sharing::SharedValue,
         test_fixture::{join3, Reconstruct, Runner, TestWorld},
     };
-    use futures::stream::iter as stream_iter;
-    use std::iter::zip;
 
     #[tokio::test]
     pub async fn semi_honest() {

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -9,6 +9,11 @@ mod multi_bit_permutation;
 mod secureapplyinv;
 mod shuffle;
 
+use std::fmt::Debug;
+
+use ipa_macros::step;
+use strum::AsRefStr;
+
 use crate::{
     error::Error,
     ff::Field,
@@ -20,9 +25,6 @@ use crate::{
     repeat64str,
     secret_sharing::{BitDecomposed, Linear as LinearSecretSharing, SecretSharing},
 };
-use ipa_macros::step;
-use std::fmt::Debug;
-use strum::AsRefStr;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum SortStep {

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -1,3 +1,5 @@
+use std::iter::repeat;
+
 use crate::{
     error::Error,
     ff::PrimeField,
@@ -10,7 +12,6 @@ use crate::{
         SecretSharing,
     },
 };
-use std::iter::repeat;
 
 /// This is an implementation of `GenMultiBitSort` (Algorithm 11) described in:
 /// "An Efficient Secure Three-Party Sorting Protocol with an Honest Majority"

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -31,6 +31,10 @@ pub async fn secureapplyinv_multi<C: Context, I: Reshare<C, RecordId> + Send + S
 #[cfg(all(test, unit_test))]
 mod tests {
     mod semi_honest {
+        use std::iter::repeat_with;
+
+        use rand::seq::SliceRandom;
+
         use crate::{
             ff::{Field, Fp31},
             protocol::{
@@ -44,8 +48,6 @@ mod tests {
             secret_sharing::BitDecomposed,
             test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use rand::seq::SliceRandom;
-        use std::iter::repeat_with;
 
         #[tokio::test]
         pub async fn multi() {

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -1,17 +1,16 @@
 use embed_doc_image::embed_doc_image;
 use rand::{seq::SliceRandom, Rng};
 
+use super::{
+    apply::{apply, apply_inv},
+    ShuffleStep::{self, Shuffle1, Shuffle2, Shuffle3},
+};
 use crate::{
     error::Error,
     ff::Field,
     helpers::{Direction, Role},
     protocol::{basics::Reshare, context::Context, step::Step, NoRecord, RecordId},
     secret_sharing::SecretSharing,
-};
-
-use super::{
-    apply::{apply, apply_inv},
-    ShuffleStep::{self, Shuffle1, Shuffle2, Shuffle3},
 };
 
 #[derive(Debug)]
@@ -199,6 +198,8 @@ mod tests {
     }
 
     mod semi_honest {
+        use std::collections::HashSet;
+
         use crate::{
             ff::{Field, Fp31},
             protocol::{
@@ -209,7 +210,6 @@ mod tests {
             },
             test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use std::collections::HashSet;
 
         #[tokio::test]
         async fn semi_honest() {
@@ -293,6 +293,8 @@ mod tests {
     }
 
     mod malicious {
+        use std::collections::HashSet;
+
         use crate::{
             ff::{Field, Fp31},
             protocol::{
@@ -303,7 +305,6 @@ mod tests {
             },
             test_fixture::{Reconstruct, Runner, TestWorld},
         };
-        use std::collections::HashSet;
 
         #[tokio::test]
         async fn malicious() {

--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -1,6 +1,8 @@
-use super::{Step, StepNarrow};
-use ipa_macros::Gate;
 use std::fmt::{Debug, Display, Formatter};
+
+use ipa_macros::Gate;
+
+use super::{Step, StepNarrow};
 
 #[derive(Gate, Clone, Hash, PartialEq, Eq, Default)]
 #[cfg_attr(

--- a/src/protocol/step/descriptive.rs
+++ b/src/protocol/step/descriptive.rs
@@ -1,7 +1,8 @@
+use std::fmt::{Debug, Display, Formatter};
+
 use super::{Step, StepNarrow};
 #[cfg(feature = "step-trace")]
 use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};
-use std::fmt::{Debug, Display, Formatter};
 
 /// A descriptive representation of a unique step in protocol execution.
 ///

--- a/src/query/completion.rs
+++ b/src/query/completion.rs
@@ -1,12 +1,14 @@
-use crate::query::{
-    runner::QueryResult,
-    state::{RemoveQuery, RunningQuery},
-};
-use futures::FutureExt;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use futures::FutureExt;
+
+use crate::query::{
+    runner::QueryResult,
+    state::{RemoveQuery, RunningQuery},
 };
 
 /// Query completion polls the tokio task to get the results and cleans up the query state after.

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,3 +1,21 @@
+use std::{
+    fmt::Debug,
+    future::{ready, Future},
+    pin::Pin,
+    sync::Arc,
+};
+
+use ::tokio::sync::oneshot;
+use futures::FutureExt;
+use generic_array::GenericArray;
+use rand::rngs::StdRng;
+use rand_core::SeedableRng;
+#[cfg(all(feature = "shuttle", test))]
+use shuttle::future as tokio;
+use typenum::Unsigned;
+
+#[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+use crate::query::runner::execute_test_multiply;
 use crate::{
     ff::{FieldType, Fp32BitPrime, Serializable},
     helpers::{
@@ -11,26 +29,11 @@ use crate::{
         prss::Endpoint as PrssEndpoint,
         step::{Gate, StepNarrow},
     },
-    query::{runner::IpaQuery, state::RunningQuery},
+    query::{
+        runner::{IpaQuery, QueryResult},
+        state::RunningQuery,
+    },
 };
-
-#[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-use crate::query::runner::execute_test_multiply;
-use crate::query::runner::QueryResult;
-use ::tokio::sync::oneshot;
-use futures::FutureExt;
-use generic_array::GenericArray;
-use rand::rngs::StdRng;
-use rand_core::SeedableRng;
-#[cfg(all(feature = "shuttle", test))]
-use shuttle::future as tokio;
-use std::{
-    fmt::Debug,
-    future::{ready, Future},
-    pin::Pin,
-    sync::Arc,
-};
-use typenum::Unsigned;
 
 pub trait Result: Send + Debug {
     fn into_bytes(self: Box<Self>) -> Vec<u8>;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -4,13 +4,10 @@ mod processor;
 mod runner;
 mod state;
 
+use completion::Handle as CompletionHandle;
 pub use executor::Result as ProtocolResult;
-
 pub use processor::{
     NewQueryError, PrepareQueryError, Processor as QueryProcessor, QueryCompletionError,
     QueryInputError, QueryStatusError,
 };
-
 pub use state::QueryStatus;
-
-use completion::Handle as CompletionHandle;

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -1,3 +1,11 @@
+use std::{
+    collections::hash_map::Entry,
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
+
+use futures::{future::try_join, stream};
+
 use crate::{
     error::Error as ProtocolError,
     helpers::{
@@ -11,12 +19,6 @@ use crate::{
         state::{QueryState, QueryStatus, RemoveQuery, RunningQueries, StateError},
         CompletionHandle, ProtocolResult,
     },
-};
-use futures::{future::try_join, stream};
-use std::{
-    collections::hash_map::Entry,
-    fmt::{Debug, Formatter},
-    sync::Arc,
 };
 
 /// `Processor` accepts and tracks requests to initiate new queries on this helper party
@@ -310,6 +312,12 @@ impl Processor {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::{array, future::Future, sync::Arc};
+
+    use futures::pin_mut;
+    use futures_util::future::poll_immediate;
+    use tokio::sync::Barrier;
+
     use super::*;
     use crate::{
         ff::FieldType,
@@ -318,10 +326,6 @@ mod tests {
             HelperIdentity, InMemoryNetwork, PrepareQueryCallback, TransportCallbacks,
         },
     };
-    use futures::pin_mut;
-    use futures_util::future::poll_immediate;
-    use std::{array, future::Future, sync::Arc};
-    use tokio::sync::Barrier;
 
     fn prepare_query_callback<T, F, Fut>(cb: F) -> Box<dyn PrepareQueryCallback<T>>
     where
@@ -520,6 +524,10 @@ mod tests {
     }
 
     mod e2e {
+        use std::time::Duration;
+
+        use tokio::time::sleep;
+
         use super::*;
         use crate::{
             error::BoxError,
@@ -530,8 +538,6 @@ mod tests {
             secret_sharing::replicated::semi_honest,
             test_fixture::{input::GenericReportTestInput, Reconstruct, TestApp},
         };
-        use std::time::Duration;
-        use tokio::time::sleep;
 
         #[tokio::test]
         async fn complete_query_test_multiply() -> Result<(), BoxError> {

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -1,3 +1,10 @@
+use std::marker::PhantomData;
+
+use futures::{
+    stream::{iter, repeat},
+    Stream, StreamExt, TryStreamExt,
+};
+
 use crate::{
     error::Error,
     ff::{Gf2, PrimeField, Serializable},
@@ -21,11 +28,6 @@ use crate::{
     },
     sync::Arc,
 };
-use futures::{
-    stream::{iter, repeat},
-    Stream, StreamExt, TryStreamExt,
-};
-use std::marker::PhantomData;
 
 pub struct IpaQuery<F, C, S> {
     config: IpaQueryConfig,
@@ -158,6 +160,11 @@ pub fn assert_stream_send<'a, T>(
 mod tests {
     use std::iter::zip;
 
+    use generic_array::GenericArray;
+    use rand::rngs::StdRng;
+    use rand_core::SeedableRng;
+    use typenum::Unsigned;
+
     use super::*;
     use crate::{
         ff::Fp31,
@@ -166,10 +173,6 @@ mod tests {
         secret_sharing::IntoShares,
         test_fixture::{input::GenericReportTestInput, join3v, Reconstruct, TestWorld},
     };
-    use generic_array::GenericArray;
-    use rand::rngs::StdRng;
-    use rand_core::SeedableRng;
-    use typenum::Unsigned;
 
     #[tokio::test]
     async fn ipa() {

--- a/src/query/runner/mod.rs
+++ b/src/query/runner/mod.rs
@@ -2,10 +2,10 @@ mod ipa;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_multiply;
 
-use crate::{error::Error, query::ProtocolResult};
-
-pub(super) use self::ipa::IpaQuery;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 pub(super) use test_multiply::execute_test_multiply;
+
+pub(super) use self::ipa::IpaQuery;
+use crate::{error::Error, query::ProtocolResult};
 
 pub(super) type QueryResult = Result<Box<dyn ProtocolResult>, Error>;

--- a/src/query/runner/test_multiply.rs
+++ b/src/query/runner/test_multiply.rs
@@ -1,3 +1,5 @@
+use futures::StreamExt;
+
 use crate::{
     error::Error,
     ff::{PrimeField, Serializable},
@@ -11,7 +13,6 @@ use crate::{
     query::runner::QueryResult,
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use futures::StreamExt;
 
 pub async fn execute_test_multiply<'a, F>(
     prss: &'a PrssEndpoint,
@@ -67,14 +68,15 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use generic_array::GenericArray;
+    use typenum::Unsigned;
+
     use super::*;
     use crate::{
         ff::{Field, Fp31},
         secret_sharing::IntoShares,
         test_fixture::{join3v, Reconstruct, TestWorld},
     };
-    use generic_array::GenericArray;
-    use typenum::Unsigned;
 
     #[tokio::test]
     async fn multiply() {

--- a/src/query/state.rs
+++ b/src/query/state.rs
@@ -1,18 +1,20 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt::{Debug, Formatter},
+    future::Future,
+    task::Poll,
+};
+
+use ::tokio::sync::oneshot::{error::TryRecvError, Receiver};
+use futures::{ready, FutureExt};
+use serde::{Deserialize, Serialize};
+
 use crate::{
     helpers::{query::QueryConfig, RoleAssignment},
     protocol::QueryId,
     query::runner::QueryResult,
     sync::Mutex,
     task::JoinHandle,
-};
-use ::tokio::sync::oneshot::{error::TryRecvError, Receiver};
-use futures::{ready, FutureExt};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    fmt::{Debug, Formatter},
-    future::Future,
-    task::Poll,
 };
 
 /// The status of query processing

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,3 +1,15 @@
+use std::{
+    fmt::{Display, Formatter},
+    marker::PhantomData,
+    ops::Deref,
+};
+
+use bytes::{BufMut, Bytes};
+use generic_array::GenericArray;
+use hpke::Serializable as _;
+use rand_core::{CryptoRng, RngCore};
+use typenum::Unsigned;
+
 use crate::{
     ff::{GaloisField, Gf40Bit, Gf8Bit, PrimeField, Serializable},
     hpke::{
@@ -6,16 +18,6 @@ use crate::{
     },
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
-use bytes::{BufMut, Bytes};
-use generic_array::GenericArray;
-use hpke::Serializable as _;
-use rand_core::{CryptoRng, RngCore};
-use std::{
-    fmt::{Display, Formatter},
-    marker::PhantomData,
-    ops::Deref,
-};
-use typenum::Unsigned;
 
 // TODO(679): This needs to come from configuration.
 static HELPER_ORIGIN: &str = "github.com/private-attribution";
@@ -386,12 +388,11 @@ where
 
 #[cfg(all(test, unit_test))]
 mod test {
-    use crate::ff::{Fp32BitPrime, Gf40Bit, Gf8Bit};
-
-    use super::*;
-
     use rand::{distributions::Alphanumeric, rngs::StdRng, Rng};
     use rand_core::SeedableRng;
+
+    use super::*;
+    use crate::ff::{Fp32BitPrime, Gf40Bit, Gf8Bit};
 
     #[test]
     fn enc_dec_roundtrip() {

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -1,5 +1,6 @@
-use crate::error::Error;
 use std::{fmt::Debug, ops::Deref};
+
+use crate::error::Error;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BitDecomposed<S> {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -4,12 +4,11 @@ mod decomposed;
 mod into_shares;
 mod scheme;
 
-pub use decomposed::BitDecomposed;
-pub use into_shares::IntoShares;
-pub use scheme::{Bitwise, Linear, SecretSharing};
+use std::fmt::Debug;
 
-use crate::ff::{ArithmeticOps, Serializable};
+pub use decomposed::BitDecomposed;
 use generic_array::ArrayLength;
+pub use into_shares::IntoShares;
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 use rand::{
     distributions::{Distribution, Standard},
@@ -17,7 +16,9 @@ use rand::{
 };
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 use replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing};
-use std::fmt::Debug;
+pub use scheme::{Bitwise, Linear, SecretSharing};
+
+use crate::ff::{ArithmeticOps, Serializable};
 
 // Trait for primitive integer types used to represent the underlying type for shared values
 pub trait Block: Sized + Copy + Debug {

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -1,3 +1,17 @@
+use std::{
+    fmt::{Debug, Formatter},
+    num::NonZeroUsize,
+    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
+};
+
+use async_trait::async_trait;
+use futures::{
+    future::{join, join_all},
+    stream::{iter as stream_iter, StreamExt},
+};
+use generic_array::{ArrayLength, GenericArray};
+use typenum::Unsigned;
+
 use crate::{
     ff::{Field, Gf2, Gf32Bit, PrimeField, Serializable},
     secret_sharing::{
@@ -6,18 +20,6 @@ use crate::{
     },
     seq_join::seq_join,
 };
-use async_trait::async_trait;
-use futures::{
-    future::{join, join_all},
-    stream::{iter as stream_iter, StreamExt},
-};
-use generic_array::{ArrayLength, GenericArray};
-use std::{
-    fmt::{Debug, Formatter},
-    num::NonZeroUsize,
-    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
-};
-use typenum::Unsigned;
 
 ///
 /// This code is an optimization to our malicious compiler that is drawn from:

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -1,3 +1,11 @@
+use std::{
+    fmt::{Debug, Formatter},
+    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
+};
+
+use generic_array::{ArrayLength, GenericArray};
+use typenum::Unsigned;
+
 use crate::{
     ff::Serializable,
     secret_sharing::{
@@ -5,12 +13,6 @@ use crate::{
         SharedValue,
     },
 };
-use generic_array::{ArrayLength, GenericArray};
-use std::{
-    fmt::{Debug, Formatter},
-    ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign},
-};
-use typenum::Unsigned;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct AdditiveShare<V: SharedValue>(V, V);

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -1,6 +1,7 @@
+use std::fmt::Debug;
+
 use super::SharedValue;
 use crate::ff::{ArithmeticRefOps, GaloisField};
-use std::fmt::Debug;
 
 /// Secret sharing scheme i.e. Replicated secret sharing
 pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {

--- a/src/seq_join.rs
+++ b/src/seq_join.rs
@@ -1,9 +1,3 @@
-use crate::exact::ExactSizeStream;
-use futures::{
-    stream::{iter, Iter as StreamIter, TryCollect},
-    Future, Stream, StreamExt, TryStreamExt,
-};
-use pin_project::pin_project;
 use std::{
     collections::VecDeque,
     future::IntoFuture,
@@ -11,6 +5,14 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures::{
+    stream::{iter, Iter as StreamIter, TryCollect},
+    Future, Stream, StreamExt, TryStreamExt,
+};
+use pin_project::pin_project;
+
+use crate::exact::ExactSizeStream;
 
 /// This helper function might be necessary to convince the compiler that
 /// the return value from [`seq_try_join_all`] implements `Send`.
@@ -212,12 +214,6 @@ where
 
 #[cfg(all(test, unit_test))]
 mod test {
-    use crate::seq_join::{seq_join, seq_try_join_all};
-    use futures::{
-        future::{lazy, BoxFuture},
-        stream::{iter, poll_fn, poll_immediate, repeat_with},
-        Future, StreamExt,
-    };
     use std::{
         convert::Infallible,
         iter::once,
@@ -226,6 +222,14 @@ mod test {
         sync::{Arc, Mutex},
         task::{Context, Poll, Waker},
     };
+
+    use futures::{
+        future::{lazy, BoxFuture},
+        stream::{iter, poll_fn, poll_immediate, repeat_with},
+        Future, StreamExt,
+    };
+
+    use crate::seq_join::{seq_join, seq_try_join_all};
 
     async fn immediate(count: u32) {
         let capacity = NonZeroUsize::new(3).unwrap();

--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use metrics::{KeyName, Label, SharedString};
-
-use crate::{helpers::Role, protocol::step::Gate, telemetry::labels};
 use metrics_util::{
     debugging::{DebugValue, Snapshot},
     CompositeKey, MetricKind,
 };
+
+use crate::{helpers::Role, protocol::step::Gate, telemetry::labels};
 
 /// Simple counter stats
 #[derive(Debug, Default)]

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -1,17 +1,18 @@
 //!
 //! Export metrics collected during protocol run in CSV format. Metrics are partitioned by step.
 
+use std::{
+    collections::{BTreeMap, HashMap},
+    io,
+    io::{Error, Write},
+};
+
 use crate::telemetry::{
     labels,
     metrics::{
         BYTES_SENT, INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED, STEP_NARROWED,
     },
     stats::Metrics,
-};
-use std::{
-    collections::{BTreeMap, HashMap},
-    io,
-    io::{Error, Write},
 };
 
 pub trait CsvExporter {

--- a/src/test_fixture/app.rs
+++ b/src/test_fixture/app.rs
@@ -1,18 +1,21 @@
+use std::iter::zip;
+
+use generic_array::GenericArray;
+use typenum::Unsigned;
+
 use crate::{
     app::Error,
     ff::Serializable,
-    helpers::query::{QueryConfig, QueryInput},
+    helpers::{
+        query::{QueryConfig, QueryInput},
+        InMemoryNetwork, InMemoryTransport,
+    },
     protocol::QueryId,
     query::QueryStatus,
     secret_sharing::IntoShares,
     test_fixture::try_join3_array,
     AppSetup, HelperApp,
 };
-use std::iter::zip;
-
-use crate::helpers::{InMemoryNetwork, InMemoryTransport};
-use generic_array::GenericArray;
-use typenum::Unsigned;
 
 pub trait IntoBuf {
     fn into_buf(self) -> Vec<u8>;

--- a/src/test_fixture/circuit.rs
+++ b/src/test_fixture/circuit.rs
@@ -1,3 +1,6 @@
+use futures_util::future::join_all;
+
+use super::join3v;
 use crate::{
     ff::Field,
     helpers::TotalRecords,
@@ -10,9 +13,6 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::{narrow_contexts, Reconstruct, TestWorld},
 };
-use futures_util::future::join_all;
-
-use super::join3v;
 
 /// Creates an arithmetic circuit with the given width and depth.
 ///

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -97,11 +97,12 @@ impl Config {
     }
 }
 
-use crate::{rand::Rng, test_fixture::ipa::TestRawDataRecord};
 use std::{
     collections::HashSet,
     num::{NonZeroU32, NonZeroU64},
 };
+
+use crate::{rand::Rng, test_fixture::ipa::TestRawDataRecord};
 
 struct UserStats {
     user_id: UserId,
@@ -265,8 +266,9 @@ impl<R: Rng> Iterator for EventGenerator<R> {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::*;
     use rand::thread_rng;
+
+    use super::*;
 
     #[test]
     fn iter() {
@@ -294,14 +296,16 @@ mod tests {
     }
 
     mod proptests {
-        use super::*;
+        use std::collections::HashMap;
+
         use proptest::{
             prelude::{Just, Strategy},
             prop_oneof, proptest,
         };
         use rand::rngs::StdRng;
         use rand_core::SeedableRng;
-        use std::collections::HashMap;
+
+        use super::*;
 
         fn report_filter_strategy() -> impl Strategy<Value = ReportFilter> {
             prop_oneof![

--- a/src/test_fixture/input/sharing.rs
+++ b/src/test_fixture/input/sharing.rs
@@ -1,3 +1,7 @@
+use std::iter::zip;
+
+use rand::{distributions::Standard, prelude::Distribution};
+
 use crate::{
     ff::{Field, GaloisField, PrimeField, Serializable},
     protocol::{
@@ -16,8 +20,6 @@ use crate::{
         Reconstruct,
     },
 };
-use rand::{distributions::Standard, prelude::Distribution};
-use std::iter::zip;
 
 impl<F, MK, BK> IntoShares<GenericReportShare<F, MK, BK>> for GenericReportTestInput<F, MK, BK>
 where

--- a/src/test_fixture/logging.rs
+++ b/src/test_fixture/logging.rs
@@ -1,5 +1,6 @@
-use metrics_tracing_context::MetricsLayer;
 use std::{str::FromStr, sync::Once};
+
+use metrics_tracing_context::MetricsLayer;
 use tracing::Level;
 use tracing_subscriber::{
     filter::Directive, fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,

--- a/src/test_fixture/metrics.rs
+++ b/src/test_fixture/metrics.rs
@@ -1,8 +1,3 @@
-use crate::{
-    rand::{thread_rng, Rng},
-    telemetry::{metrics::register, stats::Metrics},
-    test_fixture::logging,
-};
 use metrics::KeyName;
 use metrics_tracing_context::TracingContextLayer;
 use metrics_util::{
@@ -12,6 +7,12 @@ use metrics_util::{
 use once_cell::sync::OnceCell;
 use rand::distributions::Alphanumeric;
 use tracing::{Level, Span};
+
+use crate::{
+    rand::{thread_rng, Rng},
+    telemetry::{metrics::register, stats::Metrics},
+    test_fixture::logging,
+};
 
 // TODO: move to OnceCell from std once it is stabilized
 static ONCE: OnceCell<Snapshotter> = OnceCell::new();

--- a/src/test_fixture/mod.rs
+++ b/src/test_fixture/mod.rs
@@ -15,6 +15,18 @@ pub mod ipa;
 pub mod logging;
 pub mod metrics;
 
+use std::fmt::Debug;
+
+#[cfg(feature = "in-memory-infra")]
+pub use app::TestApp;
+pub use event_gen::{Config as EventGeneratorConfig, EventGenerator};
+use futures::TryFuture;
+use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
+use rand_core::{CryptoRng, RngCore};
+pub use sharing::{get_bits, into_bits, Reconstruct};
+#[cfg(feature = "in-memory-infra")]
+pub use world::{Runner, TestWorld, TestWorldConfig};
+
 use crate::{
     ff::Field,
     protocol::{
@@ -24,16 +36,6 @@ use crate::{
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
 };
-#[cfg(feature = "in-memory-infra")]
-pub use app::TestApp;
-pub use event_gen::{Config as EventGeneratorConfig, EventGenerator};
-use futures::TryFuture;
-use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
-use rand_core::{CryptoRng, RngCore};
-pub use sharing::{get_bits, into_bits, Reconstruct};
-use std::fmt::Debug;
-#[cfg(feature = "in-memory-infra")]
-pub use world::{Runner, TestWorld, TestWorldConfig};
 
 /// Narrows a set of contexts all at once.
 /// Use by assigning like so: `let [c0, c1, c2] = narrow_contexts(&contexts, "test")`

--- a/src/test_fixture/sharing.rs
+++ b/src/test_fixture/sharing.rs
@@ -1,3 +1,5 @@
+use std::{borrow::Borrow, iter::zip, ops::Deref};
+
 use crate::{
     ff::{Field, PrimeField},
     protocol::boolean::RandomBitsShare,
@@ -10,7 +12,6 @@ use crate::{
         BitDecomposed, SecretSharing,
     },
 };
-use std::{borrow::Borrow, iter::zip, ops::Deref};
 
 /// Deconstructs a field value into N values, one for each bit.
 pub fn into_bits<F: PrimeField>(v: F) -> BitDecomposed<F> {

--- a/src/test_fixture/world.rs
+++ b/src/test_fixture/world.rs
@@ -1,3 +1,11 @@
+use std::{fmt::Debug, io::stdout, iter::zip};
+
+use async_trait::async_trait;
+use futures::{future::join_all, Future};
+use rand::{distributions::Standard, prelude::Distribution, rngs::StdRng};
+use rand_core::{RngCore, SeedableRng};
+use tracing::{Instrument, Level, Span};
+
 use crate::{
     helpers::{Gateway, GatewayConfig, InMemoryNetwork, Role, RoleAssignment},
     protocol::{
@@ -22,12 +30,6 @@ use crate::{
         logging, make_participants, metrics::MetricsHandle, sharing::ValidateMalicious, Reconstruct,
     },
 };
-use async_trait::async_trait;
-use futures::{future::join_all, Future};
-use rand::{distributions::Standard, prelude::Distribution, rngs::StdRng};
-use rand_core::{RngCore, SeedableRng};
-use std::{fmt::Debug, io::stdout, iter::zip};
-use tracing::{Instrument, Level, Span};
 
 /// Test environment for protocols to run tests that require communication between helpers.
 /// For now the messages sent through it never leave the test infra memory perimeter, so

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,3 @@
-use command_fds::CommandFdExt;
-use ipa::{
-    cli::IpaQueryResult, helpers::query::IpaQueryConfig, test_fixture::ipa::IpaSecurityModel,
-};
-use rand::thread_rng;
-use rand_core::RngCore;
 use std::{
     array,
     error::Error,
@@ -15,6 +9,13 @@ use std::{
     path::Path,
     process::{Child, Command, ExitStatus, Stdio},
 };
+
+use command_fds::CommandFdExt;
+use ipa::{
+    cli::IpaQueryResult, helpers::query::IpaQueryConfig, test_fixture::ipa::IpaSecurityModel,
+};
+use rand::thread_rng;
+use rand_core::RngCore;
 use tempdir::TempDir;
 
 #[cfg(all(test, feature = "cli"))]

--- a/tests/common/tempdir.rs
+++ b/tests/common/tempdir.rs
@@ -1,4 +1,5 @@
 use std::{mem, path::Path, thread};
+
 use tempfile::tempdir;
 
 /// Wrapper around [`TempDir`] that prevents the temp directory from being deleted

--- a/tests/compact_gate.rs
+++ b/tests/compact_gate.rs
@@ -3,9 +3,10 @@
 #[allow(dead_code)]
 mod common;
 
+use std::num::NonZeroU32;
+
 use common::test_ipa_with_config;
 use ipa::{helpers::query::IpaQueryConfig, test_fixture::ipa::IpaSecurityModel};
-use std::num::NonZeroU32;
 
 fn test_compact_gate<I: TryInto<NonZeroU32>>(
     mode: IpaSecurityModel,

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -1,11 +1,12 @@
 mod common;
 
+use std::{array, net::TcpListener, path::Path, process::Command};
+
 use common::{
     spawn_helpers, tempdir::TempDir, test_ipa, test_multiply, test_network, CommandExt,
     UnwrapStatusExt, HELPER_BIN,
 };
 use ipa::{cli::CliPaths, helpers::HelperIdentity, test_fixture::ipa::IpaSecurityModel};
-use std::{array, net::TcpListener, path::Path, process::Command};
 
 #[test]
 #[cfg(all(test, web_test))]


### PR DESCRIPTION
We have a lot of empty lines in import sections that don't follow any conventions. `rustfmt` tries to be conservative and does not reorder them, leading to multiple `use crate::` statements per module. Some IDE, ahem Jetbrains ahem, also do not respect the order and just add imports to the end of the import section even if `use crate::` already exists.

There is a nightly (again) setting that may work for us:
[group_imports](https://rust-lang.github.io/rustfmt/?version=master&search=group#group_imports) so I decided to try it. It basically creates 3 import sections for std, external crates and crate imports. 

There are no functional changes in this PR, only formatting and adjusting pre-commit hook and CI settings.