### PR TITLE
Use Gate as used prss HashMap keys

### DIFF
--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -25,13 +25,13 @@ use std::{collections::HashSet, fmt::Formatter};
 /// a given step.
 #[cfg(debug_assertions)]
 struct UsedSet {
-    key: String,
+    key: Gate,
     used: Arc<Mutex<HashSet<usize>>>,
 }
 
 #[cfg(debug_assertions)]
 impl UsedSet {
-    fn new(key: String) -> Self {
+    fn new(key: Gate) -> Self {
         Self {
             key,
             used: Arc::new(Mutex::new(HashSet::new())),
@@ -158,7 +158,7 @@ impl Endpoint {
     /// When used incorrectly.  For instance, if you ask for an RNG and then ask
     /// for a PRSS using the same key.
     pub fn indexed(&self, key: &Gate) -> Arc<IndexedSharedRandomness> {
-        self.inner.lock().unwrap().indexed(key.as_ref())
+        self.inner.lock().unwrap().indexed(key)
     }
 
     /// Get a sequential shared randomness.
@@ -169,7 +169,7 @@ impl Endpoint {
         &self,
         key: &Gate,
     ) -> (SequentialSharedRandomness, SequentialSharedRandomness) {
-        self.inner.lock().unwrap().sequential(key.as_ref())
+        self.inner.lock().unwrap().sequential(key)
     }
 }
 
@@ -187,23 +187,23 @@ enum EndpointItem {
 struct EndpointInner {
     left: GeneratorFactory,
     right: GeneratorFactory,
-    items: HashMap<String, EndpointItem>,
+    items: HashMap<Gate, EndpointItem>,
 }
 
 impl EndpointInner {
-    pub fn indexed(&mut self, key: &str) -> Arc<IndexedSharedRandomness> {
+    pub fn indexed(&mut self, key: &Gate) -> Arc<IndexedSharedRandomness> {
         // The second arm of this statement would be fine, except that `HashMap::entry()`
         // only takes an owned value as an argument.
         // This makes the lookup perform an allocation, which is very much suboptimal.
         let item = if let Some(item) = self.items.get(key) {
             item
         } else {
-            self.items.entry(key.to_owned()).or_insert_with_key(|k| {
+            self.items.entry(key.clone()).or_insert_with_key(|k| {
                 EndpointItem::Indexed(Arc::new(IndexedSharedRandomness {
-                    left: self.left.generator(k.as_bytes()),
-                    right: self.right.generator(k.as_bytes()),
+                    left: self.left.generator(k.as_ref().as_bytes()),
+                    right: self.right.generator(k.as_ref().as_bytes()),
                     #[cfg(debug_assertions)]
-                    used: UsedSet::new(key.to_owned()),
+                    used: UsedSet::new(key.clone()),
                 }))
             })
         };
@@ -216,16 +216,16 @@ impl EndpointInner {
 
     pub fn sequential(
         &mut self,
-        key: &str,
+        key: &Gate,
     ) -> (SequentialSharedRandomness, SequentialSharedRandomness) {
-        let prev = self.items.insert(key.to_owned(), EndpointItem::Sequential);
+        let prev = self.items.insert(key.clone(), EndpointItem::Sequential);
         assert!(
             prev.is_none(),
             "Attempt access a sequential PRSS for {key} after another access"
         );
         (
-            SequentialSharedRandomness::new(self.left.generator(key.as_bytes())),
-            SequentialSharedRandomness::new(self.right.generator(key.as_bytes())),
+            SequentialSharedRandomness::new(self.left.generator(key.as_ref().as_bytes())),
+            SequentialSharedRandomness::new(self.right.generator(key.as_ref().as_bytes())),
         )
     }
 }


### PR DESCRIPTION
This diff updates `UsedSet`, a hash map that keeps track of used prss indexes, to use `Gate` as its keys. Previously, it used `String` which is a clone of static strings that are returned by `Step::as_ref()`. This causes a huge memory allocation even for the `Compact` gate where we could just use `u16` step IDs as keys.

Below is the DHAT memory profile showing the total memory consumption when we use `String` as the key. *20%* of the entire memory allocation (3.3GB for 1000 rows) comes from the hash map.

```
▼ PP 1/1 (16 children) {
    Total:     17,768,783,497 bytes (100%, 12,380,886.86/s) in 146,289,044 blocks (100%, 101,930.9/s), avg size 121.46 bytes, avg lifetime 3,994,725.36 µs (0.28% of program duration)
    At t-gmax: 330,879,053 bytes (100%) in 982,552 blocks (100%), avg size 336.75 bytes
    At t-end:  23,667,598 bytes (100%) in 147,483 blocks (100%), avg size 160.48 bytes
    Allocated at {
      #0: [root]
    }
  }
  ├─▶ PP 1.1/16 (2 children) {
  │     Total:     3,548,727,675 bytes (19.97%, 2,472,673.26/s) in 28,881,045 blocks (19.74%, 20,123.66/s), avg size 122.87 bytes, avg lifetime 1,469,655.39 µs (0.1% of program duration)
  │     At t-gmax: 5,752,096 bytes (1.74%) in 47,689 blocks (4.85%), avg size 120.62 bytes
  │     At t-end:  7,164,090 bytes (30.27%) in 58,926 blocks (39.95%), avg size 121.58 bytes
  │     Allocated at {
  │       #1: 0x10032d5d4: <alloc::alloc::Global as core::alloc::Allocator>::allocate (alloc/src/alloc.rs:243:9)
  │       #2: 0x10032d5d4: alloc::raw_vec::RawVec<T,A>::allocate_in (alloc/src/raw_vec.rs:184:45)
  │       #3: 0x10032d5d4: alloc::raw_vec::RawVec<T,A>::with_capacity_in (alloc/src/raw_vec.rs:130:9)
  │       #4: 0x10032d5d4: alloc::vec::Vec<T,A>::with_capacity_in (src/vec/mod.rs:672:20)
  │       #5: 0x10032d5d4: <T as alloc::slice::hack::ConvertVec>::to_vec (alloc/src/slice.rs:162:25)
  │       #6: 0x10032d5d4: alloc::slice::hack::to_vec (alloc/src/slice.rs:111:9)
  │       #7: 0x10032d5d4: alloc::slice::<impl [T]>::to_vec_in (alloc/src/slice.rs:441:9)
  │       #8: 0x10032d5d4: alloc::slice::<impl [T]>::to_vec (alloc/src/slice.rs:416:14)
  │       #9: 0x10032d5d4: alloc::slice::<impl alloc::borrow::ToOwned for [T]>::to_owned (alloc/src/slice.rs:823:14)
  │       #10: 0x10032d5d4: alloc::str::<impl alloc::borrow::ToOwned for str>::to_owned (alloc/src/str.rs:209:62)
  │       #11: 0x10032d5d4: <alloc::string::String as core::convert::From<&str>>::from (alloc/src/string.rs:2667:11)
  │       #12: 0x10032d5d4: <str as alloc::string::ToString>::to_string (alloc/src/string.rs:2604:9)
  │       #13: 0x10032d5d4: <str as metrics::cow::Cowable>::clone_from_parts (metrics-0.20.1/src/cow.rs:353:31)
  │       #14: 0x10032d5d4: <metrics::cow::Cow<T> as core::clone::Clone>::clone (metrics-0.20.1/src/cow.rs:213:33)
  │       #15: 0x10032d5d4: <metrics::label::Label as core::clone::Clone>::clone (metrics-0.20.1/src/label.rs:17:43)
  │       #16: 0x10032d5d4: <T as alloc::slice::hack::ConvertVec>::to_vec (alloc/src/slice.rs:146:32)
  │       #17: 0x10032d5d4: alloc::slice::hack::to_vec (alloc/src/slice.rs:111:9)
  │       #18: 0x10032d5d4: alloc::slice::<impl [T]>::to_vec_in (alloc/src/slice.rs:441:9)
  │       #19: 0x10032d5d4: alloc::slice::<impl [T]>::to_vec (alloc/src/slice.rs:416:14)
  │       #20: 0x10032d5d4: <[metrics::label::Label] as metrics::cow::Cowable>::clone_from_parts (metrics-0.20.1/src/cow.rs:442:30)
  │       #21: 0x10032d9e0: <metrics::cow::Cow<T> as core::clone::Clone>::clone (metrics-0.20.1/src/cow.rs:213:33)
  │       #22: 0x10032d9e0: <metrics::key::Key as core::clone::Clone>::clone (metrics-0.20.1/src/key.rs:182:21)
  │     }
```