### PR TITLE
TLS server certificate configuration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,7 +60,7 @@ jobs:
         run: cargo test
 
       - name: Run Web Tests
-        run: cargo test --no-default-features --features "web-app real-world-infra"
+        run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture"
 
   extra:
     name: Additional Builds and Concurrency Tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.vscode/
 /Cargo.lock
 /target/
+/test_data/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ disable-metrics = []
 # TODO Consider moving out benches as well
 web-app = [
     "axum", "axum-server", "clap", "comfy-table", "enable-serde", "hex",
-    "hyper", "hyper-tls", "tower", "tower-http",
+    "hyper", "hyper-tls", "rcgen", "time", "toml", "tower", "tower-http",
 ]
 self-signed-certs = ["hyper-tls"]
 test-fixture = ["enable-serde"]
@@ -62,6 +62,7 @@ once_cell = "1.16.0"
 pin-project = "1.0.12"
 rand = "0.8"
 rand_core = "0.6"
+rcgen = { version = "0.10", optional = true }
 
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -69,10 +70,12 @@ serde_json = { version = "1.0", optional = true }
 sha2 = "0.10.6"
 shuttle-crate = { package = "shuttle", version = "0.5", optional = true }
 thiserror = "1.0"
+time = { version = "0.3", optional = true }
 tinyvec = "1.6.0"
 tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = "0.1.10"
 tokio-util = "0.7.4"
+toml = { version = "0.7", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
 tracing = "0.1.37"
@@ -87,6 +90,7 @@ tikv-jemallocator = "0.5.0"
 [dev-dependencies]
 permutation = "0.4.1"
 proptest = "1.0.0"
+tempfile = "3"
 
 [profile.release]
 incremental = true
@@ -152,3 +156,7 @@ name = "oneshot_ipa"
 path = "benches/oneshot/ipa.rs"
 harness = false
 required-features = ["enable-benches"]
+
+[[test]]
+name = "helper_networks"
+required-features = ["cli", "web-app", "real-world-infra", "test-fixture"]

--- a/pre-commit
+++ b/pre-commit
@@ -89,7 +89,7 @@ check "Tests" \
     cargo test
 
 check "Web tests" \
-    cargo test --no-default-features --features "web-app real-world-infra"
+    cargo test --no-default-features --features "cli web-app real-world-infra test-fixture"
 
 check "Concurrency tests" \
     cargo test --release --features shuttle

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -8,8 +8,6 @@ use ipa::{
 };
 use std::{error::Error, fs, path::PathBuf};
 
-use tracing::info;
-
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -110,9 +108,7 @@ async fn server(args: ServerArgs) -> Result<(), Box<dyn Error>> {
         )
         .await;
 
-    info!("press Enter to quit");
-    let _ = std::io::stdin().read_line(&mut String::new())?;
-    server_handle.abort();
+    server_handle.await?;
 
     Ok(())
 }

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -1,13 +1,12 @@
-use clap::Parser;
-use hyper::http::uri::Scheme;
+use clap::{self, builder::ArgPredicate, ArgAction, Parser, Subcommand};
 use ipa::{
-    cli::Verbosity,
-    config::{NetworkConfig, ServerConfig},
+    cli::{keygen, test_setup, KeygenArgs, TestSetupArgs, Verbosity},
+    config::{NetworkConfig, ServerConfig, TlsConfig},
     helpers::HelperIdentity,
-    net::{BindTarget, HttpTransport, MpcHelperClient},
+    net::{HttpTransport, MpcHelperClient},
     AppSetup,
 };
-use std::error::Error;
+use std::{error::Error, fs, path::PathBuf};
 
 use tracing::info;
 
@@ -16,60 +15,106 @@ use tracing::info;
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[derive(Debug, Parser)]
-#[clap(name = "mpc-helper", about = "CLI to start an MPC helper endpoint")]
+#[clap(
+    name = "helper",
+    about = "Interoperable Private Attribution (IPA) MPC helper"
+)]
+#[command(subcommand_negates_reqs = true)]
 struct Args {
     /// Configure logging.
     #[clap(flatten)]
     logging: Verbosity,
 
-    /// Indicates which identity this helper has
-    #[arg(short, long)]
-    identity: usize,
+    #[clap(flatten, next_help_heading = "Server Options")]
+    server: ServerArgs,
 
-    /// Port to listen. If not specified, will ask Kernel to assign the port
-    #[arg(short, long)]
-    port: Option<u16>,
-
-    /// Indicates whether to start HTTP or HTTPS endpoint
-    #[arg(short, long, default_value = "http")]
-    scheme: Scheme,
+    #[command(subcommand)]
+    command: Option<HelperCommand>,
 }
 
