### PR TITLE
Hide compact gate module behind a feature flag

### DIFF
--- a/src/protocol/step/mod.rs
+++ b/src/protocol/step/mod.rs
@@ -1,9 +1,13 @@
+#[cfg(feature = "compact-gate")]
 mod compact;
+#[cfg(feature = "descriptive-gate")]
 mod descriptive;
 
 use std::fmt::Debug;
 
+#[cfg(feature = "compact-gate")]
 pub use compact::Compact;
+#[cfg(feature = "descriptive-gate")]
 pub use descriptive::Descriptive;
 
 #[cfg(feature = "descriptive-gate")]


### PR DESCRIPTION
Any code change causes rust-analyzer and intellij-rust to recompile macros which takes seconds.

thanks @martinthomson for this suggestion, I can finally code again