### PR TITLE
Add step/role to receive error

### DIFF
--- a/src/helpers/error.rs
+++ b/src/helpers/error.rs
@@ -26,9 +26,10 @@ pub enum Error {
         #[source]
         inner: BoxError,
     },
-    #[error("An error occurred while receiving data from {source:?}")]
+    #[error("An error occurred while receiving data from {source:?}/{step}")]
     ReceiveError {
         source: Role,
+        step: String,
         #[source]
         inner: BoxError,
     },
@@ -61,16 +62,6 @@ impl Error {
     ) -> Error {
         Self::SendError {
             channel,
-            inner: inner.into(),
-        }
-    }
-
-    pub fn receive_error<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>>(
-        source: Role,
-        inner: E,
-    ) -> Error {
-        Self::ReceiveError {
-            source,
             inner: inner.into(),
         }
     }

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -111,6 +111,7 @@ impl<T: Transport> Gateway<T> {
     #[must_use]
     pub fn get_receiver<M: Message>(&self, channel_id: &ChannelId) -> ReceivingEndBase<T, M> {
         ReceivingEndBase::new(
+            channel_id.clone(),
             self.receivers
                 .get_or_create(channel_id, || self.transport.receive(channel_id)),
         )


### PR DESCRIPTION
While dealing with #728 I noticed that end of stream error does not carry the information about the origin and step.

