### PR TITLE
Print metrics only if there are any

### DIFF
--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -152,7 +152,9 @@ impl Metrics {
             ]);
         }
 
-        writeln!(w, "{metrics_table}")?;
+        if metrics_table.row_iter().len() > 0 {
+            writeln!(w, "{metrics_table}")?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
CLI tools (helper + test_mpc) print metrics collected during the run. However, for `test_mpc` it is often true that there are no metrics emited. This leads to empty table printed to the output.

```bash
+--------+-------------+-------+------------+
| metric | description | value | dimensions |
+===========================================+
+--------+-------------+-------+------------+
```


This commit changes that, making it conditional on number of records in that table.