### PR TITLE
Remove the limit on number of concurrent streams

### DIFF
--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -232,11 +232,7 @@ where
         async move {
             server
                 // TODO: configuration
-                .http_config(
-                    HttpConfig::default()
-                        .http2_max_concurrent_streams(Some(256))
-                        .build(),
-                )
+                .http_config(HttpConfig::default())
                 .handle(handle)
                 .serve(svc)
                 .await


### PR DESCRIPTION
See #685 for details. We certainly need more than 256 streams. Having an upper limit close to that number leaves us vulnerable to having this issue again in the future.

So I'd rather not limit it and rely on performance metrics if we start seeing impact of too many streams open.

I also don't see an easy way to test this, so tests are not included :(