### PR TITLE
Attribution and Capping for OPRF approach

### DIFF
--- a/src/ff/galois_field.rs
+++ b/src/ff/galois_field.rs
@@ -561,6 +561,16 @@ bit_array_impl!(
 );
 
 bit_array_impl!(
+    bit_array_5,
+    Gf5Bit,
+    U8_1,
+    5,
+    bitarr!(const u8, Lsb0; 1, 0, 0, 0, 0),
+    // x^5 + x^4 + x^3 + x^2 + x + 1
+    0b111_111_u128
+);
+
+bit_array_impl!(
     bit_array_3,
     Gf3Bit,
     U8_1,

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -9,7 +9,7 @@ mod prime_field;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use field::{Field, FieldType};
-pub use galois_field::{GaloisField, Gf2, Gf32Bit, Gf3Bit, Gf40Bit, Gf8Bit};
+pub use galois_field::{GaloisField, Gf2, Gf32Bit, Gf3Bit, Gf40Bit, Gf5Bit, Gf8Bit};
 use generic_array::{ArrayLength, GenericArray};
 #[cfg(any(test, feature = "weak-field"))]
 pub use prime_field::Fp31;

--- a/src/protocol/boolean/mod.rs
+++ b/src/protocol/boolean/mod.rs
@@ -19,6 +19,7 @@ pub mod comparison;
 pub mod generate_random_bits;
 pub mod or;
 pub mod random_bits_generator;
+pub mod saturating_sum;
 pub mod solved_bits;
 mod xor;
 

--- a/src/protocol/boolean/saturating_sum.rs
+++ b/src/protocol/boolean/saturating_sum.rs
@@ -1,0 +1,171 @@
+use crate::{
+    error::Error,
+    ff::Gf2,
+    protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
+    secret_sharing::{BitDecomposed, Linear as LinearSecretSharing},
+};
+
+#[derive(Debug)]
+pub struct SaturatingSum<S: LinearSecretSharing<Gf2>> {
+    pub sum: BitDecomposed<S>,
+    pub is_saturated: S,
+}
+
+impl<S: LinearSecretSharing<Gf2>> SaturatingSum<S> {
+    pub fn new(value: BitDecomposed<S>, is_saturated: S) -> SaturatingSum<S> {
+        SaturatingSum {
+            sum: value,
+            is_saturated,
+        }
+    }
+
+    pub async fn add<C>(
+        &self,
+        ctx: C,
+        record_id: RecordId,
+        value: &BitDecomposed<S>,
+    ) -> Result<SaturatingSum<S>, Error>
+    where
+        C: Context,
+        S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+    {
+        assert!(self.sum.len() >= value.len());
+
+        let mut output_sum = Vec::with_capacity(self.sum.len());
+        let mut carry_in = S::ZERO;
+        for i in 0..self.sum.len() {
+            let c = ctx.narrow(&BitOpStep::from(i));
+            let (sum_bit, carry_out) = if i < value.len() {
+                one_bit_adder(c, record_id, &value[i], &self.sum[i], &carry_in).await?
+            } else {
+                one_bit_adder(c, record_id, &S::ZERO, &self.sum[i], &carry_in).await?
+            };
+
+            output_sum.push(sum_bit);
+            carry_in = carry_out;
+        }
+        let is_saturated = -carry_in
+            .clone()
+            .multiply(
+                &self.is_saturated,
+                ctx.narrow(&BitOpStep::from(self.sum.len())),
+                record_id,
+            )
+            .await?
+            + &carry_in
+            + &self.is_saturated;
+
+        Ok(SaturatingSum::new(
+            BitDecomposed::new(output_sum),
+            is_saturated,
+        ))
+    }
+}
+
+///
+/// Returns (`sum_bit`, `carry_out`)
+///
+async fn one_bit_adder<C, SB>(
+    ctx: C,
+    record_id: RecordId,
+    x: &SB,
+    y: &SB,
+    carry_in: &SB,
+) -> Result<(SB, SB), Error>
+where
+    C: Context,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    // compute sum bit as x XOR y XOR carry_in
+    let sum_bit = x.clone() + y + carry_in;
+
+    let x_xor_carry_in = x.clone() + carry_in;
+    let y_xor_carry_in = y.clone() + carry_in;
+    let carry_out = x_xor_carry_in
+        .multiply(&y_xor_carry_in, ctx, record_id)
+        .await?
+        + carry_in;
+
+    Ok((sum_bit, carry_out))
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use super::SaturatingSum;
+    use crate::{
+        ff::{Field, Gf2},
+        protocol::{context::Context, RecordId},
+        secret_sharing::{
+            replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, SharedValue,
+        },
+        test_fixture::{get_bits, Reconstruct, Runner, TestWorld},
+    };
+
+    impl Reconstruct<u128> for [SaturatingSum<Replicated<Gf2>>; 3] {
+        fn reconstruct(&self) -> u128 {
+            let [s0, s1, s2] = self;
+
+            let sum_bits: BitDecomposed<Gf2> = BitDecomposed::new(
+                s0.sum
+                    .iter()
+                    .zip(s1.sum.iter())
+                    .zip(s2.sum.iter())
+                    .map(|((a, b), c)| [a, b, c].reconstruct()),
+            );
+
+            let is_saturated = [&s0.is_saturated, &s1.is_saturated, &s2.is_saturated].reconstruct();
+
+            if is_saturated == Gf2::ZERO {
+                sum_bits
+                    .iter()
+                    .map(Field::as_u128)
+                    .enumerate()
+                    .fold(0_u128, |acc, (i, x)| acc + (x << i))
+            } else {
+                2_u128.pow(s0.sum.len() as u32)
+            }
+        }
+    }
+
+    #[tokio::test]
+    pub async fn simple() {
+        assert_eq!(2, saturating_add(1, 2, 1, 2).await);
+        assert_eq!(3, saturating_add(2, 2, 1, 2).await);
+        assert_eq!(4, saturating_add(3, 2, 1, 2).await);
+        assert_eq!(4, saturating_add(3, 2, 2, 2).await);
+        assert_eq!(4, saturating_add(3, 2, 3, 2).await);
+        assert_eq!(6, saturating_add(3, 5, 3, 3).await);
+        assert_eq!(6, saturating_add(3, 5, 3, 5).await);
+        assert_eq!(14, saturating_add(7, 5, 7, 3).await);
+        assert_eq!(14, saturating_add(7, 5, 7, 5).await);
+        assert_eq!(31, saturating_add(26, 5, 5, 3).await);
+        assert_eq!(32, saturating_add(26, 5, 6, 3).await);
+        assert_eq!(32, saturating_add(26, 5, 7, 3).await);
+        assert_eq!(32, saturating_add(31, 5, 7, 3).await);
+        assert_eq!(63, saturating_add(60, 6, 3, 3).await);
+        assert_eq!(64, saturating_add(60, 6, 4, 3).await);
+        assert_eq!(64, saturating_add(60, 6, 5, 3).await);
+    }
+
+    async fn saturating_add(a: u32, num_a_bits: u32, b: u32, num_b_bits: u32) -> u128 {
+        let world = TestWorld::default();
+
+        let a_bits = get_bits::<Gf2>(a, num_a_bits);
+        //let a_saturated = Gf2::ZERO;
+        let b_bits = get_bits::<Gf2>(b, num_b_bits);
+
+        let foo = world
+            .semi_honest(
+                (a_bits, b_bits),
+                |ctx, (a_bits, b_bits): (BitDecomposed<_>, BitDecomposed<_>)| async move {
+                    let a = SaturatingSum::new(a_bits, Replicated::ZERO);
+                    a.add(ctx.set_total_records(1), RecordId(0), &b_bits)
+                        .await
+                        .unwrap()
+                },
+            )
+            .await;
+
+        foo.reconstruct()
+    }
+}

--- a/src/protocol/boolean/saturating_sum.rs
+++ b/src/protocol/boolean/saturating_sum.rs
@@ -33,13 +33,12 @@ impl<S: LinearSecretSharing<Gf2>> SaturatingSum<S> {
 
         let mut output_sum = Vec::with_capacity(self.sum.len());
         let mut carry_in = S::ZERO;
+        let zero = S::ZERO;
         for i in 0..self.sum.len() {
             let c = ctx.narrow(&BitOpStep::from(i));
-            let (sum_bit, carry_out) = if i < value.len() {
-                one_bit_adder(c, record_id, &value[i], &self.sum[i], &carry_in).await?
-            } else {
-                one_bit_adder(c, record_id, &S::ZERO, &self.sum[i], &carry_in).await?
-            };
+            let x = if i < value.len() { &value[i] } else { &zero };
+            let (sum_bit, carry_out) =
+                one_bit_adder(c, record_id, x, &self.sum[i], &carry_in).await?;
 
             output_sum.push(sum_bit);
             carry_in = carry_out;

--- a/src/protocol/boolean/saturating_sum.rs
+++ b/src/protocol/boolean/saturating_sum.rs
@@ -232,7 +232,7 @@ mod tests {
                     .enumerate()
                     .fold(0_u128, |acc, (i, x)| acc + (x << i))
             } else {
-                2_u128.pow(s0.sum.len() as u32)
+                2_u128.pow(u32::try_from(s0.sum.len()).unwrap())
             }
         }
     }

