### PR TITLE
Match the behavior of IPA in the clear and MPC IPA

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -12,7 +12,10 @@ use ipa::{
     },
 };
 use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
-use std::{num::NonZeroUsize, time::Instant};
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    time::Instant,
+};
 use tokio::runtime::Builder;
 
 #[cfg(all(not(target_env = "msvc"), not(feature = "dhat-heap")))]
@@ -47,7 +50,7 @@ struct Args {
     max_trigger_value: u32,
     /// The size of the attribution window, in seconds.
     #[arg(short = 'w', long, default_value = "86400")]
-    attribution_window: u32,
+    attribution_window: Option<NonZeroU32>,
     /// The number of sequential bits of breakdown key and match key to process in parallel
     /// while doing modulus conversion and attribution
     #[arg(long, default_value = "3")]
@@ -74,12 +77,12 @@ impl Args {
     }
 
     fn config(&self) -> IpaQueryConfig {
-        IpaQueryConfig::new(
-            self.per_user_cap,
-            self.breakdown_keys,
-            self.attribution_window,
-            self.num_multi_bits,
-        )
+        IpaQueryConfig {
+            per_user_credit_cap: self.per_user_cap,
+            max_breakdown_key: self.breakdown_keys,
+            attribution_window_seconds: self.attribution_window,
+            num_multi_bits: self.num_multi_bits,
+        }
     }
 }
 

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 per_user_credit_cap: 3,
                 max_breakdown_key: 3,
                 num_multi_bits: 3,
-                attribution_window_seconds: 0,
+                attribution_window_seconds: None,
             });
 
             match args.input.input_type {

--- a/src/helpers/transport/query.rs
+++ b/src/helpers/transport/query.rs
@@ -8,7 +8,10 @@ use crate::{
     query::ProtocolResult,
 };
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Formatter};
+use std::{
+    fmt::{Debug, Formatter},
+    num::NonZeroU32,
+};
 use tokio::sync::oneshot;
 
 #[derive(Copy, Clone, Debug)]
@@ -183,7 +186,7 @@ impl Step for QueryType {}
 pub struct IpaQueryConfig {
     pub per_user_credit_cap: u32,
     pub max_breakdown_key: u32,
-    pub attribution_window_seconds: u32,
+    pub attribution_window_seconds: Option<NonZeroU32>,
     pub num_multi_bits: u32,
 }
 
@@ -192,13 +195,15 @@ impl Default for IpaQueryConfig {
         Self {
             per_user_credit_cap: 3,
             max_breakdown_key: 64,
-            attribution_window_seconds: 0,
+            attribution_window_seconds: None,
             num_multi_bits: 3,
         }
     }
 }
 
 impl IpaQueryConfig {
+    /// ## Panics
+    /// If attribution window is 0
     #[must_use]
     pub fn new(
         per_user_credit_cap: u32,
@@ -209,7 +214,28 @@ impl IpaQueryConfig {
         Self {
             per_user_credit_cap,
             max_breakdown_key,
-            attribution_window_seconds,
+            attribution_window_seconds: Some(
+                NonZeroU32::new(attribution_window_seconds)
+                    .expect("attribution window must be a positive value > 0"),
+            ),
+            num_multi_bits,
+        }
+    }
+
+    /// Creates an IPA query config that does not specify attribution window. That leads to short-cutting
+    /// some of the IPA steps inside attribution circuit and getting the answer faster. What it practically
+    /// means is that any trigger event can be attributed if there is at least one preceding source event
+    /// from the same user in the input.
+    #[must_use]
+    pub fn no_window(
+        per_user_credit_cap: u32,
+        max_breakdown_key: u32,
+        num_multi_bits: u32,
+    ) -> Self {
+        Self {
+            per_user_credit_cap,
+            max_breakdown_key,
+            attribution_window_seconds: None,
             num_multi_bits,
         }
     }

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -139,12 +139,12 @@ pub mod query {
                         num_multi_bits,
                     }) = req.extract().await?;
 
-                    Ok(QueryType::Ipa(IpaQueryConfig {
+                    Ok(QueryType::Ipa(IpaQueryConfig::new(
                         per_user_credit_cap,
                         max_breakdown_key,
                         attribution_window_seconds,
                         num_multi_bits,
-                    }))
+                    )))
                 }
                 other => Err(Error::bad_query_value("query_type", other)),
             }?;
