### PR TITLE
Reduce the size of Docker build context

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,2 +1,3 @@
 target/
 test_data/
+.git/

--- a/scripts/helper-image.sh
+++ b/scripts/helper-image.sh
@@ -38,4 +38,12 @@ rev=$(git log -n 1 --format='format:%H' | cut -c1-10)
 tag="private-attribution/ipa:$rev-h$identity"
 
 cd "$(dirname "$0")"/.. || exit 1
-docker build -t "$tag" -f docker/helper.Dockerfile --build-arg IDENTITY="$identity" --build-arg HOSTNAME="$hostname" .
+
+# Docker can only pick up .dockerignore from the root folder (see https://github.com/moby/moby/issues/12886).
+# Use tar to create the build context manually before sending it to Docker CLI
+tar -cvzf - --exclude-from="docker/.dockerignore" ./* \
+  | docker build \
+    -t "$tag" \
+    -f docker/helper.Dockerfile \
+    --build-arg IDENTITY="$identity" \
+    --build-arg HOSTNAME="$hostname" -


### PR DESCRIPTION
Before this change, we had Docker transferring gigabytes (if both release and debug builds exist) of data inside the image and make no use of it. It was happening because docker [expects](https://docs.docker.com/engine/reference/builder/#dockerignore-file) `.dockerignore` file to be inside the root folder of the context.

In IPA folder structure, `.dockerignore` was put right next to the `.Dockerfile` so it wasn't picked up when building the image.

There does not seem to be an option to provide path to `.dockerignore` to Docker CLI, so I build the context manually