### PR TITLE
generate events to support attribution window

### DIFF
--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -129,7 +129,7 @@ impl<R: Rng> EventGenerator<R> {
             // The next event would have timestamp upto 60 seconds after the previous
             // event generated. On an average, we should be able to start seeing spacing
             // of 7 days in query size of 100k or greater.
-            self.current_ts += self.rng.gen_range(0..60);
+            self.current_ts += self.rng.gen_range(1..=60);
         }
 
         if self.rng.gen() {

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -126,7 +126,10 @@ impl<R: Rng> EventGenerator<R> {
 
     fn gen_event(&mut self, user_id: UserId) -> TestRawDataRecord {
         if self.rng.gen() {
-            self.current_ts += 1;
+            // The next event would have timestamp upto 60 seconds after the previous
+            // event generated. On an average, we should be able to start seeing spacing
+            // of 7 days in query size of 100k or greater.
+            self.current_ts += self.rng.gen_range(0..60);
         }
 
         if self.rng.gen() {


### PR DESCRIPTION
 Instead of generating events incrementally each second, this would now generate events at a gap of upto 60 secs.

 This would ensure that we can test attribution window logic.
 We can easily generate events in > 7day attribution window with 100k query size with this.