@@ -161,15 +161,22 @@ pub mod query {
             match self.query_type {
                 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
                 QueryType::TestMultiply => write!(f, "query_type={}", QueryType::TEST_MULTIPLY_STR),
-                QueryType::Ipa(config) => write!(
-                    f,
-                    "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&attribution_window_seconds={}&num_multi_bits={}",
-                    QueryType::IPA_STR,
-                    config.per_user_credit_cap,
-                    config.max_breakdown_key,
-                    config.attribution_window_seconds,
-                    config.num_multi_bits,
-                ),
+                QueryType::Ipa(config) => {
+                    write!(
+                        f,
+                        "query_type={}&per_user_credit_cap={}&max_breakdown_key={}&num_multi_bits={}",
+                        QueryType::IPA_STR,
+                        config.per_user_credit_cap,
+                        config.max_breakdown_key,
+                        config.num_multi_bits,
+                    )?;
+
+                    if let Some(window) = config.attribution_window_seconds {
+                        write!(f, "&attribution_window_seconds={}", window.get())?;
+                    }
+
+                    Ok(())
+                }
             }
         }
     }

--- a/src/net/http_serde.rs
+++ b/src/net/http_serde.rs
@@ -91,6 +91,7 @@ pub mod query {
     use hyper::header::HeaderName;
     use std::{
         fmt::{Display, Formatter},
+        num::NonZeroU32,
         str::FromStr,
     };
 
@@ -129,7 +130,7 @@ pub mod query {
                     struct IPAQueryConfigParam {
                         per_user_credit_cap: u32,
                         max_breakdown_key: u32,
-                        attribution_window_seconds: u32,
+                        attribution_window_seconds: Option<NonZeroU32>,
                         num_multi_bits: u32,
                     }
                     let Query(IPAQueryConfigParam {
@@ -139,12 +140,12 @@ pub mod query {
                         num_multi_bits,
                     }) = req.extract().await?;
 
-                    Ok(QueryType::Ipa(IpaQueryConfig::new(
+                    Ok(QueryType::Ipa(IpaQueryConfig {
                         per_user_credit_cap,
                         max_breakdown_key,
                         attribution_window_seconds,
                         num_multi_bits,
-                    )))
+                    }))
                 }
                 other => Err(Error::bad_query_value("query_type", other)),
             }?;

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -78,7 +78,7 @@ mod tests {
             query_type: QueryType::Ipa(IpaQueryConfig {
                 per_user_credit_cap: 1,
                 max_breakdown_key: 1,
-                attribution_window_seconds: 0,
+                attribution_window_seconds: None,
                 num_multi_bits: 3,
             }),
         })

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -45,8 +45,12 @@ mod tests {
         protocol::QueryId,
     };
     use axum::http::Request;
-    use hyper::{Body, StatusCode};
-    use std::future::ready;
+
+    use hyper::{
+        http::uri::{Authority, Scheme},
+        Body, StatusCode,
+    };
+    use std::{future::ready, num::NonZeroU32};
 
     async fn create_test(expected_query_config: QueryConfig) {
         let cb = TransportCallbacks {
@@ -56,10 +60,22 @@ mod tests {
             }),
             ..Default::default()
         };
+        let TestServer { server, .. } = TestServer::builder().with_callbacks(cb).build().await;
         let req = http_serde::query::create::Request::new(expected_query_config);
-        let TestServer { transport, .. } = TestServer::builder().with_callbacks(cb).build().await;
-        let Json(resp) = handler(Extension(transport), req).await.unwrap();
-        assert_eq!(resp.query_id, QueryId);
+        let req = req
+            .try_into_http_request(Scheme::HTTP, Authority::from_static("127.0.0.1"))
+            .unwrap();
+        let resp = server.handle_req(req).await;
+
+        let status = resp.status();
+        let body_bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+        let response_str = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        assert_eq!(StatusCode::OK, status, "Request failed: {}", &response_str);
+
+        let http_serde::query::create::ResponseBody { query_id } =
+            serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(QueryId, query_id);
     }
 
     #[tokio::test]
