### PR TITLE
Add Dockerfile to create IPA helper image

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+target/
+test_data/

--- a/docker/helper.Dockerfile
+++ b/docker/helper.Dockerfile
@@ -12,14 +12,15 @@ RUN set -eux; \
 
 # Copy them to the final image
 FROM debian:bullseye-slim
+ENV HELPER_BIN_PATH=/usr/local/bin/ipa-helper
 ENV CONF_DIR=/etc/ipa
 ARG IDENTITY
 ARG HOSTNAME
 
 RUN apt-get update && rm -rf /var/lib/apt/lists/*
-COPY --from=builder ${SOURCES_DIR}/target/release/helper /usr/local/bin/ipa-helper
+COPY --from=builder ${SOURCES_DIR}/target/release/helper $HELPER_BIN_PATH
 
 # generate certificate/private key for TLS
 RUN set -eux; \
     mkdir -p $CONF_DIR/pub; \
-    /usr/local/bin/ipa-helper keygen --name $HOSTNAME --tls-cert $CONF_DIR/pub/$IDENTITY.pem --tls-key $CONF_DIR/$IDENTITY.key
+    $HELPER_BIN_PATH keygen --name $HOSTNAME --tls-cert $CONF_DIR/pub/$IDENTITY.pem --tls-key $CONF_DIR/$IDENTITY.key

--- a/docker/helper.Dockerfile
+++ b/docker/helper.Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+ARG SOURCES_DIR=/usr/src/ipa
+FROM rust:latest as builder
+
+LABEL maintainer="akoshelev"
+
+# Prepare helper binaries
+WORKDIR "$SOURCES_DIR"
+COPY . .
+RUN set -eux; \
+    cargo build --bin helper --release --no-default-features --features "web-app real-world-infra"
+
+# Copy them to the final image
+FROM debian:bullseye-slim
+ENV CONF_DIR=/etc/ipa
+ARG IDENTITY
+ARG HOSTNAME
+
+RUN apt-get update && rm -rf /var/lib/apt/lists/*
+COPY --from=builder ${SOURCES_DIR}/target/release/helper /usr/local/bin/ipa-helper
+
+# generate certificate/private key for TLS
+RUN set -eux; \
+    mkdir -p $CONF_DIR/pub; \
+    /usr/local/bin/ipa-helper keygen --name $HOSTNAME --tls-cert $CONF_DIR/pub/$IDENTITY.pem --tls-key $CONF_DIR/$IDENTITY.key

--- a/scripts/helper-image.sh
+++ b/scripts/helper-image.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eou pipefail
+
 help() {
   echo "Usage: $0 --hostname [hostname] --identity [1|2|3]"
   echo "- hostname: public hostname that will appear on TLS certificate"
@@ -32,12 +34,8 @@ if [[ -z "${identity}" || -z "${hostname}" ]]; then
     exit 1
 fi
 
-branch="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$branch" == "main" ]]; then
-  tag="private-attribution/ipa:latest.$identity"
-else
-  tag="private-attribution/ipa:$branch.$identity"
-fi
+rev=$(git log -n 1 --format='format:%H' | cut -c1-10)
+tag="private-attribution/ipa:$rev-h$identity"
 
 cd "$(dirname "$0")"/.. || exit 1
 docker build -t "$tag" -f docker/helper.Dockerfile --build-arg IDENTITY="$identity" --build-arg HOSTNAME="$hostname" .

--- a/scripts/helper-image.sh
+++ b/scripts/helper-image.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+help() {
+  echo "Usage: $0 --hostname [hostname] --identity [1|2|3]"
+  echo "- hostname: public hostname that will appear on TLS certificate"
+  echo "- identity: helper identity to be fixed inside the IPA build"
+}
+
+parse_args() {
+  while [ "${1:-}" != "" ]; do
+    case "$1" in
+      --identity)
+        shift
+        identity="$1"
+        ;;
+      --hostname)
+        shift
+        hostname="$1"
+        ;;
+      *)
+      # unknown option
+      help
+      exit 1
+    esac
+    shift
+  done
+}
+
+parse_args "$@"
+if [[ -z "${identity}" || -z "${hostname}" ]]; then
+    help
+    exit 1
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" == "main" ]]; then
+  tag="private-attribution/ipa:latest"
+else
+  tag="private-attribution/ipa:${branch}"
+fi
+
+cd "$(dirname "$0")"/.. || exit 1
+docker build -t "$tag" -f docker/helper.Dockerfile --build-arg IDENTITY="$identity" --build-arg HOSTNAME="$hostname" .

--- a/scripts/helper-image.sh
+++ b/scripts/helper-image.sh
@@ -34,9 +34,9 @@ fi
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$branch" == "main" ]]; then
-  tag="private-attribution/ipa:latest"
+  tag="private-attribution/ipa:latest.$identity"
 else
-  tag="private-attribution/ipa:${branch}"
+  tag="private-attribution/ipa:$branch.$identity"
 fi
 
 cd "$(dirname "$0")"/.. || exit 1


### PR DESCRIPTION
It is not very capable right now, want to collect some early feedback. It does set up an image with helper binary and TLS config.

Addresses #644 

## Testing

```bash
$ scripts/helper-image.sh --identity 1 --hostname localhost
1
[+] Building 181.3s (17/17) FINISHED
 => [internal] load build definition from helper.Dockerfile                                                                                                                                                              0.0s
 => => transferring dockerfile: 798B                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                          0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                                                                                                                               0.7s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:39b85bbfa7536a5feceb7372a0817649ecb2724562a38360f4d6a7782a409b14                                                                                          0.0s
 => [internal] load .dockerignore                                                                                                                                                                                        0.0s
 => [internal] load build definition from helper.Dockerfile                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                  0.6s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                                                                                           0.8s
 => [internal] load build context                                                                                                                                                                                        1.4s
 => => transferring context: 2.77MB                                                                                                                                                                                      1.4s
 => CACHED [builder 1/4] FROM docker.io/library/rust:latest@sha256:c2dcc19371a976065950915307b03a9c5514e5143bdd833635d5501a0642992e                                                                                      0.0s
 => CACHED [stage-1 1/4] FROM docker.io/library/debian:bullseye-slim@sha256:7606bef5684b393434f06a50a3d1a09808fee5a0240d37da5d181b1b121e7637                                                                             0.0s
 => [stage-1 2/4] RUN apt-get update && rm -rf /var/lib/apt/lists/*                                                                                                                                                      1.8s
 => [builder 2/4] COPY . .                                                                                                                                                                                              15.4s
 => [builder 3/4] RUN set -eux;     cargo build --bin helper --release --no-default-features --features "web-app real-world-infra"                                                                                     162.1s
 => [stage-1 3/4] COPY --from=builder /target/release/helper /usr/local/bin/ipa-helper                                                                                                                                   0.0s
 => [stage-1 4/4] RUN set -eux;     mkdir -p /etc/ipa/pub;     /usr/local/bin/ipa-helper keygen --name localhost --tls-cert /etc/ipa/pub/1.pem --tls-key /etc/ipa/1.key                                                  0.2s
 => exporting to image                                                                                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                                                                                  0.1s
 => => writing image sha256:c2ffb498408018eaa1aa57ffb030b0576e805c98b55358cd7f25c0832560405c                                                                                                                             0.0s
 => => naming to docker.io/private-attribution/ipa:dockerfile                                                                                                                                                            0.0s

```