### PR TITLE
Install docker on EC2 instances

### DIFF
--- a/scripts/ec2-instance-config.yaml
+++ b/scripts/ec2-instance-config.yaml
@@ -8,6 +8,7 @@ packages:
   - openssl-perl
   - perf
   - tmux
+  - docker
 
 runcmd:
   - yum -y groupinstall "Development Tools"


### PR DESCRIPTION
```bash
yum info docker
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
Installed Packages
Name        : docker
Arch        : x86_64
Version     : 20.10.23
Release     : 1.amzn2.0.1
Size        : 163 M
Repo        : installed
From repo   : amzn2extra-docker
Summary     : Automates deployment of containerized applications
URL         : http://www.docker.com
License     : ASL 2.0 and MIT and BSD and MPLv2.0 and WTFPL
Description : Docker is an open-source engine that automates the deployment of any
            : application as a lightweight, portable, self-sufficient container that will
            : run virtually anywhere.
            :
            : Docker containers can encapsulate any payload, and will run consistently on
            : and between virtually any server. The same container that a developer builds
            : and tests on a laptop will run at scale, in production*, on VMs, bare-metal
            : servers, OpenStack clusters, public instances, or combinations of the above.

```