@@ -72,13 +88,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_test_ipa() {
+    async fn create_test_ipa_no_attr_window() {
         create_test(QueryConfig {
             field_type: FieldType::Fp32BitPrime,
             query_type: QueryType::Ipa(IpaQueryConfig {
                 per_user_credit_cap: 1,
                 max_breakdown_key: 1,
                 attribution_window_seconds: None,
+                num_multi_bits: 3,
+            }),
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn create_test_ipa_with_attr_window() {
+        create_test(QueryConfig {
+            field_type: FieldType::Fp32BitPrime,
+            query_type: QueryType::Ipa(IpaQueryConfig {
+                per_user_credit_cap: 1,
+                max_breakdown_key: 1,
+                attribution_window_seconds: NonZeroU32::new(86_400),
                 num_multi_bits: 3,
             }),
         })

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -361,7 +361,7 @@ mod tests {
     pub async fn accumulate_cap_of_one_with_attribution_window() {
         const EXPECTED: &[u128; 20] = &[0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1];
         const PER_USER_CAP: u32 = 1;
-        let attribution_window_seconds: Option<NonZeroU32> = NonZeroU32::new(1);
+        const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(1);
 
         let input: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = accumulation_test_input!(
             [
@@ -391,7 +391,7 @@ mod tests {
         );
         let input_len = input.len();
 
-        let result = accumulate_credit_test(input, PER_USER_CAP, attribution_window_seconds).await;
+        let result = accumulate_credit_test(input, PER_USER_CAP, ATTRIBUTION_WINDOW_SECONDS).await;
 
         assert_eq!(result[0].len(), input_len - 1);
         assert_eq!(result[1].len(), input_len - 1);

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -361,7 +361,7 @@ mod tests {
     pub async fn accumulate_cap_of_one_with_attribution_window() {
         const EXPECTED: &[u128; 20] = &[0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1];
         const PER_USER_CAP: u32 = 1;
-        let attribution_window_seconds: Option<NonZeroU32> = Some(NonZeroU32::new(1).unwrap());
+        let attribution_window_seconds: Option<NonZeroU32> = NonZeroU32::new(1);
 
         let input: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = accumulation_test_input!(
             [

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -232,7 +232,7 @@ mod tests {
         const EXPECTED_ACTIVE_BITS: &[u128; 23] = &[
             1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
         ];
-        let attribution_window = NonZeroU32::new(600);
+        const ATTRIBUTION_WINDOW: Option<NonZeroU32> = NonZeroU32::new(600);
         let input: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = attribution_window_test_input!(
             [
                 { timestamp: 500, is_trigger_report: 0, helper_bit: 0, breakdown_key: 3, credit: 0 }, // delta: 0
@@ -296,7 +296,7 @@ mod tests {
                     let (itb, hb): (Vec<_>, Vec<_>) = input.iter().map(|x| (x.is_trigger_report.clone(), x.helper_bit.clone())).unzip();
                     let stop_bits = compute_stop_bits(ctx.clone(), &itb, &hb).await.unwrap().collect::<Vec<_>>();
 
-                    apply_attribution_window(ctx, &modulus_converted_shares, &stop_bits, attribution_window)
+                    apply_attribution_window(ctx, &modulus_converted_shares, &stop_bits, ATTRIBUTION_WINDOW)
                         .await
                         .unwrap()
                 },

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -232,7 +232,7 @@ mod tests {
         const EXPECTED_ACTIVE_BITS: &[u128; 23] = &[
             1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
         ];
-        let attribution_window = Some(NonZeroU32::new(600).unwrap());
+        let attribution_window = NonZeroU32::new(600);
         let input: Vec<GenericReportTestInput<Fp32BitPrime, MatchKey, BreakdownKey>> = attribution_window_test_input!(
             [
                 { timestamp: 500, is_trigger_report: 0, helper_bit: 0, breakdown_key: 3, credit: 0 }, // delta: 0

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -953,9 +953,9 @@ pub mod tests {
         const NUM_USERS: usize = 8;
         const MAX_RECORDS_PER_USER: usize = 8;
         const NUM_MULTI_BITS: u32 = 3;
+        const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
         type TestField = Fp32BitPrime;
 
-        let attribution_window_seconds = NonZeroU32::new(86_400);
         let random_seed = thread_rng().gen();
         println!("Using random seed: {random_seed}");
         let mut rng = StdRng::seed_from_u64(random_seed);
@@ -984,7 +984,7 @@ pub mod tests {
 
         for per_user_cap in [1, 3] {
             let expected_results =
-                ipa_in_the_clear(&raw_data, per_user_cap, attribution_window_seconds);
+                ipa_in_the_clear(&raw_data, per_user_cap, ATTRIBUTION_WINDOW_SECONDS);
 
             test_ipa::<TestField>(
                 &world,
@@ -993,7 +993,7 @@ pub mod tests {
                 IpaQueryConfig {
                     per_user_credit_cap: per_user_cap,
                     max_breakdown_key: MAX_BREAKDOWN_KEY,
-                    attribution_window_seconds,
+                    attribution_window_seconds: ATTRIBUTION_WINDOW_SECONDS,
                     num_multi_bits: NUM_MULTI_BITS,
                 },
                 IpaSecurityModel::SemiHonest,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -955,7 +955,7 @@ pub mod tests {
         const NUM_MULTI_BITS: u32 = 3;
         type TestField = Fp32BitPrime;
 
-        let attribution_window_seconds = Some(NonZeroU32::new(86_400).unwrap());
+        let attribution_window_seconds = NonZeroU32::new(86_400);
         let random_seed = thread_rng().gen();
         println!("Using random seed: {random_seed}");
         let mut rng = StdRng::seed_from_u64(random_seed);

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -496,7 +496,7 @@ mod tests {
                         query_type: QueryType::Ipa(IpaQueryConfig {
                             per_user_credit_cap: 3,
                             max_breakdown_key: 3,
-                            attribution_window_seconds: 0,
+                            attribution_window_seconds: None,
                             num_multi_bits: 3,
                         }),
                     },

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -117,7 +117,7 @@ mod tests {
             let query_config = IpaQueryConfig {
                 num_multi_bits: 3,
                 per_user_credit_cap: 3,
-                attribution_window_seconds: 0,
+                attribution_window_seconds: None,
                 max_breakdown_key: 3,
             };
             let input = ByteArrStream::from(shares);

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -16,8 +16,7 @@ use std::num::NonZeroU32;
 const BATCHSIZE: usize = 5;
 const PER_USER_CAP: u32 = 10;
 const MAX_BREAKDOWN_KEY: u32 = 8;
-const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> =
-    Some(unsafe { NonZeroU32::new_unchecked(86_400) });
+const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
 const MAX_TRIGGER_VALUE: u32 = 5;
 const NUM_MULTI_BITS: u32 = 3;
 const MAX_MATCH_KEY: u128 = 3;

--- a/src/tests/protocol.rs
+++ b/src/tests/protocol.rs
@@ -11,11 +11,13 @@ use crate::{
     rand::{thread_rng, Rng},
     test_fixture::{input::GenericReportTestInput, Reconstruct, Runner, TestWorld},
 };
+use std::num::NonZeroU32;
 
 const BATCHSIZE: usize = 5;
 const PER_USER_CAP: u32 = 10;
 const MAX_BREAKDOWN_KEY: u32 = 8;
-const ATTRIBUTION_WINDOW_SECONDS: u32 = 0;
+const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> =
+    Some(unsafe { NonZeroU32::new_unchecked(86_400) });
 const MAX_TRIGGER_VALUE: u32 = 5;
 const NUM_MULTI_BITS: u32 = 3;
 const MAX_MATCH_KEY: u128 = 3;
@@ -49,12 +51,12 @@ fn semi_honest_ipa() {
                             ipa::<Fp32BitPrime, MatchKey, BreakdownKey>(
                                 ctx,
                                 &input_rows,
-                                IpaQueryConfig::new(
-                                    PER_USER_CAP,
-                                    MAX_BREAKDOWN_KEY,
-                                    ATTRIBUTION_WINDOW_SECONDS,
-                                    NUM_MULTI_BITS,
-                                ),
+                                IpaQueryConfig {
+                                    per_user_credit_cap: PER_USER_CAP,
+                                    max_breakdown_key: MAX_BREAKDOWN_KEY,
+                                    attribution_window_seconds: ATTRIBUTION_WINDOW_SECONDS,
+                                    num_multi_bits: NUM_MULTI_BITS,
+                                },
                             )
                             .await
                             .unwrap()
@@ -98,12 +100,12 @@ fn malicious_ipa() {
                             ipa_malicious::<Fp32BitPrime, MatchKey, BreakdownKey>(
                                 ctx,
                                 &input_rows,
-                                IpaQueryConfig::new(
-                                    PER_USER_CAP,
-                                    MAX_BREAKDOWN_KEY,
-                                    ATTRIBUTION_WINDOW_SECONDS,
-                                    NUM_MULTI_BITS,
-                                ),
+                                IpaQueryConfig {
+                                    per_user_credit_cap: PER_USER_CAP,
+                                    max_breakdown_key: MAX_BREAKDOWN_KEY,
+                                    attribution_window_seconds: ATTRIBUTION_WINDOW_SECONDS,
+                                    num_multi_bits: NUM_MULTI_BITS,
+                                },
                             )
                             .await
                             .unwrap()


### PR DESCRIPTION
Found this issue while working on some CLI tooling. Currently MPC just skips the attribution window logic if the window is set to be 0. IPA in the clear did not do it and I was observing different results running them one after another. 

It does seem better to use the type system to make this behavior more clear. As 0 truly does not make much sense as window value, `Option<NonZeroU32>>` is used instead.