### PR TITLE
make https the default, but enable running in http mode with the https config

### DIFF
--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -20,7 +20,7 @@ pub struct TestSetupArgs {
     #[arg(short, long, default_value = "test_data")]
     output_dir: PathBuf,
 
-    /// Write http URLs to the network configuration (certificates will still be generated)
+    /// Ignored. The same configuration can be used for HTTP and HTTPS.
     #[arg(long)]
     disable_https: bool,
 
@@ -58,13 +58,7 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
             let certificate = Some(fs::read_to_string(&tls_cert)?);
 
             Ok::<_, Box<dyn Error>>(PeerConfig {
-                url: format!(
-                    "{}://localhost:{}",
-                    if args.disable_https { "http" } else { "https" },
-                    port
-                )
-                .parse()
-                .unwrap(),
+                url: format!("localhost:{port}").parse().unwrap(),
                 certificate,
             })
         })

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -275,7 +275,7 @@ pub(crate) mod tests {
     async fn untrusted_certificate() {
         const ECHO_DATA: &str = "asdf";
 
-        let TestServer { addr, .. } = TestServer::builder().https().build().await;
+        let TestServer { addr, .. } = TestServer::default().await;
 
         let client_config = PeerConfig {
             url: format!("https://localhost:{}", addr.port())
@@ -314,18 +314,18 @@ pub(crate) mod tests {
         let TestServer {
             client: http_client,
             ..
-        } = TestServer::builder().with_callbacks(http_cb).build().await;
+        } = TestServer::builder()
+            .disable_https()
+            .with_callbacks(http_cb)
+            .build()
+            .await;
 
         let clientf_res_http = clientf(http_client).await;
 
         let TestServer {
             client: https_client,
             ..
-        } = TestServer::builder()
-            .https()
-            .with_callbacks(https_cb)
-            .build()
-            .await;
+        } = TestServer::builder().with_callbacks(https_cb).build().await;
 
         let clientf_res_https = clientf(https_client).await;
 

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -1,7 +1,7 @@
 mod handlers;
 
 use crate::{
-    config::ServerConfig,
+    config::{NetworkConfig, ServerConfig},
     net::{Error, HttpTransport},
     sync::Arc,
     task::JoinHandle,
@@ -50,11 +50,20 @@ impl TracingSpanMaker for () {
 pub struct MpcHelperServer {
     transport: Arc<HttpTransport>,
     config: ServerConfig,
+    _network_config: NetworkConfig,
 }
 
 impl MpcHelperServer {
-    pub fn new(transport: Arc<HttpTransport>, config: ServerConfig) -> Self {
-        MpcHelperServer { transport, config }
+    pub fn new(
+        transport: Arc<HttpTransport>,
+        config: ServerConfig,
+        network_config: NetworkConfig,
+    ) -> Self {
+        MpcHelperServer {
+            transport,
+            config,
+            _network_config: network_config,
+        }
     }
 
     fn router(&self) -> Router {
@@ -77,36 +86,6 @@ impl MpcHelperServer {
         listener: Option<TcpListener>,
         tracing: T,
     ) -> (SocketAddr, JoinHandle<()>) {
-        async fn serve<A>(
-            server: Server<A>,
-            handle: Handle,
-            svc: IntoMakeService<Router>,
-        ) -> JoinHandle<()>
-        where
-            A: Accept<
-                    AddrStream,
-                    <IntoMakeService<Router> as MakeServiceRef<
-                        AddrStream,
-                        hyper::Request<hyper::Body>,
-                    >>::Service,
-                > + Clone
-                + Send
-                + Sync
-                + 'static,
-            A::Stream: AsyncRead + AsyncWrite + Unpin + Send,
-            A::Service: SendService<Request<hyper::Body>> + Send,
-            A::Future: Send,
-        {
-            tokio::spawn({
-                async move {
-                    server
-                        .handle(handle)
-                        .serve(svc)
-                        .await
-                        .expect("Failed to serve");
-                }
-            })
-        }
         // This should probably come from the server config.
         // Note that listening on 0.0.0.0 requires accepting a MacOS security
         // warning on each test run.
@@ -130,35 +109,35 @@ impl MpcHelperServer {
             .into_make_service();
         let handle = Handle::new();
 
-        let task_handle = match (self.config.https, listener) {
-            (false, Some(listener)) => {
-                serve(axum_server::from_tcp(listener), handle.clone(), svc).await
-            }
-            (false, None) => {
-                let addr = SocketAddr::new(BIND_ADDRESS.into(), self.config.port.unwrap_or(0));
-                serve(axum_server::bind(addr), handle.clone(), svc).await
-            }
+        let task_handle = match (self.config.disable_https, listener) {
             (true, Some(listener)) => {
+                spawn_server(axum_server::from_tcp(listener), handle.clone(), svc).await
+            }
+            (true, None) => {
+                let addr = SocketAddr::new(BIND_ADDRESS.into(), self.config.port.unwrap_or(0));
+                spawn_server(axum_server::bind(addr), handle.clone(), svc).await
+            }
+            (false, Some(listener)) => {
                 let rustls_config = self
                     .config
                     .as_rustls_config()
                     .await
                     .expect("invalid TLS configuration");
-                serve(
+                spawn_server(
                     axum_server::from_tcp_rustls(listener, rustls_config),
                     handle.clone(),
                     svc,
                 )
                 .await
             }
-            (true, None) => {
+            (false, None) => {
                 let addr = SocketAddr::new(BIND_ADDRESS.into(), self.config.port.unwrap_or(0));
                 let rustls_config = self
                     .config
                     .as_rustls_config()
                     .await
                     .expect("invalid TLS configuration");
-                serve(
+                spawn_server(
                     axum_server::bind_rustls(addr, rustls_config),
                     handle.clone(),
                     svc,
@@ -174,7 +153,11 @@ impl MpcHelperServer {
         #[cfg(not(test))] // reduce spam in test output
         tracing::info!(
             "server listening on {}://{}",
-            if self.config.https { "https" } else { "http" },
+            if self.config.disable_https {
+                "http"
+            } else {
+                "https"
+            },
             bound_addr,
         );
         (bound_addr, task_handle)
@@ -186,6 +169,37 @@ impl MpcHelperServer {
     ) -> impl Future<Output = (SocketAddr, JoinHandle<()>)> + '_ {
         self.start_on(None, tracing)
     }
+}
+
+async fn spawn_server<A>(
+    server: Server<A>,
+    handle: Handle,
+    svc: IntoMakeService<Router>,
+) -> JoinHandle<()>
+where
+    A: Accept<
+            AddrStream,
+            <IntoMakeService<Router> as MakeServiceRef<
+                AddrStream,
+                hyper::Request<hyper::Body>,
+            >>::Service,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    A::Stream: AsyncRead + AsyncWrite + Unpin + Send,
+    A::Service: SendService<Request<hyper::Body>> + Send,
+    A::Future: Send,
+{
+    tokio::spawn({
+        async move {
+            server
+                .handle(handle)
+                .serve(svc)
+                .await
+                .expect("Failed to serve");
+        }
+    })
 }
 
 #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
@@ -225,7 +239,7 @@ mod e2e_tests {
     #[tokio::test]
     async fn can_do_http() {
         // server
-        let TestServer { addr, .. } = TestServer::default().await;
+        let TestServer { addr, .. } = TestServer::builder().disable_https().build().await;
 
         // client
         let client = hyper::Client::new();
@@ -243,7 +257,7 @@ mod e2e_tests {
 
     #[tokio::test]
     async fn can_do_https() {
-        let TestServer { addr, .. } = TestServer::builder().https().build().await;
+        let TestServer { addr, .. } = TestServer::builder().build().await;
 
         // self-signed cert CN is "localhost", therefore request authority must not use the ip address
         let authority = format!("localhost:{}", addr.port());
@@ -280,6 +294,7 @@ mod e2e_tests {
 
         // server
         let TestServer { addr, .. } = TestServer::builder()
+            .disable_https() // required because this test uses a vanilla hyper client
             .with_metrics(handle.clone())
             .build()
             .await;
@@ -312,6 +327,7 @@ mod e2e_tests {
 
         // server
         let TestServer { addr, .. } = TestServer::builder()
+            .disable_https() // required because this test uses vanilla hyper clients
             .with_metrics(handle.clone())
             .build()
             .await;

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::ServerConfig,
+    config::{NetworkConfig, ServerConfig},
     helpers::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         CompleteQueryResult, HelperIdentity, LogErrors, NoResourceIdentifier, PrepareQueryResult,
@@ -30,11 +30,12 @@ impl HttpTransport {
     pub fn new(
         identity: HelperIdentity,
         server_config: ServerConfig,
+        network_config: NetworkConfig,
         clients: [MpcHelperClient; 3],
         callbacks: TransportCallbacks<Arc<HttpTransport>>,
     ) -> (Arc<Self>, MpcHelperServer) {
         let transport = Self::new_internal(identity, clients, callbacks);
-        let server = MpcHelperServer::new(Arc::clone(&transport), server_config);
+        let server = MpcHelperServer::new(Arc::clone(&transport), server_config, network_config);
         (transport, server)
     }
 
@@ -229,7 +230,13 @@ mod e2e_tests {
                     .with_network_config(client_config)
                     .build()
                     .into();
-                let (transport, server) = HttpTransport::new(id, server_config, clients, callbacks);
+                let (transport, server) = HttpTransport::new(
+                    id,
+                    server_config,
+                    network_config.clone(),
+                    clients,
+                    callbacks,
+                );
                 server.start_on(Some(socket), ()).await;
                 let app = setup.connect(transport);
                 app

--- a/src/test_fixture/config.rs
+++ b/src/test_fixture/config.rs
@@ -83,7 +83,7 @@ url = "http://localhost:{}"
     );
 
     let network = NetworkConfig::from_toml_str(&config_str).unwrap();
-    let servers = ports.map(ServerConfig::http_port);
+    let servers = ports.map(ServerConfig::insecure_http_port);
 
     (network, servers)
 }

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -2,7 +2,8 @@ use std::{
     error::Error,
     io::{self, Write},
     iter::zip,
-    process::{Command, ExitStatus, Stdio},
+    ops::Deref,
+    process::{Child, Command, ExitStatus, Stdio},
     str,
 };
 use tempfile::tempdir;
@@ -28,6 +29,51 @@ impl UnwrapStatusExt for Result<ExitStatus, io::Error> {
     }
 }
 
+trait TerminateOnDropExt {
+    fn terminate_on_drop(self) -> TerminateOnDrop;
+}
+
+impl TerminateOnDropExt for Child {
+    fn terminate_on_drop(self) -> TerminateOnDrop {
+        TerminateOnDrop::from(self)
+    }
+}
+
+pub struct TerminateOnDrop(Option<Child>);
+
+impl TerminateOnDrop {
+    fn into_inner(mut self) -> Child {
+        self.0.take().unwrap()
+    }
+
+    fn wait(self) -> io::Result<ExitStatus> {
+        self.into_inner().wait()
+    }
+}
+
+impl From<Child> for TerminateOnDrop {
+    fn from(child: Child) -> Self {
+        Self(Some(child))
+    }
+}
+
+impl Deref for TerminateOnDrop {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl Drop for TerminateOnDrop {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            eprintln!("killing process {}", child.id());
+            let _ = child.kill();
+        }
+    }
+}
+
 fn test_network(ports: &[u16; 3], https: bool) {
     let dir = tempdir().unwrap();
     let path = dir.path();
@@ -45,7 +91,7 @@ fn test_network(ports: &[u16; 3], https: bool) {
     }
     command.status().unwrap_status();
 
-    let helpers = zip([1, 2, 3], ports)
+    let _helpers = zip([1, 2, 3], ports)
         .map(|(id, port)| {
             let mut command = Command::new(HELPER_BIN);
             command
@@ -59,17 +105,18 @@ fn test_network(ports: &[u16; 3], https: bool) {
                     .args(["--tls-key".into(), dir.path().join(format!("h{id}.key"))]);
             }
 
-            command.spawn().unwrap()
+            command.spawn().unwrap().terminate_on_drop()
         })
         .collect::<Vec<_>>();
 
-    let mut test_mpc = Command::new(TEST_MPC_BIN)
+    let test_mpc = Command::new(TEST_MPC_BIN)
         .args(["--network".into(), dir.path().join("network.toml")])
         .args(["--wait", "2"])
         .arg("multiply")
         .stdin(Stdio::piped())
         .spawn()
-        .unwrap();
+        .unwrap()
+        .terminate_on_drop();
 
     test_mpc
         .stdin
@@ -78,10 +125,6 @@ fn test_network(ports: &[u16; 3], https: bool) {
         .write_all(b"3,6\n")
         .unwrap();
     test_mpc.wait().unwrap_status();
-
-    for mut helper in helpers {
-        helper.kill().unwrap();
-    }
 
     // Uncomment this to preserve the temporary directory after the test runs.
     //std::mem::forget(dir);


### PR DESCRIPTION
Branch includes #637.

@akoshelev observed that `https` URLs in `network.toml` were honored even when running in HTTP mode. With this change, the URL scheme in the configuration is overridden with whatever is selected on the command line. To reduce confusion, I also changed `test-setup` to write URLs in the config with host and port only.

I also made HTTPS the default when running a helper (option is now `--disable-https` instead of `--https`), and in the default configuration for real-infra unit tests.