### PR TITLE
Build docker CI image with compact-gate feature

### DIFF
--- a/docker/ci/helper.Dockerfile
+++ b/docker/ci/helper.Dockerfile
@@ -4,7 +4,7 @@ FROM rust:latest as builder
 COPY . /ipa/
 RUN cd /ipa && \
   cargo build --bin helper --release --no-default-features \
-        --features "web-app real-world-infra"
+        --features "web-app real-world-infra compact-gate"
 
 # Copy them to the final image
 FROM debian:bullseye-slim


### PR DESCRIPTION
This fixes #734.

We need to specify either `descriptive-gate` or `compact-gate` if `--no-default-features` is on. For CI, we want to use the compact gate.