### PR TITLE
Single producer single consumer channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,12 @@ harness = false
 required-features = ["enable-benches"]
 
 [[bench]]
+name = "criterion_spsc"
+path = "benches/ct/spsc.rs"
+harness = false
+required-features = ["enable-benches"]
+
+[[bench]]
 name = "iai_arithmetic"
 path = "benches/iai/arithmetic_circuit.rs"
 harness = false

--- a/benches/ct/spsc.rs
+++ b/benches/ct/spsc.rs
@@ -1,0 +1,49 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
+use futures_util::future::{join, try_join};
+use std::num::NonZeroUsize;
+use tokio_stream::StreamExt;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("spsc-reader-writer")
+        .enable_time()
+        .build()
+        .expect("Creating runtime failed");
+
+    let mut group = c.benchmark_group("spsc");
+    group.sample_size(10);
+    group.sampling_mode(SamplingMode::Flat);
+
+    for capacity in [1_usize, 1 << 8, 1 << 10] {
+        group.throughput(Throughput::Elements(10000));
+        group.bench_with_input(
+            BenchmarkId::new("with_capacity", capacity),
+            &capacity,
+            |b, &capacity| {
+                b.to_async(&rt).iter(|| async {
+                    let capacity = NonZeroUsize::new(capacity).unwrap();
+                    let (tx, mut rx) = ipa::helpers::spsc::channel(capacity);
+
+                    let writer_handle = rt.spawn(async move {
+                        for _ in 1..100 * capacity.get() {
+                            tx.push(1).await;
+                        }
+                    });
+                    let reader_handle = rt.spawn(async move {
+                        while let Some(item) = rx.next().await {
+                            black_box(item);
+                        }
+                    });
+
+                    try_join(writer_handle, reader_handle).await.unwrap();
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/ct/spsc.rs
+++ b/benches/ct/spsc.rs
@@ -1,7 +1,7 @@
 use criterion::{
     black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
-use futures_util::future::{join, try_join};
+use futures_util::future::try_join;
 use std::num::NonZeroUsize;
 use tokio_stream::StreamExt;
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -7,7 +7,7 @@ mod buffers;
 mod error;
 mod gateway;
 pub(crate) mod prss_protocol;
-mod spsc;
+pub mod spsc;
 mod transport;
 
 pub use error::{Error, Result};

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -7,6 +7,7 @@ mod buffers;
 mod error;
 mod gateway;
 pub(crate) mod prss_protocol;
+mod spsc;
 mod transport;
 
 pub use error::{Error, Result};

--- a/src/helpers/spsc.rs
+++ b/src/helpers/spsc.rs
@@ -152,8 +152,8 @@ impl<T: Send> Stream for Receiver<T> {
                 }
             } else {
                 // Take the value out, update the head pointer and notify the writer, in this order.
-                // This operation is less expensive than writer update because it wakes up the
-                // writer task iff there is an active push waiting.
+                // This operation is less expensive than the writer update because it wakes up the
+                // writer task iff there is an active wait to push a new element into the queue.
                 let item = state.take(head, None);
                 debug_assert!(item.is_some());
 
@@ -191,7 +191,9 @@ impl<T> Drop for Receiver<T> {
 /// API to push several items at a time per single reader wake.
 ///
 /// Sender and receiver may over-communicate the updates in contention which happens
-/// when the capacity is small. See `contention` test for more details.
+/// when the capacity is small. See `contention` test for more details. Pushing data to the channel
+/// is generally more expensive in terms of task wakeups than reading it. See [`Receiver`] docs for
+/// more details.
 ///
 /// [`push`]: Sender::push
 /// [`Sender`]: Sender

--- a/src/helpers/spsc.rs
+++ b/src/helpers/spsc.rs
@@ -1,0 +1,355 @@
+use futures::Stream;
+use std::{
+    future::Future,
+    iter::repeat_with,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    task::{Context, Poll, Waker},
+};
+
+/// FIFO queue that backs spsc channel. Uses the ring buffer and two pointers to last element written
+/// and read.
+struct Queue<T> {
+    /// Pointer to the next write slot. If `head` == `tail`, queue is considered empty.
+    head: AtomicUsize,
+    /// Pointer to the next read slot. If `tail` - `head` == capacity, queue is considered full.
+    tail: AtomicUsize,
+    /// Ring buffer.
+    buf: Box<[Mutex<Option<T>>]>,
+    /// A task to wake when there is a next element to read from the queue.
+    read_waker: Mutex<Option<Waker>>,
+    /// A task to wake when there is at least one slot available in the queue to write.
+    write_waker: Mutex<Option<Waker>>,
+    /// Indicates that queue is closed.
+    closed: AtomicBool,
+}
+
+impl<T> Queue<T> {
+    fn queue_op<F: FnOnce(usize, usize) -> R, R>(&self, f: F) -> R {
+        let head = self.head.load(Ordering::Relaxed);
+        let tail = self.tail.load(Ordering::Acquire);
+        f(head, tail)
+    }
+
+    /// Writes a new value at `index` mod buffer size and returns the previous value.
+    fn write(&self, index: usize, value: T) -> Option<T> {
+        self.buf[index % self.buf.len()]
+            .lock()
+            .unwrap()
+            .replace(value)
+    }
+
+    /// Takes the value stored at `index` mod size out and places `None` in that cell.
+    /// This method has no effect if the value wasn't set before.
+    fn take(&self, index: usize) -> Option<T> {
+        self.buf[index % self.buf.len()]
+            .lock()
+            .unwrap()
+            .take()
+    }
+
+    /// Closes this queue, making it unavailable for new writes. Queue can still be drained after
+    /// this call. It is safe to call this method more than once.
+    fn close(&self) {
+        self.closed.swap(true, Ordering::Release);
+    }
+
+    /// Checks whether this queue is closed.
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+}
+
+/// Sending end of the spsc channel. Allows messages to be pushed into the channel via [`push`].
+/// Dropping the sender will wake the receiver and close the stream.
+///
+/// [`push`]: Sender::push
+struct Sender<T> {
+    state: Arc<Queue<T>>,
+}
+
+#[allow(dead_code)]
+impl <T: Send> Sender<T> {
+    fn push(&self, value: T) -> Push<'_, T> {
+        Push {
+            value: Some(value),
+            sender: self,
+        }
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        self.state.close();
+    }
+}
+
+/// Receiving end of the spsc channel. Items can be taken out of it using the standard [`Stream`]
+/// API.
+///
+/// Dropping the receiver handle prematurely will cause a panic on the producer's side. This behaviour
+/// is chosen because it suits the IPA use-case where downstream tasks live longer than upstream.
+///
+/// [`Stream`]: Stream
+struct Receiver<T> {
+    state: Arc<Queue<T>>,
+}
+
+impl <T: Send> Stream for Receiver<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let state = &self.state;
+        let v = state.queue_op(|head, tail| {
+            if head == tail {
+                if state.is_closed() {
+                    Poll::Ready(None)
+                } else {
+                    save_waker(&state.read_waker, cx.waker());
+                    Poll::Pending
+                }
+            } else {
+                let item = state.take(head);
+                debug_assert!(item.is_some());
+
+                state.head.store(head.wrapping_add(1), Ordering::Release);
+                Poll::Ready(item)
+            }
+        });
+        wake(&state.write_waker);
+
+        v
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        self.state.close();
+    }
+}
+
+/// Creates a new single-producer single-consumer channel with the given capacity and returns
+/// its sending and receiving ends. Up to `capacity` elements can be added to this channel without
+/// waiting by using [`push`]. The receiving end is a stream that takes these elements out in FIFO
+/// order.
+///
+/// If channel is full, [`push`] waits until at least one element is taken out by polling
+/// the receiver. Channel is closed automatically when either [`Sender`] or [`Receiver`] is dropped.
+/// Closed channel will reject [`push`] requests, but will let the receiver drain the remaining items.
+///
+/// ### Performance considerations
+///
+/// This channel is backed by a ring buffer. Although it uses mutexes internally, they are not
+/// contended between reader and writer. Slow writer may cause excessive context switching between
+/// read and write tasks, if that becomes a problem, consider additional buffering or extending the
+/// API to push several items at a time per single reader wake.
+///
+/// Sender and receiver may over-communicate the updates in contention which happens
+/// when the capacity is small. See `contention` test for more details.
+///
+/// [`push`]: Sender::push
+/// [`Sender`]: Sender
+/// [`Receiver`]: Receiver
+#[allow(dead_code)]
+fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    let state = Arc::new(Queue {
+        head: AtomicUsize::new(0),
+        tail: AtomicUsize::new(0),
+        buf: repeat_with(|| Mutex::new(None))
+            .take(capacity)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        read_waker: Mutex::new(None),
+        write_waker: Mutex::new(None),
+        closed: AtomicBool::new(false),
+    });
+
+    (
+        Sender {
+            state: Arc::clone(&state),
+        },
+        Receiver { state },
+    )
+}
+
+/// Future for [`push`] method.
+///
+/// [`push`]: Sender::push
+#[must_use = "futures do nothing unless polled"]
+pub struct Push<'a, T> {
+    value: Option<T>,
+    sender: &'a Sender<T>,
+}
+
+impl<T: Send + Unpin> Future for Push<'_, T> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        assert!(!self.sender.state.is_closed(), "Channel is closed");
+        let state = &self.sender.state;
+        let value = &mut self.value;
+
+        let v = state.queue_op(|head, tail| {
+            if tail.wrapping_sub(head) == state.buf.len() {
+                // buffer is full, we have no capacity to write
+                save_waker(&state.write_waker, cx.waker());
+                Poll::Pending
+            } else {
+                let value = value.take().expect("value hasn't been moved yet");
+                let prev = state.write(tail, value);
+                debug_assert!(prev.is_none());
+
+                state.tail.store(tail.wrapping_add(1), Ordering::Release);
+                Poll::Ready(())
+            }
+        });
+
+        wake(&self.sender.state.read_waker);
+
+        v
+    }
+}
+
+fn wake(cell: &Mutex<Option<Waker>>) {
+    if let Some(waker) = cell.lock().unwrap().take() {
+        waker.wake();
+    }
+}
+
+fn save_waker(cell: &Mutex<Option<Waker>>, waker: &Waker) {
+    *cell.lock().unwrap() = Some(waker.clone());
+}
+
+#[cfg(all(test, any(unit_test, feature = "shuttle")))]
+mod tests {
+    use super::*;
+    use crate::{
+        rand::thread_rng,
+        test_executor::{run, spawn},
+    };
+    use futures_util::{
+        future::{poll_immediate, try_join},
+        StreamExt,
+    };
+    use rand::Rng;
+    use std::pin::pin;
+
+    #[test]
+    fn sender_fills_buffer() {
+        run(|| async {
+            let (tx, _rx) = channel::<u32>(100);
+
+            for i in 0..100 {
+                tx.push(i).await;
+            }
+
+            let mut f = pin!(tx.push(100));
+            assert_eq!(None, poll_immediate(&mut f).await);
+        });
+    }
+
+    #[test]
+    fn receiver_unblocks_sender() {
+        run(|| async {
+            let (tx, mut rx) = channel(1);
+
+            let send_handle = spawn(async move {
+                tx.push(1).await;
+                tx.push(2).await;
+            });
+
+            assert_eq!(Some(1), rx.next().await);
+            send_handle.await.unwrap();
+        });
+    }
+
+    #[test]
+    fn sender_unblocks_receiver() {
+        run(|| async {
+            let (tx, mut rx) = channel(1);
+
+            let recv_handle = spawn(async move { rx.next().await });
+
+            tx.push(1).await;
+            assert_eq!(Some(1), recv_handle.await.unwrap());
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Channel is closed")]
+    #[cfg(not(feature = "shuttle"))]
+    fn dropping_receiver_unblocks_sender() {
+        use std::panic;
+
+        run(|| async {
+            let (tx, rx) = channel(1);
+            tx.push(1).await;
+            let send_handle = spawn(async move {
+                tx.push(2).await;
+            });
+
+            drop(rx);
+            panic::resume_unwind(send_handle.await.unwrap_err().into_panic());
+        });
+    }
+
+    #[test]
+    fn random() {
+        run(|| async {
+            let fwd_capacity = thread_rng().gen_range(1..=100);
+            let (fwd_tx, mut fwd_rx) = channel(fwd_capacity);
+
+            let a_handle = spawn(async move {
+                let iterations = thread_rng().gen_range(fwd_capacity..=5 * fwd_capacity);
+                let mut sum: u64 = 0;
+                for _ in 0..iterations {
+                    sum = sum.wrapping_add(1);
+                    fwd_tx.push(1).await;
+                }
+
+                sum
+            });
+
+            let b_handle = spawn(async move {
+                let mut sum: u64 = 0;
+                while let Some(value) = fwd_rx.next().await {
+                    sum = sum.wrapping_add(value);
+                }
+
+                sum
+            });
+
+            let (a, b) = try_join(a_handle, b_handle).await.unwrap();
+            assert_eq!(a, b);
+        });
+    }
+
+    #[test]
+    fn contention() {
+        run(|| async {
+            let (tx, mut rx) = channel(1);
+            // writer throughput is 2x compared to reader.
+            // this causes head and tail pointers to be read/written by two threads often at
+            // the same time. Without excessive wakes, this test will stall.
+            spawn(async move {
+                for i in 0..100 {
+                    tx.push(i).await;
+                    tx.push(100 + i).await;
+                }
+            });
+            let read_handle = spawn(async move {
+                let mut sum = 0;
+                while let Some(value) = rx.next().await {
+                    sum += value;
+                }
+
+                sum
+            });
+
+            assert_eq!(19900, read_handle.await.unwrap());
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub(crate) mod task {
     pub use tokio::task::{JoinError, JoinHandle};
 }
 
-#[cfg(all(feature = "shuttle", test))]
+#[cfg(all(test, feature = "shuttle"))]
 pub(crate) mod test_executor {
     use std::future::Future;
 
@@ -97,6 +97,14 @@ pub(crate) mod test_executor {
         Fut: Future<Output = ()>,
     {
         shuttle::check_random(move || shuttle::future::block_on(f()), ITER);
+    }
+
+    pub fn spawn<F>(f: F) -> shuttle::future::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        shuttle::future::spawn(f)
     }
 }
 
@@ -122,6 +130,14 @@ pub(crate) mod test_executor {
             .build()
             .unwrap()
             .block_on(f());
+    }
+
+    pub fn spawn<F>(f: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio::spawn(f)
     }
 }
 


### PR DESCRIPTION
This is a step towards adding more parallelism to IPA. Tasks spawned to execute steps need to communicate with each other. Some that will use internal parallelism need the full power of MPSC channels, others that execute just a few multiplications per row need a more efficient channel implementation. There is always a single downstream consumer that takes a stream from producing task, having a single producer allows to use a more efficient implementation that does not require synchronization on the writer side.

The proposed implementation uses a single ring buffer with two pointers that are updated exclusively by reader/writer. Whenever a pointer is updated, the opposite end of the channel is notified.  

I don't know if there is a better implementation with 100% safe Rust, there are ways to improve it with unsafe pointers but not sure if we want to cross that bridge now.