### PR TITLE
Add an exact-sized stream trait

### DIFF
--- a/src/exact.rs
+++ b/src/exact.rs
@@ -1,0 +1,144 @@
+use futures::stream::Stream;
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// An analogue of [`ExactSizeIterator`] for [`Stream`].
+/// This behaves exactly as you might expect based on the documentation of
+/// [`ExactSizeIterator`].
+///
+/// [`ExactSizeIterator`]: std::iter::ExactSizeIterator
+/// [`Stream`]: futures::stream::Stream
+pub trait ExactSizeStream: Stream {
+    /// Return the length of the stream that remains.
+    fn len(&self) -> usize {
+        let (lower, upper) = self.size_hint();
+        assert_eq!(upper, Some(lower));
+        lower
+    }
+
+    /// Return whether there are values remaining in the stream.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[pin_project]
+pub struct FixedLength<S> {
+    #[pin]
+    inner: S,
+    len: usize,
+}
+
+impl<S: Stream> FixedLength<S> {
+    /// Create a new fixed-length stream.
+    ///
+    /// Note that this is safe on the same basis that `ExactSizeIterator` is safe in
+    /// that code cannot rely on the claims of this type for ensuring safety of code.
+    #[allow(dead_code)] // TODO - use in infra
+    pub fn new(inner: S, len: usize) -> Self {
+        Self { inner, len }
+    }
+}
+
+impl<S: Stream> Stream for FixedLength<S> {
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        let res = this.inner.as_mut().poll_next(cx);
+        if let Poll::Ready(v) = &res {
+            if v.is_some() {
+                *this.len = (*this.len).wrapping_sub(1);
+            } else {
+                // This can't be a real assertion because we are at the mercy of
+                // remote inputs here; that error will be caught in other ways.
+                // Note that wrapping is fine in this case.
+                #[cfg_attr(debug_assertions, allow(clippy::cast_possible_wrap))]
+                {
+                    debug_assert_eq!(
+                        *this.len, 0,
+                        "FixedLength stream ended with {} remaining",
+                        *this.len as isize
+                    );
+                }
+            }
+        }
+        res
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl<S: Stream> ExactSizeStream for FixedLength<S> {}
+
+#[cfg(all(test, not(feature = "shuttle")))]
+mod test {
+    use crate::exact::{ExactSizeStream, FixedLength};
+    use futures::stream::iter;
+    use futures_util::StreamExt;
+
+    #[test]
+    fn fixed_stream() {
+        const COUNT: usize = 7;
+        let fixed = FixedLength::new(iter(0..COUNT), COUNT);
+        assert_eq!(fixed.len(), COUNT);
+    }
+
+    #[tokio::test]
+    async fn polling_works() {
+        const COUNT: usize = 5;
+        let mut fixed = FixedLength::new(iter(0..COUNT), COUNT);
+        assert_eq!(fixed.len(), COUNT);
+        assert_eq!(fixed.next().await, Some(0));
+        assert_eq!(fixed.len(), COUNT - 1);
+        assert_eq!(
+            fixed.collect::<Vec<_>>().await,
+            (1..COUNT).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_correct() {
+        const COUNT: usize = 4;
+        let mut fixed = FixedLength::new(iter(0..COUNT), COUNT);
+        assert_eq!(fixed.len(), COUNT);
+        while fixed.next().await.is_some() {
+            // noop
+        }
+        assert!(fixed.is_empty());
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "FixedLength stream ended with 1 remaining"
+    )]
+    async fn oversized() {
+        const COUNT: usize = 6;
+        let fixed = FixedLength::new(iter(0..COUNT), COUNT + 1);
+        assert_eq!(fixed.len(), COUNT + 1);
+        assert_eq!(
+            fixed.collect::<Vec<_>>().await,
+            (0..COUNT).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic = "FixedLength stream ended with -1 remaining"
+    )]
+    async fn undersized() {
+        const COUNT: usize = 4;
+        let fixed = FixedLength::new(iter(0..COUNT), COUNT - 1);
+        assert_eq!(fixed.len(), COUNT - 1);
+        assert_eq!(
+            fixed.collect::<Vec<_>>().await,
+            (0..COUNT).collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod uri;
 pub mod test_fixture;
 
 mod app;
+mod exact;
 mod seq_join;
 mod tests;
 

--- a/src/seq_join.rs
+++ b/src/seq_join.rs
@@ -1,3 +1,4 @@
+use crate::exact::ExactSizeStream;
 use futures::{
     stream::{iter, Iter as StreamIter, TryCollect},
     Future, Stream, StreamExt, TryStreamExt,
@@ -207,6 +208,13 @@ where
             upper.and_then(|u| u.checked_add(in_progress)),
         )
     }
+}
+
+impl<S, F> ExactSizeStream for SequentialFutures<S, F>
+where
+    S: Stream<Item = F> + Send + ExactSizeStream,
+    F: IntoFuture,
+{
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If we're going to use streams, there will come a time where we need to be somewhat more definite about the length of the stream.  Our contexts need to know how many records are processed for a given step, so being able to interrogate a stream to determine its length will help a fair bit.

This change defines a new trait, modeled from `ExactSizeIterator` for streams and a stream wrapper that provides an implementation of that trait.  The idea is that when we get a stream from the network, we'll be able to explicitly mark the size of that stream so that protocol step implementations can just know how many records are being processed.