### PR TITLE
Improve logging in IPA

### DIFF
--- a/src/protocol/basics/reshare.rs
+++ b/src/protocol/basics/reshare.rs
@@ -169,6 +169,7 @@ impl<S, C: Context> Reshare<C, NoRecord> for Vec<S>
 where
     S: Reshare<C, RecordId> + Send + Sync,
 {
+    #[tracing::instrument(name = "reshare", skip_all, fields(to = ?to_helper))]
     async fn reshare<'fut>(
         &self,
         ctx: C,

--- a/src/protocol/context/validator.rs
+++ b/src/protocol/context/validator.rs
@@ -215,7 +215,7 @@ impl<'a, F: ExtendableField> Validator<MaliciousContext<'a>, F> for Malicious<'a
     ///
     /// ## Panics
     /// Will panic if the mutex is poisoned
-    #[tracing::instrument(name = "validate", skip_all, fields(gate = %self.validate_ctx.gate()))]
+    #[tracing::instrument(name = "validate", skip_all, fields(gate = %self.validate_ctx.gate().as_ref()))]
     async fn validate<D: DowngradeMalicious>(self, values: D) -> Result<D::Target, Error> {
         // send our `u_i+1` value to the helper on the right
         let (u_share, w_share) = self.propagate_u_and_w().await?;

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -130,7 +130,7 @@ where
 /// Propagates errors from convert shares
 /// # Panics
 /// Propagates panics from convert shares
-#[tracing::instrument(name = "modulus_conversion", skip_all, fields(bits = %num_bits, parallel = %num_multi_bits, gate = %ctx.gate()))]
+#[tracing::instrument(name = "modulus_conversion", skip_all, fields(bits = %num_bits, parallel = %num_multi_bits, gate = %ctx.gate().as_ref()))]
 pub async fn convert_all_bits<F, C, S>(
     ctx: &C,
     locally_converted_bits: &[BitDecomposed<BitConversionTriple<S>>],

--- a/src/protocol/sort/apply_sort/mod.rs
+++ b/src/protocol/sort/apply_sort/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// # Errors
 /// Propagates errors from shuffle/reshare
-#[tracing::instrument(name = "apply_sort", skip_all, fields(gate = %ctx.gate()))]
+#[tracing::instrument(name = "apply_sort", skip_all, fields(gate = %ctx.gate().as_ref()))]
 pub async fn apply_sort_permutation<C, I>(
     ctx: C,
     input: Vec<I>,

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -36,6 +36,7 @@ impl From<usize> for InnerVectorElementStep {
 /// i)   2 helpers receive permutation pair and choose the permutation to be applied
 /// ii)  2 helpers apply the permutation to their shares
 /// iii) reshare to `to_helper`
+#[tracing::instrument(name = "shuffle_once", skip_all, fields(to = ?shuffle_for_helper(which_step)))]
 async fn shuffle_once<C, I>(
     mut input: Vec<I>,
     random_permutations: (&[u32], &[u32]),

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -67,7 +67,7 @@ where
         DowngradeMalicious<Target = MCAggregateCreditOutputRow<F, AdditiveShare<F>, BreakdownKey>>,
     AdditiveShare<F>: Serializable,
 {
-    #[tracing::instrument("ipa_query", skip_all, fields(query_config=?self.config, %query_size))]
+    #[tracing::instrument("ipa_query", skip_all, fields(sz=%query_size))]
     pub async fn execute<'a>(
         self,
         ctx: C,
@@ -79,6 +79,7 @@ where
             key_registry,
             phantom_data: _,
         } = self;
+        tracing::info!("New query: {config:?}");
         let sz = usize::from(query_size);
 
         let input = if config.plaintext_match_keys {


### PR DESCRIPTION
* Use gate.as_ref() to print step names, rather than gate id
* Log reshare(vec) and shuffle steps
* Do not print IPA query config for every log line

```
ipa_query{query_config=IpaQueryConfig { per_user_credit_cap: 5, max_breakdown_key: 20, attribution_window_seconds: None, num_multi_bits: 3, plaintext_match_keys: false } query_size=500000}:sort_permutation:validate{gate=6939}: ipa::protocol::context::validator: new
```

is hard to read