### PR TITLE
fix flaky dp test

### DIFF
--- a/src/protocol/dp/insecure.rs
+++ b/src/protocol/dp/insecure.rs
@@ -232,7 +232,7 @@ mod test {
                 sample_variance,
                 dp.rounded_normal_dist.std().powi(2)
             );
-            assert!(f64::abs(sample_variance - dp.rounded_normal_dist.std().powi(2)) < 1.0);
+            assert!(f64::abs(sample_variance - dp.rounded_normal_dist.std().powi(2)) < 2.0);
         }
     }
 }


### PR DESCRIPTION
giving some more room on the difference between variance of rounded and continuous gaussians.  We don't have a theoretical bound to use here right now, so is a simple test but for small epsilon where these can diverge it was failing often.  Ideally, we get a better bound in the future, but the actual plan is to switch to generating a discrete gaussian (or laplace) and stop using the rounded gaussian. 