-fn config(identity: HelperIdentity) -> (NetworkConfig, ServerConfig) {
-    let port = match identity {
-        HelperIdentity::ONE => 3000,
-        HelperIdentity::TWO => 3001,
-        HelperIdentity::THREE => 3002,
-        _ => panic!("invalid helper identity {:?}", identity),
+#[derive(Debug, clap::Args)]
+struct ServerArgs {
+    /// Identity of this helper in the MPC protocol (1, 2, or 3)
+    // This is required when running the server, but the `subcommand_negates_reqs`
+    // attribute on `Args` makes it optional when running a utility command.
+    #[arg(short, long, required = true)]
+    identity: Option<usize>,
+
+    /// Port to listen on
+    #[arg(short, long, default_value = "3000")]
+    port: Option<u16>,
+
+    /// Use HTTPS. Enabled automatically if a certificate is supplied.
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        default_value_if("tls_cert", ArgPredicate::IsPresent, Some("true")),
+    )]
+    https: bool,
+
+    /// File containing helper network configuration
+    #[arg(long, required = true)]
+    network: Option<PathBuf>,
+
+    /// TLS certificate for helper-to-helper communication
+    #[arg(
+        long,
+        visible_alias("cert"),
+        visible_alias("tls-certificate"),
+        requires = "tls_key"
+    )]
+    tls_cert: Option<PathBuf>,
+
+    /// TLS key for helper-to-helper communication
+    #[arg(long, visible_alias("key"), requires = "tls_cert")]
+    tls_key: Option<PathBuf>,
+}
+
+#[derive(Debug, Subcommand)]
+enum HelperCommand {
+    Keygen(KeygenArgs),
+    TestSetup(TestSetupArgs),
+}
+
+async fn server(args: ServerArgs) -> Result<(), Box<dyn Error>> {
+    let my_identity = HelperIdentity::try_from(args.identity.expect("enforced by clap")).unwrap();
+
+    let tls = match (args.tls_cert, args.tls_key) {
+        (Some(cert), Some(key)) => Some(TlsConfig::File {
+            certificate_file: cert,
+            private_key_file: key,
+        }),
+        (None, None) => None,
+        _ => panic!("should have been rejected by clap"),
+    };
+    let server_config = ServerConfig {
+        port: args.port,
+        https: args.https,
+        tls,
     };
 
-    let config_str = r#"
-# H1
-[[peers]]
-origin = "http://localhost:3000"
+    let (setup, callbacks) = AppSetup::new();
 
-[peers.tls]
-public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
+    let network_config_path = args.network.as_deref().unwrap();
+    let network_config = NetworkConfig::from_toml_str(&fs::read_to_string(network_config_path)?)?;
+    let clients = MpcHelperClient::from_conf(&network_config);
 
-# H2
-[[peers]]
-origin = "http://localhost:3001"
+    let (transport, server) = HttpTransport::new(my_identity, server_config, clients, callbacks);
 
-[peers.tls]
-public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
+    let _app = setup.connect(transport.clone());
 
-# H3
-[[peers]]
-origin = "http://localhost:3002"
+    let (_addr, server_handle) = server
+        .start(
+            // TODO, trace based on the content of the query.
+            None as Option<()>,
+        )
+        .await;
 
-[peers.tls]
-public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
-"#;
+    info!("press Enter to quit");
+    let _ = std::io::stdin().read_line(&mut String::new())?;
+    server_handle.abort();
 
-    let network = NetworkConfig::from_toml_str(&config_str).unwrap();
-    let server = ServerConfig::with_http_and_port(port);
-
-    (network, server)
+    Ok(())
 }
 
 #[tokio::main]
@@ -77,47 +122,9 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let _handle = args.logging.setup_logging();
 
-    let my_identity = HelperIdentity::try_from(args.identity).unwrap();
-    info!("configured with identity {:?}", my_identity);
-
-    // TODO(596): the config should be loaded from a file, possibly with some values merged from the
-    // command line arguments.
-    let (network_config, server_config) = config(my_identity);
-
-    let (setup, callbacks) = AppSetup::new();
-
-    let clients = MpcHelperClient::from_conf(&network_config);
-
-    let (transport, server) = HttpTransport::new(
-        my_identity,
-        //server_config,
-        clients,
-        callbacks,
-    );
-
-    let _app = setup.connect(transport.clone());
-
-    // TODO(596): Bind target was moved here from `HttpTransport::bind()`. It needs to come
-    // from a config file. Probably, the config should be stored in the server when
-    // constructed, and the argument to server.bind() should go away.
-    let (addr, server_handle) = server
-        .bind(
-            BindTarget::Http(
-                format!("0.0.0.0:{}", server_config.port.unwrap())
-                    .parse()
-                    .unwrap(),
-            ),
-            // TODO, trace based on the content of the query.
-            None as Option<()>,
-        )
-        .await;
-
-    info!(
-        "listening to {}://{}, press Enter to quit",
-        args.scheme, addr
-    );
-    let _ = std::io::stdin().read_line(&mut String::new())?;
-    server_handle.abort();
-
-    Ok(())
+    match args.command {
+        None => server(args.server).await,
+        Some(HelperCommand::Keygen(args)) => keygen(args),
+        Some(HelperCommand::TestSetup(args)) => test_setup(args),
+    }
 }

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -77,6 +77,12 @@ enum TestAction {
     SemiHonestIPA,
 }
 
