### PR TITLE
Add cfg_aliases and two aliases: unit-test and web-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,6 @@ disable-metrics = []
 # TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
 # TODO Consider moving out benches as well
 web-app = ["axum", "axum-server", "base64", "clap", "comfy-table", "enable-serde", "hyper", "hyper-rustls", "rcgen", "rustls-pemfile", "time", "tokio-rustls", "toml", "tower", "tower-http"]
-# The test-http and test-fixture features are mutually incompatible, and the
-# code doesn't support building tests without test-fixture. So if you want to
-# run the tests enabled by test-http, you unfortunately need to do something
-# like `s/cfg(any(test,/cfg(any(never, test/`.
-test-http = []
 test-fixture = ["enable-serde", "weak-field"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,7 @@ no-prss = []
 disable-metrics = []
 # TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
 # TODO Consider moving out benches as well
-web-app = [
-    "axum", "axum-server", "base64", "clap", "comfy-table", "enable-serde", "hyper", "hyper-tls",
-    "rcgen", "rustls-pemfile", "sec1", "time", "tokio-rustls", "toml", "tower", "tower-http",
-]
+web-app = ["axum", "axum-server", "base64", "clap", "comfy-table", "enable-serde", "hyper", "hyper-tls", "rcgen", "rustls-pemfile", "sec1", "time", "tokio-rustls", "toml", "tower", "tower-http"]
 # The test-http and test-fixture features are mutually incompatible, and the
 # code doesn't support building tests without test-fixture. So if you want to
 # run the tests enabled by test-http, you unfortunately need to do something
@@ -95,6 +92,9 @@ x25519-dalek = "2.0.0-pre.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5.0"
+
+[build-dependencies]
+cfg_aliases = "0.1.1"
 
 [dev-dependencies]
 command-fds = "0.2.2"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    cfg_aliases! {
+        unit_test: { all(not(feature = "shuttle"), feature = "in-memory-infra") },
+        web_test: { all(not(feature = "shuttle"), feature = "real-world-infra") },
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,10 @@
 use cfg_aliases::cfg_aliases;
 
 fn main() {
+    // test is not supported because cfg_aliases is based on
+    // https://docs.rs/tectonic_cfg_support macro and that only supports features, target_os, family
+    // env, etc.
+    // https://docs.rs/tectonic_cfg_support/latest/tectonic_cfg_support/struct.TargetConfiguration.html
     cfg_aliases! {
         unit_test: { all(not(feature = "shuttle"), feature = "in-memory-infra") },
         web_test: { all(not(feature = "shuttle"), feature = "real-world-infra") },

--- a/src/bin/ipa_bench/gen_events.rs
+++ b/src/bin/ipa_bench/gen_events.rs
@@ -167,7 +167,7 @@ fn add_event_timestamps(rhs: EventTimestamp, lhs: EventTimestamp) -> EventTimest
     EventTimestamp::new((epoch % (c(Epoch::MAX) + 1)) as Epoch, offset)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::{gen_reports, generate_events, EventTimestamp, GenericReport};
     use crate::{gen_events::add_event_timestamps, models::Epoch, sample::Sample};

--- a/src/bin/ipa_bench/models.rs
+++ b/src/bin/ipa_bench/models.rs
@@ -316,7 +316,7 @@ impl Debug for TriggerFanoutQuery {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::models::Epoch;
 

--- a/src/cli/playbook/input.rs
+++ b/src/cli/playbook/input.rs
@@ -132,7 +132,7 @@ impl BufRead for InputSource {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         cli::playbook::input::InputItem,

--- a/src/config.rs
+++ b/src/config.rs
@@ -377,7 +377,7 @@ impl Debug for Http2Configurator {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{config::HpkeClientConfig, helpers::HelperIdentity, net::test::TestConfigBuilder};
     use hpke::{kem::X25519HkdfSha256, Kem};

--- a/src/exact.rs
+++ b/src/exact.rs
@@ -75,7 +75,7 @@ impl<S: Stream> Stream for FixedLength<S> {
 
 impl<S: Stream> ExactSizeStream for FixedLength<S> {}
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, unit_test))]
 mod test {
     use crate::exact::{ExactSizeStream, FixedLength};
     use futures::stream::iter;

--- a/src/ff/galois_field.rs
+++ b/src/ff/galois_field.rs
@@ -401,7 +401,7 @@ macro_rules! bit_array_impl {
                 }
             }
 
-            #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+            #[cfg(all(test, unit_test))]
             mod tests {
                 use super::*;
                 use crate::{ff::GaloisField, secret_sharing::SharedValue};

--- a/src/ff/prime_field.rs
+++ b/src/ff/prime_field.rs
@@ -179,7 +179,7 @@ macro_rules! field_impl {
             }
         }
 
-        #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+        #[cfg(all(test, unit_test))]
         mod common_tests {
             use super::*;
             use crate::ff::Serializable;
@@ -225,7 +225,7 @@ macro_rules! field_impl {
 mod fp31 {
     field_impl! { Fp31, u8, 8, 31 }
 
-    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+    #[cfg(all(test, unit_test))]
     mod specialized_tests {
         use super::*;
 
@@ -248,7 +248,7 @@ mod fp31 {
 mod fp32bit {
     field_impl! { Fp32BitPrime, u32, 32, 4_294_967_291 }
 
-    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+    #[cfg(all(test, unit_test))]
     mod specialized_tests {
         use super::*;
 

--- a/src/helpers/buffers/ordering_mpsc.rs
+++ b/src/helpers/buffers/ordering_mpsc.rs
@@ -355,7 +355,7 @@ mod fixture {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod unit {
     use crate::{
         ff::{Field, Fp31, Serializable},
@@ -487,7 +487,7 @@ mod concurrency {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod proptests {
     use crate::helpers::buffers::ordering_mpsc::fixture::{shuffle_indices, shuffled_send_recv};
 

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -142,7 +142,7 @@ impl GatewayConfig {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -500,7 +500,7 @@ impl From<usize> for TotalRecords {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
 

--- a/src/helpers/transport/callbacks.rs
+++ b/src/helpers/transport/callbacks.rs
@@ -66,7 +66,7 @@ pub struct TransportCallbacks<T> {
     pub complete_query: Box<dyn CompleteQueryCallback<T>>,
 }
 
-#[cfg(any(test, feature = "test-fixture", feature = "in-memory-infra"))]
+#[cfg(any(test, unit_test, feature = "test-fixture"))]
 impl<T> Default for TransportCallbacks<T> {
     fn default() -> Self {
         // `TransportCallbacks::default()` is commonly used with struct update syntax

--- a/src/helpers/transport/callbacks.rs
+++ b/src/helpers/transport/callbacks.rs
@@ -66,7 +66,7 @@ pub struct TransportCallbacks<T> {
     pub complete_query: Box<dyn CompleteQueryCallback<T>>,
 }
 
-#[cfg(any(test, unit_test, feature = "test-fixture"))]
+#[cfg(any(test, feature = "in-memory-infra"))]
 impl<T> Default for TransportCallbacks<T> {
     fn default() -> Self {
         // `TransportCallbacks::default()` is commonly used with struct update syntax

--- a/src/helpers/transport/in_memory/transport.rs
+++ b/src/helpers/transport/in_memory/transport.rs
@@ -213,7 +213,7 @@ pub struct InMemoryStream {
 }
 
 impl InMemoryStream {
-    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+    #[cfg(all(test, unit_test))]
     fn empty() -> Self {
         Self::from_iter(std::iter::empty())
     }
@@ -224,7 +224,7 @@ impl InMemoryStream {
         }
     }
 
-    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+    #[cfg(all(test, unit_test))]
     fn from_iter<I>(input: I) -> Self
     where
         I: IntoIterator<Item = StreamItem>,
@@ -291,7 +291,7 @@ impl Addr {
         serde_json::from_str(&self.params).unwrap()
     }
 
-    #[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+    #[cfg(all(test, unit_test))]
     fn records(from: HelperIdentity, query_id: QueryId, gate: Gate) -> Self {
         Self {
             route: RouteId::Records,
@@ -366,7 +366,7 @@ impl Setup {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/helpers/transport/stream/input.rs
+++ b/src/helpers/transport/stream/input.rs
@@ -32,7 +32,7 @@ impl BufDeque {
     }
 
     /// Returns the total amount of buffered data
-    #[cfg(all(test, not(feature = "shuttle")))]
+    #[cfg(all(test, unit_test))]
     fn len(&self) -> usize {
         self.buffered_size
     }
@@ -440,7 +440,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle")))]
+#[cfg(all(test, unit_test))]
 mod test {
     use rand::Rng;
     use rand_core::RngCore;

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -168,7 +168,7 @@ pub(crate) fn seal_in_place<'a, R: CryptoRng + RngCore, K: PublicKeyRegistry>(
 /// Represents an encrypted share of single match key.
 #[derive(Clone)]
 // temporarily to appease clippy while we don't have actual consumers of this struct
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 struct MatchKeyEncryption<'a> {
     /// Encapsulated key as defined in [`url`] specification.
     /// Key size depends on the AEAD type used in HPKE, in current setting IPA uses [`aead`] type.
@@ -186,7 +186,7 @@ struct MatchKeyEncryption<'a> {
     info: Info<'a>,
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use generic_array::GenericArray;

--- a/src/hpke/registry.rs
+++ b/src/hpke/registry.rs
@@ -119,7 +119,7 @@ impl PublicKeyRegistry for KeyRegistry<PublicKeyOnly> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::hpke::{IpaAead, IpaKdf, IpaKem};

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -293,7 +293,7 @@ fn make_http_connector() -> HttpConnector {
     connector
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]
+#[cfg(all(test, web_test))]
 pub(crate) mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/echo.rs
+++ b/src/net/server/handlers/echo.rs
@@ -10,7 +10,7 @@ pub fn router() -> Router {
     Router::new().route(http_serde::echo::AXUM_PATH, get(handler))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/src/net/server/handlers/query/create.rs
+++ b/src/net/server/handlers/query/create.rs
@@ -29,7 +29,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/query/input.rs
+++ b/src/net/server/handlers/query/input.rs
@@ -23,7 +23,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/net/server/handlers/query/mod.rs
+++ b/src/net/server/handlers/query/mod.rs
@@ -111,7 +111,7 @@ impl MaybeExtensionExt for request::Builder {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 pub mod test_helpers {
     use crate::net::test::TestServer;
     use futures_util::future::poll_immediate;

--- a/src/net/server/handlers/query/prepare.rs
+++ b/src/net/server/handlers/query/prepare.rs
@@ -29,7 +29,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::future::ready;
 

--- a/src/net/server/handlers/query/results.rs
+++ b/src/net/server/handlers/query/results.rs
@@ -26,7 +26,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::future::ready;
 

--- a/src/net/server/handlers/query/step.rs
+++ b/src/net/server/handlers/query/step.rs
@@ -26,7 +26,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
         .layer(Extension(transport))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::task::Poll;
 

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -100,7 +100,7 @@ impl MpcHelperServer {
         handlers::router(Arc::clone(&self.transport))
     }
 
-    #[cfg(all(test, feature = "in-memory-infra", not(feature = "shuttle")))]
+    #[cfg(all(test, unit_test))]
     async fn handle_req(&self, req: hyper::Request<hyper::Body>) -> axum::response::Response {
         let mut router = self.router();
         let router = tower::ServiceExt::ready(&mut router).await.unwrap();
@@ -480,7 +480,7 @@ impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod e2e_tests {
     use super::*;
     use crate::{

--- a/src/net/test.rs
+++ b/src/net/test.rs
@@ -245,7 +245,7 @@ impl TestServerBuilder {
         self
     }
 
-    #[cfg(all(test, feature = "in-memory-infra"))] // only used in unit tests
+    #[cfg(all(test, unit_test))]
     #[must_use]
     pub fn with_metrics(mut self, metrics: MetricsHandle) -> Self {
         self.metrics = Some(metrics);
@@ -266,7 +266,7 @@ impl TestServerBuilder {
         self
     }
 
-    #[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]
+    #[cfg(all(test, web_test))]
     pub fn use_http1(mut self) -> Self {
         self.use_http1 = true;
         self

--- a/src/net/transport.rs
+++ b/src/net/transport.rs
@@ -182,7 +182,7 @@ impl Transport for Arc<HttpTransport> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "real-world-infra"))]
+#[cfg(all(test, web_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/protocol/attribution/accumulate_credit.rs
+++ b/src/protocol/attribution/accumulate_credit.rs
@@ -158,7 +158,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::{iter, num::NonZeroU32};
 

--- a/src/protocol/attribution/aggregate_credit.rs
+++ b/src/protocol/attribution/aggregate_credit.rs
@@ -419,7 +419,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
 
     use super::aggregate_credit;

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -202,7 +202,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         attribution_window_test_input,

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -488,7 +488,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         credit_capping_test_input,

--- a/src/protocol/basics/check_zero.rs
+++ b/src/protocol/basics/check_zero.rs
@@ -73,7 +73,7 @@ pub async fn check_zero<C: Context, F: Field>(
     Ok(rv == F::ZERO)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         error::Error,

--- a/src/protocol/basics/mul/malicious.rs
+++ b/src/protocol/basics/mul/malicious.rs
@@ -119,7 +119,7 @@ where
     Ok(malicious_ab)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod test {
     use crate::{
         ff::Fp31,

--- a/src/protocol/basics/mul/semi_honest.rs
+++ b/src/protocol/basics/mul/semi_honest.rs
@@ -81,7 +81,7 @@ where
     Ok(Replicated::new(lhs, rhs))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod test {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/basics/mul/sparse.rs
+++ b/src/protocol/basics/mul/sparse.rs
@@ -185,7 +185,7 @@ impl MultiplyWork for MultiplyZeroPositions {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 pub(in crate::protocol) mod test {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -235,7 +235,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     mod semi_honest {
         use crate::{

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -151,7 +151,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         protocol::context::{UpgradableContext, UpgradedContext, Validator},

--- a/src/protocol/basics/share_known_value.rs
+++ b/src/protocol/basics/share_known_value.rs
@@ -34,7 +34,7 @@ impl<'a, F: ExtendableField> ShareKnownValue<UpgradedMaliciousContext<'a, F>, F>
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::ShareKnownValue;
     use crate::{

--- a/src/protocol/basics/sum_of_product/malicious.rs
+++ b/src/protocol/basics/sum_of_product/malicious.rs
@@ -154,7 +154,7 @@ where
     Ok(malicious_ab)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod test {
     use super::sum_of_products;
     use crate::{

--- a/src/protocol/basics/sum_of_product/semi_honest.rs
+++ b/src/protocol/basics/sum_of_product/semi_honest.rs
@@ -66,7 +66,7 @@ where
     Ok(Replicated::new(lhs, rhs))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod test {
     use super::sum_of_products;
     use crate::{

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -200,7 +200,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},

--- a/src/protocol/boolean/bit_decomposition.rs
+++ b/src/protocol/boolean/bit_decomposition.rs
@@ -96,7 +96,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::BitDecomposition;
     use crate::{

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -121,7 +121,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime},

--- a/src/protocol/boolean/bitwise_less_than_prime.rs
+++ b/src/protocol/boolean/bitwise_less_than_prime.rs
@@ -197,7 +197,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::BitwiseLessThanPrime;
     use crate::{

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -111,7 +111,7 @@ struct RBounds {
     invert: bool,
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 impl RBounds {
     // This is used for the proptest. It must match the actual implementation!
     fn evaluate(&self, r: u128) -> bool {
@@ -316,7 +316,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::{
         bitwise_greater_than_constant, bitwise_less_than_constant, compute_r_bounds,

--- a/src/protocol/boolean/or.rs
+++ b/src/protocol/boolean/or.rs
@@ -20,7 +20,7 @@ pub async fn or<F: Field, C: Context, S: LinearSecretSharing<F> + SecureMul<C>>(
     Ok(-ab + a + b)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::or;
     use crate::{

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -93,7 +93,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::RandomBitsGenerator;
     use crate::{

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -146,7 +146,7 @@ impl AsRef<str> for Step {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, PrimeField},

--- a/src/protocol/boolean/xor.rs
+++ b/src/protocol/boolean/xor.rs
@@ -41,7 +41,7 @@ where
     Ok(-(ab * F::truncate_from(2_u128)) + a + b)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::xor;
     use crate::{

--- a/src/protocol/context/mod.rs
+++ b/src/protocol/context/mod.rs
@@ -277,7 +277,7 @@ impl<'a> Inner<'a> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in_memory_infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, Serializable},

--- a/src/protocol/context/validator.rs
+++ b/src/protocol/context/validator.rs
@@ -329,7 +329,7 @@ impl<F: ExtendableField> Debug for Malicious<'_, F> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         error::Error,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -455,7 +455,7 @@ where
         .collect::<Vec<_>>()
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 pub mod tests {
     use super::{ipa, IPAInputRow};
     use crate::{

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -206,7 +206,7 @@ where
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         error::Error,

--- a/src/protocol/prss/mod.rs
+++ b/src/protocol/prss/mod.rs
@@ -261,7 +261,7 @@ impl EndpointSetup {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 pub mod test {
     use super::{Generator, KeyExchange, SequentialSharedRandomness};
     use crate::{

--- a/src/protocol/sort/apply.rs
+++ b/src/protocol/sort/apply.rs
@@ -46,7 +46,7 @@ pub fn apply_inv<T>(permutation: &[u32], values: &mut [T]) {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::{apply, apply_inv};
     use crate::rand::thread_rng;

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -41,7 +41,7 @@ where
     Ok(shuffled_objects)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         accumulation_test_input,

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -109,7 +109,7 @@ where
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
 
     mod semi_honest {

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -72,7 +72,7 @@ pub async fn bit_permutation<
     Ok(mult_output)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/sort/compose.rs
+++ b/src/protocol/sort/compose.rs
@@ -48,7 +48,7 @@ pub async fn compose<F: Field, S: SecretSharing<F> + Reshare<C, RecordId>, C: Co
     Ok(unshuffled_rho)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31},

--- a/src/protocol/sort/generate_permutation.rs
+++ b/src/protocol/sort/generate_permutation.rs
@@ -151,7 +151,7 @@ impl<'a, F: ExtendableField> DowngradeMalicious
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in_memory_infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::iter::zip;
 

--- a/src/protocol/sort/generate_permutation_opt.rs
+++ b/src/protocol/sort/generate_permutation_opt.rs
@@ -154,7 +154,7 @@ where
     ))
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31, GaloisField, Gf40Bit},

--- a/src/protocol/sort/multi_bit_permutation.rs
+++ b/src/protocol/sort/multi_bit_permutation.rs
@@ -105,7 +105,7 @@ where
     Ok(one_off_permutation)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::multi_bit_permutation;
     use crate::{

--- a/src/protocol/sort/secureapplyinv.rs
+++ b/src/protocol/sort/secureapplyinv.rs
@@ -22,7 +22,7 @@ pub async fn secureapplyinv_multi<C: Context, I: Reshare<C, RecordId> + Send + S
     Ok(shuffled_input)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     mod semi_honest {
         use rand::seq::SliceRandom;

--- a/src/protocol/sort/shuffle.rs
+++ b/src/protocol/sort/shuffle.rs
@@ -165,7 +165,7 @@ pub async fn unshuffle_shares<F: Field, S: SecretSharing<F> + Reshare<C, RecordI
     .await
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         protocol::{sort::shuffle::get_two_of_three_random_permutations, step::Gate},

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -165,7 +165,7 @@ where
     })
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
         ff::{Field, Fp31},

--- a/src/query/processor.rs
+++ b/src/query/processor.rs
@@ -291,7 +291,7 @@ impl Processor {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -145,7 +145,7 @@ pub fn assert_stream_send<'a, T>(
 }
 
 /// no dependency on `weak-field` feature because it is enabled in tests by default
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra",))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::iter::zip;
 

--- a/src/query/runner/test_multiply.rs
+++ b/src/query/runner/test_multiply.rs
@@ -65,7 +65,7 @@ where
     Ok(results)
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use crate::{

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -290,7 +290,7 @@ impl<T> ThisCodeIsAuthorizedToDowngradeFromMalicious<T> for UnauthorizedDowngrad
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::{AdditiveShare, Downgrade, ThisCodeIsAuthorizedToDowngradeFromMalicious};
     use crate::{

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -162,7 +162,7 @@ where
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::AdditiveShare;
     use crate::{

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -211,7 +211,7 @@ impl<R: Rng> Iterator for EventGenerator<R> {
     }
 }
 
-#[cfg(all(test, not(feature = "shuttle"), feature = "in-memory-infra"))]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::*;
     use rand::thread_rng;


### PR DESCRIPTION
For some reason I could not use `test` inside the alias definition, it never enables the alias when `cargo test`. Other than that, it should reduce the repetitive definitions. We are going to have more once `descriptive-gate` will be a required feature for unit tests and we would run some of them with compact as well