### PR TITLE
set TCP_NODELAY for helper-to-helper connection

### DIFF
--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -101,7 +101,10 @@ impl MpcHelperClient {
                 )),
                 ClientIdentity::None => None,
             };
-            (HttpsConnector::new(), auth_header)
+            (
+                HttpsConnector::new_with_connector(make_http_connector()),
+                auth_header,
+            )
         } else {
             let mut builder = TlsConnector::builder();
             if let Some(certificate) = peer_config.certificate {
@@ -120,7 +123,7 @@ impl MpcHelperClient {
             }
             // `enforce_http` must be false to request HTTPS URLs. This is done automatically by
             // `HttpsConnector::new()`, but not by `HttpsConnector::from()`.
-            let mut http = HttpConnector::new();
+            let mut http = make_http_connector();
             http.enforce_http(false);
             (
                 HttpsConnector::from((http, builder.build().unwrap().into())),
@@ -279,6 +282,15 @@ impl MpcHelperClient {
             Err(Error::from_failed_resp(resp).await)
         }
     }
+}
+
+fn make_http_connector() -> HttpConnector {
+    let mut connector = HttpConnector::new();
+    // IPA uses HTTP2 and it is sensitive to those delays especially in high-latency network
+    // configurations.
+    connector.set_nodelay(true);
+
+    connector
 }
 
 #[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]


### PR DESCRIPTION
Tested it in the worst setup possible (US->AU->US helper configuration) on 5k input

Before this change

```
2023-06-09T23:10:06.630888Z  INFO ipa_query: ipa::query::runner::ipa: new
...
2023-06-09T23:13:54.409354Z  INFO ipa_query: ipa::query::runner::ipa: close time.busy=10.3s time.idle=217s
```

After this change

```
2023-06-10T00:00:20.559948Z  INFO ipa_query: ipa::query::runner::ipa: new
...
2023-06-10T00:02:20.118076Z  INFO ipa_query: ipa::query::runner::ipa: close time.busy=10.2s time.idle=109s
```