### PR TITLE
Some integration tests improvements

### DIFF
--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -12,7 +12,10 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     str,
 };
-use tempfile::tempdir;
+use tempdir::TempDir;
+
+#[cfg(all(test, feature = "cli"))]
+pub mod tempdir;
 
 const HELPER_BIN: &str = env!("CARGO_BIN_EXE_helper");
 const TEST_MPC_BIN: &str = env!("CARGO_BIN_EXE_test_mpc");
@@ -147,13 +150,19 @@ fn spawn_helpers(
             command.preserved_fds(vec![socket.as_raw_fd()]);
             command.args(["--server-socket-fd", &socket.as_raw_fd().to_string()]);
 
-            command.spawn().unwrap().terminate_on_drop()
+            // something went wrong if command is terminated at this point.
+            let mut child = command.spawn().unwrap();
+            if let Ok(Some(status)) = child.try_wait() {
+                panic!("Helper binary terminated early with status = {status}");
+            }
+
+            child.terminate_on_drop()
         })
         .collect::<Vec<_>>()
 }
 
 fn test_network(https: bool) {
-    let dir = tempdir().unwrap();
+    let dir = TempDir::new(false); // set to true if tempdir needs to be preserved
     let path = dir.path();
 
     println!("generating configuration in {}", path.display());
@@ -171,9 +180,6 @@ fn test_network(https: bool) {
 
     let test_mpc = command.spawn().unwrap().terminate_on_drop();
 
-    // Uncomment this to preserve the temporary directory after the test runs.
-    // std::mem::forget(dir);
-
     test_mpc
         .stdin
         .as_ref()
@@ -184,7 +190,7 @@ fn test_network(https: bool) {
 }
 
 fn test_ipa(mode: IpaSecurityModel, https: bool) {
-    let dir = tempdir().unwrap();
+    let dir = TempDir::new(false); // set to true if tempdir needs to be preserved
     let path = dir.path();
 
     println!("generating configuration in {}", path.display());
@@ -223,9 +229,6 @@ fn test_ipa(mode: IpaSecurityModel, https: bool) {
         .arg(protocol)
         .args(["--max-breakdown-key", "20"])
         .stdin(Stdio::piped());
-
-    // Uncomment this to preserve the temporary directory after the test runs.
-    // std::mem::forget(dir);
 
     let test_mpc = command.spawn().unwrap().terminate_on_drop();
     test_mpc.wait().unwrap_status();

--- a/tests/tempdir.rs
+++ b/tests/tempdir.rs
@@ -1,0 +1,42 @@
+use std::{mem, path::Path, thread};
+use tempfile::tempdir;
+
+/// Wrapper around [`TempDir`] that prevents the temp directory from being deleted
+/// if a panic occurs or if it was told not to.
+///
+/// [`TempDir`]: tempfile::TempDir
+pub struct TempDir {
+    inner: Option<tempfile::TempDir>,
+    delete: bool,
+}
+
+impl TempDir {
+    /// Creates a new temporary directory. If `delete` is set to `false`, then it won't be cleaned up
+    /// after drop.
+    ///
+    /// ## Panics
+    /// Panics if a new temp dir cannot be created.
+    #[must_use]
+    pub fn new(delete: bool) -> Self {
+        Self {
+            inner: Some(tempdir().expect("Can create temp directory")),
+            delete,
+        }
+    }
+
+    /// Returns the path to the temp dir.
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn path(&self) -> &Path {
+        self.inner.as_ref().unwrap().path()
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        if !self.delete || thread::panicking() {
+            let td = self.inner.take().unwrap();
+            mem::forget(td);
+        }
+    }
+}


### PR DESCRIPTION
Things that I noticed:

* When helper CLI fails to interpret its arguments, it just hangs because tests never check its status. That causes integration tests to hang. Fixed by checking whether the helper CLI exited before allowing to proceed
* temp dir contains useful artifacts to reproduce failures. Unfortunately it drops the directory by default, even if tests failed with a panic. This PR changes that by always preserving the temp directory if panic occurs.