--- a/src/protocol/boolean/saturating_sum.rs
+++ b/src/protocol/boolean/saturating_sum.rs
@@ -120,7 +120,7 @@ impl<S: LinearSecretSharing<Gf2>> SaturatingSum<S> {
 /// This can be computed "for free" in Gf2
 ///
 /// The `carry_out` bit can be efficiently computed with just a single multiplication as:
-/// `c_(i+1) = c_i ⊕ ((x_i ⊕ c_i) ∧ (y_i ⊕ c_i))`
+/// `c_(i+1) = c_i ⊕ ((x_i ⊕ c_i) & (y_i ⊕ c_i))`
 ///
 /// Returns `sum_bit`
 ///
@@ -185,11 +185,11 @@ where
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
 {
     // compute difference bit as not_y XOR x XOR carry_in
-    let difference_bit = SB::share_known_value(&ctx, Gf2::ONE) - y + x + carry_in;
+    let difference_bit = SB::share_known_value(&ctx, Gf2::ONE) + y + x + carry_in;
     if compute_carry_out {
         let x_xor_carry_in = x.clone() + carry_in;
         let y_xor_carry_in = y.clone() + carry_in;
-        let not_y_xor_carry_in = SB::share_known_value(&ctx, Gf2::ONE) - &y_xor_carry_in;
+        let not_y_xor_carry_in = SB::share_known_value(&ctx, Gf2::ONE) + &y_xor_carry_in;
 
         *carry_in = x_xor_carry_in
             .multiply(&not_y_xor_carry_in, ctx, record_id)

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -6,6 +6,7 @@ pub mod context;
 pub mod dp;
 pub mod ipa;
 pub mod modulus_conversion;
+#[cfg(feature = "descriptive-gate")]
 pub mod prf_sharding;
 pub mod prss;
 pub mod sort;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -6,6 +6,7 @@ pub mod context;
 pub mod dp;
 pub mod ipa;
 pub mod modulus_conversion;
+pub mod prf_sharding;
 pub mod prss;
 pub mod sort;
 pub mod step;

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -489,6 +489,32 @@ pub mod tests {
         trigger_value: TV,
     }
 
+    fn test_input(
+        prf_of_match_key: u64,
+        is_trigger: bool,
+        breakdown_key: u8,
+        trigger_value: u8,
+    ) -> PreShardedAndSortedOPRFTestInput<Gf5Bit, Gf3Bit> {
+        let is_trigger_bit = if is_trigger { Gf2::ONE } else { Gf2::ZERO };
+
+        PreShardedAndSortedOPRFTestInput {
+            prf_of_match_key,
+            is_trigger_bit,
+            breakdown_key: Gf5Bit::truncate_from(breakdown_key),
+            trigger_value: Gf3Bit::truncate_from(trigger_value),
+        }
+    }
+
+    fn test_output(
+        attributed_breakdown_key: u128,
+        capped_attributed_trigger_value: u128,
+    ) -> PreAggregationTestOutput {
+        PreAggregationTestOutput {
+            attributed_breakdown_key,
+            capped_attributed_trigger_value,
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     struct PreAggregationTestOutput {
         attributed_breakdown_key: u128,
@@ -573,146 +599,43 @@ pub mod tests {
 
     #[test]
     fn semi_honest() {
-        const EXPECTED: &[PreAggregationTestOutput] = &[
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 17,
-                capped_attributed_trigger_value: 7,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 20,
-                capped_attributed_trigger_value: 0,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 20,
-                capped_attributed_trigger_value: 3,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 5,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 20,
-                capped_attributed_trigger_value: 7,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 18,
-                capped_attributed_trigger_value: 0,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 0,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 7,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 7,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 7,
-            },
-            PreAggregationTestOutput {
-                attributed_breakdown_key: 12,
-                capped_attributed_trigger_value: 4,
-            },
-        ];
-        const NUM_SATURATING_SUM_BITS: usize = 5;
-
-        run(|| async {
+        run(|| async move {
             let world = TestWorld::default();
 
             let records: Vec<PreShardedAndSortedOPRFTestInput<Gf5Bit, Gf3Bit>> = vec![
                 /* First User */
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 123,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(17_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 123,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 123,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(20_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 123,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(3_u8),
-                },
+                test_input(123, false, 17, 0),
+                test_input(123, true, 0, 7),
+                test_input(123, false, 20, 0),
+                test_input(123, true, 0, 3),
                 /* Second User */
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 234,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(12_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 234,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(5_u8),
-                },
+                test_input(234, false, 12, 0),
+                test_input(234, true, 0, 5),
                 /* Third User */
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(20_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(18_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ZERO,
-                    breakdown_key: Gf5Bit::truncate_from(12_u8),
-                    trigger_value: Gf3Bit::truncate_from(0_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
-                PreShardedAndSortedOPRFTestInput {
-                    prf_of_match_key: 345,
-                    is_trigger_bit: Gf2::ONE,
-                    breakdown_key: Gf5Bit::truncate_from(0_u8),
-                    trigger_value: Gf3Bit::truncate_from(7_u8),
-                },
+                test_input(345, false, 20, 0),
+                test_input(345, true, 0, 7),
+                test_input(345, false, 18, 0),
+                test_input(345, false, 12, 0),
+                test_input(345, true, 0, 7),
+                test_input(345, true, 0, 7),
+                test_input(345, true, 0, 7),
+                test_input(345, true, 0, 7),
             ];
+
+            let expected: [PreAggregationTestOutput; 11] = [
+                test_output(17, 7),
+                test_output(20, 0),
+                test_output(20, 3),
+                test_output(12, 5),
+                test_output(20, 7),
+                test_output(18, 0),
+                test_output(12, 0),
+                test_output(12, 7),
+                test_output(12, 7),
+                test_output(12, 7),
+                test_output(12, 4),
+            ];
+            const NUM_SATURATING_SUM_BITS: usize = 5;
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
@@ -726,7 +649,7 @@ pub mod tests {
                 })
                 .await
                 .reconstruct();
-            assert_eq!(result, EXPECTED);
+            assert_eq!(result, &expected);
         });
     }
 }

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -1,0 +1,450 @@
+use std::iter::repeat;
+
+use futures_util::future::try_join_all;
+use ipa_macros::step;
+use strum::AsRefStr;
+
+use super::step::BitOpStep;
+use crate::{
+    error::Error,
+    ff::{Field, Gf2},
+    protocol::{
+        context::{UpgradableContext, UpgradedContext, Validator},
+        BasicProtocols, RecordId,
+    },
+    secret_sharing::{
+        replicated::{malicious::DowngradeMalicious, semi_honest::AdditiveShare as Replicated},
+        Linear as LinearSecretSharing,
+    },
+};
+
+pub struct PrfShardedIpaInputRow<SB: LinearSecretSharing<Gf2>> {
+    prf_of_match_key: u64,
+    is_trigger_bit: SB,
+    breakdown_key: Vec<SB>,
+    trigger_value: Vec<SB>,
+}
+
+struct InputsRequiredFromPrevRow<SB: LinearSecretSharing<Gf2>> {
+    ever_encountered_a_source_event: SB,
+    attributed_breakdown_key_bits: Vec<SB>,
+    saturating_sum: Vec<SB>,
+    is_saturated: SB,
+    difference_to_cap: Vec<SB>,
+}
+
+pub struct CappedAttributionOutputs<SB: LinearSecretSharing<Gf2>> {
+    did_trigger_get_attributed: SB,
+    attributed_breakdown_key_bits: Vec<SB>,
+    capped_attributed_trigger_value: Vec<SB>,
+}
+
+#[step]
+pub(crate) enum Step {
+    BinaryValidator,
+    EverEncounteredSourceEvent,
+    DidTriggerGetAttributed,
+    AttributedBreakdownKey,
+    AttributedTriggerValue,
+    ComputeSaturatingSum,
+    IsSaturatedAndPrevRowNotSaturated,
+    ComputeDifferenceToCap,
+    ComputedCappedAttributedTriggerValueNotSaturatedCase,
+    ComputedCappedAttributedTriggerValueJustSaturatedCase,
+}
+
+/// Sub-protocol of the PRF-sharded IPA Protocol
+///
+/// After the computation of the per-user PRF, addition of dummy records and shuffling,
+/// the PRF column can be revealed. After that, all of the records corresponding to a single
+/// device can be processed together.
+///
+/// This circuit expects to receive records from multiple users,
+/// but with all of the records from a given user adjacent to one another, and in time order.
+///
+/// This circuit will compute attribution, and per-user capping.
+///
+/// The output of this circuit is the input to the next stage: Aggregation.
+///
+/// # Errors
+/// Propagates errors from multiplications
+/// # Panics
+/// Propagates errors from multiplications
+pub async fn attribution_and_capping_and_aggregation<C, SB, F>(
+    sh_ctx: C,
+    input_rows: &[PrfShardedIpaInputRow<SB>],
+    num_breakdown_key_bits: usize,
+    num_trigger_value_bits: usize,
+    num_saturating_sum_bits: usize,
+) -> Result<Vec<CappedAttributionOutputs<SB>>, Error>
+where
+    C: UpgradableContext,
+    C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2>
+        + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
+        + DowngradeMalicious<Target = Replicated<Gf2>>
+        + 'static,
+{
+    assert!(num_saturating_sum_bits > num_trigger_value_bits);
+    assert!(num_trigger_value_bits > 0);
+    assert!(num_breakdown_key_bits > 0);
+
+    let binary_validator = sh_ctx.narrow(&Step::BinaryValidator).validator::<Gf2>();
+    let binary_m_ctx = binary_validator.context();
+
+    let mut output = vec![];
+
+    assert!(input_rows.len() > 0);
+    let first_row = &input_rows[0];
+    let mut prev_prf = first_row.prf_of_match_key;
+    let mut prev_row_inputs = initialize_new_device_attribution_variables(
+        SB::share_known_value(&binary_m_ctx, Gf2::ONE),
+        first_row,
+        num_trigger_value_bits,
+        num_saturating_sum_bits,
+    );
+    let mut i: usize = 1;
+    while i < input_rows.len() {
+        let cur_row = &input_rows[i];
+        if prev_prf != cur_row.prf_of_match_key {
+            prev_prf = cur_row.prf_of_match_key;
+            prev_row_inputs = initialize_new_device_attribution_variables(
+                SB::share_known_value(&binary_m_ctx, Gf2::ONE),
+                cur_row,
+                num_trigger_value_bits,
+                num_saturating_sum_bits,
+            );
+        } else {
+            // Do some actual computation
+            let (inputs_required_for_next_row, capped_attribution_outputs) =
+                compute_row_with_previous(
+                    binary_m_ctx.clone(),
+                    cur_row,
+                    &prev_row_inputs,
+                    num_breakdown_key_bits,
+                    num_trigger_value_bits,
+                    num_saturating_sum_bits,
+                )
+                .await?;
+            output.push(capped_attribution_outputs);
+            prev_row_inputs = inputs_required_for_next_row;
+        }
+        i += 1;
+    }
+
+    Ok(output)
+}
+
+fn initialize_new_device_attribution_variables<SB>(
+    share_of_one: SB,
+    input_row: &PrfShardedIpaInputRow<SB>,
+    num_trigger_value_bits: usize,
+    num_saturating_sum_bits: usize,
+) -> InputsRequiredFromPrevRow<SB>
+where
+    SB: LinearSecretSharing<Gf2>,
+{
+    InputsRequiredFromPrevRow {
+        ever_encountered_a_source_event: share_of_one - &input_row.is_trigger_bit,
+        attributed_breakdown_key_bits: input_row.breakdown_key.clone(),
+        saturating_sum: vec![SB::ZERO; num_saturating_sum_bits],
+        is_saturated: SB::ZERO,
+        difference_to_cap: vec![SB::ZERO; num_trigger_value_bits],
+    }
+}
+
+///
+/// Returns (sum_bit, carry_out)
+///
+async fn one_bit_adder<C, SB>(
+    ctx: C,
+    record_id: RecordId,
+    x: &SB,
+    y: &SB,
+    carry_in: &SB,
+) -> Result<(SB, SB), Error>
+where
+    C: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    // compute sum bit as x XOR y XOR carry_in
+    let sum_bit = x.clone() + y + carry_in;
+
+    let x_xor_carry_in = x.clone() + carry_in;
+    let y_xor_carry_in = y.clone() + carry_in;
+    let carry_out = x_xor_carry_in
+        .multiply(&y_xor_carry_in, ctx, record_id)
+        .await?
+        + carry_in;
+
+    Ok((sum_bit, carry_out))
+}
+
+async fn compute_saturating_sum<C, SB>(
+    ctx: C,
+    record_id: RecordId,
+    cur_value: &Vec<SB>,
+    prev_sum: &Vec<SB>,
+    prev_is_saturated: &SB,
+    num_trigger_value_bits: usize,
+    num_saturating_sum_bits: usize,
+) -> Result<(Vec<SB>, SB), Error>
+where
+    C: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    assert!(cur_value.len() == num_trigger_value_bits);
+    assert!(prev_sum.len() == num_saturating_sum_bits);
+
+    let mut carry_in = SB::ZERO;
+    let mut output = vec![];
+    for i in 0..num_saturating_sum_bits {
+        let c = ctx.narrow(&BitOpStep::from(i));
+        let (sum_bit, carry_out) = if i < num_trigger_value_bits {
+            one_bit_adder(c, record_id, &cur_value[i], &prev_sum[i], &carry_in).await?
+        } else {
+            one_bit_adder(c, record_id, &SB::ZERO, &prev_sum[i], &carry_in).await?
+        };
+
+        output.push(sum_bit);
+        carry_in = carry_out;
+    }
+    let updated_is_saturated = -carry_in
+        .clone()
+        .multiply(
+            prev_is_saturated,
+            ctx.narrow(&BitOpStep::from(num_saturating_sum_bits)),
+            record_id,
+        )
+        .await?
+        + &carry_in
+        + prev_is_saturated;
+    Ok((output, updated_is_saturated))
+}
+
+///
+/// Returns (difference_bit, carry_out)
+///
+async fn one_bit_subtractor<C, SB>(
+    ctx: C,
+    record_id: RecordId,
+    x: &SB,
+    y: &SB,
+    carry_in: &SB,
+) -> Result<(SB, SB), Error>
+where
+    C: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    // compute difference bit as not_y XOR x XOR carry_in
+    let difference_bit = SB::share_known_value(&ctx, Gf2::ONE) - y + x + carry_in;
+
+    let x_xor_carry_in = x.clone() + carry_in;
+    let y_xor_carry_in = y.clone() + carry_in;
+    let not_y_xor_carry_in = SB::share_known_value(&ctx, Gf2::ONE) - &y_xor_carry_in;
+
+    let carry_out = x_xor_carry_in
+        .multiply(&not_y_xor_carry_in, ctx, record_id)
+        .await?
+        + carry_in;
+
+    Ok((difference_bit, carry_out))
+}
+
+///
+/// TODO: optimize this
+/// We can avoid doing this many multiplications given the foreknowledge that we are always subtracting from zero
+/// There's also no reason to compute the carry_out for the final bit since it will go unused
+///
+async fn compute_truncated_difference_to_cap<C, SB>(
+    ctx: C,
+    record_id: RecordId,
+    cur_sum: &Vec<SB>,
+    num_trigger_value_bits: usize,
+    num_saturating_sum_bits: usize,
+) -> Result<Vec<SB>, Error>
+where
+    C: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    assert!(cur_sum.len() == num_saturating_sum_bits);
+
+    let mut carry_in = SB::share_known_value(&ctx, Gf2::ONE);
+    let mut output = vec![];
+    for i in 0..num_trigger_value_bits {
+        let c = ctx.narrow(&BitOpStep::from(i));
+        let (difference_bit, carry_out) =
+            one_bit_subtractor(c, record_id, &SB::ZERO, &cur_sum[i], &carry_in).await?;
+
+        output.push(difference_bit);
+        carry_in = carry_out;
+    }
+    Ok(output)
+}
+
+async fn compute_row_with_previous<C, SB>(
+    ctx: C,
+    input_row: &PrfShardedIpaInputRow<SB>,
+    inputs_required_from_previous_row: &InputsRequiredFromPrevRow<SB>,
+    num_breakdown_key_bits: usize,
+    num_trigger_value_bits: usize,
+    num_saturating_sum_bits: usize,
+) -> Result<(InputsRequiredFromPrevRow<SB>, CappedAttributionOutputs<SB>), Error>
+where
+    C: UpgradedContext<Gf2, Share = SB>,
+    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+{
+    assert!(input_row.breakdown_key.len() == num_breakdown_key_bits);
+    assert!(
+        inputs_required_from_previous_row
+            .attributed_breakdown_key_bits
+            .len()
+            == num_breakdown_key_bits
+    );
+    assert!(input_row.trigger_value.len() == num_trigger_value_bits);
+    assert!(inputs_required_from_previous_row.saturating_sum.len() == num_saturating_sum_bits);
+
+    let record_id = RecordId(0);
+    let share_of_one = SB::share_known_value(&ctx, Gf2::ONE);
+
+    // TODO: compute ever_encountered_a_source_event and attributed_breakdown_key_bits in parallel
+    let ever_encountered_a_source_event = input_row
+        .is_trigger_bit
+        .multiply(
+            &inputs_required_from_previous_row.ever_encountered_a_source_event,
+            ctx.narrow(&Step::EverEncounteredSourceEvent),
+            record_id,
+        )
+        .await?
+        + &share_of_one
+        - &input_row.is_trigger_bit;
+
+    let narrowed_ctx = ctx.narrow(&Step::AttributedBreakdownKey);
+    let attributed_breakdown_key_bits = try_join_all(
+        input_row
+            .breakdown_key
+            .iter()
+            .zip(
+                inputs_required_from_previous_row
+                    .attributed_breakdown_key_bits
+                    .iter(),
+            )
+            .enumerate()
+            .map(|(i, (bd_key_bit, prev_row_attributed_bd_key_bit))| {
+                let c = narrowed_ctx.narrow(&BitOpStep::from(i));
+                async move {
+                    let maybe_diff = input_row
+                        .is_trigger_bit
+                        .multiply(
+                            &(prev_row_attributed_bd_key_bit.clone() - bd_key_bit),
+                            c,
+                            record_id,
+                        )
+                        .await?;
+                    Ok::<_, Error>(maybe_diff + bd_key_bit)
+                }
+            }),
+    )
+    .await?;
+
+    let did_trigger_get_attributed = input_row
+        .is_trigger_bit
+        .multiply(
+            &ever_encountered_a_source_event,
+            ctx.narrow(&Step::DidTriggerGetAttributed),
+            record_id,
+        )
+        .await?;
+
+    let narrowed_ctx = ctx.narrow(&Step::AttributedTriggerValue);
+    let attributed_trigger_value = try_join_all(
+        input_row
+            .trigger_value
+            .iter()
+            .zip(repeat(did_trigger_get_attributed.clone()))
+            .enumerate()
+            .map(|(i, (trigger_value_bit, did_trigger_get_attributed))| {
+                let c = narrowed_ctx.narrow(&BitOpStep::from(i));
+                async move {
+                    trigger_value_bit
+                        .multiply(&did_trigger_get_attributed, c, record_id)
+                        .await
+                }
+            }),
+    )
+    .await?;
+    let (saturating_sum, is_saturated) = compute_saturating_sum(
+        ctx.narrow(&Step::ComputeSaturatingSum),
+        record_id,
+        &attributed_trigger_value,
+        &inputs_required_from_previous_row.saturating_sum,
+        &inputs_required_from_previous_row.is_saturated,
+        num_trigger_value_bits,
+        num_saturating_sum_bits,
+    )
+    .await?;
+
+    // TODO: compute is_saturated_and_prev_row_not_saturated and difference_to_cap in parallel
+    let is_saturated_and_prev_row_not_saturated = is_saturated
+        .multiply(
+            &(share_of_one - &inputs_required_from_previous_row.is_saturated),
+            ctx.narrow(&Step::IsSaturatedAndPrevRowNotSaturated),
+            record_id,
+        )
+        .await?;
+    let difference_to_cap = compute_truncated_difference_to_cap(
+        ctx.narrow(&Step::ComputeDifferenceToCap),
+        record_id,
+        &saturating_sum,
+        num_trigger_value_bits,
+        num_saturating_sum_bits,
+    )
+    .await?;
+    let narrowed_ctx1 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueNotSaturatedCase);
+    let narrowed_ctx2 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueJustSaturatedCase);
+    let capped_attributed_trigger_value = try_join_all(
+        attributed_trigger_value
+            .iter()
+            .zip(inputs_required_from_previous_row.difference_to_cap.iter())
+            .zip(repeat(is_saturated.clone()))
+            .zip(repeat(is_saturated_and_prev_row_not_saturated))
+            .enumerate()
+            .map(
+                |(
+                    i,
+                    (
+                        ((attributed_tv_bit, prev_row_diff_to_cap_bit), is_saturated),
+                        is_saturated_and_prev_row_not_saturated,
+                    ),
+                )| {
+                    let c1 = narrowed_ctx1.narrow(&BitOpStep::from(i));
+                    let c2 = narrowed_ctx2.narrow(&BitOpStep::from(i));
+                    async move {
+                        let not_saturated_case = (SB::share_known_value(&c1, Gf2::ONE)
+                            - &is_saturated)
+                            .multiply(attributed_tv_bit, c1, record_id)
+                            .await?;
+                        let just_saturated_case = is_saturated_and_prev_row_not_saturated
+                            .multiply(&prev_row_diff_to_cap_bit, c2, record_id)
+                            .await?;
+                        Ok::<_, Error>(not_saturated_case + &just_saturated_case)
+                    }
+                },
+            ),
+    )
+    .await?;
+
+    let inputs_required_for_next_row = InputsRequiredFromPrevRow {
+        ever_encountered_a_source_event,
+        attributed_breakdown_key_bits: attributed_breakdown_key_bits.clone(),
+        saturating_sum,
+        is_saturated,
+        difference_to_cap,
+    };
+    let outputs_for_aggregation = CappedAttributionOutputs {
+        did_trigger_get_attributed,
+        attributed_breakdown_key_bits,
+        capped_attributed_trigger_value,
+    };
+    Ok((inputs_required_for_next_row, outputs_for_aggregation))
+}

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -635,14 +635,14 @@ pub mod tests {
                 test_output(12, 7),
                 test_output(12, 4),
             ];
-            const NUM_SATURATING_SUM_BITS: usize = 5;
+            let num_saturating_bits: usize = 5;
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
                     attribution_and_capping::<_, Gf5Bit, Gf3Bit>(
                         ctx,
                         input_rows,
-                        NUM_SATURATING_SUM_BITS,
+                        num_saturating_bits,
                     )
                     .await
                     .unwrap()

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -7,50 +7,89 @@ use strum::AsRefStr;
 use super::step::BitOpStep;
 use crate::{
     error::Error,
-    ff::{Field, Gf2},
+    ff::{Field, GaloisField, Gf2},
     protocol::{
-        context::{UpgradableContext, UpgradedContext, Validator},
+        basics::{SecureMul, ShareKnownValue},
+        context::{Context, UpgradableContext, UpgradedContext, Validator},
         BasicProtocols, RecordId,
     },
+    repeat64str,
     secret_sharing::{
-        replicated::{malicious::DowngradeMalicious, semi_honest::AdditiveShare as Replicated},
-        Linear as LinearSecretSharing,
+        replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},
+        BitDecomposed, Linear as LinearSecretSharing,
     },
 };
 
-pub struct PrfShardedIpaInputRow<SB: LinearSecretSharing<Gf2>> {
+pub struct PrfShardedIpaInputRow<BK: GaloisField, TV: GaloisField> {
     prf_of_match_key: u64,
-    is_trigger_bit: SB,
-    breakdown_key: Vec<SB>,
-    trigger_value: Vec<SB>,
+    is_trigger_bit: Replicated<Gf2>,
+    breakdown_key: Replicated<BK>,
+    trigger_value: Replicated<TV>,
 }
 
-struct InputsRequiredFromPrevRow<SB: LinearSecretSharing<Gf2>> {
-    ever_encountered_a_source_event: SB,
-    attributed_breakdown_key_bits: Vec<SB>,
-    saturating_sum: Vec<SB>,
-    is_saturated: SB,
-    difference_to_cap: Vec<SB>,
+struct InputsRequiredFromPrevRow {
+    ever_encountered_a_source_event: Replicated<Gf2>,
+    attributed_breakdown_key_bits: BitDecomposed<Replicated<Gf2>>,
+    saturating_sum: BitDecomposed<Replicated<Gf2>>,
+    is_saturated: Replicated<Gf2>,
+    difference_to_cap: BitDecomposed<Replicated<Gf2>>,
 }
 
-pub struct CappedAttributionOutputs<SB: LinearSecretSharing<Gf2>> {
-    did_trigger_get_attributed: SB,
-    attributed_breakdown_key_bits: Vec<SB>,
-    capped_attributed_trigger_value: Vec<SB>,
+#[derive(Debug)]
+pub struct CappedAttributionOutputs {
+    did_trigger_get_attributed: Replicated<Gf2>,
+    attributed_breakdown_key_bits: BitDecomposed<Replicated<Gf2>>,
+    capped_attributed_trigger_value: BitDecomposed<Replicated<Gf2>>,
 }
 
-#[step]
+#[derive(PartialEq, Eq, Debug)]
 pub(crate) enum Step {
     BinaryValidator,
-    EverEncounteredSourceEvent,
-    DidTriggerGetAttributed,
-    AttributedBreakdownKey,
-    AttributedTriggerValue,
-    ComputeSaturatingSum,
-    IsSaturatedAndPrevRowNotSaturated,
-    ComputeDifferenceToCap,
-    ComputedCappedAttributedTriggerValueNotSaturatedCase,
-    ComputedCappedAttributedTriggerValueJustSaturatedCase,
+    EverEncounteredSourceEvent(usize),
+    DidTriggerGetAttributed(usize),
+    AttributedBreakdownKey(usize),
+    AttributedTriggerValue(usize),
+    ComputeSaturatingSum(usize),
+    IsSaturatedAndPrevRowNotSaturated(usize),
+    ComputeDifferenceToCap(usize),
+    ComputedCappedAttributedTriggerValueNotSaturatedCase(usize),
+    ComputedCappedAttributedTriggerValueJustSaturatedCase(usize),
+}
+
+impl crate::protocol::step::Step for Step {}
+
+impl AsRef<str> for Step {
+    fn as_ref(&self) -> &str {
+        const EVER_ENCOUNTERED_SOURCE_EVENT: [&str; 64] = repeat64str!["eese_row"];
+        const DID_TRIGGER_GET_ATTRIBUTED: [&str; 64] = repeat64str!["dtga_row"];
+        const ATTRIBUTED_BREAKDOWN_KEY: [&str; 64] = repeat64str!["abk_row"];
+        const ATTRIBUTED_TRIGGER_VALUE: [&str; 64] = repeat64str!["atv_row"];
+        const COMPUTE_SATURATING_SUM: [&str; 64] = repeat64str!["css_row"];
+        const IS_SATURATED_AND_PREV_ROW_NOT_SATURATED: [&str; 64] = repeat64str!["isaprns_row"];
+        const COMPUTE_DIFFERENCE_TO_CAP: [&str; 64] = repeat64str!["cdtc_row"];
+        const COMPUTE_CAPPED_ATTRIBUTED_TRIGGER_VALUE_NOT_SATURATED_CASE: [&str; 64] =
+            repeat64str!["ccatvnsc_row"];
+        const COMPUTE_CAPPED_ATTRIBUTED_TRIGGER_VALUE_JUST_SATURATED_CASE: [&str; 64] =
+            repeat64str!["ccatvjsc_row"];
+        match self {
+            Self::BinaryValidator => "binary_validator",
+            Self::EverEncounteredSourceEvent(i) => EVER_ENCOUNTERED_SOURCE_EVENT[*i],
+            Self::DidTriggerGetAttributed(i) => DID_TRIGGER_GET_ATTRIBUTED[*i],
+            Self::AttributedBreakdownKey(i) => ATTRIBUTED_BREAKDOWN_KEY[*i],
+            Self::AttributedTriggerValue(i) => ATTRIBUTED_TRIGGER_VALUE[*i],
+            Self::ComputeSaturatingSum(i) => COMPUTE_SATURATING_SUM[*i],
+            Self::IsSaturatedAndPrevRowNotSaturated(i) => {
+                IS_SATURATED_AND_PREV_ROW_NOT_SATURATED[*i]
+            }
+            Self::ComputeDifferenceToCap(i) => COMPUTE_DIFFERENCE_TO_CAP[*i],
+            Self::ComputedCappedAttributedTriggerValueNotSaturatedCase(i) => {
+                COMPUTE_CAPPED_ATTRIBUTED_TRIGGER_VALUE_NOT_SATURATED_CASE[*i]
+            }
+            Self::ComputedCappedAttributedTriggerValueJustSaturatedCase(i) => {
+                COMPUTE_CAPPED_ATTRIBUTED_TRIGGER_VALUE_JUST_SATURATED_CASE[*i]
+            }
+        }
+    }
 }
 
 /// Sub-protocol of the PRF-sharded IPA Protocol
@@ -70,55 +109,52 @@ pub(crate) enum Step {
 /// Propagates errors from multiplications
 /// # Panics
 /// Propagates errors from multiplications
-pub async fn attribution_and_capping_and_aggregation<C, SB, F>(
+pub async fn attribution_and_capping<C, BK, TV>(
     sh_ctx: C,
-    input_rows: &[PrfShardedIpaInputRow<SB>],
+    input_rows: &[PrfShardedIpaInputRow<BK, TV>],
     num_breakdown_key_bits: usize,
     num_trigger_value_bits: usize,
     num_saturating_sum_bits: usize,
-) -> Result<Vec<CappedAttributionOutputs<SB>>, Error>
+) -> Result<Vec<CappedAttributionOutputs>, Error>
 where
     C: UpgradableContext,
-    C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
-    SB: LinearSecretSharing<Gf2>
-        + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
-        + DowngradeMalicious<Target = Replicated<Gf2>>
-        + 'static,
+    C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = Replicated<Gf2>>,
+    BK: GaloisField,
+    TV: GaloisField,
 {
     assert!(num_saturating_sum_bits > num_trigger_value_bits);
     assert!(num_trigger_value_bits > 0);
     assert!(num_breakdown_key_bits > 0);
 
     let binary_validator = sh_ctx.narrow(&Step::BinaryValidator).validator::<Gf2>();
-    let binary_m_ctx = binary_validator.context();
+    // TODO: fix num total records to be not a hard-coded constant, but variable per step
+    // based on the histogram of how many users have how many records a piece
+    let binary_m_ctx = binary_validator.context().set_total_records(1);
 
     let mut output = vec![];
 
-    assert!(input_rows.len() > 0);
+    assert!(!input_rows.is_empty());
     let first_row = &input_rows[0];
     let mut prev_prf = first_row.prf_of_match_key;
     let mut prev_row_inputs = initialize_new_device_attribution_variables(
-        SB::share_known_value(&binary_m_ctx, Gf2::ONE),
+        Replicated::share_known_value(&binary_m_ctx, Gf2::ONE),
         first_row,
+        num_breakdown_key_bits,
         num_trigger_value_bits,
         num_saturating_sum_bits,
     );
     let mut i: usize = 1;
+    let mut num_users_encountered = 0;
+    let mut row_for_user = 0;
     while i < input_rows.len() {
         let cur_row = &input_rows[i];
-        if prev_prf != cur_row.prf_of_match_key {
-            prev_prf = cur_row.prf_of_match_key;
-            prev_row_inputs = initialize_new_device_attribution_variables(
-                SB::share_known_value(&binary_m_ctx, Gf2::ONE),
-                cur_row,
-                num_trigger_value_bits,
-                num_saturating_sum_bits,
-            );
-        } else {
+        if prev_prf == cur_row.prf_of_match_key {
             // Do some actual computation
             let (inputs_required_for_next_row, capped_attribution_outputs) =
                 compute_row_with_previous(
                     binary_m_ctx.clone(),
+                    RecordId(num_users_encountered),
+                    row_for_user,
                     cur_row,
                     &prev_row_inputs,
                     num_breakdown_key_bits,
@@ -128,6 +164,19 @@ where
                 .await?;
             output.push(capped_attribution_outputs);
             prev_row_inputs = inputs_required_for_next_row;
+
+            row_for_user += 1;
+        } else {
+            prev_prf = cur_row.prf_of_match_key;
+            prev_row_inputs = initialize_new_device_attribution_variables(
+                Replicated::share_known_value(&binary_m_ctx, Gf2::ONE),
+                cur_row,
+                num_breakdown_key_bits,
+                num_trigger_value_bits,
+                num_saturating_sum_bits,
+            );
+            row_for_user = 0;
+            num_users_encountered += 1;
         }
         i += 1;
     }
@@ -135,26 +184,35 @@ where
     Ok(output)
 }
 
-fn initialize_new_device_attribution_variables<SB>(
-    share_of_one: SB,
-    input_row: &PrfShardedIpaInputRow<SB>,
+fn initialize_new_device_attribution_variables<BK, TV>(
+    share_of_one: Replicated<Gf2>,
+    input_row: &PrfShardedIpaInputRow<BK, TV>,
+    num_breakdown_key_bits: usize,
     num_trigger_value_bits: usize,
     num_saturating_sum_bits: usize,
-) -> InputsRequiredFromPrevRow<SB>
+) -> InputsRequiredFromPrevRow
 where
-    SB: LinearSecretSharing<Gf2>,
+    BK: GaloisField,
+    TV: GaloisField,
 {
     InputsRequiredFromPrevRow {
         ever_encountered_a_source_event: share_of_one - &input_row.is_trigger_bit,
-        attributed_breakdown_key_bits: input_row.breakdown_key.clone(),
-        saturating_sum: vec![SB::ZERO; num_saturating_sum_bits],
-        is_saturated: SB::ZERO,
-        difference_to_cap: vec![SB::ZERO; num_trigger_value_bits],
+        attributed_breakdown_key_bits: BitDecomposed::decompose(num_breakdown_key_bits, |i| {
+            Replicated::new(
+                Gf2::truncate_from(input_row.breakdown_key.left()[i]),
+                Gf2::truncate_from(input_row.breakdown_key.right()[i]),
+            )
+        }),
+        saturating_sum: BitDecomposed::new(vec![Replicated::ZERO; num_saturating_sum_bits]),
+        is_saturated: Replicated::ZERO,
+        // This is incorrect in the case that the CAP is less than the maximum value of "trigger value" for a single row
+        // Not a problem if you assume that's an invalid input
+        difference_to_cap: BitDecomposed::new(vec![Replicated::ZERO; num_trigger_value_bits]),
     }
 }
 
 ///
-/// Returns (sum_bit, carry_out)
+/// Returns (`sum_bit`, `carry_out`)
 ///
 async fn one_bit_adder<C, SB>(
     ctx: C,
@@ -183,12 +241,12 @@ where
 async fn compute_saturating_sum<C, SB>(
     ctx: C,
     record_id: RecordId,
-    cur_value: &Vec<SB>,
-    prev_sum: &Vec<SB>,
+    cur_value: &BitDecomposed<SB>,
+    prev_sum: &BitDecomposed<SB>,
     prev_is_saturated: &SB,
     num_trigger_value_bits: usize,
     num_saturating_sum_bits: usize,
-) -> Result<(Vec<SB>, SB), Error>
+) -> Result<(BitDecomposed<SB>, SB), Error>
 where
     C: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
@@ -219,11 +277,11 @@ where
         .await?
         + &carry_in
         + prev_is_saturated;
-    Ok((output, updated_is_saturated))
+    Ok((BitDecomposed::new(output), updated_is_saturated))
 }
 
 ///
-/// Returns (difference_bit, carry_out)
+/// Returns (`difference_bit`, `carry_out`)
 ///
 async fn one_bit_subtractor<C, SB>(
     ctx: C,
@@ -254,15 +312,15 @@ where
 ///
 /// TODO: optimize this
 /// We can avoid doing this many multiplications given the foreknowledge that we are always subtracting from zero
-/// There's also no reason to compute the carry_out for the final bit since it will go unused
+/// There's also no reason to compute the `carry_out` for the final bit since it will go unused
 ///
 async fn compute_truncated_difference_to_cap<C, SB>(
     ctx: C,
     record_id: RecordId,
-    cur_sum: &Vec<SB>,
+    cur_sum: &BitDecomposed<SB>,
     num_trigger_value_bits: usize,
     num_saturating_sum_bits: usize,
-) -> Result<Vec<SB>, Error>
+) -> Result<BitDecomposed<SB>, Error>
 where
     C: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
@@ -271,110 +329,127 @@ where
 
     let mut carry_in = SB::share_known_value(&ctx, Gf2::ONE);
     let mut output = vec![];
-    for i in 0..num_trigger_value_bits {
+    for (i, bit) in cur_sum.iter().enumerate().take(num_trigger_value_bits) {
         let c = ctx.narrow(&BitOpStep::from(i));
         let (difference_bit, carry_out) =
-            one_bit_subtractor(c, record_id, &SB::ZERO, &cur_sum[i], &carry_in).await?;
+            one_bit_subtractor(c, record_id, &SB::ZERO, bit, &carry_in).await?;
 
         output.push(difference_bit);
         carry_in = carry_out;
     }
-    Ok(output)
+    Ok(BitDecomposed::new(output))
 }
 
-async fn compute_row_with_previous<C, SB>(
+#[allow(clippy::too_many_lines)]
+async fn compute_row_with_previous<C, BK, TV>(
     ctx: C,
-    input_row: &PrfShardedIpaInputRow<SB>,
-    inputs_required_from_previous_row: &InputsRequiredFromPrevRow<SB>,
+    record_id: RecordId,
+    row_for_user: usize,
+    input_row: &PrfShardedIpaInputRow<BK, TV>,
+    inputs_required_from_previous_row: &InputsRequiredFromPrevRow,
     num_breakdown_key_bits: usize,
     num_trigger_value_bits: usize,
     num_saturating_sum_bits: usize,
-) -> Result<(InputsRequiredFromPrevRow<SB>, CappedAttributionOutputs<SB>), Error>
+) -> Result<(InputsRequiredFromPrevRow, CappedAttributionOutputs), Error>
 where
-    C: UpgradedContext<Gf2, Share = SB>,
-    SB: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+    C: UpgradedContext<Gf2, Share = Replicated<Gf2>>,
+    BK: GaloisField,
+    TV: GaloisField,
 {
-    assert!(input_row.breakdown_key.len() == num_breakdown_key_bits);
+    let bd_key = BitDecomposed::decompose(num_breakdown_key_bits, |i| {
+        Replicated::new(
+            Gf2::truncate_from(input_row.breakdown_key.left()[i]),
+            Gf2::truncate_from(input_row.breakdown_key.right()[i]),
+        )
+    });
+    let tv = BitDecomposed::decompose(num_trigger_value_bits, |i| {
+        Replicated::new(
+            Gf2::truncate_from(input_row.trigger_value.left()[i]),
+            Gf2::truncate_from(input_row.trigger_value.right()[i]),
+        )
+    });
+    assert!(bd_key.len() == num_breakdown_key_bits);
     assert!(
         inputs_required_from_previous_row
             .attributed_breakdown_key_bits
             .len()
             == num_breakdown_key_bits
     );
-    assert!(input_row.trigger_value.len() == num_trigger_value_bits);
+    assert!(tv.len() == num_trigger_value_bits);
     assert!(inputs_required_from_previous_row.saturating_sum.len() == num_saturating_sum_bits);
 
-    let record_id = RecordId(0);
-    let share_of_one = SB::share_known_value(&ctx, Gf2::ONE);
+    let share_of_one = Replicated::share_known_value(&ctx, Gf2::ONE);
 
     // TODO: compute ever_encountered_a_source_event and attributed_breakdown_key_bits in parallel
     let ever_encountered_a_source_event = input_row
         .is_trigger_bit
         .multiply(
             &inputs_required_from_previous_row.ever_encountered_a_source_event,
-            ctx.narrow(&Step::EverEncounteredSourceEvent),
+            ctx.narrow(&Step::EverEncounteredSourceEvent(row_for_user)),
             record_id,
         )
         .await?
         + &share_of_one
         - &input_row.is_trigger_bit;
 
-    let narrowed_ctx = ctx.narrow(&Step::AttributedBreakdownKey);
-    let attributed_breakdown_key_bits = try_join_all(
-        input_row
-            .breakdown_key
-            .iter()
-            .zip(
-                inputs_required_from_previous_row
-                    .attributed_breakdown_key_bits
-                    .iter(),
-            )
-            .enumerate()
-            .map(|(i, (bd_key_bit, prev_row_attributed_bd_key_bit))| {
-                let c = narrowed_ctx.narrow(&BitOpStep::from(i));
-                async move {
-                    let maybe_diff = input_row
-                        .is_trigger_bit
-                        .multiply(
-                            &(prev_row_attributed_bd_key_bit.clone() - bd_key_bit),
-                            c,
-                            record_id,
-                        )
-                        .await?;
-                    Ok::<_, Error>(maybe_diff + bd_key_bit)
-                }
-            }),
-    )
-    .await?;
+    let narrowed_ctx = ctx.narrow(&Step::AttributedBreakdownKey(row_for_user));
+    let attributed_breakdown_key_bits = BitDecomposed::new(
+        try_join_all(
+            bd_key
+                .iter()
+                .zip(
+                    inputs_required_from_previous_row
+                        .attributed_breakdown_key_bits
+                        .iter(),
+                )
+                .enumerate()
+                .map(|(i, (bd_key_bit, prev_row_attributed_bd_key_bit))| {
+                    let c = narrowed_ctx.narrow(&BitOpStep::from(i));
+                    async move {
+                        let maybe_diff = input_row
+                            .is_trigger_bit
+                            .multiply(
+                                &(prev_row_attributed_bd_key_bit.clone() - bd_key_bit),
+                                c,
+                                record_id,
+                            )
+                            .await?;
+                        Ok::<_, Error>(maybe_diff + bd_key_bit)
+                    }
+                }),
+        )
+        .await?,
+    );
 
     let did_trigger_get_attributed = input_row
         .is_trigger_bit
         .multiply(
             &ever_encountered_a_source_event,
-            ctx.narrow(&Step::DidTriggerGetAttributed),
+            ctx.narrow(&Step::DidTriggerGetAttributed(row_for_user)),
             record_id,
         )
         .await?;
 
-    let narrowed_ctx = ctx.narrow(&Step::AttributedTriggerValue);
-    let attributed_trigger_value = try_join_all(
-        input_row
-            .trigger_value
-            .iter()
-            .zip(repeat(did_trigger_get_attributed.clone()))
-            .enumerate()
-            .map(|(i, (trigger_value_bit, did_trigger_get_attributed))| {
-                let c = narrowed_ctx.narrow(&BitOpStep::from(i));
-                async move {
-                    trigger_value_bit
-                        .multiply(&did_trigger_get_attributed, c, record_id)
-                        .await
-                }
-            }),
-    )
-    .await?;
+    let narrowed_ctx = ctx.narrow(&Step::AttributedTriggerValue(row_for_user));
+    let attributed_trigger_value = BitDecomposed::new(
+        try_join_all(
+            tv.iter()
+                .zip(repeat(did_trigger_get_attributed.clone()))
+                .enumerate()
+                .map(|(i, (trigger_value_bit, did_trigger_get_attributed))| {
+                    let c = narrowed_ctx.narrow(&BitOpStep::from(i));
+                    async move {
+                        trigger_value_bit
+                            .multiply(&did_trigger_get_attributed, c, record_id)
+                            .await
+                    }
+                }),
+        )
+        .await?,
+    );
+
     let (saturating_sum, is_saturated) = compute_saturating_sum(
-        ctx.narrow(&Step::ComputeSaturatingSum),
+        ctx.narrow(&Step::ComputeSaturatingSum(row_for_user)),
         record_id,
         &attributed_trigger_value,
         &inputs_required_from_previous_row.saturating_sum,
@@ -388,55 +463,64 @@ where
     let is_saturated_and_prev_row_not_saturated = is_saturated
         .multiply(
             &(share_of_one - &inputs_required_from_previous_row.is_saturated),
-            ctx.narrow(&Step::IsSaturatedAndPrevRowNotSaturated),
+            ctx.narrow(&Step::IsSaturatedAndPrevRowNotSaturated(row_for_user)),
             record_id,
         )
         .await?;
-    let difference_to_cap = compute_truncated_difference_to_cap(
-        ctx.narrow(&Step::ComputeDifferenceToCap),
-        record_id,
-        &saturating_sum,
-        num_trigger_value_bits,
-        num_saturating_sum_bits,
-    )
-    .await?;
-    let narrowed_ctx1 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueNotSaturatedCase);
-    let narrowed_ctx2 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueJustSaturatedCase);
-    let capped_attributed_trigger_value = try_join_all(
-        attributed_trigger_value
-            .iter()
-            .zip(inputs_required_from_previous_row.difference_to_cap.iter())
-            .zip(repeat(is_saturated.clone()))
-            .zip(repeat(is_saturated_and_prev_row_not_saturated))
-            .enumerate()
-            .map(
-                |(
-                    i,
-                    (
-                        ((attributed_tv_bit, prev_row_diff_to_cap_bit), is_saturated),
-                        is_saturated_and_prev_row_not_saturated,
-                    ),
-                )| {
-                    let c1 = narrowed_ctx1.narrow(&BitOpStep::from(i));
-                    let c2 = narrowed_ctx2.narrow(&BitOpStep::from(i));
-                    async move {
-                        let not_saturated_case = (SB::share_known_value(&c1, Gf2::ONE)
-                            - &is_saturated)
-                            .multiply(attributed_tv_bit, c1, record_id)
-                            .await?;
-                        let just_saturated_case = is_saturated_and_prev_row_not_saturated
-                            .multiply(&prev_row_diff_to_cap_bit, c2, record_id)
-                            .await?;
-                        Ok::<_, Error>(not_saturated_case + &just_saturated_case)
-                    }
-                },
-            ),
-    )
-    .await?;
+
+    let difference_to_cap = BitDecomposed::new(
+        compute_truncated_difference_to_cap(
+            ctx.narrow(&Step::ComputeDifferenceToCap(row_for_user)),
+            record_id,
+            &saturating_sum,
+            num_trigger_value_bits,
+            num_saturating_sum_bits,
+        )
+        .await?,
+    );
+
+    let narrowed_ctx1 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueNotSaturatedCase(
+        row_for_user,
+    ));
+    let narrowed_ctx2 =
+        ctx.narrow(&Step::ComputedCappedAttributedTriggerValueJustSaturatedCase(row_for_user));
+    let capped_attributed_trigger_value = BitDecomposed::new(
+        try_join_all(
+            attributed_trigger_value
+                .iter()
+                .zip(inputs_required_from_previous_row.difference_to_cap.iter())
+                .zip(repeat(is_saturated.clone()))
+                .zip(repeat(is_saturated_and_prev_row_not_saturated))
+                .enumerate()
+                .map(
+                    |(
+                        i,
+                        (
+                            ((attributed_tv_bit, prev_row_diff_to_cap_bit), is_saturated),
+                            is_saturated_and_prev_row_not_saturated,
+                        ),
+                    )| {
+                        let c1 = narrowed_ctx1.narrow(&BitOpStep::from(i));
+                        let c2 = narrowed_ctx2.narrow(&BitOpStep::from(i));
+                        async move {
+                            let not_saturated_case = (Replicated::share_known_value(&c1, Gf2::ONE)
+                                - &is_saturated)
+                                .multiply(attributed_tv_bit, c1, record_id)
+                                .await?;
+                            let just_saturated_case = is_saturated_and_prev_row_not_saturated
+                                .multiply(prev_row_diff_to_cap_bit, c2, record_id)
+                                .await?;
+                            Ok::<_, Error>(not_saturated_case + &just_saturated_case)
+                        }
+                    },
+                ),
+        )
+        .await?,
+    );
 
     let inputs_required_for_next_row = InputsRequiredFromPrevRow {
         ever_encountered_a_source_event,
-        attributed_breakdown_key_bits: attributed_breakdown_key_bits.clone(),
+        attributed_breakdown_key_bits: BitDecomposed::new(attributed_breakdown_key_bits.clone()),
         saturating_sum,
         is_saturated,
         difference_to_cap,
@@ -447,4 +531,176 @@ where
         capped_attributed_trigger_value,
     };
     Ok((inputs_required_for_next_row, outputs_for_aggregation))
+}
+
+#[cfg(all(test, any(unit_test, feature = "shuttle")))]
+pub mod tests {
+    use super::{attribution_and_capping, CappedAttributionOutputs, PrfShardedIpaInputRow};
+    use crate::{
+        ff::{Field, GaloisField, Gf2, Gf8Bit},
+        rand::Rng,
+        secret_sharing::{
+            replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, IntoShares,
+            SharedValue,
+        },
+        test_executor::run,
+        test_fixture::{Reconstruct, Runner, TestWorld},
+    };
+
+    struct PreShardedAndSortedOPRFTestInput<BK: GaloisField, TV: GaloisField> {
+        prf_of_match_key: u64,
+        is_trigger_bit: Gf2,
+        breakdown_key: BK,
+        trigger_value: TV,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct PreAggregationTestOutput {
+        attributed_breakdown_key: u128,
+        capped_attributed_trigger_value: u128,
+    }
+
+    impl<BK, TV> IntoShares<PrfShardedIpaInputRow<BK, TV>> for PreShardedAndSortedOPRFTestInput<BK, TV>
+    where
+        BK: GaloisField + IntoShares<Replicated<BK>>,
+        TV: GaloisField + IntoShares<Replicated<TV>>,
+    {
+        fn share_with<R: Rng>(self, rng: &mut R) -> [PrfShardedIpaInputRow<BK, TV>; 3] {
+            let PreShardedAndSortedOPRFTestInput {
+                prf_of_match_key,
+                is_trigger_bit,
+                breakdown_key,
+                trigger_value,
+            } = self;
+
+            let [is_trigger_bit0, is_trigger_bit1, is_trigger_bit2] =
+                is_trigger_bit.share_with(rng);
+            let [breakdown_key0, breakdown_key1, breakdown_key2] = breakdown_key.share_with(rng);
+            let [trigger_value0, trigger_value1, trigger_value2] = trigger_value.share_with(rng);
+
+            [
+                PrfShardedIpaInputRow {
+                    prf_of_match_key,
+                    is_trigger_bit: is_trigger_bit0,
+                    breakdown_key: breakdown_key0,
+                    trigger_value: trigger_value0,
+                },
+                PrfShardedIpaInputRow {
+                    prf_of_match_key,
+                    is_trigger_bit: is_trigger_bit1,
+                    breakdown_key: breakdown_key1,
+                    trigger_value: trigger_value1,
+                },
+                PrfShardedIpaInputRow {
+                    prf_of_match_key,
+                    is_trigger_bit: is_trigger_bit2,
+                    breakdown_key: breakdown_key2,
+                    trigger_value: trigger_value2,
+                },
+            ]
+        }
+    }
+
+    impl Reconstruct<PreAggregationTestOutput> for [&CappedAttributionOutputs; 3] {
+        fn reconstruct(&self) -> PreAggregationTestOutput {
+            let [s0, s1, s2] = self;
+
+            let attributed_breakdown_key_bits: BitDecomposed<Gf2> = BitDecomposed::new(
+                s0.attributed_breakdown_key_bits
+                    .iter()
+                    .zip(s1.attributed_breakdown_key_bits.iter())
+                    .zip(s2.attributed_breakdown_key_bits.iter())
+                    .map(|((a, b), c)| [a, b, c].reconstruct()),
+            );
+
+            let capped_attributed_trigger_value_bits: BitDecomposed<Gf2> = BitDecomposed::new(
+                s0.capped_attributed_trigger_value
+                    .iter()
+                    .zip(s1.capped_attributed_trigger_value.iter())
+                    .zip(s2.capped_attributed_trigger_value.iter())
+                    .map(|((a, b), c)| [a, b, c].reconstruct()),
+            );
+
+            PreAggregationTestOutput {
+                attributed_breakdown_key: attributed_breakdown_key_bits
+                    .iter()
+                    .map(|x| x.as_u128())
+                    .enumerate()
+                    .fold(0_u128, |acc, (i, x)| acc + (x << i)),
+                capped_attributed_trigger_value: capped_attributed_trigger_value_bits
+                    .iter()
+                    .map(|x| x.as_u128())
+                    .enumerate()
+                    .fold(0_u128, |acc, (i, x)| acc + (x << i)),
+            }
+        }
+    }
+
+    #[test]
+    fn semi_honest() {
+        const EXPECTED: &[PreAggregationTestOutput] = &[
+            PreAggregationTestOutput {
+                attributed_breakdown_key: 17,
+                capped_attributed_trigger_value: 7,
+            },
+            PreAggregationTestOutput {
+                attributed_breakdown_key: 20,
+                capped_attributed_trigger_value: 0,
+            },
+            PreAggregationTestOutput {
+                attributed_breakdown_key: 20,
+                capped_attributed_trigger_value: 3,
+            },
+        ];
+        const NUM_BREAKDOWN_KEY_BITS: usize = 5;
+        const NUM_TRIGGER_VALUE_BITS: usize = 3;
+        const NUM_SATURATING_SUM_BITS: usize = 5;
+
+        run(|| async {
+            let world = TestWorld::default();
+
+            let records: Vec<PreShardedAndSortedOPRFTestInput<Gf8Bit, Gf8Bit>> = vec![
+                PreShardedAndSortedOPRFTestInput {
+                    prf_of_match_key: 123,
+                    is_trigger_bit: Gf2::ZERO,
+                    breakdown_key: Gf8Bit::truncate_from(17_u8),
+                    trigger_value: Gf8Bit::truncate_from(0_u8),
+                },
+                PreShardedAndSortedOPRFTestInput {
+                    prf_of_match_key: 123,
+                    is_trigger_bit: Gf2::ONE,
+                    breakdown_key: Gf8Bit::truncate_from(0_u8),
+                    trigger_value: Gf8Bit::truncate_from(7_u8),
+                },
+                PreShardedAndSortedOPRFTestInput {
+                    prf_of_match_key: 123,
+                    is_trigger_bit: Gf2::ZERO,
+                    breakdown_key: Gf8Bit::truncate_from(20_u8),
+                    trigger_value: Gf8Bit::truncate_from(0_u8),
+                },
+                PreShardedAndSortedOPRFTestInput {
+                    prf_of_match_key: 123,
+                    is_trigger_bit: Gf2::ONE,
+                    breakdown_key: Gf8Bit::truncate_from(0_u8),
+                    trigger_value: Gf8Bit::truncate_from(3_u8),
+                },
+            ];
+
+            let result: Vec<_> = world
+                .semi_honest(records.into_iter(), |ctx, input_rows| async move {
+                    attribution_and_capping(
+                        ctx,
+                        input_rows.as_slice(),
+                        NUM_BREAKDOWN_KEY_BITS,
+                        NUM_TRIGGER_VALUE_BITS,
+                        NUM_SATURATING_SUM_BITS,
+                    )
+                    .await
+                    .unwrap()
+                })
+                .await
+                .reconstruct();
+            assert_eq!(result, EXPECTED);
+        });
+    }
 }

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -89,7 +89,7 @@ fn set_up_contexts<C>(root_ctx: C, histogram: Vec<usize>) -> Vec<C>
 where
     C: UpgradedContext<Gf2, Share = Replicated<Gf2>>,
 {
-    let mut context_per_row_depth = vec![];
+    let mut context_per_row_depth = Vec::with_capacity(histogram.len());
     for (row_number, num_users_having_that_row_number) in histogram.iter().enumerate() {
         if row_number == 0 {
             // no multiplications needed for each user's row 0. No context needed
@@ -168,16 +168,11 @@ where
 
     let rows_chunked_by_user = chunk_rows_by_user(input_rows);
     let histogram = compute_histogram_of_users_with_row_count(&rows_chunked_by_user);
-
     let binary_validator = sh_ctx.narrow(&Step::BinaryValidator).validator::<Gf2>();
-    // TODO: fix num total records to be not a hard-coded constant, but variable per step
-    // based on the histogram of how many users have how many records a piece
     let binary_m_ctx = binary_validator.context();
-
+    let mut num_users_who_encountered_row_depth = Vec::with_capacity(histogram.len());
     let ctx_for_row_number = set_up_contexts(binary_m_ctx.clone(), histogram);
-
     let mut futures = Vec::with_capacity(rows_chunked_by_user.len());
-    let mut num_users_who_encountered_row_depth = vec![];
     for rows_for_user in rows_chunked_by_user {
         for i in 0..rows_for_user.len() {
             if i >= num_users_who_encountered_row_depth.len() {

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -1,8 +1,7 @@
 use std::iter::repeat;
 
 use futures_util::future::try_join;
-use ipa_macros::step;
-use strum::AsRefStr;
+use ipa_macros::Step;
 
 use super::{boolean::saturating_sum::SaturatingSum, step::BitOpStep};
 use crate::{
@@ -14,7 +13,6 @@ use crate::{
         context::{UpgradableContext, UpgradedContext, Validator},
         RecordId,
     },
-    repeat64str,
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},
         BitDecomposed,
@@ -43,24 +41,19 @@ pub struct CappedAttributionOutputs {
     pub capped_attributed_trigger_value: BitDecomposed<Replicated<Gf2>>,
 }
 
-pub struct UserNthRowStep(usize);
-
-impl crate::protocol::step::Step for UserNthRowStep {}
-
-impl AsRef<str> for UserNthRowStep {
-    fn as_ref(&self) -> &str {
-        const ROW: [&str; 64] = repeat64str!["row"];
-        ROW[self.0]
-    }
+#[derive(Step)]
+pub enum UserNthRowStep {
+    #[dynamic]
+    Row(usize),
 }
 
 impl From<usize> for UserNthRowStep {
     fn from(v: usize) -> Self {
-        Self(v)
+        Self::Row(v)
     }
 }
 
-#[step]
+#[derive(Step)]
 pub(crate) enum Step {
     BinaryValidator,
     EverEncounteredSourceEvent,

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -622,12 +622,12 @@ pub mod tests {
             PreAggregationTestOutput {
                 attributed_breakdown_key: attributed_breakdown_key_bits
                     .iter()
-                    .map(ff::field::Field::as_u128)
+                    .map(Field::as_u128)
                     .enumerate()
                     .fold(0_u128, |acc, (i, x)| acc + (x << i)),
                 capped_attributed_trigger_value: capped_attributed_trigger_value_bits
                     .iter()
-                    .map(ff::field::Field::as_u128)
+                    .map(Field::as_u128)
                     .enumerate()
                     .fold(0_u128, |acc, (i, x)| acc + (x << i)),
             }

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -1,8 +1,6 @@
 use std::iter::repeat;
 
 use futures_util::future::try_join_all;
-use ipa_macros::step;
-use strum::AsRefStr;
 
 use super::step::BitOpStep;
 use crate::{
@@ -37,9 +35,9 @@ struct InputsRequiredFromPrevRow {
 
 #[derive(Debug)]
 pub struct CappedAttributionOutputs {
-    did_trigger_get_attributed: Replicated<Gf2>,
-    attributed_breakdown_key_bits: BitDecomposed<Replicated<Gf2>>,
-    capped_attributed_trigger_value: BitDecomposed<Replicated<Gf2>>,
+    pub did_trigger_get_attributed: Replicated<Gf2>,
+    pub attributed_breakdown_key_bits: BitDecomposed<Replicated<Gf2>>,
+    pub capped_attributed_trigger_value: BitDecomposed<Replicated<Gf2>>,
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -340,7 +338,7 @@ where
     Ok(BitDecomposed::new(output))
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn compute_row_with_previous<C, BK, TV>(
     ctx: C,
     record_id: RecordId,
@@ -624,12 +622,12 @@ pub mod tests {
             PreAggregationTestOutput {
                 attributed_breakdown_key: attributed_breakdown_key_bits
                     .iter()
-                    .map(|x| x.as_u128())
+                    .map(ff::field::Field::as_u128)
                     .enumerate()
                     .fold(0_u128, |acc, (i, x)| acc + (x << i)),
                 capped_attributed_trigger_value: capped_attributed_trigger_value_bits
                     .iter()
-                    .map(|x| x.as_u128())
+                    .map(ff::field::Field::as_u128)
                     .enumerate()
                     .fold(0_u128, |acc, (i, x)| acc + (x << i)),
             }

--- a/src/secret_sharing/replicated/mod.rs
+++ b/src/secret_sharing/replicated/mod.rs
@@ -7,4 +7,8 @@ pub trait ReplicatedSecretSharing<V: SharedValue>: SecretSharing<V> {
     fn new(a: V, b: V) -> Self;
     fn left(&self) -> V;
     fn right(&self) -> V;
+
+    fn map<F: Fn(V) -> T, R: ReplicatedSecretSharing<T>, T: SharedValue>(&self, f: F) -> R {
+        R::new(f(self.left()), f(self.right()))
+    }
 }


### PR DESCRIPTION
This PR correctly implements the new OPRF approach to attribution and per-user contribution capping.

Aggregation is left for another day.

This uses a bitwise saturating sum approach to perform the contribution capping, where the caller specifies how many bits to use.

All the logic is reflected in this Google sheet which implements the same oblivious algorithm: https://docs.google.com/spreadsheets/d/1-6cvFe7GbhdzuiaTuiZ9ojq36rA4AVMjBvTqvvpJaHw/edit?usp=sharing

While multiple users can be run in parallel (using a try_join_all for now), each user's circuit is rather deep, with each row of data depending on the preceding row. This can lead to very deep circuits for users with many rows of data.