### PR TITLE
Breakdown key index is 0-based

### DIFF
--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -149,7 +149,7 @@ impl<R: Rng> EventGenerator<R> {
     }
 
     fn gen_source(&mut self, user_id: UserId) -> TestRawDataRecord {
-        let breakdown_key = self.rng.gen_range(1..self.config.max_breakdown_key.get());
+        let breakdown_key = self.rng.gen_range(0..self.config.max_breakdown_key.get());
 
         TestRawDataRecord {
             user_id: user_id.into(),


### PR DESCRIPTION
# Repro steps
1. On main, run:
`cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches" -- -b 1`

## actual result
`thread 'tokio-runtime-worker' panicked at 'cannot sample empty range', /Users/taiki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/rng.rs:134:9`

# Note
bug from this [line](https://github.com/private-attribution/ipa/pull/647/files#diff-a2e596e6cd259bc063f0615516e2e11a06a41eacfbe1dcedf880d73b2a6cd21aR152).