### PR TITLE
Initialize key registry from a set of public/private keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,8 @@ command-fds = "0.2.2"
 permutation = "0.4.1"
 proptest = "1.0.0"
 tempfile = "3"
+# std to use open/seal in unit tests
+hpke = { version = "0.10.0", default-features = false, features = ["x25519-dalek", "std"] }
 
 [profile.release]
 incremental = true

--- a/src/hpke/registry.rs
+++ b/src/hpke/registry.rs
@@ -47,6 +47,16 @@ pub struct KeyRegistry {
 }
 
 impl KeyRegistry {
+    pub fn from_key_pairs<const N: usize, I: Into<KeyPair>>(pairs: [I; N]) -> Self {
+        Self {
+            keys: pairs
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }
+    }
+
     #[cfg(any(test, feature = "test-fixture"))]
     pub fn random<R: rand::RngCore + rand::CryptoRng>(keys_count: usize, r: &mut R) -> Self {
         let keys = (0..keys_count).map(|_| KeyPair::gen(r)).collect::<Vec<_>>();
@@ -71,5 +81,70 @@ impl KeyRegistry {
             key_id if key_id < self.keys.len() => Some(&self.keys[key_id]),
             _ => None,
         }
+    }
+}
+
+#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+mod tests {
+    use super::*;
+    use crate::hpke::{IpaAead, IpaKdf, IpaKem};
+    use hpke::{kem::EncappedKey, HpkeError, OpModeR, OpModeS};
+    use rand::rngs::StdRng;
+    use rand_core::{CryptoRng, RngCore, SeedableRng};
+
+    const INFO_STR: &[u8] = b"This is an INFO string.";
+    const AAD: &[u8] = b"This is AAD.";
+
+    fn encrypt<R: RngCore + CryptoRng>(
+        pk: &IpaPublicKey,
+        pt: &[u8],
+        r: &mut R,
+    ) -> (EncappedKey, Vec<u8>) {
+        let (encapsulated_key, mut encryption_context) =
+            hpke::setup_sender::<IpaAead, IpaKdf, IpaKem, _>(&OpModeS::Base, pk, INFO_STR, r)
+                .expect("Can setup the sender.");
+
+        (
+            encapsulated_key,
+            encryption_context
+                .seal(pt, AAD)
+                .expect("Encryption failed."),
+        )
+    }
+
+    fn decrypt<I: AsRef<[u8]>>(
+        sk: &IpaPrivateKey,
+        payload: &(EncappedKey, I),
+    ) -> Result<Vec<u8>, HpkeError> {
+        let (encap_key, ct) = payload;
+        let mut decryption_context = hpke::setup_receiver::<IpaAead, IpaKdf, IpaKem>(
+            &OpModeR::Base,
+            sk,
+            encap_key,
+            INFO_STR,
+        )
+        .expect("Can setup the receiver.");
+
+        decryption_context.open(ct.as_ref(), AAD)
+    }
+
+    #[test]
+    fn encrypt_decrypt() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let keypair1 = KeyPair::gen(&mut rng);
+        let keypair2 = KeyPair::gen(&mut rng);
+
+        let registry = KeyRegistry::from_key_pairs([keypair1, keypair2]);
+        let pt = b"This is a plaintext.";
+        let ct_payload = encrypt(registry.public_key(0).unwrap(), pt, &mut rng);
+        assert_eq!(
+            Ok(pt.to_vec()),
+            decrypt(registry.private_key(0).unwrap(), &ct_payload)
+        );
+
+        assert_eq!(
+            HpkeError::OpenError,
+            decrypt(registry.private_key(1).unwrap(), &ct_payload).unwrap_err()
+        );
     }
 }


### PR DESCRIPTION
I was thinking about taking a file name instead, but it seems that it should be done at the higher level.

@andyleiserson lmk if that's what you expect