### PR TITLE
Use strings in Compact gate Display

### DIFF
--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -20,13 +20,13 @@ impl From<&str> for Compact {
 
 impl Display for Compact {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.as_ref())
     }
 }
 
 impl Debug for Compact {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "step={}", self.0)
+        write!(f, "gate[{}]={}", self.0, self.as_ref())
     }
 }
 


### PR DESCRIPTION
and Debug impl

These are mostly used to print errors, so allocations don't happen often

Otherwise, errors look like this

```
InfraError(ReceiveError { source: H1, step: "12287", inner: EndOfStream { record_id: RecordId(999424) } })
```