### PR TITLE
Command to generate `network.toml`

### DIFF
--- a/docker/helper.Dockerfile
+++ b/docker/helper.Dockerfile
@@ -21,11 +21,12 @@ RUN apt-get update && rm -rf /var/lib/apt/lists/*
 COPY --from=builder ${SOURCES_DIR}/target/release/helper $HELPER_BIN_PATH
 
 # generate certificate/private key for TLS
+# make sure these names are consistent with the ones defined in CliPaths trait: src\cli\paths.rs
 RUN set -eux; \
     mkdir -p $CONF_DIR/pub; \
     $HELPER_BIN_PATH keygen \
     --name $HOSTNAME \
-    --tls-cert $CONF_DIR/pub/$IDENTITY.pem \
-    --tls-key $CONF_DIR/$IDENTITY.key \
-    --mk-public-key $CONF_DIR/pub/$IDENTITY-mk.pub \
-    --mk-private-key $CONF_DIR/$IDENTITY-mk.key
+    --tls-cert $CONF_DIR/pub/h$IDENTITY.pem \
+    --tls-key $CONF_DIR/h$IDENTITY.key \
+    --mk-public-key $CONF_DIR/pub/h$IDENTITY-mk.pub \
+    --mk-private-key $CONF_DIR/h$IDENTITY-mk.key

--- a/docker/helper.Dockerfile
+++ b/docker/helper.Dockerfile
@@ -28,5 +28,5 @@ RUN set -eux; \
     --name $HOSTNAME \
     --tls-cert $CONF_DIR/pub/h$IDENTITY.pem \
     --tls-key $CONF_DIR/h$IDENTITY.key \
-    --mk-public-key $CONF_DIR/pub/h$IDENTITY-mk.pub \
-    --mk-private-key $CONF_DIR/h$IDENTITY-mk.key
+    --mk-public-key $CONF_DIR/pub/h${IDENTITY}_mk.pub \
+    --mk-private-key $CONF_DIR/h${IDENTITY}_mk.key

--- a/in-market-test/helper-nodes/setup_instructions.md
+++ b/in-market-test/helper-nodes/setup_instructions.md
@@ -59,13 +59,13 @@ Here are the instructions for setting up node for running IPA.
 
         You will know what is your Helper party number i.e. 1,2 or 3. Here we show for Helper `1`:
 
-        `docker cp <CONTAINER_ID>:/etc/ipa/pub/1.pem .  `
-        `docker cp <CONTAINER_ID>:/etc/ipa/pub/1-mk.pub .  `
+        `docker cp <CONTAINER_ID>:/etc/ipa/pub/h1.pem .  `
+        `docker cp <CONTAINER_ID>:/etc/ipa/pub/h1-mk.pub .  `
 
         To copy a TLS public key and matchkey encryption public key from Helper `2` from the host onto the docker image run from the directory with the public key `2.pem`:
 
-        `docker cp 2.pem <IMAGE_ID>:/etc/ipa/pub/`
-        `docker cp 2-mk.pub <IMAGE_ID>:/etc/ipa/pub/`
+        `docker cp h2.pem <IMAGE_ID>:/etc/ipa/pub/`
+        `docker cp h2-mk.pub <IMAGE_ID>:/etc/ipa/pub/`
 
 
 

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -17,6 +17,7 @@ use std::{
     process,
 };
 use tracing::{error, info};
+use ipa::cli::{client_config_setup, ConfGenArgs};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -139,6 +140,7 @@ struct ServerArgs {
 
 #[derive(Debug, Subcommand)]
 enum HelperCommand {
+    ClientConfGen(ConfGenArgs),
     Keygen(KeygenArgs),
     TestSetup(TestSetupArgs),
 }
@@ -242,6 +244,7 @@ pub async fn main() {
         None => server(args.server).await,
         Some(HelperCommand::Keygen(args)) => keygen(&args),
         Some(HelperCommand::TestSetup(args)) => test_setup(args),
+        Some(HelperCommand::ClientConfGen(args)) => client_config_setup(args),
     };
 
     if let Err(e) = res {

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -140,7 +140,7 @@ struct ServerArgs {
 
 #[derive(Debug, Subcommand)]
 enum HelperCommand {
-    ClientConfGen(ConfGenArgs),
+    Confgen(ConfGenArgs),
     Keygen(KeygenArgs),
     TestSetup(TestSetupArgs),
 }
@@ -244,7 +244,7 @@ pub async fn main() {
         None => server(args.server).await,
         Some(HelperCommand::Keygen(args)) => keygen(&args),
         Some(HelperCommand::TestSetup(args)) => test_setup(args),
-        Some(HelperCommand::ClientConfGen(args)) => client_config_setup(args),
+        Some(HelperCommand::Confgen(args)) => client_config_setup(args),
     };
 
     if let Err(e) = res {

--- a/src/bin/helper.rs
+++ b/src/bin/helper.rs
@@ -2,7 +2,9 @@ use clap::{self, Parser, Subcommand};
 use hyper::http::uri::Scheme;
 use hyper_tls::native_tls::Identity;
 use ipa::{
-    cli::{keygen, test_setup, KeygenArgs, TestSetupArgs, Verbosity},
+    cli::{
+        client_config_setup, keygen, test_setup, ConfGenArgs, KeygenArgs, TestSetupArgs, Verbosity,
+    },
     config::{HpkeServerConfig, NetworkConfig, ServerConfig, TlsConfig},
     helpers::HelperIdentity,
     net::{ClientIdentity, HttpTransport, MpcHelperClient},
@@ -17,7 +19,6 @@ use std::{
     process,
 };
 use tracing::{error, info};
-use ipa::cli::{client_config_setup, ConfGenArgs};
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]

--- a/src/cli/clientconf.rs
+++ b/src/cli/clientconf.rs
@@ -64,10 +64,10 @@ pub fn setup(args: ConfGenArgs) -> Result<(), Box<dyn Error>> {
 
 #[derive(Debug)]
 pub struct HelperClientConf<'a> {
-    host: &'a str,
-    port: u16,
-    tls_cert_file: PathBuf,
-    mk_public_key_file: PathBuf,
+    pub(crate) host: &'a str,
+    pub(crate) port: u16,
+    pub(crate) tls_cert_file: PathBuf,
+    pub(crate) mk_public_key_file: PathBuf,
 }
 
 /// Generates client configuration file at the requested destination. The destination must exist
@@ -81,9 +81,9 @@ pub fn gen_client_config<'a>(
     let mut peers = Vec::<Value>::with_capacity(3);
     for client_conf in clients_conf {
         let certificate = fs::read_to_string(&client_conf.tls_cert_file)
-            .map_err(|e| format!("Failed to open {}", client_conf.tls_cert_file.display()))?;
+            .map_err(|e| format!("Failed to open {}: {e}", client_conf.tls_cert_file.display()))?;
         let mk_public_key = fs::read_to_string(&client_conf.mk_public_key_file)
-            .map_err(|e| format!("Failed to open {}", client_conf.mk_public_key_file.display()))?;
+            .map_err(|e| format!("Failed to open {}: {e}", client_conf.mk_public_key_file.display()))?;
 
         // Constructing toml directly because it avoids linking
         // a PEM library to serialize the certificate.

--- a/src/cli/clientconf.rs
+++ b/src/cli/clientconf.rs
@@ -1,0 +1,167 @@
+use std::error::Error;
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use clap::Args;
+use config::Map;
+use toml::{Table, Value};
+use crate::config::{ClientConfig, HpkeClientConfig, NetworkConfig, PeerConfig};
+use crate::helpers::HelperIdentity;
+
+#[derive(Debug, Args)]
+#[clap(name = "conf-gen", about = "Generate client config for 3 MPC helper parties")]
+pub struct ConfGenArgs {
+    #[arg(long, visible_alias = "h1")]
+    pub(crate) h1_url: String,
+    #[arg(long, visible_alias = "h2")]
+    pub(crate) h2_url: String,
+    #[arg(long, visible_alias = "h3")]
+    pub(crate) h3_url: String,
+
+    /// Path to the folder where certificates and public keys are stored. It must have all 3 helper's
+    /// public keys and TLS certificates. Additionally DNS names on the certificates must match
+    /// `h1_name`,..,`h3_name` values provided for this command, otherwise configuration won't work.
+    #[arg(long)]
+    pub(crate) keys_folder: PathBuf,
+
+    /// Destination folder for the config file. If not specified, `keys_folder` will be used.
+    #[arg(long)]
+    pub(crate) out_folder: Option<PathBuf>,
+
+    /// Overwrite configuration file if it exists at destination.
+    #[arg(long)]
+    pub(crate) overwrite: bool,
+}
+
+
+pub fn setup(args: ConfGenArgs) -> Result<(), Box<dyn Error>> {
+    // let peers = [
+    //     peer_config(HelperIdentity::ONE, &args.keys_folder),
+    //     peer_config(HelperIdentity::TWO, &args.keys_folder),
+    //     peer_config(HelperIdentity::THREE, &args.keys_folder),
+    // ];
+    //
+    // let network_config = NetworkConfig::new(peers, ClientConfig::use_http2());
+    // let out_folder = args.out_folder.unwrap_or(args.keys_folder);
+    // let mut conf_file = File::options().write(true)
+    //     .create_new(!args.overwrite)
+    //     .truncate(args.overwrite)
+    //     .open(out_folder.join("network.toml"))?;
+    // conf_file.write(toml::to_string_pretty(&network_config)?.as_bytes())?;
+    // Ok(())
+    todo!()
+}
+
+pub struct HelperClientConf<'a> {
+    host: &'a str,
+    port: u16,
+    tls_cert_file: &'a Path,
+    mk_public_key_file: &'a Path
+}
+
+/// Generates client configuration file at the destination requested.
+pub fn gen_client_config<'a>(
+    clients_conf: [HelperClientConf<'a>; 3],
+    use_http1: bool,
+    conf_file_name: &Path
+) -> Result<(), Box<dyn Error>> {
+
+    conf_file_name.is_file().then_some(()).ok_or_else(|| format!("{} is not a file", conf_file_name.display()))?;
+
+    let mut peers = Vec::<Value>::with_capacity(3);
+    for client_conf in clients_conf {
+        let certificate = fs::read_to_string(&client_conf.tls_cert_file)?;
+        let mk_public_key = fs::read_to_string(&client_conf.mk_public_key_file)?;
+
+        // Constructing toml directly because it avoids linking
+        // a PEM library to serialize the certificate.
+        let mut peer = Map::new();
+        peer.insert(
+            String::from("url"),
+            Value::String(format!("{host}:{port}", host = client_conf.host, port = client_conf.port)),
+        );
+        peer.insert(String::from("certificate"), Value::String(certificate));
+        peer.insert(
+            String::from("hpke"),
+            Value::Table(encode_hpke(mk_public_key)),
+        );
+        peers.push(peer.into())
+    }
+
+    let client_config = if use_http1 {
+        ClientConfig::use_http1()
+    } else {
+        ClientConfig::default()
+    };
+    let mut network_config = Map::new();
+    network_config.insert(String::from("peers"), peers.into());
+    network_config.insert(
+        String::from("client"),
+        Table::try_from(client_config)?.into(),
+    );
+    let config_str = toml::to_string_pretty(&network_config)?;
+
+    // make sure network config is valid
+    if cfg!(debug_assertions) {
+        assert_network_config(&network_config, &config_str);
+    }
+
+    fs::write(conf_file_name, config_str)?;
+
+    Ok(())
+}
+
+/// Creates a section in TOML that describes the HPKE configuration for match key encryption.
+fn encode_hpke(public_key: String) -> Table {
+    let mut hpke_table = Table::new();
+    // TODO: key registry requires a set of public keys with their "identifier". Right now
+    // we encode only one key
+    hpke_table.insert(String::from("public_key"), Value::String(public_key));
+
+    hpke_table
+}
+
+/// Validates that the resulting [`NetworkConfig`] can be read by helper binary correctly, i.e.
+/// all the values get serialized.
+///
+/// [`NetworkConfig`]: NetworkConfig
+fn assert_network_config(config_toml: &Map<String, Value>, config_str: &str) {
+    let nw_config =
+        NetworkConfig::from_toml_str(config_str).expect("Can deserialize network config");
+
+    let Value::Array(peer_config_expected) = config_toml.get("peers").expect("peer section must be present") else {
+        panic!("peers section in toml config is not a table");
+    };
+    for (i, peer_config_actual) in nw_config.peers.iter().enumerate() {
+        assert_peer_config(&peer_config_expected[i], peer_config_actual);
+    }
+}
+
+/// Validates that the resulting [`PeerConfig`] can be read by helper binary correctly.
+///
+/// [`PeerConfig`]: PeerConfig
+fn assert_peer_config(expected: &Value, actual: &PeerConfig) {
+    assert_eq!(
+        expected.get("url").unwrap().as_str(),
+        Some(actual.url.to_string()).as_deref()
+    );
+
+    assert_hpke_config(
+        expected.get("hpke").expect("hpke section must be present"),
+        actual.hpke_config.as_ref(),
+    );
+}
+
+/// Validates that the resulting [`HpkeClientConfig`] can be read by helper binary correctly.
+///
+/// [`HpkeClientConfig`]: HpkeClientConfig
+fn assert_hpke_config(expected: &Value, actual: Option<&HpkeClientConfig>) {
+    assert_eq!(
+        expected
+            .get("public_key")
+            .and_then(toml::Value::as_str)
+            .map(ToOwned::to_owned),
+        actual.map(|v| v.public_key.clone())
+    );
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,3 +18,4 @@ pub use metric_collector::{install_collector, CollectorHandle};
 pub use test_setup::{test_setup, TestSetupArgs};
 pub use verbosity::Verbosity;
 pub use clientconf::{setup as client_config_setup, ConfGenArgs};
+pub use paths::PathExt as CliPaths;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "web-app")]
 mod clientconf;
 mod csv;
 #[cfg(feature = "web-app")]
@@ -10,6 +11,7 @@ pub mod playbook;
 mod test_setup;
 mod verbosity;
 
+#[cfg(feature = "web-app")]
 pub use clientconf::{setup as client_config_setup, ConfGenArgs};
 pub use csv::Serializer as CsvSerializer;
 #[cfg(feature = "web-app")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod playbook;
 #[cfg(feature = "web-app")]
 mod test_setup;
 mod verbosity;
+mod clientconf;
 
 pub use csv::Serializer as CsvSerializer;
 #[cfg(feature = "web-app")]
@@ -15,3 +16,4 @@ pub use metric_collector::{install_collector, CollectorHandle};
 #[cfg(feature = "web-app")]
 pub use test_setup::{test_setup, TestSetupArgs};
 pub use verbosity::Verbosity;
+pub use clientconf::{setup as client_config_setup, ConfGenArgs};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod playbook;
 mod test_setup;
 mod verbosity;
 mod clientconf;
+mod paths;
 
 pub use csv::Serializer as CsvSerializer;
 #[cfg(feature = "web-app")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,21 +1,21 @@
+mod clientconf;
 mod csv;
 #[cfg(feature = "web-app")]
 mod keygen;
 mod metric_collector;
+mod paths;
 #[cfg(all(feature = "test-fixture", feature = "web-app", feature = "cli"))]
 pub mod playbook;
 #[cfg(feature = "web-app")]
 mod test_setup;
 mod verbosity;
-mod clientconf;
-mod paths;
 
+pub use clientconf::{setup as client_config_setup, ConfGenArgs};
 pub use csv::Serializer as CsvSerializer;
 #[cfg(feature = "web-app")]
 pub use keygen::{keygen, KeygenArgs};
 pub use metric_collector::{install_collector, CollectorHandle};
+pub use paths::PathExt as CliPaths;
 #[cfg(feature = "web-app")]
 pub use test_setup::{test_setup, TestSetupArgs};
 pub use verbosity::Verbosity;
-pub use clientconf::{setup as client_config_setup, ConfGenArgs};
-pub use paths::PathExt as CliPaths;

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -1,13 +1,11 @@
 use std::path::Path;
-use crate::helpers::HelperIdentity;
 
-pub trait PathExt : ToOwned {
+pub trait PathExt: ToOwned {
     fn helper_tls_cert<I: Into<u8>>(&self, id: I) -> Self::Owned;
     fn helper_tls_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
     fn helper_mk_public_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
     fn helper_mk_private_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
 }
-
 
 impl PathExt for Path {
     fn helper_tls_cert<I: Into<u8>>(&self, id: I) -> Self::Owned {

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+/// Naming conventions for files that store public/private HPKE and TLS keys.
 pub trait PathExt: ToOwned {
     fn helper_tls_cert<I: Into<u8>>(&self, id: I) -> Self::Owned;
     fn helper_tls_key<I: Into<u8>>(&self, id: I) -> Self::Owned;

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+use crate::helpers::HelperIdentity;
+
+pub trait PathExt : ToOwned {
+    fn helper_tls_cert<I: Into<u8>>(&self, id: I) -> Self::Owned;
+    fn helper_tls_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
+    fn helper_mk_public_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
+    fn helper_mk_private_key<I: Into<u8>>(&self, id: I) -> Self::Owned;
+}
+
+
+impl PathExt for Path {
+    fn helper_tls_cert<I: Into<u8>>(&self, id: I) -> Self::Owned {
+        let id = id.into();
+        self.join(format!("h{id}.pem"))
+    }
+
+    fn helper_tls_key<I: Into<u8>>(&self, id: I) -> Self::Owned {
+        let id = id.into();
+        self.join(format!("h{id}.key"))
+    }
+
+    fn helper_mk_public_key<I: Into<u8>>(&self, id: I) -> Self::Owned {
+        let id = id.into();
+        self.join(format!("h{id}_mk.pub"))
+    }
+
+    fn helper_mk_private_key<I: Into<u8>>(&self, id: I) -> Self::Owned {
+        let id = id.into();
+        self.join(format!("h{id}_mk.key"))
+    }
+}

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -56,7 +56,7 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
                 tls_cert: args.output_dir.join(format!("h{id}.pem")),
                 tls_key: args.output_dir.join(format!("h{id}.key")),
                 mk_public_key: args.output_dir.join(format!("h{id}_mk.pub")),
-                mk_private_key: args.output_dir.join(format!("h{id}_mk")),
+                mk_private_key: args.output_dir.join(format!("h{id}_mk.key")),
             };
 
             keygen(&keygen_args)?;

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -67,8 +67,8 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
             Ok(HelperClientConf {
                 host: &localhost,
                 port,
-                tls_cert_file: keygen_args.tls_cert.clone(),
-                mk_public_key_file: keygen_args.mk_public_key.clone(),
+                tls_cert_file: keygen_args.tls_cert,
+                mk_public_key_file: keygen_args.mk_public_key,
             })
         })
         .collect::<Result<Vec<_>, Box<dyn Error>>>()?
@@ -76,9 +76,5 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let mut conf_file = File::create(args.output_dir.join("network.toml"))?;
-    Ok(gen_client_config(
-        clients_config,
-        args.use_http1,
-        &mut conf_file,
-    )?)
+    gen_client_config(clients_config, args.use_http1, &mut conf_file)
 }

--- a/src/cli/test_setup.rs
+++ b/src/cli/test_setup.rs
@@ -9,7 +9,10 @@ use std::{
     iter::zip,
     path::PathBuf,
 };
+use std::fs::File;
 use toml::{map::Map, Table, Value};
+use crate::cli::clientconf::{gen_client_config, HelperClientConf};
+use crate::cli::paths::PathExt;
 
 #[derive(Debug, Args)]
 #[clap(
@@ -49,112 +52,27 @@ pub fn test_setup(args: TestSetupArgs) -> Result<(), Box<dyn Error>> {
         DirBuilder::new().create(&args.output_dir)?;
     }
 
-    let peers = zip([1, 2, 3], args.ports)
-        .map(|(id, port)| {
-            let keygen_args = KeygenArgs {
-                name: String::from("localhost"),
-                tls_cert: args.output_dir.join(format!("h{id}.pem")),
-                tls_key: args.output_dir.join(format!("h{id}.key")),
-                mk_public_key: args.output_dir.join(format!("h{id}_mk.pub")),
-                mk_private_key: args.output_dir.join(format!("h{id}_mk.key")),
-            };
+    let localhost = String::from("localhost");
 
-            keygen(&keygen_args)?;
+    let clients_config: [_; 3] = zip([1, 2, 3], args.ports).map(|(id, port)| {
+        let keygen_args = KeygenArgs {
+            name: localhost.clone(),
+            tls_cert: args.output_dir.helper_tls_cert(id),
+            tls_key: args.output_dir.helper_tls_key(id),
+            mk_public_key: args.output_dir.helper_mk_public_key(id),
+            mk_private_key: args.output_dir.helper_mk_private_key(id),
+        };
 
-            let certificate = fs::read_to_string(&keygen_args.tls_cert)?;
-            let mk_public_key = fs::read_to_string(&keygen_args.mk_public_key)?;
+        keygen(&keygen_args)?;
 
-            // Constructing toml directly because it avoids linking
-            // a PEM library to serialize the certificate.
-            let mut peer = Map::new();
-            peer.insert(
-                String::from("url"),
-                Value::String(format!("localhost:{port}")),
-            );
-            peer.insert(String::from("certificate"), Value::String(certificate));
-            peer.insert(
-                String::from("hpke"),
-                Value::Table(encode_hpke(mk_public_key)),
-            );
-
-            Ok::<_, Box<dyn Error>>(peer.into())
+        Ok(HelperClientConf {
+            host: &localhost,
+            port,
+            tls_cert_file: keygen_args.tls_cert.clone(),
+            mk_public_key_file: keygen_args.mk_public_key.clone()
         })
-        .collect::<Result<Vec<Value>, _>>()?
-        .into();
+    }).collect::<Result<Vec<_>, Box<dyn Error>>>()?.try_into().unwrap();
 
-    let client_config = if args.use_http1 {
-        ClientConfig::use_http1()
-    } else {
-        ClientConfig::default()
-    };
-    let mut network_config = Map::new();
-    network_config.insert(String::from("peers"), peers);
-    network_config.insert(
-        String::from("client"),
-        Table::try_from(client_config)?.into(),
-    );
-    let config_str = toml::to_string_pretty(&network_config)?;
-
-    // make sure network config is valid
-    if cfg!(debug_assertions) {
-        assert_network_config(&network_config, &config_str);
-    }
-
-    fs::write(args.output_dir.join("network.toml"), config_str)?;
-
-    Ok(())
-}
-
-/// Creates a section in TOML that describes the HPKE configuration for match key encryption.
-fn encode_hpke(public_key: String) -> Table {
-    let mut hpke_table = Table::new();
-    // TODO: key registry requires a set of public keys with their "identifier". Right now
-    // we encode only one key
-    hpke_table.insert(String::from("public_key"), Value::String(public_key));
-
-    hpke_table
-}
-
-/// Validates that the resulting [`NetworkConfig`] can be read by helper binary correctly, i.e.
-/// all the values get serialized.
-///
-/// [`NetworkConfig`]: NetworkConfig
-fn assert_network_config(config_toml: &Map<String, Value>, config_str: &str) {
-    let nw_config =
-        NetworkConfig::from_toml_str(config_str).expect("Can deserialize network config");
-
-    let Value::Array(peer_config_expected) = config_toml.get("peers").expect("peer section must be present") else {
-        panic!("peers section in toml config is not a table");
-    };
-    for (i, peer_config_actual) in nw_config.peers.iter().enumerate() {
-        assert_peer_config(&peer_config_expected[i], peer_config_actual);
-    }
-}
-
-/// Validates that the resulting [`PeerConfig`] can be read by helper binary correctly.
-///
-/// [`PeerConfig`]: PeerConfig
-fn assert_peer_config(expected: &Value, actual: &PeerConfig) {
-    assert_eq!(
-        expected.get("url").unwrap().as_str(),
-        Some(actual.url.to_string()).as_deref()
-    );
-
-    assert_hpke_config(
-        expected.get("hpke").expect("hpke section must be present"),
-        actual.hpke_config.as_ref(),
-    );
-}
-
-/// Validates that the resulting [`HpkeClientConfig`] can be read by helper binary correctly.
-///
-/// [`HpkeClientConfig`]: HpkeClientConfig
-fn assert_hpke_config(expected: &Value, actual: Option<&HpkeClientConfig>) {
-    assert_eq!(
-        expected
-            .get("public_key")
-            .and_then(toml::Value::as_str)
-            .map(ToOwned::to_owned),
-        actual.map(|v| v.public_key.clone())
-    );
+    let mut conf_file = File::create(args.output_dir.join("network.toml"))?;
+    Ok(gen_client_config(clients_config, args.use_http1, &mut conf_file)?)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,10 +58,7 @@ impl NetworkConfig {
     }
 
     pub fn new(peers: [PeerConfig; 3], client: ClientConfig) -> Self {
-        Self {
-            peers,
-            client,
-        }
+        Self { peers, client }
     }
 
     pub fn peers(&self) -> &[PeerConfig; 3] {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,13 @@ impl NetworkConfig {
         Ok(conf)
     }
 
+    pub fn new(peers: [PeerConfig; 3], client: ClientConfig) -> Self {
+        Self {
+            peers,
+            client,
+        }
+    }
+
     pub fn peers(&self) -> &[PeerConfig; 3] {
         &self.peers
     }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -92,6 +92,12 @@ impl TryFrom<usize> for HelperIdentity {
     }
 }
 
+impl From<HelperIdentity> for u8 {
+    fn from(value: HelperIdentity) -> Self {
+        value.id
+    }
+}
+
 impl Debug for HelperIdentity {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -255,3 +255,10 @@ fn http_semi_honest_ipa() {
 fn https_semi_honest_ipa() {
     test_ipa(IpaSecurityModel::SemiHonest, true);
 }
+
+#[test]
+fn keygen_confgen() {
+    /// Similar to test_network, but it uses keygen + confgen to generate helper client config
+    /// and then just runs test multiply to make sure helpers are up and running
+    ///
+}

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -1,5 +1,5 @@
 use command_fds::CommandFdExt;
-use ipa::test_fixture::ipa::IpaSecurityModel;
+use ipa::{cli::CliPaths, helpers::HelperIdentity, test_fixture::ipa::IpaSecurityModel};
 use std::{
     array,
     error::Error,
@@ -12,8 +12,6 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     str,
 };
-use ipa::cli::CliPaths;
-use ipa::helpers::HelperIdentity;
 use tempdir::TempDir;
 
 #[cfg(all(test, feature = "cli"))]
@@ -307,10 +305,22 @@ fn exec_keygen_cmd(helper_identity: HelperIdentity, dest_dir: &Path) {
         .silent()
         .arg("keygen")
         .args(["--name", "localhost"])
-        .args(["--tls-cert".as_ref(), dest_dir.helper_tls_cert(helper_identity).as_os_str()])
-        .args(["--tls-key".as_ref(), dest_dir.helper_tls_key(helper_identity).as_os_str()])
-        .args(["--mk-private-key".as_ref(), dest_dir.helper_mk_private_key(helper_identity).as_os_str()])
-        .args(["--mk-public-key".as_ref(), dest_dir.helper_mk_public_key(helper_identity).as_os_str()]);
+        .args([
+            "--tls-cert".as_ref(),
+            dest_dir.helper_tls_cert(helper_identity).as_os_str(),
+        ])
+        .args([
+            "--tls-key".as_ref(),
+            dest_dir.helper_tls_key(helper_identity).as_os_str(),
+        ])
+        .args([
+            "--mk-private-key".as_ref(),
+            dest_dir.helper_mk_private_key(helper_identity).as_os_str(),
+        ])
+        .args([
+            "--mk-public-key".as_ref(),
+            dest_dir.helper_mk_public_key(helper_identity).as_os_str(),
+        ]);
 
     command.status().unwrap_status();
 }

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -12,6 +12,8 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     str,
 };
+use ipa::cli::CliPaths;
+use ipa::helpers::HelperIdentity;
 use tempdir::TempDir;
 
 #[cfg(all(test, feature = "cli"))]
@@ -161,18 +163,10 @@ fn spawn_helpers(
         .collect::<Vec<_>>()
 }
 
-fn test_network(https: bool) {
-    // set to true to always keep the temp dir after test finishes
-    let dir = TempDir::new(false);
-    let path = dir.path();
-
-    println!("generating configuration in {}", path.display());
-    let sockets = test_setup(path);
-    let _helpers = spawn_helpers(path, &sockets, https);
-
+fn test_multiply(config_dir: &Path, https: bool) {
     let mut command = Command::new(TEST_MPC_BIN);
     command
-        .args(["--network".into(), dir.path().join("network.toml")])
+        .args(["--network".into(), config_dir.join("network.toml")])
         .args(["--wait", "2"]);
     if !https {
         command.arg("--disable-https");
@@ -188,6 +182,18 @@ fn test_network(https: bool) {
         .write_all(b"3,6\n")
         .unwrap();
     test_mpc.wait().unwrap_status();
+}
+
+fn test_network(https: bool) {
+    // set to true to always keep the temp dir after test finishes
+    let dir = TempDir::new(false);
+    let path = dir.path();
+
+    println!("generating configuration in {}", path.display());
+    let sockets = test_setup(path);
+    let _helpers = spawn_helpers(path, &sockets, https);
+
+    test_multiply(&path, https);
 }
 
 fn test_ipa(mode: IpaSecurityModel, https: bool) {
@@ -256,9 +262,55 @@ fn https_semi_honest_ipa() {
     test_ipa(IpaSecurityModel::SemiHonest, true);
 }
 
+/// Similar to [`network`] tests, but it uses keygen + confgen CLIs to generate helper client config
+/// and then just runs test multiply to make sure helpers are up and running
+///
+/// [`network`]: crate::test_network
 #[test]
 fn keygen_confgen() {
-    /// Similar to test_network, but it uses keygen + confgen to generate helper client config
-    /// and then just runs test multiply to make sure helpers are up and running
-    ///
+    let dir = TempDir::new(false);
+    let path = dir.path();
+
+    let sockets: [_; 3] = array::from_fn(|_| TcpListener::bind("127.0.0.1:0").unwrap());
+    let ports: [u16; 3] = sockets
+        .iter()
+        .map(|sock| sock.local_addr().unwrap().port())
+        .collect::<Vec<_>>()
+        .try_into()
+        .unwrap();
+
+    /// generate keys for all 3 helpers
+    for id in HelperIdentity::make_three() {
+        exec_keygen_cmd(id, &path)
+    }
+
+    /// generate config file (network.toml)
+    let mut command = Command::new(HELPER_BIN);
+    command
+        .silent()
+        .arg("confgen")
+        .args(["--output-dir".as_ref(), path.as_os_str()])
+        .args(["--keys-dir".as_ref(), path.as_os_str()])
+        .arg("--ports")
+        .args(ports.map(|p| p.to_string()))
+        .arg("--hosts")
+        .args(["localhost", "localhost", "localhost"]);
+    command.status().unwrap_status();
+
+    let _helpers = spawn_helpers(path, &sockets, true);
+    test_multiply(&path, true);
+}
+
+fn exec_keygen_cmd(helper_identity: HelperIdentity, dest_dir: &Path) {
+    let mut command = Command::new(HELPER_BIN);
+    command
+        .silent()
+        .arg("keygen")
+        .args(["--name", "localhost"])
+        .args(["--tls-cert".as_ref(), dest_dir.helper_tls_cert(helper_identity).as_os_str()])
+        .args(["--tls-key".as_ref(), dest_dir.helper_tls_key(helper_identity).as_os_str()])
+        .args(["--mk-private-key".as_ref(), dest_dir.helper_mk_private_key(helper_identity).as_os_str()])
+        .args(["--mk-public-key".as_ref(), dest_dir.helper_mk_public_key(helper_identity).as_os_str()]);
+
+    command.status().unwrap_status();
 }


### PR DESCRIPTION
In order to streamline our helper image bootstrap, we need a command to generate a valid `network.toml` from a set of public keys and public uris. The flow would be as follows:

* script generates 3 docker images, each with its own configuration (DNS name)
* script copies public configuration from each helper to each other helper
* script runs `docker run` to execute this command to generate `network.toml` on each image

after this, images will be fully ready to be copied to the nodes that will run helpers


## Example
```bash
  cargo run --bin helper --no-default-features --features="cli web-app real-world-infra" -- confgen --keys-dir test_data --output-dir /tmp/ipaconfgen
```