### PR TITLE
Make helpers capable of running more than one query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ sec1 = { version = "0.7", features = ["alloc", "pem", "pkcs8"], optional = true 
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 sha2 = "0.10.6"
-shuttle-crate = { package = "shuttle", version = "0.5", optional = true }
+shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tinyvec = "1.6.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
+use crate::task::JoinError;
 use std::fmt::Debug;
 use thiserror::Error;
-use tokio::task::JoinError;
 
 /// An error raised by the IPA protocol.
 ///
@@ -36,8 +36,13 @@ pub enum Error {
     MaliciousRevealFailed,
     #[error("problem during IO: {0}")]
     Io(#[from] std::io::Error),
+    // TODO remove if this https://github.com/awslabs/shuttle/pull/109 gets approved
+    #[cfg(not(feature = "shuttle"))]
     #[error("runtime error")]
     RuntimeError(#[from] JoinError),
+    #[cfg(feature = "shuttle")]
+    #[error("runtime error")]
+    RuntimeError(JoinError),
     #[error("failed to parse json: {0}")]
     #[cfg(feature = "enable-serde")]
     Serde(#[from] serde_json::Error),

--- a/src/helpers/transport/in_memory/mod.rs
+++ b/src/helpers/transport/in_memory/mod.rs
@@ -79,4 +79,11 @@ impl InMemoryNetwork {
             .unwrap();
         transports
     }
+
+    /// Reset all transports to the clear state.
+    pub fn reset(&self) {
+        for t in &self.transports {
+            t.reset();
+        }
+    }
 }

--- a/src/helpers/transport/in_memory/transport.rs
+++ b/src/helpers/transport/in_memory/transport.rs
@@ -142,6 +142,11 @@ impl InMemoryTransport {
             })
             .clone()
     }
+
+    /// Resets this transport, making it forget its state and be ready for processing another query.
+    pub fn reset(&self) {
+        self.record_streams.clear();
+    }
 }
 
 #[async_trait]

--- a/src/helpers/transport/stream.rs
+++ b/src/helpers/transport/stream.rs
@@ -104,6 +104,15 @@ impl<S: Stream> StreamCollection<S> {
             }
         }
     }
+
+    /// Clears up this collection, leaving no streams inside it.
+    ///
+    /// ## Panics
+    /// if mutex is poisoned.
+    pub fn clear(&self) {
+        let mut streams = self.inner.lock().unwrap();
+        streams.clear();
+    }
 }
 
 /// Describes the lifecycle of records stream inside [`StreamCollection`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,12 +71,12 @@ pub(crate) mod rand {
 
 #[cfg(all(feature = "shuttle", test))]
 pub(crate) mod task {
-    pub use shuttle::future::JoinHandle;
+    pub use shuttle::future::{JoinError, JoinHandle};
 }
 
 #[cfg(not(all(feature = "shuttle", test)))]
 pub(crate) mod task {
-    pub use tokio::task::JoinHandle;
+    pub use tokio::task::{JoinError, JoinHandle};
 }
 
 #[cfg(all(feature = "in-memory-infra", feature = "real-world-infra"))]

--- a/src/query/completion.rs
+++ b/src/query/completion.rs
@@ -1,0 +1,46 @@
+use std::future::Future;
+
+use std::{
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use crate::{
+    error::Error,
+    query::{runner::QueryResult, state::RemoveQuery},
+    task::JoinHandle,
+};
+
+use pin_project::pin_project;
+
+/// Query completion polls the tokio task to get the results and cleans up the query state after.
+#[pin_project]
+pub struct Handle<'a> {
+    query_state_guard: RemoveQuery<'a>,
+    #[pin]
+    inner: JoinHandle<QueryResult>,
+}
+
+impl<'a> Future for Handle<'a> {
+    type Output = QueryResult;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match ready!(this.inner.poll(cx)) {
+            Ok(results) => Poll::Ready(results),
+            Err(e) => {
+                tracing::error!("query task error: {e:?}");
+                Poll::Ready(Err(Error::RuntimeError(e)))
+            }
+        }
+    }
+}
+
+impl<'a> Handle<'a> {
+    pub fn new(guard: RemoveQuery<'a>, inner: JoinHandle<QueryResult>) -> Self {
+        Self {
+            query_state_guard: guard,
+            inner,
+        }
+    }
+}

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -14,6 +14,8 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare, Linear as LinearSecretSharing},
     task::JoinHandle,
 };
+
+use crate::query::runner::QueryResult;
 use generic_array::GenericArray;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
