### PR TITLE
EC2: increase the size of root partition to 200Gb

### DIFF
--- a/scripts/ec2-provision.sh
+++ b/scripts/ec2-provision.sh
@@ -107,6 +107,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
   --instance-type $INSTANCE_TYPE \
   --key-name "$KEY_NAME" \
   --region $AWS_REGION \
+  --block-device-mappings '[{"DeviceName":"/dev/xvda","Ebs":{"VolumeSize":200,"VolumeType":"gp3","Iops":10000}}]' \
   --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$INSTANCE_NAME}]" \
   --query 'Instances[0].InstanceId' \
   --user-data file://$CLOUD_INIT_FILE \


### PR DESCRIPTION
By default EC2 provisions ~9Gb partitions which is not enough for Rust toolchain and IPA deps. I was manually resizing it, but now that we need to provision more and more instances, it is better to set up volume size at the start.

Note that NVME-backed instances use the same convention name for root partition, but they are shown as `/dev/nvme0n1p1` in `df`

Here is how it looks now:

```
df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs         31G     0   31G   0% /dev
tmpfs            31G     0   31G   0% /dev/shm
tmpfs            31G  532K   31G   1% /run
tmpfs            31G     0   31G   0% /sys/fs/cgroup
/dev/nvme0n1p1  200G  6.5G  194G   4% /
tmpfs           6.2G     0  6.2G   0% /run/user/1000
```


before this change

```
df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs         31G     0   31G   0% /dev
tmpfs            31G     0   31G   0% /dev/shm
tmpfs            31G  532K   31G   1% /run
tmpfs            31G     0   31G   0% /sys/fs/cgroup
/dev/nvme0n1p1  8.0G  6.3G  1.7G  79% /
tmpfs           6.2G     0  6.2G   0% /run/user/1000
```