### PR TITLE
Streaming: Make seq_join take a stream

### DIFF
--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -15,7 +15,10 @@ use crate::{
     secret_sharing::Linear as LinearSecretSharing,
     seq_join::seq_join,
 };
-use futures::{stream::once, StreamExt, TryStreamExt};
+use futures::{
+    stream::{iter, once},
+    StreamExt, TryStreamExt,
+};
 use std::iter::{repeat, zip};
 
 /// User-level credit capping protocol.
@@ -445,7 +448,7 @@ where
 
     let last = original_credits.last().ok_or(Error::Internal).cloned();
 
-    seq_join(ctx.active_work(), capped)
+    seq_join(ctx.active_work(), iter(capped))
         .chain(once(async { last }))
         .try_collect()
         .await


### PR DESCRIPTION
I've started to look for places to apply this, and there are fewer than I'd have liked.  But this change was easy enough to execute.

Next step is to start changing the gap between protocol steps so that one produces a stream and the other consumes it.  Not as many options on that front as I had hoped, based on my first look, but we'll see.