### PR TITLE
Trigger CI actions on integration tests changes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,12 +6,14 @@ on:
       - '**/Cargo.lock'
       - 'src/**/*'
       - 'benches/**/*'
+      - 'tests/**/*'
   pull_request:
       paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'src/**/*'
       - 'benches/**/*'
+      - 'tests/**/*'
 
 jobs:
   basic:


### PR DESCRIPTION
If a PR includes only integration test changes, it does not trigger the workflow, see https://github.com/private-attribution/ipa/pull/666