### PR TITLE
Add seed, report-filter and conversion probability arguments to event generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ axum-server = { version = "0.5.1", optional = true, features = ["rustls", "rustl
 base64 = { version = "0.21.2", optional = true }
 bitvec = "1.0"
 bytes = "1.4"
-clap = { version = "4.0", optional = true, features = ["derive"] }
+clap = { version = "4.3.2", optional = true, features = ["derive"] }
 comfy-table = { version = "7.0", optional = true }
 config = "0.13.2"
 criterion = { version = "0.5.1", optional = true, default-features = false, features = ["async_tokio", "plotters", "html_reports"] }

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -1,5 +1,7 @@
 use command_fds::CommandFdExt;
 use ipa::{cli::CliPaths, helpers::HelperIdentity, test_fixture::ipa::IpaSecurityModel};
+use rand::thread_rng;
+use rand_core::RngCore;
 use std::{
     array,
     error::Error,
@@ -12,8 +14,6 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     str,
 };
-use rand::thread_rng;
-use rand_core::RngCore;
 use tempdir::TempDir;
 
 #[cfg(all(test, feature = "cli"))]

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -12,6 +12,8 @@ use std::{
     process::{Child, Command, ExitStatus, Stdio},
     str,
 };
+use rand::thread_rng;
+use rand_core::RngCore;
 use tempdir::TempDir;
 
 #[cfg(all(test, feature = "cli"))]
@@ -211,6 +213,7 @@ fn test_ipa(mode: IpaSecurityModel, https: bool) {
         .arg("gen-ipa-inputs")
         .args(["--count", "10"])
         .args(["--max-breakdown-key", "20"])
+        .args(["--seed", &thread_rng().next_u64().to_string()])
         .args(["--output-file".as_ref(), inputs_file.as_os_str()])
         .silent()
         .stdin(Stdio::piped());


### PR DESCRIPTION
For synthetic test we need to be able to generate uncoordinated impressions and conversions on different machines. That requires sharing a seed for random generator, new argument that tells `EventGenerator` to skip source or trigger events and conversion probability. 

I tested it using the following script

```bash
cargo run --release --bin report_collector --features="clap cli test-fixture" -- gen-ipa-inputs -n 1000 --output-file /tmp/ipa-conversions.txt --max-breakdown-key 20 --report-filter trigger-only --seed 123

cargo run --release --bin report_collector --features="clap cli test-fixture" -- gen-ipa-inputs -n 1000 --output-file /tmp/ipa-impressions.txt --max-breakdown-key 20 --report-filter source-only --seed 123

cat /tmp/ipa-impressions.txt /tmp/ipa-conversions.txt | sort -t ',' -k1 >! /tmp/ipa-gen-test.txt

cargo run --release --bin report_collector --features="cli test-fixture" -- --disable-https --input-file /tmp/ipa-gen-test.txt --network test_data/network.toml semi-honest-ipa --max-breakdown-key 20 --plaintext-match-keys
```

I was looking for the following outcome: some breakdowns must've had conversions occurred and aggregates should be greater than 0

```bash
+-----+----------+---------+-------+
| Row | Expected | Actual  | Diff? |
+==================================+
| 0   | Some(3)  | Some(3) |       |
|-----+----------+---------+-------|
| 1   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 2   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 3   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 4   | Some(4)  | Some(4) |       |
|-----+----------+---------+-------|
| 5   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 6   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 7   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 8   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 9   | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 10  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 11  | Some(2)  | Some(2) |       |
|-----+----------+---------+-------|
| 12  | Some(2)  | Some(2) |       |
|-----+----------+---------+-------|
| 13  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 14  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 15  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 16  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 17  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 18  | Some(0)  | Some(0) |       |
|-----+----------+---------+-------|
| 19  | Some(0)  | Some(0) |       |
+-----+----------+---------+-------+
```

that seems satisfactory for 2000 events and 2% conversion rate