+async fn clients_ready(clients: &[MpcHelperClient; 3]) -> bool {
+    clients[0].echo("").await.is_ok()
+        && clients[1].echo("").await.is_ok()
+        && clients[2].echo("").await.is_ok()
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     fn print_output<O: Debug>(values: &[Vec<O>; 3]) {
@@ -110,7 +116,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let clients = make_clients(args.network);
 
     let mut wait = args.wait;
-    while wait > 0 && !clients[0].echo("").await.is_ok() {
+    while wait > 0 && !clients_ready(&clients).await {
+        println!("waiting for servers to come up");
         sleep(Duration::from_secs(1)).await;
         wait -= 1;
     }

--- a/src/cli/keygen.rs
+++ b/src/cli/keygen.rs
@@ -1,0 +1,80 @@
+use clap::Args;
+use rand::{thread_rng, Rng};
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose,
+    IsCa, KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
+};
+use std::{
+    error::Error,
+    fs::File,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+use time::{Duration, OffsetDateTime};
+
+#[derive(Debug, Args)]
+#[clap(
+    name = "keygen",
+    about = "Generate keys used by an MPC helper",
+    next_help_heading = "Key Generation Options"
+)]
+pub struct KeygenArgs {
+    /// DNS name to use for the TLS certificate
+    #[arg(short, long)]
+    pub(crate) name: String,
+
+    /// Writes the generated TLS certificate to the file
+    #[arg(long, visible_alias("cert"), visible_alias("tls-certificate"))]
+    pub(crate) tls_cert: PathBuf,
+
+    /// Writes the generated TLS private key to the file
+    #[arg(long, visible_alias("key"))]
+    pub(crate) tls_key: PathBuf,
+}
+
+fn create_new<P: AsRef<Path>>(path: P) -> io::Result<File> {
+    File::options()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+/// Generate keys necessary for running a helper service.
+///
+/// # Errors
+/// If a problem is encountered during key generation.
+///
+/// # Panics
+/// If something that shouldn't happen goes wrong during key generation.
+pub fn keygen(args: KeygenArgs) -> Result<(), Box<dyn Error>> {
+    let mut params = CertificateParams::default();
+    params.alg = &PKCS_ECDSA_P256_SHA256;
+
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+        KeyUsagePurpose::KeyCertSign,
+    ];
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+    params.not_before = OffsetDateTime::now_utc() - Duration::days(1);
+    params.not_after = params.not_before + Duration::days(91);
+    params.serial_number = Some(thread_rng().gen_range(0..=i64::MAX.try_into().unwrap()));
+
+    let mut name = DistinguishedName::new();
+    name.push(rcgen::DnType::CommonName, args.name.clone());
+    params.distinguished_name = name;
+
+    params.subject_alt_names = vec![SanType::DnsName(args.name)];
+
+    let gen = Certificate::from_params(params)?;
+
+    create_new(args.tls_cert)?.write_all(gen.serialize_pem().unwrap().as_bytes())?;
+    create_new(args.tls_key)?.write_all(gen.serialize_private_key_pem().as_bytes())?;
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,15 @@
+#[cfg(feature = "web-app")]
+mod keygen;
 mod metric_collector;
 #[cfg(all(feature = "test-fixture", feature = "web-app", feature = "cli"))]
 pub mod playbook;
+#[cfg(feature = "web-app")]
+mod test_setup;
 mod verbosity;
 
+#[cfg(feature = "web-app")]
+pub use keygen::{keygen, KeygenArgs};
 pub use metric_collector::{install_collector, CollectorHandle};
+#[cfg(feature = "web-app")]
+pub use test_setup::{test_setup, TestSetupArgs};
 pub use verbosity::Verbosity;

--- a/src/cli/playbook/mod.rs
+++ b/src/cli/playbook/mod.rs
@@ -2,6 +2,6 @@ mod input;
 mod ipa;
 mod multiply;
 
+pub use self::ipa::semi_honest;
 pub use input::InputSource;
-pub use ipa::semi_honest;
 pub use multiply::secure_mul;

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -20,10 +20,11 @@ pub struct TestSetupArgs {
     #[arg(short, long, default_value = "test_data")]
     output_dir: PathBuf,
 
+    /// Write http URLs to the network configuration (certificates will still be generated)
     #[arg(long)]
-    https: bool,
+    disable_https: bool,
 
-    #[arg(long, num_args = 3, value_name = "PORT", default_values = vec!["3000", "3001", "3002"])]
+    #[arg(short, long, num_args = 3, value_name = "PORT", default_values = vec!["3000", "3001", "3002"])]
     ports: Vec<u16>,
 }
 
@@ -59,7 +60,7 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
             Ok::<_, Box<dyn Error>>(PeerConfig {
                 url: format!(
                     "{}://localhost:{}",
-                    if args.https { "https" } else { "http" },
+                    if args.disable_https { "http" } else { "https" },
                     port
                 )
                 .parse()

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -1,0 +1,79 @@
+use crate::{
+    cli::{keygen, KeygenArgs},
+    config::{NetworkConfig, PeerConfig},
+};
+use clap::Args;
+use std::{
+    error::Error,
+    fs::{self, DirBuilder},
+    iter::zip,
+    path::PathBuf,
+};
+
+#[derive(Debug, Args)]
+#[clap(
+    name = "test_setup",
+    about = "Prepare a test network of three helpers",
+    next_help_heading = "Test Setup Options"
+)]
+pub struct TestSetupArgs {
+    #[arg(short, long, default_value = "test_data")]
+    output_dir: PathBuf,
+
+    #[arg(long)]
+    https: bool,
+
+    #[arg(long, num_args = 3, value_name = "PORT", default_values = vec!["3000", "3001", "3002"])]
+    ports: Vec<u16>,
+}
+
+/// Prepare a test network of three helpers.
+///
+/// # Errors
+/// If a problem is encountered.
+///
+/// # Panics
+/// If something that shouldn't happen goes wrong.
+pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
+    if args.output_dir.exists() {
+        if !args.output_dir.is_dir() || args.output_dir.read_dir()?.next().is_some() {
+            return Err("output directory already exists and is not empty".into());
+        }
+    } else {
+        DirBuilder::new().create(&args.output_dir)?;
+    }
+
+    let peers = zip([1, 2, 3], args.ports)
+        .map(|(id, port)| {
+            let tls_cert = args.output_dir.join(format!("h{id}.pem"));
+            let tls_key = args.output_dir.join(format!("h{id}.key"));
+
+            keygen(KeygenArgs {
+                name: String::from("localhost"),
+                tls_cert: tls_cert.clone(),
+                tls_key,
+            })?;
+
+            let certificate = Some(fs::read_to_string(&tls_cert)?);
+
+            Ok::<_, Box<dyn Error>>(PeerConfig {
+                url: format!(
+                    "{}://localhost:{}",
+                    if args.https { "https" } else { "http" },
+                    port
+                )
+                .parse()
+                .unwrap(),
+                certificate,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .try_into()
+        .unwrap();
+
+    let network_config = toml::to_string_pretty(&NetworkConfig { peers })?;
+
+    fs::write(args.output_dir.join("network.toml"), network_config)?;
+
+    Ok(())
+}

--- a/src/cli/verbosity.rs
+++ b/src/cli/verbosity.rs
@@ -11,8 +11,8 @@ pub struct Verbosity {
     #[clap(short, long, global = true)]
     quiet: bool,
 
-    /// Verbose mode (-v, -vv, -vvv, etc)
-    #[arg(short, long, action = clap::ArgAction::Count)]
+    /// Verbose mode (-v, or -vv for even more verbose)
+    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     verbose: u8,
 }
 
@@ -47,10 +47,8 @@ impl Verbosity {
             LevelFilter::OFF
         } else {
             LevelFilter::from_level(match self.verbose {
-                0 => Level::ERROR,
-                1 => Level::WARN,
-                2 => Level::INFO,
-                3 => Level::DEBUG,
+                0 => Level::INFO,
+                1 => Level::DEBUG,
                 _ => Level::TRACE,
             })
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ pub struct PeerConfig {
     #[serde(with = "crate::uri")]
     pub url: Uri,
 
-    /// Peer's TLS certificate or CA
+    /// Peer's TLS certificate or CA in PEM format
     ///
     /// If the peer's TLS certificate can be verified using the system truststore, this may be omitted.
     ///

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -273,7 +273,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn untrusted_certificate() {
-        let echo_data = "asdf";
+        const ECHO_DATA: &str = "asdf";
 
         let TestServer { addr, .. } = TestServer::builder().https().build().await;
 
@@ -287,7 +287,7 @@ pub(crate) mod tests {
 
         // The server's self-signed test cert is not in the system truststore, and we didn't supply
         // it in the client config, so the connection should fail with a certificate error.
-        let res = client.echo(echo_data).await;
+        let res = client.echo(ECHO_DATA).await;
         assert!(matches!(res, Err(Error::HyperPassthrough(e)) if e.is_connect()));
     }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,5 +8,5 @@ mod transport;
 
 pub use client::MpcHelperClient;
 pub use error::Error;
-pub use server::{BindTarget, MpcHelperServer, TracingSpanMaker};
+pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::HttpTransport;

--- a/src/net/test.rs
+++ b/src/net/test.rs
@@ -1,7 +1,7 @@
 use crate::{
-    config::NetworkConfig,
+    config::{NetworkConfig, PeerConfig, ServerConfig},
     helpers::{HelperIdentity, TransportCallbacks},
-    net::{BindTarget, HttpTransport, MpcHelperClient, MpcHelperServer},
+    net::{HttpTransport, MpcHelperClient, MpcHelperServer},
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
 };
@@ -10,8 +10,6 @@ use axum::{
     extract::{BodyStream, FromRequest, RequestParts},
     http::Request,
 };
-#[cfg(any(test, feature = "self-signed-certs"))]
-use axum_server::tls_rustls::RustlsConfig;
 use futures::Stream;
 use hyper::{
     client::HttpConnector,
@@ -19,10 +17,11 @@ use hyper::{
 };
 use hyper_tls::{native_tls::TlsConnector, HttpsConnector};
 use once_cell::sync::Lazy;
-use std::{error::Error as StdError, net::SocketAddr, ops::Deref};
+use std::{array, error::Error as StdError, net::SocketAddr, ops::Deref};
 use tokio::task::JoinHandle;
 
-static DEFAULT_SERVER_URL: Lazy<Uri> = Lazy::new(|| "http://localhost:3000".parse().unwrap());
+static DEFAULT_CLIENT_CONFIG: Lazy<PeerConfig> =
+    Lazy::new(|| PeerConfig::new("http://localhost:3000".parse().unwrap()));
 
 type HttpTransportCallbacks = TransportCallbacks<Arc<HttpTransport>>;
 
@@ -110,19 +109,19 @@ impl TestServerBuilder {
     }
 
     pub async fn build(self) -> TestServer {
+        let server_config = if self.https {
+            ServerConfig::https_self_signed()
+        } else {
+            ServerConfig::http()
+        };
         let clients = TestClients::default();
         let (transport, server) = HttpTransport::new(
             HelperIdentity::ONE,
+            server_config,
             clients.into(),
             self.callbacks.unwrap_or_default(),
         );
-        let bind_target = if self.https {
-            let config = tls_config_from_self_signed_cert().await.unwrap();
-            BindTarget::Https("127.0.0.1:0".parse().unwrap(), config)
-        } else {
-            BindTarget::Http("127.0.0.1:0".parse().unwrap())
-        };
-        let (addr, handle) = server.bind(bind_target, self.metrics).await;
+        let (addr, handle) = server.start(self.metrics).await;
         let client = if self.https {
             https_client(addr)
         } else {
@@ -183,72 +182,7 @@ impl TestClientsBuilder {
     pub fn build(self) -> TestClients {
         TestClients(match self.network_config {
             Some(config) => MpcHelperClient::from_conf(&config),
-            None => [0, 1, 2].map(|_| MpcHelperClient::new(DEFAULT_SERVER_URL.clone())),
+            None => array::from_fn(|_| MpcHelperClient::new(DEFAULT_CLIENT_CONFIG.clone())),
         })
     }
-}
-
-/// Returns `RustlsConfig` instance configured with self-signed cert and key. Not intended to
-/// use in production, therefore it is hidden behind a feature flag.
-/// # Errors
-/// if cert is invalid
-#[cfg(any(test, feature = "self-signed-certs"))]
-#[allow(dead_code)]
-pub async fn tls_config_from_self_signed_cert() -> std::io::Result<RustlsConfig> {
-    let cert: &'static str = r#"
------BEGIN CERTIFICATE-----
-MIIDGjCCAgICCQCHChhHY+kV3TANBgkqhkiG9w0BAQsFADBPMQswCQYDVQQGEwJD
-QTELMAkGA1UECAwCQkMxHzAdBgNVBAoMFkFudGxlcnMgYW5kIEhvb3ZlcyBMdGQx
-EjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0yMjA2MjAyMzE0NTdaFw0yMzA2MjAyMzE0
-NTdaME8xCzAJBgNVBAYTAkNBMQswCQYDVQQIDAJCQzEfMB0GA1UECgwWQW50bGVy
-cyBhbmQgSG9vdmVzIEx0ZDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG
-9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3eSjoj9iWbnQy0T6E0swvba0oH6swRHNKv8m
-eBPmyljhEz0IpP+D7PKiR3us1pBFaLlYJzIeGVWWY6rTThsfZmtGMP7HXXtMh9Ya
-eObZ/LqBiS7gKJqiAQTaZI3lOWwnXGF4rqNENQrglwf0JL/kojgsLIgfXjOhy0ng
-wb7rhy/GFYXQ8U9QUZQbvq/J4SYWZlGnLjZW4na6faImo4HoIAW3s1XlmV+XdYdS
-Yw8aejmQu/8mPfSYzAP4YN3J3gOGb81Om9XrfBUAUWw0aJ+5pt3qnhe8vkzw/Vt1
-8CI4SlicGySwSC0QXa3wXum4N0EE1go+yoFSbQPf2r3L2rcE5QIDAQABMA0GCSqG
-SIb3DQEBCwUAA4IBAQAXZjgkd22AqIWeygTT5bgnF8fLBkI0Vo8zp8AR15TE9FBc
-K/BO2+aDCloOp8D0VgHXWMZdo5DRxXV7djXDxaME00H7kajRF6UKW3NIMGO5YFcw
-UUdf5GgZ5KGWjZ/6JknoypWWlFMW2Nf97CkubIX5We+jDLnuv12esBwQTXBw5oJV
-jdfFfYtuVDex9fQKXa5aiBTttW4QeoGUSZT47x4RfGXAbfd2Ry9W2mhuOg7H8cZo
-UsZiTnlkXIFp6VdLlfJbsbt3KXiZxrgiZX0OEEmWCtVvwswsKlY5FAMcKVsV68ok
-fmJoQjCmSYjTuQrnOZMxK4tYwGqoY+vjZi4C91/P
------END CERTIFICATE-----
-   "#
-    .trim();
-
-    let key: &'static str = r#"
------BEGIN PRIVATE KEY-----
-MIIEwAIBADANBgkqhkiG9w0BAQEFAASCBKowggSmAgEAAoIBAQDd5KOiP2JZudDL
-RPoTSzC9trSgfqzBEc0q/yZ4E+bKWOETPQik/4Ps8qJHe6zWkEVouVgnMh4ZVZZj
-qtNOGx9ma0Yw/sdde0yH1hp45tn8uoGJLuAomqIBBNpkjeU5bCdcYXiuo0Q1CuCX
-B/Qkv+SiOCwsiB9eM6HLSeDBvuuHL8YVhdDxT1BRlBu+r8nhJhZmUacuNlbidrp9
-oiajgeggBbezVeWZX5d1h1JjDxp6OZC7/yY99JjMA/hg3cneA4ZvzU6b1et8FQBR
-bDRon7mm3eqeF7y+TPD9W3XwIjhKWJwbJLBILRBdrfBe6bg3QQTWCj7KgVJtA9/a
-vcvatwTlAgMBAAECggEBAKYLfG/jYqOmKxqRSVm6wISW/l/Dq17nBVMRkCX3LpNp
-IzSUTa27D2v2vX0kjVgaqfYODGt4U5G9vEZlBK7EGSE5UVNEtMe9hq13iGPEzIcU
-we54R4HbBTQh/5OTo17vEh1NS1PUFSxkMWCTsRz3BA5oXpYMXvzNQluvsyMIzZNg
-xZTEZujsuc9GLy87SkCTvbgZnB4sBrRs5L678MQN5+uF3lmd6bIDRzY2jPetDHpm
-9KbtHkBosFLwt7BzBtTkbYDkpSwho+3jAUee3+SxVzgie6IZuQKKfSZ5j7CNPgVQ
-PbLrC2RT4GN6AL3LoDVj3cq1qAd9jrKcSEbLNA6sT1kCgYEA+XLBFu2YXWna6NDd
-GSR8AUw+ACVMvPYEOYlbFr/QFNjhxCCdZgo7iyucdoMjFXoaDWivXH00UQsG8dwh
-Hq9VMbtQWHy9WnZk2eMDVAiBlQMcROUBXyamtf8u55UV7pqAR7hMWsgP5RWmyUT1
-mQoFULRPBzH5bGQDv5RZaFJCw58CgYEA47ib7bzpiZNg4mMf7a0WgCee+Tr2FT0p
-SBw1BjjUXxqtbSu9Jc58X+0uC3WMY1bnUbm4GUbxPX5FadFno20DB15rdADY0cC8
-vBX7V5pV2gGyiAn4Oti5g8lCoB0SNFAxLfCbOhPoJp44As1tHykz9h7E7CvKJmhS
-w8VLHpZzyPsCgYEAhlsTu2i/z1irqwiMffVTwVMydduhSInt3pun70njJsdmWsAC
-ZyqNxbj4rjCV3gSFMcG36kYZvqkE1ZJuWFuxtHaioPaW+rmYOm92pHVsbjldqZH7
-OifUVWSb++omBP08qOSQY7ksLoSJ8BBvhD2MfVqQ0lxNbt8z0aVyvqjIAxsCgYEA
-q0ZSoUERNdSPbja38P/aiJFEVJgwNlFGF2J/zyo3MUDTZ+UZ4rGngk7V7vB+osje
-Ou3AteJR17p9YtWJabW4LXaqwxlP+pNIYP73iDAgmlPkf8Vf2oLfJWvenKbA5m/a
-TX9GgSwv07v0zMbNaD6JQnhqDGfzJ2gXt/9QPLVUaLkCgYEAlQBtUEAWIdWjKVc5
-EMgsVSUkdG+N/3TT6A/f2o862yOpPh8N54Pe7UR3d+sfqwD6rKmDLKgA2KeNwEBm
-6fBFT5iVlJtIa7/rFYxC/HjOYPGd5ZPyXyuiq34mmDMr5P8NDLekBHzbNQrjO4aB
-ShF2TD9MWOlghJSEC6+W3nModkc=
------END PRIVATE KEY-----
-    "#
-    .trim();
-
-    RustlsConfig::from_pem(cert.as_bytes().to_vec(), key.as_bytes().to_vec()).await
 }

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::ServerConfig,
     helpers::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         CompleteQueryResult, HelperIdentity, LogErrors, NoResourceIdentifier, PrepareQueryResult,
@@ -28,11 +29,12 @@ impl HttpTransport {
     #[must_use]
     pub fn new(
         identity: HelperIdentity,
+        server_config: ServerConfig,
         clients: [MpcHelperClient; 3],
         callbacks: TransportCallbacks<Arc<HttpTransport>>,
     ) -> (Arc<Self>, MpcHelperServer) {
         let transport = Self::new_internal(identity, clients, callbacks);
-        let server = MpcHelperServer::new(Arc::clone(&transport));
+        let server = MpcHelperServer::new(Arc::clone(&transport), server_config);
         (transport, server)
     }
 
@@ -151,7 +153,7 @@ impl Transport for Arc<HttpTransport> {
 mod e2e_tests {
     use super::*;
     use crate::{
-        config::{NetworkConfig, PeerConfig, ServerConfig},
+        config::{NetworkConfig, ServerConfig},
         ff::{FieldType, Fp31, Serializable},
         helpers::{query::QueryType, ByteArrStream},
         net::test::{body_stream, TestClients, TestServer},
@@ -219,17 +221,16 @@ mod e2e_tests {
         server_config: [ServerConfig; 3],
         network_config: &NetworkConfig,
     ) -> [HelperApp; 3] {
-        use crate::net::BindTarget;
-
         join_all(zip(ids, zip(sockets, server_config)).map(
-            |(id, (socket, _server_conf))| async move {
+            |(id, (socket, server_config))| async move {
                 let (setup, callbacks) = AppSetup::new();
                 let client_config = network_config.clone();
                 let clients = TestClients::builder()
                     .with_network_config(client_config)
-                    .build();
-                let (transport, server) = HttpTransport::new(id, clients.0, callbacks);
-                server.bind(BindTarget::HttpListener(socket), ()).await;
+                    .build()
+                    .into();
+                let (transport, server) = HttpTransport::new(id, server_config, clients, callbacks);
+                server.start_on(Some(socket), ()).await;
                 let app = setup.connect(transport);
                 app
             },
@@ -240,21 +241,12 @@ mod e2e_tests {
         .unwrap()
     }
 
-    fn make_clients(confs: &[PeerConfig; 3]) -> [MpcHelperClient; 3] {
-        confs
-            .iter()
-            .map(|conf| MpcHelperClient::new(conf.origin.clone()))
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap()
-    }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn happy_case() {
         const SZ: usize = <AdditiveShare<Fp31> as Serializable>::Size::USIZE;
         let mut conf = TestConfigBuilder::with_open_ports().build();
         let ids = HelperIdentity::make_three();
-        let clients = make_clients(conf.network.peers());
+        let clients = MpcHelperClient::from_conf(&conf.network);
         let _helpers = make_helpers(
             ids,
             conf.sockets.take().unwrap(),

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -273,7 +273,7 @@ mod tests {
     };
     use futures::pin_mut;
     use futures_util::future::poll_immediate;
-    use std::{future::Future, sync::Arc};
+    use std::{array, future::Future, sync::Arc};
     use tokio::sync::Barrier;
 
     fn prepare_query_callback<T, F, Fut>(cb: F) -> Box<dyn PrepareQueryCallback<T>>
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_duplicate_query_id() {
-        let cb = [0, 1, 2].map(|_| TransportCallbacks {
+        let cb = array::from_fn(|_| TransportCallbacks {
             prepare_query: prepare_query_callback(|_, _| async { Ok(()) }),
             ..Default::default()
         });

--- a/src/test_fixture/config.rs
+++ b/src/test_fixture/config.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "web-app")]
 
 use crate::config::{NetworkConfig, ServerConfig};
-use std::{fmt::Debug, net::TcpListener};
+use std::{array, fmt::Debug, net::TcpListener};
 
 pub const DEFAULT_TEST_PORTS: [u16; 3] = [3000, 3001, 3002];
 
@@ -33,7 +33,7 @@ impl TestConfigBuilder {
     pub fn build(self) -> Config {
         let mut sockets = None;
         let ports = self.ports.unwrap_or_else(|| {
-            let socks = [(); 3].map(|_| TcpListener::bind("127.0.0.1:0").unwrap());
+            let socks = array::from_fn(|_| TcpListener::bind("127.0.0.1:0").unwrap());
             let ports = socks
                 .iter()
                 .map(|sock| sock.local_addr().unwrap().port())
@@ -69,30 +69,21 @@ where
         r#"
 # H1
 [[peers]]
-origin = "http://localhost:{}"
-
-[peers.tls]
-public_key = "13ccf4263cecbc30f50e6a8b9c8743943ddde62079580bc0b9019b05ba8fe924"
+url = "http://localhost:{}"
 
 # H2
 [[peers]]
-origin = "http://localhost:{}"
-
-[peers.tls]
-public_key = "925bf98243cf70b729de1d75bf4fe6be98a986608331db63902b82a1691dc13b"
+url = "http://localhost:{}"
 
 # H3
 [[peers]]
-origin = "http://localhost:{}"
-
-[peers.tls]
-public_key = "12c09881a1c7a92d1c70d9ea619d7ae0684b9cb45ecc207b98ef30ec2160a074"
+url = "http://localhost:{}"
 "#,
         ports[0], ports[1], ports[2]
     );
 
     let network = NetworkConfig::from_toml_str(&config_str).unwrap();
-    let servers = ports.map(ServerConfig::with_http_and_port);
+    let servers = ports.map(ServerConfig::http_port);
 
     (network, servers)
 }

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -1,0 +1,97 @@
+use std::{
+    error::Error,
+    io::{self, Write},
+    iter::zip,
+    process::{Command, ExitStatus, Stdio},
+    str,
+};
+use tempfile::tempdir;
+
+const HELPER_BIN: &str = env!("CARGO_BIN_EXE_helper");
+const TEST_MPC_BIN: &str = env!("CARGO_BIN_EXE_test_mpc");
+
+trait UnwrapStatusExt {
+    fn unwrap_status(self);
+}
+
+impl UnwrapStatusExt for Result<ExitStatus, io::Error> {
+    fn unwrap_status(self) {
+        self.map_err(Box::<dyn Error>::from)
+            .and_then(|status| {
+                if status.success() {
+                    Ok(())
+                } else {
+                    Err(status.to_string().into())
+                }
+            })
+            .unwrap()
+    }
+}
+
+fn test_network(ports: &[u16; 3], https: bool) {
+    let dir = tempdir().unwrap();
+    let path = dir.path();
+
+    println!("generating configuration in {}", path.display());
+
+    let mut command = Command::new(HELPER_BIN);
+    command
+        .arg("test-setup")
+        .args(["--output-dir".as_ref(), dir.path().as_os_str()])
+        .arg("--ports")
+        .args(ports.map(|p| p.to_string()));
+    if https {
+        command.arg("--https");
+    }
+    command.status().unwrap_status();
+
+    let helpers = zip([1, 2, 3], ports)
+        .map(|(id, port)| {
+            let mut command = Command::new(HELPER_BIN);
+            command
+                .args(["-i", &id.to_string()])
+                .args(["--port", &port.to_string()])
+                .args(["--network".into(), dir.path().join("network.toml")]);
+
+            if https {
+                command
+                    .args(["--tls-cert".into(), dir.path().join(format!("h{id}.pem"))])
+                    .args(["--tls-key".into(), dir.path().join(format!("h{id}.key"))]);
+            }
+
+            command.spawn().unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let mut test_mpc = Command::new(TEST_MPC_BIN)
+        .args(["--network".into(), dir.path().join("network.toml")])
+        .arg("multiply")
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    test_mpc
+        .stdin
+        .as_ref()
+        .unwrap()
+        .write_all(b"3,6\n")
+        .unwrap();
+    test_mpc.wait().unwrap_status();
+
+    for mut helper in helpers.into_iter() {
+        helper.kill().unwrap();
+    }
+
+    // Uncomment this to preserve the temporary directory after the test runs.
+    //std::mem::forget(dir);
+}
+
+#[test]
+fn http_network() {
+    test_network(&[3000, 3001, 3002], false);
+}
+
+#[test]
+fn https_network() {
+    test_network(&[4430, 4431, 4432], true);
+}

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -40,8 +40,8 @@ fn test_network(ports: &[u16; 3], https: bool) {
         .args(["--output-dir".as_ref(), dir.path().as_os_str()])
         .arg("--ports")
         .args(ports.map(|p| p.to_string()));
-    if https {
-        command.arg("--https");
+    if !https {
+        command.arg("--disable-https");
     }
     command.status().unwrap_status();
 
@@ -65,6 +65,7 @@ fn test_network(ports: &[u16; 3], https: bool) {
 
     let mut test_mpc = Command::new(TEST_MPC_BIN)
         .args(["--network".into(), dir.path().join("network.toml")])
+        .args(["--wait", "2"])
         .arg("multiply")
         .stdin(Stdio::piped())
         .spawn()
@@ -78,7 +79,7 @@ fn test_network(ports: &[u16; 3], https: bool) {
         .unwrap();
     test_mpc.wait().unwrap_status();
 
-    for mut helper in helpers.into_iter() {
+    for mut helper in helpers {
         helper.kill().unwrap();
     }
 


### PR DESCRIPTION
Some possible points for discussion:
* This changes the default log level to info (#608).
* I have added `keygen` and `test-setup` commands as alternate functions of the `helper` binary. I like having utility commands embedded in the server binary since it means you always have the utilities anywhere you have the server. However, this does have the consequence that the utility-only dependencies `rcgen` and `time` become dependencies of `web-app`. If there is a preference to make each of the CLI functions a standalone binary (or to put the CLI utilities together in a `helper-tool` binary), I can do that.
* I add `cli` and `test-fixture` to the feature set for web tests because the new end-to-end test invokes `test_mpc`. I started to do the work to have test_mpc optionally print the results in machine-parsable format but decided it was more trouble than it was worth (mostly due to `print_output` being generic over `T: Debug`), for this test just checking that any output is produced successfully seems sufficient. It would also be possible to implement the client portion of this test inline like `net::transport::e2e_tests::happy_case`, but it seemed useful to have some test coverage of the test_mpc utility.
* The end-to-end test is noisier than I expect -- the server and test_mpc output is printed to the console even if the test passes. Maybe this is because logging is set up to go to stderr by default? Do we want to change that? Related, I moved printing of the "server listening on <address>" from helper main to MpcHelperServer, because it seems like a generally useful thing to do when a server starts. However, that meant it got printed lots of times by unit tests, which I silenced with `#[cfg(not(test))]`.