### PR TITLE
Print the step's full path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ real-world-infra = []
 dhat-heap = ["cli", "test-fixture"]
 # Enable this feature to enable our colossally weak Fp31.
 weak-field = []
+step-trace = []
 
 [dependencies]
 aes = "0.8"

--- a/src/protocol/step.rs
+++ b/src/protocol/step.rs
@@ -75,7 +75,7 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
         }
 
         let mut id = self.id.clone() + "/";
-        #[cfg(feature = "step-trace")]
+        #[cfg(all(feature = "step-trace", feature = "in-memory-infra"))]
         {
             id += &(std::any::type_name::<S>().to_owned() + "::");
         }

--- a/src/protocol/step.rs
+++ b/src/protocol/step.rs
@@ -74,9 +74,14 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
             assert!(!s.contains('/'), "The string for a step cannot contain '/'");
         }
 
-        Self {
-            id: self.id.clone() + "/" + step.as_ref(),
+        let mut id = self.id.clone() + "/";
+        #[cfg(feature = "step-trace")]
+        {
+            id += &(std::any::type_name::<S>().to_owned() + "::");
         }
+        id += step.as_ref();
+
+        Self { id }
     }
 }
 

--- a/src/protocol/step.rs
+++ b/src/protocol/step.rs
@@ -77,7 +77,7 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
         let mut id = self.id.clone() + "/";
         #[cfg(all(feature = "step-trace", feature = "in-memory-infra"))]
         {
-            id += &(std::any::type_name::<S>().to_owned() + "::");
+            id += [std::any::type_name::<S>(), "::"].concat().as_ref();
         }
         id += step.as_ref();
 


### PR DESCRIPTION
Let say we have this:

#[Step]
pub enum Step {
    ModulusConversionForMatchKeys,
}

The proc macro expansion function called at the compile time will receive the `Step` token but it doesn't have attributes like its full module path. I believe that path resolution is done at build time and there's no way to interpret that in proc macro.

This change adds a feature that, when enabled, narrowed steps will be prefixed with their full module paths. This information is used in the proc macro to generate StepNarrow implementations for IPA steps.