### PR TITLE
Generate dynamic steps

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -102,8 +102,7 @@ async fn run(args: Args) -> Result<(), Error> {
     };
 
     let seed = args.random_seed.unwrap_or_else(|| thread_rng().gen());
-    #[cfg(not(feature = "step-trace"))]
-    println!(
+    tracing::trace!(
         "Using random seed: {seed} for {q} records",
         q = args.query_size
     );
@@ -124,8 +123,7 @@ async fn run(args: Args) -> Result<(), Error> {
         ipa_in_the_clear(&raw_data, args.per_user_cap, args.attribution_window());
 
     let world = TestWorld::new_with(config.clone());
-    #[cfg(not(feature = "step-trace"))]
-    println!("Preparation complete in {:?}", _prep_time.elapsed());
+    tracing::trace!("Preparation complete in {:?}", _prep_time.elapsed());
 
     let _protocol_time = Instant::now();
     test_ipa::<BenchField>(
@@ -136,8 +134,7 @@ async fn run(args: Args) -> Result<(), Error> {
         args.mode,
     )
     .await;
-    #[cfg(not(feature = "step-trace"))]
-    println!(
+    tracing::trace!(
         "{m:?} IPA for {q} records took {t:?}",
         m = args.mode,
         q = args.query_size,

--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -95,13 +95,14 @@ impl Args {
 async fn run(args: Args) -> Result<(), Error> {
     type BenchField = Fp32BitPrime;
 
-    let prep_time = Instant::now();
+    let _prep_time = Instant::now();
     let config = TestWorldConfig {
         gateway_config: GatewayConfig::new(args.active()),
         ..TestWorldConfig::default()
     };
 
     let seed = args.random_seed.unwrap_or_else(|| thread_rng().gen());
+    #[cfg(not(feature = "step-trace"))]
     println!(
         "Using random seed: {seed} for {q} records",
         q = args.query_size
@@ -123,9 +124,10 @@ async fn run(args: Args) -> Result<(), Error> {
         ipa_in_the_clear(&raw_data, args.per_user_cap, args.attribution_window());
 
     let world = TestWorld::new_with(config.clone());
-    println!("Preparation complete in {:?}", prep_time.elapsed());
+    #[cfg(not(feature = "step-trace"))]
+    println!("Preparation complete in {:?}", _prep_time.elapsed());
 
-    let protocol_time = Instant::now();
+    let _protocol_time = Instant::now();
     test_ipa::<BenchField>(
         &world,
         &raw_data,
@@ -134,11 +136,12 @@ async fn run(args: Args) -> Result<(), Error> {
         args.mode,
     )
     .await;
+    #[cfg(not(feature = "step-trace"))]
     println!(
         "{m:?} IPA for {q} records took {t:?}",
         m = args.mode,
         q = args.query_size,
-        t = protocol_time.elapsed()
+        t = _protocol_time.elapsed()
     );
     Ok(())
 }

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -20,8 +20,14 @@ ARGS = [
     "3",
 ]
 QUERY_SIZE = 10
+# per_user_cap = 1 runs an optimized protocol, so 1 and anything larger than 1
 PER_USER_CAP = [1, 3]
+# attribution_window_seconds = 0 runs an optimized protocol, so 0 and anything larger
 ATTRIBUTION_WINDOW = [0, 86400]
+# breakdown_key_bits = [1, 32] runs an optimized protocol, and the steps generated
+# depend on the number of bits in the breakdown key. So we run the protocol with "8",
+# which is enough to generate all possible steps and sub-steps for the optimized case,
+# and "33" to cover the general case. See the comment below for more details.
 BREAKDOWN_KEYS = [8, 33]
 SECURITY_MODEL = ["malicious", "semi-honest"]
 ROOT_STEP_PREFIX = "protocol/alloc::string::String::run-0"

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -26,7 +26,9 @@ BREAKDOWN_KEYS = [8, 33]
 SECURITY_MODEL = ["malicious", "semi-honest"]
 ROOT_STEP_PREFIX = "protocol/alloc::string::String::run-0"
 
-DEPTH_DYNAMIC_STEPS = "ipa::protocol::attribution::InteractionPatternStep"
+DEPTH_DYNAMIC_STEPS = [
+    "ipa::protocol::attribution::InteractionPatternStep",
+]
 BIT_DYNAMIC_STEPS = [
     "ipa::protocol::attribution::aggregate_credit::Step::compute_equality_checks",
     "ipa::protocol::attribution::aggregate_credit::Step::check_times_credit",
@@ -69,6 +71,7 @@ def collect_steps(args):
     count = 0
     while True:
         line = proc.stdout.readline()
+
         if not line or line == "":
             break
 
@@ -76,6 +79,7 @@ def collect_steps(args):
             print("Unexpected line: " + line)
             exit(1)
 
+        count += 1
         # There are protocols in IPA that that will generate log(N) steps where N is the number
         # of input rows to IPA. In this script, we execute IPA with 10 input rows, hence it
         # only generates log2(10) (maybe a few more/less because of the optimizations) dynamic
@@ -102,7 +106,6 @@ def collect_steps(args):
             continue
 
         output.update([remove_root_step_name_from_line(line)])
-        count += 1
 
     # safeguard against empty output
     if count == 0:

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -79,14 +79,14 @@ def collect_steps(args):
         # There are protocols in IPA that that will generate log(N) steps where N is the number
         # of input rows to IPA. In this script, we execute IPA with 10 input rows, hence it
         # only generates log2(10) (maybe a few more/less because of the optimizations) dynamic
-        # steps. Our goal is to generate generate 32 sets of these steps. (32 > log2(1B))
+        # steps. Our goal is to generate 32 sets of these steps. (32 > log2(1B))
         # We do this by replacing all "depth\d+" in the steps with "depthX", store them in the
         # set, and later replace X with the depth of the iteration [0..32). We do that because
         # there are more optimizations done at row index level (i.e., skip the multiplication
         # for the last row), so the number of sub-steps branching off at each depth may differ.
         # To workaround this issue, we do the "depthX" replacement and collect all possible
-        # steps and sub-steps (log2(10) steps should be enough to execute all possible
-        # sub-steps). That means the generated `Compact` gate code will contain state
+        # steps and sub-steps (log2(10) steps should be enough to generate all possible
+        # combinations). That means the generated `Compact` gate code will contain state
         # transitions that are not actually executed. This is not optimal, but not a big deal.
         # It's impossible to generate the exact set of steps that are executed in the actual
         # protocol without executing the protocol or analyzing the code statically.

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -70,13 +70,6 @@ def remove_root_step_name_from_line(l):
     return l.split(",")[0][len(ROOT_STEP_PREFIX) + 1 :]
 
 
-def to_int_or(s):
-    try:
-        return int(s)
-    except ValueError:
-        return s
-
-
 def collect_steps(args):
     output = set()
     interaction_pattern_steps = set()

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -24,7 +24,7 @@ QUERY_SIZE = 10
 PER_USER_CAP = [1, 3]
 # attribution_window_seconds = 0 runs an optimized protocol, so 0 and anything larger
 ATTRIBUTION_WINDOW = [0, 86400]
-# breakdown_key_bits = [1, 32] runs an optimized protocol, and the steps generated
+# breakdown_key_bits = [1..32] runs an optimized protocol, and the steps generated
 # depend on the number of bits in the breakdown key. So we run the protocol with "8",
 # which is enough to generate all possible steps and sub-steps for the optimized case,
 # and "33" to cover the general case. See the comment below for more details.

--- a/src/telemetry/stats.rs
+++ b/src/telemetry/stats.rs
@@ -35,6 +35,7 @@ pub struct CounterDetails {
 pub struct Metrics {
     pub counters: HashMap<KeyName, CounterDetails>,
     pub metric_description: HashMap<KeyName, SharedString>,
+    pub print_header: bool,
 }
 
 impl CounterDetails {
@@ -75,6 +76,7 @@ impl Metrics {
         let mut this = Metrics {
             counters: HashMap::new(),
             metric_description: HashMap::new(),
+            print_header: !cfg!(feature = "step-trace"),
         };
 
         let snapshot = snapshot.into_vec();

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -35,11 +35,12 @@ impl CsvExporter for Metrics {
         // then dump them to the provided Write interface
         // TODO: include role dimension. That requires rethinking `Metrics` implementation
         // because it does not allow such breakdown atm.
-        #[cfg(not(feature = "step-trace"))]
-        writeln!(
-            w,
-            "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS"
-        )?;
+        if self.print_header {
+            writeln!(
+                w,
+                "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS"
+            )?;
+        }
         for (step, stats) in steps_stats.all_steps() {
             writeln!(
                 w,

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -35,6 +35,7 @@ impl CsvExporter for Metrics {
         // then dump them to the provided Write interface
         // TODO: include role dimension. That requires rethinking `Metrics` implementation
         // because it does not allow such breakdown atm.
+        #[cfg(not(feature = "step-trace"))]
         writeln!(
             w,
             "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS"


### PR DESCRIPTION
There are dynamic steps that are generated based on the number of input rows to IPA.

Since we are only executing IPA with 10 input rows, it only generates log2(10) (maybe a few more/less because of the optimizations) dynamic steps. We want to generate all possible steps for code generation without actually executing IPA with 1B rows.

This change also suppresses header lines not needed for step colleciton.