### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ generic-array = "0.14.6"
 hex = { version = "0.4", optional = true, features = ["serde"] }
 hkdf = "0.12.3"
 hpke = { version = "0.10.0", default-features = false, features = ["x25519-dalek"] }
-hyper = { version = "0.14.20", optional = true, features = ["client", "h2", "stream"] }
+hyper = { version = "0.14.26", optional = true, features = ["client", "h2", "stream"] }
 hyper-tls = { version = "0.5.0", optional = true }
 iai = { version = "0.1.1", optional = true }
 metrics = "0.20.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,24 +39,25 @@ step-trace = []
 
 [dependencies]
 aes = "0.8"
-async-trait = "0.1.57"
-axum = { version = "0.5.16", optional = true, features = ["http2"] }
-axum-server = { version = "0.4.2", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
+async-trait = "0.1.68"
+axum = { version = "0.5.17", optional = true, features = ["http2"] }
+axum-server = { version = "0.5.1", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
 base64 = { version = "0.21.2", optional = true }
-bitvec = "1.0.1"
+bitvec = "1.0"
 # TODO: the only place where we use bytes is in ByteArrStream. ordering_mpsc is a replacement for it
 # so we can remove this dependency after migrating to it. It is added only to avoid having `web-app` feature enabled
 # by default.
-bytes = "1.4.0"
-clap = { version = "4.0.10", optional = true, features = ["derive"] }
-comfy-table = { version = "7.0.0", optional = true }
+bytes = "1.4"
+clap = { version = "4.0", optional = true, features = ["derive"] }
+comfy-table = { version = "7.0", optional = true }
 config = "0.13.2"
 criterion = { version = "0.5.1", optional = true, default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
-dashmap = "5.4.0"
+dashmap = "5.4"
+dhat = "0.3.2"
 embed-doc-image = "0.1.4"
-futures = "0.3.24"
-futures-util = "0.3.24"
-generic-array = "0.14.6"
+futures = "0.3.28"
+futures-util = "0.3.28"
+generic-array = "0.14.7"
 hex = { version = "0.4", optional = true, features = ["serde"] }
 hkdf = "0.12.3"
 hpke = { version = "0.10.0", default-features = false, features = ["x25519-dalek"] }
@@ -66,8 +67,8 @@ iai = { version = "0.1.1", optional = true }
 metrics = "0.21.0"
 metrics-tracing-context = "0.14.0"
 metrics-util = { version = "0.15.0" }
-once_cell = "1.16.0"
-pin-project = "1.0.12"
+once_cell = "1.18"
+pin-project = "1.0"
 rand = "0.8"
 rand_core = "0.6"
 rcgen = { version = "0.10", optional = true }
@@ -81,19 +82,19 @@ sha2 = "0.10.6"
 shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
-tinyvec = "1.6.0"
-tokio = { version = "1.28.2", features = ["rt", "rt-multi-thread", "macros"] }
+tinyvec = "1.6"
+tokio = { version = "1.28", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-rustls = { version = "0.24.0", optional = true }
-tokio-stream = "0.1.10"
-tokio-util = "0.7.4"
+tokio-stream = "0.1.14"
+tokio-util = "0.7.8"
 toml = { version = "0.7", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", optional = true, features = ["trace"] }
+tower-http = { version = "0.4.0", optional = true, features = ["trace"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-typenum = "1.16.0"
-x25519-dalek = "2.0.0-pre.1"
-dhat = "0.3.2"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+typenum = "1.16"
+# hpke is pinned to it
+x25519-dalek = "2.0.0-pre.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ aes = "0.8"
 async-trait = "0.1.57"
 axum = { version = "0.5.16", optional = true, features = ["http2"] }
 axum-server = { version = "0.4.2", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }
-base64 = { version = "0.13", optional = true }
+base64 = { version = "0.21.2", optional = true }
 bitvec = "1.0.1"
 # TODO: the only place where we use bytes is in ByteArrStream. ordering_mpsc is a replacement for it
 # so we can remove this dependency after migrating to it. It is added only to avoid having `web-app` feature enabled

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,8 @@ shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tinyvec = "1.6.0"
-tokio = { version = "1.21.2", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-rustls = { version = "0.23", optional = true }
+tokio = { version = "1.28.2", features = ["rt", "rt-multi-thread", "macros"] }
+tokio-rustls = { version = "0.24.0", optional = true }
 tokio-stream = "0.1.10"
 tokio-util = "0.7.4"
 toml = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ bitvec = "1.0.1"
 # by default.
 bytes = "1.4.0"
 clap = { version = "4.0.10", optional = true, features = ["derive"] }
-comfy-table = { version = "6.0.0", optional = true }
+comfy-table = { version = "7.0.0", optional = true }
 config = "0.13.2"
-criterion = { version = "0.4.0", optional = true, default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
+criterion = { version = "0.5.1", optional = true, default-features = false, features = ["async_tokio", "plotters", "html_reports"] }
 dashmap = "5.4.0"
 embed-doc-image = "0.1.4"
 futures = "0.3.24"
@@ -63,9 +63,9 @@ hpke = { version = "0.10.0", default-features = false, features = ["x25519-dalek
 hyper = { version = "0.14.26", optional = true, features = ["client", "h2", "stream"] }
 hyper-tls = { version = "0.5.0", optional = true }
 iai = { version = "0.1.1", optional = true }
-metrics = "0.20.1"
-metrics-tracing-context = "0.12.0"
-metrics-util = { version = "0.14.0" }
+metrics = "0.21.0"
+metrics-tracing-context = "0.14.0"
+metrics-util = { version = "0.15.0" }
 once_cell = "1.16.0"
 pin-project = "1.0.12"
 rand = "0.8"

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -20,6 +20,7 @@ use axum_server::{
     tls_rustls::{RustlsAcceptor, RustlsConfig},
     Handle, HttpConfig, Server,
 };
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use futures::{
     future::{ready, BoxFuture, Either, Ready},
     Future, FutureExt,
@@ -308,7 +309,7 @@ async fn rustls_config(
 
     let mut config = RustlsServerConfig::builder()
         .with_safe_defaults()
-        .with_client_cert_verifier(verifier)
+        .with_client_cert_verifier(verifier.boxed())
         .with_single_cert(cert, key)?;
 
     config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
@@ -367,7 +368,7 @@ impl ClientCertRecognizingAcceptor {
         // It might be nice to log something here. We could log the certificate base64?
         error!(
             "A client certificate was presented that does not match a known helper. Certificate: {}",
-            base64::encode(cert),
+            BASE64.encode(cert),
         );
         None
     }


### PR DESCRIPTION
It's been long since the last update and we need to pick up some bug fixes (particularly in Hyper)

Upgrading Axum is more involved, so it is not included