### PR TITLE
collect step tracing each time a step is narrowed

### DIFF
--- a/src/protocol/step/descriptive.rs
+++ b/src/protocol/step/descriptive.rs
@@ -1,4 +1,5 @@
 use super::{Step, StepNarrow};
+#[cfg(feature = "step-trace")]
 use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -54,7 +55,10 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
             id += [std::any::type_name::<S>(), "::"].concat().as_ref();
         }
         id += step.as_ref();
-        metrics::increment_counter!(STEP_NARROWED, STEP => id.clone());
+        #[cfg(feature = "step-trace")]
+        {
+            metrics::increment_counter!(STEP_NARROWED, STEP => id.clone());
+        }
 
         Self { id }
     }

--- a/src/protocol/step/descriptive.rs
+++ b/src/protocol/step/descriptive.rs
@@ -1,4 +1,5 @@
 use super::{Step, StepNarrow};
+use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};
 use std::fmt::{Debug, Display, Formatter};
 
 /// A descriptive representation of a unique step in protocol execution.
@@ -53,6 +54,7 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
             id += [std::any::type_name::<S>(), "::"].concat().as_ref();
         }
         id += step.as_ref();
+        metrics::increment_counter!(STEP_NARROWED, STEP => id.clone());
 
         Self { id }
     }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -103,7 +103,7 @@ pub mod metrics {
         describe_counter!(
             STEP_NARROWED,
             Unit::Count,
-            "Trace steps each time they are narrowed"
+            "Number of times the step is narrowed"
         );
     }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -16,6 +16,7 @@ pub mod metrics {
     pub const BYTES_SENT: &str = "bytes.sent";
     pub const INDEXED_PRSS_GENERATED: &str = "i.prss.gen";
     pub const SEQUENTIAL_PRSS_GENERATED: &str = "s.prss.gen";
+    pub const STEP_NARROWED: &str = "step.narrowed";
 
     #[cfg(feature = "web-app")]
     pub mod web {
@@ -97,6 +98,12 @@ pub mod metrics {
             SEQUENTIAL_PRSS_GENERATED,
             Unit::Count,
             "Number of times PRSS is used as CPRNG to generate a random value"
+        );
+
+        describe_counter!(
+            STEP_NARROWED,
+            Unit::Count,
+            "Trace steps each time they are narrowed"
         );
     }
 }

--- a/src/telemetry/step_stats.rs
+++ b/src/telemetry/step_stats.rs
@@ -3,7 +3,9 @@
 
 use crate::telemetry::{
     labels,
-    metrics::{BYTES_SENT, INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED},
+    metrics::{
+        BYTES_SENT, INDEXED_PRSS_GENERATED, RECORDS_SENT, SEQUENTIAL_PRSS_GENERATED, STEP_NARROWED,
+    },
     stats::Metrics,
 };
 use std::{
@@ -38,18 +40,19 @@ impl CsvExporter for Metrics {
         if self.print_header {
             writeln!(
                 w,
-                "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS"
+                "Step,Records sent,Bytes sent,Indexed PRSS,Sequential PRSS,Step narrowed"
             )?;
         }
         for (step, stats) in steps_stats.all_steps() {
             writeln!(
                 w,
-                "{},{},{},{},{}",
+                "{},{},{},{},{},{}",
                 step,
                 stats.get(RECORDS_SENT),
                 stats.get(BYTES_SENT),
                 stats.get(INDEXED_PRSS_GENERATED),
-                stats.get(SEQUENTIAL_PRSS_GENERATED)
+                stats.get(SEQUENTIAL_PRSS_GENERATED),
+                stats.get(STEP_NARROWED),
             )?;
         }
 


### PR DESCRIPTION
Current compact gate has an issue (#706) that not all narrowed steps are not executed. This diff adds one metric to our tracing. Each time we narrow a step, we log it and generate metrics output when debug tracing is on. Since `steps.txt` (file we use to generate compact gate) will contain all narrowed steps rather than executed steps, we don't need special handlings for such steps anymore.

This resolves the issue #706, but it also comes with a side effect. The compact gate would now contain state transitions that don't actually trigger communications. I can't think of that being a problem in production, but it is a bit of a concern that we cannot distinguish between comms/no-comms state transitions.

That said, the benefit of being able to get rid of that "magic" in compact.rs surpasses the side effect.