@@ -66,7 +68,7 @@ pub fn start_query(
     config: QueryConfig,
     gateway: Gateway,
     input: ByteArrStream,
-) -> JoinHandle<Box<dyn Result>> {
+) -> JoinHandle<QueryResult> {
     tokio::spawn(async move {
         // TODO: make it a generic argument for this function
         let mut rng = StdRng::from_entropy();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,3 +1,4 @@
+mod completion;
 mod executor;
 mod processor;
 mod runner;
@@ -9,3 +10,5 @@ pub use processor::{
     NewQueryError, PrepareQueryError, Processor as QueryProcessor, QueryCompletionError,
     QueryInputError,
 };
+
+use completion::Handle as CompletionHandle;

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -23,20 +23,18 @@ impl Runner {
         ctx: SemiHonestContext<'_>,
         field: FieldType,
         input: ByteArrStream,
-    ) -> Box<dyn ProtocolResult> {
-        match field {
+    ) -> Result<Box<dyn ProtocolResult>, Error> {
+        Ok(match field {
             #[cfg(any(test, feature = "weak-field"))]
             FieldType::Fp31 => Box::new(
                 self.run_internal::<crate::ff::Fp31, MatchKey, BreakdownKey>(ctx, input)
-                    .await
-                    .expect("IPA query failed"),
+                    .await?,
             ),
             FieldType::Fp32BitPrime => Box::new(
                 self.run_internal::<Fp32BitPrime, MatchKey, BreakdownKey>(ctx, input)
-                    .await
-                    .expect("IPA query failed"),
+                    .await?,
             ),
-        }
+        })
     }
 
     // This is intentionally made not async because it does not capture `self`.

--- a/src/query/runner/mod.rs
+++ b/src/query/runner/mod.rs
@@ -3,5 +3,8 @@ mod ipa;
 mod test_multiply;
 
 pub(super) use self::ipa::Runner as IpaRunner;
+use crate::{error::Error, query::ProtocolResult};
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 pub(super) use test_multiply::Runner as TestMultiplyRunner;
+
+pub(super) type QueryResult = Result<Box<dyn ProtocolResult>, Error>;

--- a/src/query/runner/test_multiply.rs
+++ b/src/query/runner/test_multiply.rs
@@ -21,18 +21,14 @@ impl Runner {
         ctx: SemiHonestContext<'_>,
         field: FieldType,
         input: ByteArrStream,
-    ) -> Box<dyn ProtocolResult> {
-        match field {
+    ) -> Result<Box<dyn ProtocolResult>, Error> {
+        Ok(match field {
             #[cfg(any(test, feature = "weak-field"))]
-            FieldType::Fp31 => Box::new(
-                self.run_internal::<crate::ff::Fp31>(ctx, input)
-                    .await
-                    .unwrap(),
-            ),
+            FieldType::Fp31 => Box::new(self.run_internal::<crate::ff::Fp31>(ctx, input).await?),
             FieldType::Fp32BitPrime => {
-                Box::new(self.run_internal::<Fp32BitPrime>(ctx, input).await.unwrap())
+                Box::new(self.run_internal::<Fp32BitPrime>(ctx, input).await?)
             }
-        }
+        })
     }
 
     async fn run_internal<F: Field>(

--- a/src/test_fixture/app.rs
+++ b/src/test_fixture/app.rs
@@ -47,7 +47,7 @@ where
 /// [`TestWorld`]: crate::test_fixture::TestWorld
 pub struct TestApp {
     drivers: [HelperApp; 3],
-    _network: InMemoryNetwork,
+    network: InMemoryNetwork,
 }
 
 fn unzip_tuple_array<T, U>(input: [(T, U); 3]) -> ([T; 3], [U; 3]) {
@@ -71,10 +71,7 @@ impl Default for TestApp {
             .map_err(|_| "infallible")
             .unwrap();
 
-        Self {
-            drivers,
-            _network: network,
-        }
+        Self { drivers, network }
     }
 }
 
@@ -110,6 +107,8 @@ impl TestApp {
             })
         }))
         .await?;
+
+        self.network.reset();
 
         Ok(<[_; 3]>::try_from(r).unwrap())
     }


### PR DESCRIPTION
 Make helpers capable of running more than one query

This change allows both in memory and HTTP implementations to run more than one query in sequence.
There were two things preventing it: `QueryProcessor` not properly cleaning up its state and transports keeping the stream
collections after query completion. The former was easy to fix, but I am not super happy with the fix for the latter.

There were a couple of options how to fix the transports:

* Generate a unique query id for each run (#615). We need this anyway, so this could be an incomplete fix.
  Incomplete because one may consider keeping streams for completed query around forever as memleak.
* Teach `Transport` trait to be aware of query completion. That looked as too big of a fix and a violation of the design we have right now
* Implement `reset` for both transports that cleans up their internal state.
  That's the approach taken in this change. HTTP transport is aware of query completion callback,
  so changing it was easy, in memory transport does not directly interact with it, so the fix is implemented at `TestApp` level