### PR TITLE
Python script to generate (mostly) complete IPA steps

### DIFF
--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -6,8 +6,7 @@ import subprocess
 # all possible configurations.
 
 IPA_ENV = [["RUST_LOG", "ipa=DEBUG"]]
-CARGO = "cargo"
-OPTIONS = [
+ARGS = [
     "cargo",
     "bench",
     "--bench",
@@ -58,7 +57,6 @@ def collect_steps(args):
     output = []
 
     proc = subprocess.Popen(
-        executable=CARGO,
         args=args,
         env=set_env(),
         stdout=subprocess.PIPE,
@@ -146,7 +144,7 @@ if __name__ == "__main__":
         for w in ATTRIBUTION_WINDOW:
             for b in BREAKDOWN_KEYS:
                 for m in SECURITY_MODEL:
-                    args = OPTIONS + [
+                    args = ARGS + [
                         "-n",
                         str(QUERY_SIZE),
                         "-c",

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -1,0 +1,167 @@
+import os
+import re
+import subprocess
+
+# This script collects all the steps that are executed in the oneshot_ipa with
+# all possible configurations.
+
+IPA_ENV = [["RUST_LOG", "ipa=DEBUG"]]
+CARGO = "cargo"
+OPTIONS = [
+    "cargo",
+    "bench",
+    "--bench",
+    "oneshot_ipa",
+    "--no-default-features",
+    "--features=enable-benches debug-trace step-trace",
+    "--",
+    "--num-multi-bits",
+    "1",
+]
+QUERY_SIZE = 10
+PER_USER_CAP = [1, 3]
+ATTRIBUTION_WINDOW = [0, 86400]
+BREAKDOWN_KEYS = [1, 33]
+SECURITY_MODEL = ["malicious", "semi-honest"]
+ROOT_STEP_PREFIX = "protocol/alloc::string::String::run-0"
+EXPECTED_HEADER_LINES_COUNT = 4
+
+
+def set_env():
+    env = os.environ.copy()
+    for k, v in IPA_ENV:
+        env[k] = v
+    return env
+
+
+def remove_root_step_name_from_line(l):
+    return l.split(",")[0][len(ROOT_STEP_PREFIX) + 1 :]
+
+
+def to_int_or(s):
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+# Split string into list of strings and ints.
+#
+# E.g. "protocol/run-0/mc0/xor1" -> ["protocol/run-", 0, "/mc", 0, "/xor", 1]
+#
+# This is used to sort the steps in the natural order (e.g. 1, 2, 10, 11, 20).
+def natural_sort_key(s):
+    return [to_int_or(v) for v in re.split("(\d+)", s)]
+
+
+def collect_steps(args):
+    output = []
+
+    proc = subprocess.Popen(
+        executable=CARGO,
+        args=args,
+        env=set_env(),
+        stdout=subprocess.PIPE,
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+    count = 0
+    header = 0
+    while True:
+        line = proc.stdout.readline()
+        if not line or line == "":
+            break
+
+        if not line.startswith(ROOT_STEP_PREFIX):
+            header += 1
+            continue
+
+        output.append(remove_root_step_name_from_line(line))
+        count += 1
+
+    # safeguard against empty output
+    if count == 0:
+        print("No steps in the output")
+        exit(1)
+
+    # oneshot_ipa produces 4 header lines
+    if header != EXPECTED_HEADER_LINES_COUNT:
+        print("Unexpected header lines in the output")
+        exit(1)
+
+    return output
+
+
+# Splits a line by "/" and create a vector consisting each splitted string
+# concatenated by all the preceding strings.
+#
+# # Example
+# input = "mod_conv_match_key/mc0/mc0/xor1"
+# output = ["mod_conv_match_key",
+#           "mod_conv_match_key/mc0",
+#           "mod_conv_match_key/mc0/mc0",
+#           "mod_conv_match_key/mc0/mc0/xor1"]
+#
+# We do this because not all substeps invoke communications between helpers.
+#
+# For example, a leaf substep "mod_conv_match_key/mc0/mc0/xor1" invokes
+# multiplications, but "mod_conv_match_key/mc0/mc0" and "mod_conv_match_key/mc0"
+# do not. However, we want to include these intermediate substeps in the output
+# since each `narrow`, even if it doesn't actually do anything, is a state
+# transition.
+#
+# This function generates a lot of duplicates. It is inefficient but we don't
+# really care because we execute this script only once when we add a new
+# protocol which is a pretty rare case. The duplicates will be removed in the
+# `remove_duplicates_and_sort`.
+def extract_intermediate_steps(steps):
+    output = []
+    for step in steps:
+        substeps = step.split("/")
+        for i in range(1, len(substeps)):
+            output.append("/".join(substeps[:i]))
+    steps.extend(output)
+
+
+def remove_duplicates_and_sort(steps):
+    # Converting a list to dict removes duplicates. We want a list for the sorting.
+    unique_steps = list(dict.fromkeys(steps))
+
+    # "natural" sort
+    unique_steps.sort(key=natural_sort_key)
+
+    # remove empty string if present
+    try:
+        unique_steps.remove("")
+    except Exception:
+        pass
+
+    return unique_steps
+
+
+if __name__ == "__main__":
+    steps = []
+    for c in PER_USER_CAP:
+        for w in ATTRIBUTION_WINDOW:
+            for b in BREAKDOWN_KEYS:
+                for m in SECURITY_MODEL:
+                    args = OPTIONS + [
+                        "-n",
+                        str(QUERY_SIZE),
+                        "-c",
+                        str(c),
+                        "-w",
+                        str(w),
+                        "-b",
+                        str(b),
+                        "-m",
+                        m,
+                    ]
+                    steps.extend(collect_steps(args))
+
+    extract_intermediate_steps(steps)
+    steps = remove_duplicates_and_sort(steps)
+
+    for step in steps:
+        print(step)


### PR DESCRIPTION
A python script to run `oneshot_ipa` benchmark for all combinations of IPA options to generate all the possible steps, sort them and print them out. The output will be used to codegen the optimized `Steps` implementation.

This script basically executes the following command:
`RUST_LOG=ipa=DEBUG cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches debug-trace step-trace" -- --num-multi-bits 1 -n 10 -c $1 -w $2 -b $3 -m $4`

where options that affect IPA protocol paths are:

* `-c` PER_USER_CAP = [1, 3]
* `-w` ATTRIBUTION_WINDOW = [0, 86400]
* `-b` BREAKDOWN_KEYS = [1, 33]
* `-m` SECURITY_MODEL = ["malicious", "semi-honest"]

The output is not 100% complete because there are protocols that change the number of narrows based on the number of bits or rows that are processed. However, the limits are well bounded and will be less than 64 or lower for both (log(100B) < 37). For these missing steps, it's not realistic to generate them by actually running IPA. Instead, we'll generate them using macros, or maybe some other primitive methods during codegen time.

# Output

```shell
❯ python3 ./scripts/collect_steps.py | wc -l
    Finished bench [optimized] target(s) in 1.02s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.52s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.40s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.48s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.42s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.41s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.44s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.87s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.88s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 1.05s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.41s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.71s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.42s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 1.13s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 0.39s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    Finished bench [optimized] target(s) in 1.20s
     Running benches/oneshot/ipa.rs (target/release/deps/oneshot_ipa-ff953e773cf9b04c)
    8740
```