### PR TITLE
Reduce duplicated code involved in running a query

### DIFF
--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ff::{Field, GaloisField, Serializable},
+    ff::{Field, FieldType, Fp32BitPrime, GaloisField, Serializable},
     helpers::{
         negotiate_prss,
         query::{QueryConfig, QueryType},
@@ -8,20 +8,28 @@ use crate::{
     protocol::{
         attribution::input::MCAggregateCreditOutputRow,
         context::{MaliciousContext, SemiHonestContext},
+        prss::Endpoint as PrssEndpoint,
         step::{self, StepNarrow},
     },
-    query::runner::IpaRunner,
+    query::runner::IpaQuery,
     secret_sharing::{replicated::semi_honest::AdditiveShare, Linear as LinearSecretSharing},
     task::JoinHandle,
 };
 
+#[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+use crate::query::runner::execute_test_multiply;
 use crate::query::runner::QueryResult;
+use futures::FutureExt;
 use generic_array::GenericArray;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    future::{ready, Future},
+    pin::Pin,
+};
 use typenum::Unsigned;
 
 pub trait Result: Send + Debug {
@@ -63,12 +71,86 @@ where
     }
 }
 
-#[allow(unused)]
-pub fn start_query(
+pub fn execute(
     config: QueryConfig,
     gateway: Gateway,
     input: ByteArrStream,
 ) -> JoinHandle<QueryResult> {
+    match (config.query_type, config.field_type) {
+        #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+        (QueryType::TestMultiply, FieldType::Fp31) => {
+            do_query(config, gateway, input, |prss, gateway, input| {
+                Box::pin(execute_test_multiply::<crate::ff::Fp31>(
+                    prss, gateway, input,
+                ))
+            })
+        }
+        #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+        (QueryType::TestMultiply, FieldType::Fp32BitPrime) => {
+            do_query(config, gateway, input, |prss, gateway, input| {
+                Box::pin(execute_test_multiply::<Fp32BitPrime>(prss, gateway, input))
+            })
+        }
+        #[cfg(any(test, feature = "weak-field"))]
+        (QueryType::SemiHonestIpa(ipa_config), FieldType::Fp31) => {
+            do_query(config, gateway, input, move |prss, gateway, input| {
+                let ctx = SemiHonestContext::new(prss, gateway);
+                Box::pin(
+                    IpaQuery::<crate::ff::Fp31, _, _>::new(ipa_config)
+                        .execute(ctx, input)
+                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
+                )
+            })
+        }
+        (QueryType::SemiHonestIpa(ipa_config), FieldType::Fp32BitPrime) => {
+            do_query(config, gateway, input, move |prss, gateway, input| {
+                let ctx = SemiHonestContext::new(prss, gateway);
+                Box::pin(
+                    IpaQuery::<Fp32BitPrime, _, _>::new(ipa_config)
+                        .execute(ctx, input)
+                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
+                )
+            })
+        }
+        #[cfg(any(test, feature = "weak-field"))]
+        (QueryType::MaliciousIpa(ipa_config), FieldType::Fp31) => {
+            do_query(config, gateway, input, move |prss, gateway, input| {
+                let ctx = MaliciousContext::new(prss, gateway);
+                Box::pin(
+                    IpaQuery::<crate::ff::Fp31, _, _>::new(ipa_config)
+                        .execute(ctx, input)
+                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
+                )
+            })
+        }
+        (QueryType::MaliciousIpa(ipa_config), FieldType::Fp32BitPrime) => {
+            do_query(config, gateway, input, move |prss, gateway, input| {
+                let ctx = MaliciousContext::new(prss, gateway);
+                Box::pin(
+                    IpaQuery::<Fp32BitPrime, _, _>::new(ipa_config)
+                        .execute(ctx, input)
+                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
+                )
+            })
+        }
+    }
+}
+
+pub fn do_query<F>(
+    config: QueryConfig,
+    gateway: Gateway,
+    input: ByteArrStream,
+    query_impl: F,
+) -> JoinHandle<QueryResult>
+where
+    F: for<'a> FnOnce(
+            &'a PrssEndpoint,
+            &'a Gateway,
+            ByteArrStream,
+        ) -> Pin<Box<dyn Future<Output = QueryResult> + Send + 'a>>
+        + Send
+        + 'static,
+{
     tokio::spawn(async move {
         // TODO: make it a generic argument for this function
         let mut rng = StdRng::from_entropy();
@@ -76,41 +158,17 @@ pub fn start_query(
         let step = step::Descriptive::default().narrow(&config.query_type);
         let prss = negotiate_prss(&gateway, &step, &mut rng).await.unwrap();
 
-        match config.query_type {
-            #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-            QueryType::TestMultiply => {
-                super::runner::TestMultiplyRunner
-                    .run(
-                        SemiHonestContext::new(&prss, &gateway),
-                        config.field_type,
-                        input,
-                    )
-                    .await
-            }
-            QueryType::SemiHonestIpa(ipa_query_config) => {
-                IpaRunner(ipa_query_config)
-                    .run(
-                        SemiHonestContext::new(&prss, &gateway),
-                        config.field_type,
-                        input,
-                    )
-                    .await
-            }
-            QueryType::MaliciousIpa(ipa_query_config) => Ok(IpaRunner(ipa_query_config)
-                .malicious_run(
-                    MaliciousContext::new(&prss, &gateway),
-                    config.field_type,
-                    input,
-                )
-                .await),
-        }
+        query_impl(&prss, &gateway, input).await
     })
 }
 
 #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
 mod tests {
-    use super::*;
-    use crate::{ff::Fp31, secret_sharing::IntoShares};
+    use crate::{
+        ff::{Field, Fp31},
+        query::ProtocolResult,
+        secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
+    };
 
     #[test]
     fn serialize_result() {

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -20,24 +20,9 @@ use futures::StreamExt;
 use std::marker::PhantomData;
 use typenum::Unsigned;
 
-pub struct IpaQuery<F, C, S>(IpaQueryConfig, PhantomData<(F, C, S)>)
-where
-    F: PrimeField,
-    AdditiveShare<F>: Serializable,
-    C: UpgradableContext,
-    C::UpgradedContext<F>: UpgradedContext<F, Share = S>,
-    S: LinearSecretSharing<F> + Serializable,
-    IPAInputRow<F, MatchKey, BreakdownKey>: Serializable;
+pub struct IpaQuery<F, C, S>(IpaQueryConfig, PhantomData<(F, C, S)>);
 
-impl<F, C, S> IpaQuery<F, C, S>
-where
-    F: PrimeField,
-    AdditiveShare<F>: Serializable,
-    C: UpgradableContext,
-    C::UpgradedContext<F>: UpgradedContext<F, Share = S>,
-    S: LinearSecretSharing<F> + Serializable,
-    IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,
-{
+impl<F, C, S> IpaQuery<F, C, S> {
     pub fn new(config: IpaQueryConfig) -> Self {
         Self(config, PhantomData)
     }

--- a/src/query/runner/mod.rs
+++ b/src/query/runner/mod.rs
@@ -2,9 +2,10 @@ mod ipa;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_multiply;
 
-pub(super) use self::ipa::Runner as IpaRunner;
 use crate::{error::Error, query::ProtocolResult};
+
+pub(super) use self::ipa::IpaQuery;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-pub(super) use test_multiply::Runner as TestMultiplyRunner;
+pub(super) use test_multiply::execute_test_multiply;
 
 pub(super) type QueryResult = Result<Box<dyn ProtocolResult>, Error>;


### PR DESCRIPTION
In particular, this makes there be only one copy of the code that processes the input reports for an IPA query.