### PR TITLE
Relax normal distribution bounds for DP test even more

### DIFF
--- a/src/protocol/dp/insecure.rs
+++ b/src/protocol/dp/insecure.rs
@@ -159,12 +159,12 @@ mod test {
         // LB = (n - 1) * std^2 / chi2inv(alpha/2,n - 1)
         // UB = (n - 1) * std^2 / chi2inv(1 - alpha/2, n - 1)
         // where N is the size of the sample, alpha - the probability of any value to be outside
-        // of the expected distribution range. For the purpose of this test, alpha is set to 0.02%,
-        // chi2inv(0.0001, 10000 - 1) = 9482.6
-        // chi2inv(0.9999, 10000 - 1) = 10535
+        // of the expected distribution range. For the purpose of this test, alpha is set to 0.00002%,
+        // chi2inv(0.000001, 10000 - 1) = 9341.1
+        // chi2inv(0.999999, 10000 - 1) = 10686
         // if the dataset size changes, those values need to be recomputed
-        const CHI2_INV_UB: f64 = 9_482.6;
-        const CHI2_INV_LB: f64 = 10_535.0;
+        const CHI2_INV_UB: f64 = 9_341.1;
+        const CHI2_INV_LB: f64 = 10_686.0;
 
         let mut rng = StdRng::seed_from_u64(seed);
         let mut sample = [0_f64; N];


### PR DESCRIPTION
https://github.com/private-attribution/ipa/actions/runs/5694472598