### PR TITLE
Allow addition and multiplication for references to secret shared values

### DIFF
--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -63,11 +63,15 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
 /// The trait for references which implement local arithmetic operations, taking the
 /// second operand either by value or by reference.
 ///
+/// The need for this trait is dictated by [`rust-issue`] that causes us not being able to constrain
+/// references to `Self`. Once this issue is fixed, we can simply get rid of it.
+///
 /// This is automatically implemented for types which implement the operators. The idea is borrowed
 /// from [`RefNum`] trait, but I couldn't really make it work with HRTB and secret shares. Primitive
 /// types worked just fine though, so it is possible that it is another compiler issue.
 ///
 /// [`RefNum`]: https://docs.rs/num/0.4.1/num/traits/trait.RefNum.html
+/// [`rust-issue`]: https://github.com/rust-lang/rust/issues/20671
 pub trait RefOps<'a, Base: 'a, R: 'a>:
     LocalArithmeticOps<Base, Base>
     + LocalArithmeticOps<&'a Base, Base>

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -25,19 +25,38 @@ pub enum Error {
 /// locally.
 pub trait LocalArithmeticOps<Rhs = Self, Output = Self>:
 Add<Rhs, Output = Output>
-+ AddAssign<Rhs>
+// + AddAssign<Rhs>
 + Sub<Rhs, Output = Output>
-+ SubAssign<Rhs>
-+ Neg<Output = Output>
+// + SubAssign<Rhs>
+// + Neg<Output = Output>
 + Sized
 {
 }
 
+impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
+    T: Add<Rhs, Output = Output>
+    // + AddAssign<Rhs>
+    + Sub<Rhs, Output = Output>
+    // + SubAssign<Rhs>
+    // + Neg<Output = Output>
+    + Sized {}
+
+
+pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> + Neg<Output = Self> {}
+impl <T, Rhs> LocalAssignOps<Rhs> for T where T:AddAssign<Rhs> + SubAssign<Rhs> + Neg<Output = Self> {}
+
 /// TODO: add docs
 /// May or may not require communication, depending on the value. Multiplying field values is a
 /// local operation, while multiplying secret shares is not.
-pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Output>
+pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
 // TODO: make mul a trait and implement it for secret sharing
+    + Mul<Rhs, Output = Output>
+    + MulAssign<Rhs>
+{
+}
+
+impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
+    T: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
     + Mul<Rhs, Output = Output>
     + MulAssign<Rhs>
 {
@@ -47,23 +66,9 @@ pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Outp
 /// second operand either by value or by reference.
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait RefLocalArithmeticOps<Base>: LocalArithmeticOps<Base, Base> + for <'r> LocalArithmeticOps<&'r Base, Base> {}
-impl<T, Base> RefLocalArithmeticOps<Base> for T where T: LocalArithmeticOps<Base, Base> + for<'r> LocalArithmeticOps<&'r Base, Base> {}
+// pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<&'a Base, Base> {}
 
-impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
-    T: Add<Rhs, Output = Output>
-    + AddAssign<Rhs>
-    + Sub<Rhs, Output = Output>
-    + SubAssign<Rhs>
-    + Neg<Output = Output>
-    + Sized {}
-
-impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
-    T: LocalArithmeticOps<Rhs, Output>
-    + Mul<Rhs, Output = Output>
-    + MulAssign<Rhs>
-{
-}
+// impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
 
 // pub trait ArithmeticRefOps<V: SharedValue>:
 //     for<'a> Add<&'a Self, Output = Self>

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -28,25 +28,24 @@ pub enum Error {
 /// The problem is that it does not use `Rhs` generic and rustc overflows trying to compile functions
 /// that use HRTB generics bounded by `LocalArithmeticOps`.
 pub trait LocalArithmeticOps<Rhs = Self, Output = Self>:
-Add<Rhs, Output = Output>
-+ Sub<Rhs, Output = Output>
-+ Sized
+    Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + Sized
 {
 }
 
 impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
-    T: Add<Rhs, Output = Output>
-    + Sub<Rhs, Output = Output>
-    + Sized {}
-
+    T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + Sized
+{
+}
 
 pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> {}
-impl <T, Rhs> LocalAssignOps<Rhs> for T where T:AddAssign<Rhs> + SubAssign<Rhs> {}
+impl<T, Rhs> LocalAssignOps<Rhs> for T where T: AddAssign<Rhs> + SubAssign<Rhs> {}
 
 /// TODO: add docs
 /// May or may not require communication, depending on the value. Multiplying field values is a
 /// local operation, while multiplying secret shares is not.
-pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
+pub trait ArithmeticOps<Rhs = Self, Output = Self>:
+    LocalArithmeticOps<Rhs, Output>
+    + LocalAssignOps<Rhs>
     + Mul<Rhs, Output = Output>
     + MulAssign<Rhs>
     + Neg<Output = Output>
@@ -54,10 +53,11 @@ pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Outp
 }
 
 impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
-    T: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
-    + Mul<Rhs, Output = Output>
-    + MulAssign<Rhs>
-    + Neg<Output = Output>
+    T: LocalArithmeticOps<Rhs, Output>
+        + LocalAssignOps<Rhs>
+        + Mul<Rhs, Output = Output>
+        + MulAssign<Rhs>
+        + Neg<Output = Output>
 {
 }
 
@@ -70,37 +70,16 @@ pub trait RefLocalArithmeticOps<'a, Base: 'a, R: 'a>:
     + LocalArithmeticOps<&'a Base, Base>
     + Mul<R, Output = Base>
     + Mul<&'a R, Output = Base>
-{}
-impl<'a, T, Base: 'a, R: 'a> RefLocalArithmeticOps<'a, Base, R> for T
-    where T: LocalArithmeticOps<Base, Base>
-    + LocalArithmeticOps<&'a Base, Base> + 'a
-    + Mul<R, Output = Base>
-    + Mul<&'a R, Output = Base>
-{}
-
-// impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
-
-// pub trait ArithmeticRefOps<V: SharedValue>:
-//     for<'a> Add<&'a Self, Output = Self>
-//     + for<'a> AddAssign<&'a Self>
-//     + Neg<Output = Self>
-//     + for<'a> Sub<&'a Self, Output = Self>
-//     + for<'a> SubAssign<&'a Self>
-//     + Mul<V, Output = Self>
-// {
-// }
-//
-// impl<T, V> ArithmeticRefOps<V> for T
-// where
-//     T: for<'a> Add<&'a Self, Output = Self>
-//         + for<'a> AddAssign<&'a Self>
-//         + Neg<Output = Self>
-//         + for<'a> Sub<&'a Self, Output = Self>
-//         + for<'a> SubAssign<&'a Self>
-//         + Mul<V, Output = Self>,
-//     V: SharedValue,
-// {
-// }
+{
+}
+impl<'a, T, Base: 'a, R: 'a> RefLocalArithmeticOps<'a, Base, R> for T where
+    T: LocalArithmeticOps<Base, Base>
+        + LocalArithmeticOps<&'a Base, Base>
+        + 'a
+        + Mul<R, Output = Base>
+        + Mul<&'a R, Output = Base>
+{
+}
 
 /// Trait for items that have fixed-byte length representation.
 pub trait Serializable: Sized {

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -60,33 +60,6 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
 {
 }
 
-/// The trait for references which implement local arithmetic operations, taking the
-/// second operand either by value or by reference.
-///
-/// The need for this trait is dictated by [`rust-issue`] that causes us not being able to constrain
-/// references to `Self`. Once this issue is fixed, we can simply get rid of it.
-///
-/// This is automatically implemented for types which implement the operators. The idea is borrowed
-/// from [`RefNum`] trait, but I couldn't really make it work with HRTB and secret shares. Primitive
-/// types worked just fine though, so it is possible that it is another compiler issue.
-///
-/// [`RefNum`]: https://docs.rs/num/0.4.1/num/traits/trait.RefNum.html
-/// [`rust-issue`]: https://github.com/rust-lang/rust/issues/20671
-pub trait RefOps<'a, Base: 'a, R: 'a>:
-    LocalArithmeticOps<Base, Base>
-    + LocalArithmeticOps<&'a Base, Base>
-    + Mul<R, Output = Base>
-    + Mul<&'a R, Output = Base>
-{
-}
-impl<'a, T, Base: 'a, R: 'a> RefOps<'a, Base, R> for T where
-    T: LocalArithmeticOps<Base, Base>
-        + LocalArithmeticOps<&'a Base, Base>
-        + 'a
-        + Mul<R, Output = Base>
-        + Mul<&'a R, Output = Base>
-{
-}
 
 /// Trait for items that have fixed-byte length representation.
 pub trait Serializable: Sized {

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -6,7 +6,7 @@ mod field;
 mod galois_field;
 mod prime_field;
 
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 pub use field::{Field, FieldType};
 pub use galois_field::{GaloisField, Gf2, Gf32Bit, Gf3Bit, Gf40Bit, Gf8Bit};
@@ -21,45 +21,19 @@ pub enum Error {
     UnknownField { type_str: String },
 }
 
-/// Arithmetic operations that do not require communication in our MPC setting and can be performed
-/// locally.
-///
-/// Note: Neg operation is also local, but is causing issues when added as a bound to this trait.
-/// The problem is that it does not use `Rhs` generic and rustc overflows trying to compile functions
-/// that use HRTB generics bounded by `LocalArithmeticOps`.
-pub trait LocalArithmeticOps<Rhs = Self, Output = Self>:
+/// Addition and subtraction operations that are supported by secret sharings and shared values.
+pub trait AddSub<Rhs = Self, Output = Self>:
     Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + Sized
 {
 }
 
-impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
+impl<T, Rhs, Output> AddSub<Rhs, Output> for T where
     T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + Sized
 {
 }
 
-pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> {}
-impl<T, Rhs> LocalAssignOps<Rhs> for T where T: AddAssign<Rhs> + SubAssign<Rhs> {}
-
-/// Arithmetic operations that may or may not require communication.
-/// for example, multiplying field values is a local operation, while multiplying secret shares is not.
-pub trait ArithmeticOps<Rhs = Self, Output = Self>:
-    LocalArithmeticOps<Rhs, Output>
-    + LocalAssignOps<Rhs>
-    + Mul<Rhs, Output = Output>
-    + MulAssign<Rhs>
-    + Neg<Output = Output>
-{
-}
-
-impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
-    T: LocalArithmeticOps<Rhs, Output>
-        + LocalAssignOps<Rhs>
-        + Mul<Rhs, Output = Output>
-        + MulAssign<Rhs>
-        + Neg<Output = Output>
-{
-}
-
+pub trait AddSubAssign<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> {}
+impl<T, Rhs> AddSubAssign<Rhs> for T where T: AddAssign<Rhs> + SubAssign<Rhs> {}
 
 /// Trait for items that have fixed-byte length representation.
 pub trait Serializable: Sized {

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -40,9 +40,8 @@ impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
 pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> {}
 impl<T, Rhs> LocalAssignOps<Rhs> for T where T: AddAssign<Rhs> + SubAssign<Rhs> {}
 
-/// TODO: add docs
-/// May or may not require communication, depending on the value. Multiplying field values is a
-/// local operation, while multiplying secret shares is not.
+/// Arithmetic operations that may or may not require communication.
+/// for example, multiplying field values is a local operation, while multiplying secret shares is not.
 pub trait ArithmeticOps<Rhs = Self, Output = Self>:
     LocalArithmeticOps<Rhs, Output>
     + LocalAssignOps<Rhs>
@@ -64,15 +63,19 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
 /// The trait for references which implement local arithmetic operations, taking the
 /// second operand either by value or by reference.
 ///
-/// This is automatically implemented for types which implement the operators.
-pub trait RefLocalArithmeticOps<'a, Base: 'a, R: 'a>:
+/// This is automatically implemented for types which implement the operators. The idea is borrowed
+/// from [`RefNum`] trait, but I couldn't really make it work with HRTB and secret shares. Primitive
+/// types worked just fine though, so it is possible that it is another compiler issue.
+///
+/// [`RefNum`]: https://docs.rs/num/0.4.1/num/traits/trait.RefNum.html
+pub trait RefOps<'a, Base: 'a, R: 'a>:
     LocalArithmeticOps<Base, Base>
     + LocalArithmeticOps<&'a Base, Base>
     + Mul<R, Output = Base>
     + Mul<&'a R, Output = Base>
 {
 }
-impl<'a, T, Base: 'a, R: 'a> RefLocalArithmeticOps<'a, Base, R> for T where
+impl<'a, T, Base: 'a, R: 'a> RefOps<'a, Base, R> for T where
     T: LocalArithmeticOps<Base, Base>
         + LocalArithmeticOps<&'a Base, Base>
         + 'a

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -66,7 +66,8 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
 /// second operand either by value or by reference.
 ///
 /// This is automatically implemented for types which implement the operators.
-// pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<&'a Base, Base> {}
+pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> {}
+impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> + 'a {}
 
 // impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
 

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -23,35 +23,33 @@ pub enum Error {
 
 /// Arithmetic operations that do not require communication in our MPC setting and can be performed
 /// locally.
+///
+/// Note: Neg operation is also local, but is causing issues when added as a bound to this trait.
+/// The problem is that it does not use `Rhs` generic and rustc overflows trying to compile functions
+/// that use HRTB generics bounded by `LocalArithmeticOps`.
 pub trait LocalArithmeticOps<Rhs = Self, Output = Self>:
 Add<Rhs, Output = Output>
-// + AddAssign<Rhs>
 + Sub<Rhs, Output = Output>
-// + SubAssign<Rhs>
-// + Neg<Output = Output>
 + Sized
 {
 }
 
 impl<T, Rhs, Output> LocalArithmeticOps<Rhs, Output> for T where
     T: Add<Rhs, Output = Output>
-    // + AddAssign<Rhs>
     + Sub<Rhs, Output = Output>
-    // + SubAssign<Rhs>
-    // + Neg<Output = Output>
     + Sized {}
 
 
-pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> + Neg<Output = Self> {}
-impl <T, Rhs> LocalAssignOps<Rhs> for T where T:AddAssign<Rhs> + SubAssign<Rhs> + Neg<Output = Self> {}
+pub trait LocalAssignOps<Rhs = Self>: AddAssign<Rhs> + SubAssign<Rhs> {}
+impl <T, Rhs> LocalAssignOps<Rhs> for T where T:AddAssign<Rhs> + SubAssign<Rhs> {}
 
 /// TODO: add docs
 /// May or may not require communication, depending on the value. Multiplying field values is a
 /// local operation, while multiplying secret shares is not.
 pub trait ArithmeticOps<Rhs = Self, Output = Self>: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
-// TODO: make mul a trait and implement it for secret sharing
     + Mul<Rhs, Output = Output>
     + MulAssign<Rhs>
+    + Neg<Output = Output>
 {
 }
 
@@ -59,6 +57,7 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
     T: LocalArithmeticOps<Rhs, Output> + LocalAssignOps<Rhs>
     + Mul<Rhs, Output = Output>
     + MulAssign<Rhs>
+    + Neg<Output = Output>
 {
 }
 

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -65,8 +65,18 @@ impl<T, Rhs, Output> ArithmeticOps<Rhs, Output> for T where
 /// second operand either by value or by reference.
 ///
 /// This is automatically implemented for types which implement the operators.
-pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> {}
-impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> + 'a {}
+pub trait RefLocalArithmeticOps<'a, Base: 'a, R: 'a>:
+    LocalArithmeticOps<Base, Base>
+    + LocalArithmeticOps<&'a Base, Base>
+    + Mul<R, Output = Base>
+    + Mul<&'a R, Output = Base>
+{}
+impl<'a, T, Base: 'a, R: 'a> RefLocalArithmeticOps<'a, Base, R> for T
+    where T: LocalArithmeticOps<Base, Base>
+    + LocalArithmeticOps<&'a Base, Base> + 'a
+    + Mul<R, Output = Base>
+    + Mul<&'a R, Output = Base>
+{}
 
 // impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
 

--- a/src/protocol/aggregation/mod.rs
+++ b/src/protocol/aggregation/mod.rs
@@ -7,7 +7,7 @@ pub use input::SparseAggregateInputRow;
 use super::{context::Context, sort::bitwise_to_onehot, step::BitOpStep, RecordId};
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, RefOps, Serializable},
     protocol::{
         context::{UpgradableContext, UpgradedContext, Validator},
         modulus_conversion::convert_bits,
@@ -76,7 +76,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C::UpgradedContext<Gf2>, Gf2> + 'static,
     F: PrimeField + ExtendableField,
@@ -131,7 +131,7 @@ where
     I2: Stream<Item = Result<BitDecomposed<S>, Error>> + Send,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable + 'static,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let equality_check_ctx = ctx.narrow(&Step::ComputeEqualityChecks);
 

--- a/src/protocol/aggregation/mod.rs
+++ b/src/protocol/aggregation/mod.rs
@@ -174,6 +174,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable + 'static,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let check_times_value_ctx = ctx.narrow(&Step::CheckTimesValue);
 

--- a/src/protocol/aggregation/mod.rs
+++ b/src/protocol/aggregation/mod.rs
@@ -7,7 +7,7 @@ pub use input::SparseAggregateInputRow;
 use super::{context::Context, sort::bitwise_to_onehot, step::BitOpStep, RecordId};
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, RefOps, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
     protocol::{
         context::{UpgradableContext, UpgradedContext, Validator},
         modulus_conversion::convert_bits,
@@ -23,6 +23,7 @@ use crate::{
     },
     seq_join::seq_join,
 };
+use crate::secret_sharing::RefOps;
 
 // TODO: Use `#[derive(Step)]` once the protocol is implemented and the bench test is enabled.
 //       Once that is done, run `collect_steps.py` to generate `steps.txt` that includes these steps.

--- a/src/protocol/aggregation/mod.rs
+++ b/src/protocol/aggregation/mod.rs
@@ -19,11 +19,10 @@ use crate::{
             semi_honest::AdditiveShare as Replicated,
             ReplicatedSecretSharing,
         },
-        BitDecomposed, Linear as LinearSecretSharing,
+        BitDecomposed, Linear as LinearSecretSharing, LinearRefOps,
     },
     seq_join::seq_join,
 };
-use crate::secret_sharing::RefOps;
 
 // TODO: Use `#[derive(Step)]` once the protocol is implemented and the bench test is enabled.
 //       Once that is done, run `collect_steps.py` to generate `steps.txt` that includes these steps.
@@ -77,7 +76,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefOps<'r, S, F>,
+    for<'r> &'r S: LinearRefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C::UpgradedContext<Gf2>, Gf2> + 'static,
     F: PrimeField + ExtendableField,
@@ -132,7 +131,7 @@ where
     I2: Stream<Item = Result<BitDecomposed<S>, Error>> + Send,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable + 'static,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let equality_check_ctx = ctx.narrow(&Step::ComputeEqualityChecks);
 
@@ -175,7 +174,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable + 'static,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let check_times_value_ctx = ctx.narrow(&Step::CheckTimesValue);
 

--- a/src/protocol/aggregation/mod.rs
+++ b/src/protocol/aggregation/mod.rs
@@ -7,7 +7,7 @@ pub use input::SparseAggregateInputRow;
 use super::{context::Context, sort::bitwise_to_onehot, step::BitOpStep, RecordId};
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
     protocol::{
         context::{UpgradableContext, UpgradedContext, Validator},
         modulus_conversion::convert_bits,
@@ -76,6 +76,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
+    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2> + BasicProtocols<C::UpgradedContext<Gf2>, Gf2> + 'static,
     F: PrimeField + ExtendableField,
@@ -130,6 +131,7 @@ where
     I2: Stream<Item = Result<BitDecomposed<S>, Error>> + Send,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + Serializable + 'static,
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let equality_check_ctx = ctx.narrow(&Step::ComputeEqualityChecks);
 

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefOps},
+    ff::{Field, PrimeField, },
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
         context::{Context, UpgradedContext},
@@ -19,6 +19,7 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 /// This protocol applies the specified attribution window to trigger events. All trigger values of
 /// events that are outside the window will be replaced with 0, hence will not be attributed to

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -38,7 +38,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + 'static,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         let mut t_deltas = prefix_sum_time_deltas(&ctx, input, stop_bits).await?;
@@ -92,7 +92,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a T: RefLocalArithmeticOps<'a, T>,
+    for <'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
 {
     let num_rows = input.len();
 
@@ -152,7 +152,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     let ctx = ctx.set_total_records(input.len());
     let random_bits_generator =

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, PrimeField},
+    ff::{Field, PrimeField, RefLocalArithmeticOps},
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
         context::{Context, UpgradedContext},
@@ -19,7 +19,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// This protocol applies the specified attribution window to trigger events. All trigger values of
 /// events that are outside the window will be replaced with 0, hence will not be attributed to
@@ -38,7 +37,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + 'static,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         let mut t_deltas = prefix_sum_time_deltas(&ctx, input, stop_bits).await?;
@@ -92,7 +91,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
+    for<'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
 {
     let num_rows = input.len();
 
@@ -152,7 +151,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let ctx = ctx.set_total_records(input.len());
     let random_bits_generator =

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefLocalArithmeticOps},
+    ff::{Field, PrimeField, RefOps},
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
         context::{Context, UpgradedContext},
@@ -37,7 +37,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + 'static,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         let mut t_deltas = prefix_sum_time_deltas(&ctx, input, stop_bits).await?;
@@ -91,7 +91,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
+    for<'a> &'a T: RefOps<'a, T, F>,
 {
     let num_rows = input.len();
 
@@ -151,7 +151,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let ctx = ctx.set_total_records(input.len());
     let random_bits_generator =

--- a/src/protocol/attribution/apply_attribution_window.rs
+++ b/src/protocol/attribution/apply_attribution_window.rs
@@ -11,15 +11,14 @@ use super::{
 };
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, },
+    ff::{Field, PrimeField},
     protocol::{
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
         context::{Context, UpgradedContext},
         BasicProtocols, RecordId,
     },
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 /// This protocol applies the specified attribution window to trigger events. All trigger values of
 /// events that are outside the window will be replaced with 0, hence will not be attributed to
@@ -38,7 +37,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F> + 'static,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         let mut t_deltas = prefix_sum_time_deltas(&ctx, input, stop_bits).await?;
@@ -92,7 +91,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a T: RefOps<'a, T, F>,
+    for<'a> &'a T: LinearRefOps<'a, T, F>,
 {
     let num_rows = input.len();
 
@@ -152,7 +151,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let ctx = ctx.set_total_records(input.len());
     let random_bits_generator =

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -19,6 +19,7 @@ use crate::{
     secret_sharing::Linear as LinearSecretSharing,
     seq_join::seq_join,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// User-level credit capping protocol.
 ///
@@ -35,6 +36,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -241,6 +243,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     let share_of_cap = S::share_known_value(&ctx, F::truncate_from(cap));
     let cap_ref = &share_of_cap;
@@ -295,6 +298,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(prefix_summed_credits.len());
@@ -357,6 +361,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a T: RefLocalArithmeticOps<'a, T>
 {
     let num_rows = input.len();
     let cap_share = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());
@@ -413,7 +418,7 @@ where
                     record_id,
                     next_credit_exceeds_cap,
                     &T::ZERO,
-                    &(cap.clone() - next_prefix_summed_credit),
+                    &(cap - next_prefix_summed_credit),
                 )
                 .await?,
                 cap,

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -9,7 +9,7 @@ use ipa_macros::Step;
 use super::{do_the_binary_tree_thing, input::CreditCappingInputRow, prefix_or_binary_tree_style};
 use crate::{
     error::Error,
-    ff::{Field, PrimeField},
+    ff::{Field, PrimeField, RefLocalArithmeticOps},
     protocol::{
         basics::{if_else, SecureMul},
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
@@ -19,7 +19,6 @@ use crate::{
     secret_sharing::Linear as LinearSecretSharing,
     seq_join::seq_join,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// User-level credit capping protocol.
 ///
@@ -36,7 +35,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -243,7 +242,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let share_of_cap = S::share_known_value(&ctx, F::truncate_from(cap));
     let cap_ref = &share_of_cap;
@@ -298,7 +297,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(prefix_summed_credits.len());
@@ -361,7 +360,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a T: RefLocalArithmeticOps<'a, T, F>
+    for<'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
 {
     let num_rows = input.len();
     let cap_share = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -9,7 +9,7 @@ use ipa_macros::Step;
 use super::{do_the_binary_tree_thing, input::CreditCappingInputRow, prefix_or_binary_tree_style};
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefLocalArithmeticOps},
+    ff::{Field, PrimeField, RefOps},
     protocol::{
         basics::{if_else, SecureMul},
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
@@ -35,7 +35,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -242,7 +242,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let share_of_cap = S::share_known_value(&ctx, F::truncate_from(cap));
     let cap_ref = &share_of_cap;
@@ -297,7 +297,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(prefix_summed_credits.len());
@@ -360,7 +360,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a T: RefLocalArithmeticOps<'a, T, F>,
+    for<'a> &'a T: RefOps<'a, T, F>,
 {
     let num_rows = input.len();
     let cap_share = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -9,7 +9,7 @@ use ipa_macros::Step;
 use super::{do_the_binary_tree_thing, input::CreditCappingInputRow, prefix_or_binary_tree_style};
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefOps},
+    ff::{Field, PrimeField, },
     protocol::{
         basics::{if_else, SecureMul},
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
@@ -19,6 +19,7 @@ use crate::{
     secret_sharing::Linear as LinearSecretSharing,
     seq_join::seq_join,
 };
+use crate::secret_sharing::RefOps;
 
 /// User-level credit capping protocol.
 ///

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -9,17 +9,16 @@ use ipa_macros::Step;
 use super::{do_the_binary_tree_thing, input::CreditCappingInputRow, prefix_or_binary_tree_style};
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, },
+    ff::{Field, PrimeField},
     protocol::{
         basics::{if_else, SecureMul},
         boolean::{greater_than_constant, random_bits_generator::RandomBitsGenerator},
         context::{Context, UpgradedContext},
         BasicProtocols, RecordId,
     },
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
     seq_join::seq_join,
 };
-use crate::secret_sharing::RefOps;
 
 /// User-level credit capping protocol.
 ///
@@ -36,7 +35,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -243,7 +242,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let share_of_cap = S::share_known_value(&ctx, F::truncate_from(cap));
     let cap_ref = &share_of_cap;
@@ -298,7 +297,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(prefix_summed_credits.len());
@@ -361,7 +360,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a T: RefOps<'a, T, F>,
+    for<'a> &'a T: LinearRefOps<'a, T, F>,
 {
     let num_rows = input.len();
     let cap_share = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());

--- a/src/protocol/attribution/credit_capping.rs
+++ b/src/protocol/attribution/credit_capping.rs
@@ -36,7 +36,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     if cap == 1 {
         return Ok(credit_capping_max_one(ctx, input)
@@ -243,7 +243,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     let share_of_cap = S::share_known_value(&ctx, F::truncate_from(cap));
     let cap_ref = &share_of_cap;
@@ -298,7 +298,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(prefix_summed_credits.len());
@@ -361,7 +361,7 @@ where
     F: Field,
     C: Context,
     T: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a T: RefLocalArithmeticOps<'a, T>
+    for <'a> &'a T: RefLocalArithmeticOps<'a, T, F>
 {
     let num_rows = input.len();
     let cap_share = T::share_known_value(&ctx, F::try_from(cap.into()).unwrap());

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -19,7 +19,7 @@ use self::{
 };
 use crate::{
     error::Error,
-    ff::{Field, Gf2, PrimeField, Serializable},
+    ff::{Field, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
     helpers::query::IpaQueryConfig,
     protocol::{
         basics::SecureMul,
@@ -39,7 +39,6 @@ use crate::{
     },
     seq_join::assert_send,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///
@@ -63,13 +62,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB> + Context,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'a> &'a SB: RefLocalArithmeticOps<'a, SB, Gf2>,
+    for<'a> &'a SB: RefLocalArithmeticOps<'a, SB, Gf2>,
     F: PrimeField + ExtendableField,
     ShuffledPermutationWrapper<S, C::UpgradedContext<F>>: DowngradeMalicious<Target = Vec<u32>>,
 {
@@ -406,7 +405,7 @@ async fn compute_helper_bits_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>,
 {
     let narrowed_ctx = ctx
         .narrow(&Step::ComputeHelperBits)

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -63,13 +63,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB> + Context,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'a> &'a SB: RefLocalArithmeticOps<'a, SB>,
+    for <'a> &'a SB: RefLocalArithmeticOps<'a, SB, Gf2>,
     F: PrimeField + ExtendableField,
     ShuffledPermutationWrapper<S, C::UpgradedContext<F>>: DowngradeMalicious<Target = Vec<u32>>,
 {
@@ -406,7 +406,7 @@ async fn compute_helper_bits_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>
 {
     let narrowed_ctx = ctx
         .narrow(&Step::ComputeHelperBits)

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -19,7 +19,7 @@ use self::{
 };
 use crate::{
     error::Error,
-    ff::{Field, Gf2, PrimeField, RefOps, Serializable},
+    ff::{Field, Gf2, PrimeField, Serializable},
     helpers::query::IpaQueryConfig,
     protocol::{
         basics::SecureMul,
@@ -39,6 +39,7 @@ use crate::{
     },
     seq_join::assert_send,
 };
+use crate::secret_sharing::RefOps;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -39,6 +39,7 @@ use crate::{
     },
     seq_join::assert_send,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///
@@ -62,11 +63,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB> + Context,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
+    for <'a> &'a SB: RefLocalArithmeticOps<'a, SB>,
     F: PrimeField + ExtendableField,
     ShuffledPermutationWrapper<S, C::UpgradedContext<F>>: DowngradeMalicious<Target = Vec<u32>>,
 {
@@ -403,6 +406,7 @@ async fn compute_helper_bits_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     let narrowed_ctx = ctx
         .narrow(&Step::ComputeHelperBits)

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -19,7 +19,7 @@ use self::{
 };
 use crate::{
     error::Error,
-    ff::{Field, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
+    ff::{Field, Gf2, PrimeField, RefOps, Serializable},
     helpers::query::IpaQueryConfig,
     protocol::{
         basics::SecureMul,
@@ -62,13 +62,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB> + Context,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'a> &'a SB: RefLocalArithmeticOps<'a, SB, Gf2>,
+    for<'a> &'a SB: RefOps<'a, SB, Gf2>,
     F: PrimeField + ExtendableField,
     ShuffledPermutationWrapper<S, C::UpgradedContext<F>>: DowngradeMalicious<Target = Vec<u32>>,
 {
@@ -405,7 +405,7 @@ async fn compute_helper_bits_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>,
+    for<'a> &'a S: RefOps<'a, S, Gf2>,
 {
     let narrowed_ctx = ctx
         .narrow(&Step::ComputeHelperBits)

--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -35,11 +35,10 @@ use crate::{
             malicious::{DowngradeMalicious, ExtendableField},
             semi_honest::AdditiveShare as Replicated,
         },
-        Linear as LinearSecretSharing,
+        Linear as LinearSecretSharing, LinearRefOps,
     },
     seq_join::assert_send,
 };
-use crate::secret_sharing::RefOps;
 
 /// Performs a set of attribution protocols on the sorted IPA input.
 ///
@@ -63,13 +62,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB> + Context,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'a> &'a SB: RefOps<'a, SB, Gf2>,
+    for<'a> &'a SB: LinearRefOps<'a, SB, Gf2>,
     F: PrimeField + ExtendableField,
     ShuffledPermutationWrapper<S, C::UpgradedContext<F>>: DowngradeMalicious<Target = Vec<u32>>,
 {
@@ -406,7 +405,7 @@ async fn compute_helper_bits_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for<'a> &'a S: RefOps<'a, S, Gf2>,
+    for<'a> &'a S: LinearRefOps<'a, S, Gf2>,
 {
     let narrowed_ctx = ctx
         .narrow(&Step::ComputeHelperBits)

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, RefLocalArithmeticOps},
+    ff::{Field, RefOps},
     protocol::{basics::SecureMul, context::Context, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -19,7 +19,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -1,9 +1,10 @@
 use crate::{
     error::Error,
-    ff::{Field, RefOps},
+    ff::{Field, },
     protocol::{basics::SecureMul, context::Context, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.
 /// # Errors

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -20,7 +20,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -29,7 +29,7 @@ where
     // If `condition` is a share of 0 (false), then
     //   = false_value + 0 * (true_value - false_value)
     //   = false_value
-    Ok(false_value.clone()
+    Ok(false_value
         + &condition
             .multiply(&(true_value - false_value), ctx, record_id)
             .await?)

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -1,10 +1,9 @@
 use crate::{
     error::Error,
-    ff::{Field, },
+    ff::Field,
     protocol::{basics::SecureMul, context::Context, RecordId},
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.
 /// # Errors
@@ -20,7 +19,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -4,6 +4,7 @@ use crate::{
     protocol::{basics::SecureMul, context::Context, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.
 /// # Errors
@@ -19,6 +20,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)
@@ -30,6 +32,6 @@ where
     //   = false_value
     Ok(false_value.clone()
         + &condition
-            .multiply(&(true_value.clone() - false_value), ctx, record_id)
+            .multiply(&(true_value - false_value), ctx, record_id)
             .await?)
 }

--- a/src/protocol/basics/if_else.rs
+++ b/src/protocol/basics/if_else.rs
@@ -1,10 +1,9 @@
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, RefLocalArithmeticOps},
     protocol::{basics::SecureMul, context::Context, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// Returns `true_value` if `condition` is a share of 1, else `false_value`.
 /// # Errors
@@ -20,7 +19,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + SecureMul<C>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     // If `condition` is a share of 1 (true), then
     //   = false_value + 1 * (true_value - false_value)

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -255,7 +255,7 @@ mod tests {
 
         let m_shares = join3v(
             zip(m_ctx.iter(), input.share_with(&mut rng))
-                .map(|(m_ctx, share)| async { m_ctx.upgrade(share).await }),
+                .map(|(m_ctx, share)| async move { m_ctx.upgrade(share).await }),
         )
         .await;
         let result = try_join3(

--- a/src/protocol/basics/reveal.rs
+++ b/src/protocol/basics/reveal.rs
@@ -255,7 +255,7 @@ mod tests {
 
         let m_shares = join3v(
             zip(m_ctx.iter(), input.share_with(&mut rng))
-                .map(|(m_ctx, share)| async move { m_ctx.upgrade(share).await }),
+                .map(|(m_ctx, share)| async { m_ctx.upgrade(share).await }),
         )
         .await;
         let result = try_join3(

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,10 +1,9 @@
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, RefLocalArithmeticOps},
     protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///
@@ -53,7 +52,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 
@@ -97,12 +96,9 @@ where
         // the current bit of `a` + the current bit of `b` + the carry from the previous bit `-2*next_carry`
         // Since the current bit of `b` has a known value (either 1 or 0), we either add a `share_of_one`, or nothing.
         let result_bit = if next_bit_a_one {
-            -(&next_carry * &two)
-                + &S::share_known_value(&ctx, F::ONE)
-                + bit
-                + &last_carry
+            -(&next_carry * two) + &S::share_known_value(&ctx, F::ONE) + bit + &last_carry
         } else {
-            -(&next_carry * &two) + bit + &last_carry
+            -(&next_carry * two) + bit + &last_carry
         };
         output.push(result_bit);
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -4,6 +4,7 @@ use crate::{
     protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///
@@ -52,6 +53,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 
@@ -67,6 +69,7 @@ where
         S::share_known_value(&ctx, F::ONE) - &a[0]
     };
     output.push(result_bit);
+    let two = F::truncate_from(2_u8);
 
     for (bit_index, bit) in a.iter().enumerate().skip(1) {
         let mult_result = if last_carry_known_to_be_zero {
@@ -94,12 +97,12 @@ where
         // the current bit of `a` + the current bit of `b` + the carry from the previous bit `-2*next_carry`
         // Since the current bit of `b` has a known value (either 1 or 0), we either add a `share_of_one`, or nothing.
         let result_bit = if next_bit_a_one {
-            -next_carry.clone() * F::truncate_from(2_u128)
+            -(&next_carry * &two)
                 + &S::share_known_value(&ctx, F::ONE)
                 + bit
                 + &last_carry
         } else {
-            -next_carry.clone() * F::truncate_from(2_u128) + bit + &last_carry
+            -(&next_carry * &two) + bit + &last_carry
         };
         output.push(result_bit);
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    ff::{Field, RefLocalArithmeticOps},
+    ff::{Field, RefOps},
     protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -52,7 +52,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,10 +1,9 @@
 use crate::{
     error::Error,
-    ff::{Field, },
+    ff::Field,
     protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///
@@ -53,7 +52,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let mut output = Vec::with_capacity(a.len() + 1);
 

--- a/src/protocol/boolean/add_constant.rs
+++ b/src/protocol/boolean/add_constant.rs
@@ -1,9 +1,10 @@
 use crate::{
     error::Error,
-    ff::{Field, RefOps},
+    ff::{Field, },
     protocol::{context::Context, step::BitOpStep, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 /// This is an implementation of a Bitwise Sum of a bitwise-shared number with a constant.
 ///

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -6,6 +6,7 @@ use crate::{
     protocol::{boolean::all_zeroes, context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// Compares `[a]` and `c`, and returns 1 iff `a == c`
 ///
@@ -24,6 +25,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     assert!(a.len() <= 128);
 
@@ -36,7 +38,7 @@ where
             if ((c >> i) & 1) == 0 {
                 a_bit.clone()
             } else {
-                one.clone() - a_bit
+                &one - a_bit
             }
         })
         .collect::<Vec<_>>();
@@ -56,10 +58,11 @@ pub async fn bitwise_equal_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     debug_assert!(a.len() == b.len());
     let c = zip(a.iter(), b.iter())
-        .map(|(a_bit, b_bit)| a_bit.clone() - b_bit)
+        .map(|(a_bit, b_bit)| a_bit - b_bit)
         .collect::<Vec<_>>();
 
     all_zeroes(ctx, record_id, &c).await

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -2,11 +2,10 @@ use std::iter::zip;
 
 use crate::{
     error::Error,
-    ff::{Field, Gf2},
+    ff::{Field, Gf2, RefLocalArithmeticOps},
     protocol::{boolean::all_zeroes, context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// Compares `[a]` and `c`, and returns 1 iff `a == c`
 ///
@@ -25,7 +24,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -58,7 +57,7 @@ pub async fn bitwise_equal_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>,
 {
     debug_assert!(a.len() == b.len());
     let c = zip(a.iter(), b.iter())

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -2,11 +2,10 @@ use std::iter::zip;
 
 use crate::{
     error::Error,
-    ff::{Field, Gf2, },
+    ff::{Field, Gf2},
     protocol::{boolean::all_zeroes, context::Context, BasicProtocols, RecordId},
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 /// Compares `[a]` and `c`, and returns 1 iff `a == c`
 ///
@@ -25,7 +24,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -58,7 +57,7 @@ pub async fn bitwise_equal_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for<'a> &'a S: RefOps<'a, S, Gf2>,
+    for<'a> &'a S: LinearRefOps<'a, S, Gf2>,
 {
     debug_assert!(a.len() == b.len());
     let c = zip(a.iter(), b.iter())

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -25,7 +25,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     assert!(a.len() <= 128);
 
@@ -58,7 +58,7 @@ pub async fn bitwise_equal_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>
 {
     debug_assert!(a.len() == b.len());
     let c = zip(a.iter(), b.iter())

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 
 use crate::{
     error::Error,
-    ff::{Field, Gf2, RefLocalArithmeticOps},
+    ff::{Field, Gf2, RefOps},
     protocol::{boolean::all_zeroes, context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -24,7 +24,7 @@ where
     F: Field,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -57,7 +57,7 @@ pub async fn bitwise_equal_gf2<C, S>(
 where
     C: Context,
     S: LinearSecretSharing<Gf2> + BasicProtocols<C, Gf2>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, Gf2>,
+    for<'a> &'a S: RefOps<'a, S, Gf2>,
 {
     debug_assert!(a.len() == b.len());
     let c = zip(a.iter(), b.iter())

--- a/src/protocol/boolean/bitwise_equal.rs
+++ b/src/protocol/boolean/bitwise_equal.rs
@@ -2,10 +2,11 @@ use std::iter::zip;
 
 use crate::{
     error::Error,
-    ff::{Field, Gf2, RefOps},
+    ff::{Field, Gf2, },
     protocol::{boolean::all_zeroes, context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 /// Compares `[a]` and `c`, and returns 1 iff `a == c`
 ///

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -3,7 +3,7 @@ use ipa_macros::Step;
 use super::or::or;
 use crate::{
     error::Error,
-    ff::{PrimeField, RefLocalArithmeticOps},
+    ff::{PrimeField, RefOps},
     protocol::{
         boolean::random_bits_generator::RandomBitsGenerator,
         context::{Context, UpgradedContext},
@@ -73,7 +73,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     use GreaterThanConstantStep as Step;
 
@@ -175,7 +175,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -208,7 +208,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -239,7 +239,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     let one = S::share_known_value(ctx, F::ONE);
 

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
 //
@@ -73,6 +74,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     use GreaterThanConstantStep as Step;
 
@@ -81,7 +83,7 @@ where
     let r = rbg.generate(record_id).await?;
 
     // Mask `a` with random `r` and reveal.
-    let b = (r.b_p.clone() + a)
+    let b = (r.b_p + a)
         .reveal(ctx.narrow(&Step::Reveal), record_id)
         .await?;
 
@@ -174,6 +176,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     assert!(a.len() <= 128);
 
@@ -206,6 +209,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     assert!(a.len() <= 128);
 
@@ -236,6 +240,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
 {
     let one = S::share_known_value(ctx, F::ONE);
 
@@ -248,7 +253,7 @@ where
             if ((b >> i) & 1) == 0 {
                 a_bit.clone()
             } else {
-                one.clone() - a_bit
+                &one - a_bit
             }
         })
         .collect::<Vec<_>>();
@@ -278,7 +283,7 @@ where
         // differing bit. Note that at the index where the transition from 0 to 1 happens,
         // `prefix_or[i + 1] > prefix_or[i]`. Do not change the order of the subtraction
         // unless we use Fp2, or the result will be `[p-1]`.
-        first_diff_bit.push(result.clone() - &previous_bit);
+        first_diff_bit.push(&result - &previous_bit);
 
         previous_bit = result;
     }

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -3,7 +3,7 @@ use ipa_macros::Step;
 use super::or::or;
 use crate::{
     error::Error,
-    ff::PrimeField,
+    ff::{PrimeField, RefLocalArithmeticOps},
     protocol::{
         boolean::random_bits_generator::RandomBitsGenerator,
         context::{Context, UpgradedContext},
@@ -12,7 +12,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
 //
@@ -74,7 +73,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     use GreaterThanConstantStep as Step;
 
@@ -176,7 +175,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -209,7 +208,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -240,7 +239,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     let one = S::share_known_value(ctx, F::ONE);
 

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -3,16 +3,15 @@ use ipa_macros::Step;
 use super::or::or;
 use crate::{
     error::Error,
-    ff::{PrimeField, },
+    ff::PrimeField,
     protocol::{
         boolean::random_bits_generator::RandomBitsGenerator,
         context::{Context, UpgradedContext},
         step::BitOpStep,
         BasicProtocols, RecordId,
     },
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
 //
@@ -74,7 +73,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     use GreaterThanConstantStep as Step;
 
@@ -176,7 +175,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -209,7 +208,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     assert!(a.len() <= 128);
 
@@ -240,7 +239,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     let one = S::share_known_value(ctx, F::ONE);
 

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -74,7 +74,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     use GreaterThanConstantStep as Step;
 
@@ -176,7 +176,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     assert!(a.len() <= 128);
 
@@ -209,7 +209,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     assert!(a.len() <= 128);
 
@@ -240,7 +240,7 @@ where
     F: PrimeField,
     C: Context,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S>
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     let one = S::share_known_value(ctx, F::ONE);
 

--- a/src/protocol/boolean/comparison.rs
+++ b/src/protocol/boolean/comparison.rs
@@ -3,7 +3,7 @@ use ipa_macros::Step;
 use super::or::or;
 use crate::{
     error::Error,
-    ff::{PrimeField, RefOps},
+    ff::{PrimeField, },
     protocol::{
         boolean::random_bits_generator::RandomBitsGenerator,
         context::{Context, UpgradedContext},
@@ -12,6 +12,7 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 // Compare an arithmetic-shared value `a` to a known value `c`.
 //

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -7,7 +7,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::PrimeField,
+    ff::{PrimeField, RefLocalArithmeticOps},
     helpers::TotalRecords,
     protocol::{
         boolean::solved_bits::{solved_bits, RandomBitsShare},
@@ -16,7 +16,6 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 /// A struct that generates random sharings of bits from the
 /// `SolvedBits` protocol. Any protocol who wish to use a random-bits can draw
@@ -45,7 +44,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     #[must_use]
     pub fn new(ctx: C) -> Self {

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -7,16 +7,15 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{PrimeField, },
+    ff::PrimeField,
     helpers::TotalRecords,
     protocol::{
         boolean::solved_bits::{solved_bits, RandomBitsShare},
         context::UpgradedContext,
         BasicProtocols, RecordId,
     },
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 /// A struct that generates random sharings of bits from the
 /// `SolvedBits` protocol. Any protocol who wish to use a random-bits can draw
@@ -45,7 +44,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     #[must_use]
     pub fn new(ctx: C) -> Self {

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -7,7 +7,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{PrimeField, RefLocalArithmeticOps},
+    ff::{PrimeField, RefOps},
     helpers::TotalRecords,
     protocol::{
         boolean::solved_bits::{solved_bits, RandomBitsShare},
@@ -44,7 +44,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     #[must_use]
     pub fn new(ctx: C) -> Self {

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -7,7 +7,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{PrimeField, RefOps},
+    ff::{PrimeField, },
     helpers::TotalRecords,
     protocol::{
         boolean::solved_bits::{solved_bits, RandomBitsShare},
@@ -16,6 +16,7 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 /// A struct that generates random sharings of bits from the
 /// `SolvedBits` protocol. Any protocol who wish to use a random-bits can draw

--- a/src/protocol/boolean/random_bits_generator.rs
+++ b/src/protocol/boolean/random_bits_generator.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 /// A struct that generates random sharings of bits from the
 /// `SolvedBits` protocol. Any protocol who wish to use a random-bits can draw
@@ -44,6 +45,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     #[must_use]
     pub fn new(ctx: C) -> Self {

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -5,7 +5,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, },
+    ff::{Field, PrimeField},
     protocol::{
         boolean::{
             bitwise_less_than_prime::BitwiseLessThanPrime, generate_random_bits::one_random_bit,
@@ -18,10 +18,9 @@ use crate::{
             AdditiveShare as MaliciousReplicated, DowngradeMalicious, ExtendableField,
             UnauthorizedDowngradeWrapper,
         },
-        BitDecomposed, Linear as LinearSecretSharing, SecretSharing,
+        BitDecomposed, Linear as LinearSecretSharing, LinearRefOps, SecretSharing,
     },
 };
-use crate::secret_sharing::RefOps;
 
 #[derive(Debug)]
 pub struct RandomBitsShare<F, S>
@@ -95,7 +94,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefOps<'a, S, F>,
+    for<'a> &'a S: LinearRefOps<'a, S, F>,
 {
     //
     // step 1 & 2

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -113,6 +113,7 @@ where
     //
     // if success, then compute `[b_p]` by `Σ 2^i * [b_i]_B`
     let b_p: S = b_b.iter().enumerate().fold(S::ZERO, |acc, (i, x)| {
+        // todo: fix multiplication
         acc + &(x.clone() * F::try_from(1 << i).unwrap())
     });
 

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -5,7 +5,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefOps},
+    ff::{Field, PrimeField, },
     protocol::{
         boolean::{
             bitwise_less_than_prime::BitwiseLessThanPrime, generate_random_bits::one_random_bit,
@@ -21,6 +21,7 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing, SecretSharing,
     },
 };
+use crate::secret_sharing::RefOps;
 
 #[derive(Debug)]
 pub struct RandomBitsShare<F, S>

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -115,8 +115,7 @@ where
     //
     // if success, then compute `[b_p]` by `Σ 2^i * [b_i]_B`
     let b_p: S = b_b.iter().enumerate().fold(S::ZERO, |acc, (i, x)| {
-        // todo: fix multiplication
-        acc + &(x.clone() * F::try_from(1 << i).unwrap())
+        acc + &(x * F::try_from(1 << i).unwrap())
     });
 
     Ok(Some(RandomBitsShare {

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -5,7 +5,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField},
+    ff::{Field, PrimeField, RefLocalArithmeticOps},
     protocol::{
         boolean::{
             bitwise_less_than_prime::BitwiseLessThanPrime, generate_random_bits::one_random_bit,
@@ -21,7 +21,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing, SecretSharing,
     },
 };
-use crate::ff::RefLocalArithmeticOps;
 
 #[derive(Debug)]
 pub struct RandomBitsShare<F, S>
@@ -95,7 +94,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
+    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
 {
     //
     // step 1 & 2

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -5,7 +5,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField, RefLocalArithmeticOps},
+    ff::{Field, PrimeField, RefOps},
     protocol::{
         boolean::{
             bitwise_less_than_prime::BitwiseLessThanPrime, generate_random_bits::one_random_bit,
@@ -94,7 +94,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
-    for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+    for<'a> &'a S: RefOps<'a, S, F>,
 {
     //
     // step 1 & 2

--- a/src/protocol/boolean/solved_bits.rs
+++ b/src/protocol/boolean/solved_bits.rs
@@ -21,6 +21,7 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing, SecretSharing,
     },
 };
+use crate::ff::RefLocalArithmeticOps;
 
 #[derive(Debug)]
 pub struct RandomBitsShare<F, S>
@@ -94,6 +95,7 @@ where
     F: PrimeField,
     C: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + BasicProtocols<C, F>,
+    for <'a> &'a S: RefLocalArithmeticOps<'a, S, F>
 {
     //
     // step 1 & 2

--- a/src/protocol/context/malicious.rs
+++ b/src/protocol/context/malicious.rs
@@ -199,7 +199,7 @@ impl<'a, F: ExtendableField> UpgradedContext<F> for Upgraded<'a, F> {
     fn share_known_value(&self, value: F) -> MaliciousReplicated<F> {
         MaliciousReplicated::new(
             Replicated::share_known_value(&self.clone().base_context(), value),
-            self.inner.r_share.clone() * value.to_extended(),
+            &self.inner.r_share * value.to_extended(),
         )
     }
 

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -11,7 +11,7 @@ use typenum::Unsigned;
 
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, RefOps, Serializable},
     helpers::{query::IpaQueryConfig, Role},
     protocol::{
         attribution::secure_attribution,
@@ -315,13 +315,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
+    for<'r> &'r SB: RefOps<'r, SB, Gf2>,
     F: PrimeField + ExtendableField,
     MK: GaloisField,
     BK: GaloisField,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -35,10 +35,9 @@ use crate::{
             semi_honest::AdditiveShare as Replicated,
             ReplicatedSecretSharing,
         },
-        BitDecomposed, Linear as LinearSecretSharing,
+        BitDecomposed, Linear as LinearSecretSharing, LinearRefOps,
     },
 };
-use crate::secret_sharing::RefOps;
 
 #[derive(Step)]
 pub(crate) enum Step {
@@ -316,13 +315,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefOps<'r, S, F>,
+    for<'r> &'r S: LinearRefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'r> &'r SB: RefOps<'r, SB, Gf2>,
+    for<'r> &'r SB: LinearRefOps<'r, SB, Gf2>,
     F: PrimeField + ExtendableField,
     MK: GaloisField,
     BK: GaloisField,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -11,7 +11,7 @@ use typenum::Unsigned;
 
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
     helpers::{query::IpaQueryConfig, Role},
     protocol::{
         attribution::secure_attribution,
@@ -38,7 +38,6 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
 };
-use crate::ff::RefLocalArithmeticOps;
 
 #[derive(Step)]
 pub(crate) enum Step {
@@ -316,13 +315,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
+    for<'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
     F: PrimeField + ExtendableField,
     MK: GaloisField,
     BK: GaloisField,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -11,7 +11,7 @@ use typenum::Unsigned;
 
 use crate::{
     error::Error,
-    ff::{Field, GaloisField, Gf2, PrimeField, RefOps, Serializable},
+    ff::{Field, GaloisField, Gf2, PrimeField, Serializable},
     helpers::{query::IpaQueryConfig, Role},
     protocol::{
         attribution::secure_attribution,
@@ -38,6 +38,7 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
 };
+use crate::secret_sharing::RefOps;
 
 #[derive(Step)]
 pub(crate) enum Step {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -316,13 +316,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'r> &'r S: RefLocalArithmeticOps<'r, S>,
+    for <'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB>,
+    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
     F: PrimeField + ExtendableField,
     MK: GaloisField,
     BK: GaloisField,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -38,6 +38,7 @@ use crate::{
         BitDecomposed, Linear as LinearSecretSharing,
     },
 };
+use crate::ff::RefLocalArithmeticOps;
 
 #[derive(Step)]
 pub(crate) enum Step {
@@ -315,11 +316,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
+    for <'r> &'r S: RefLocalArithmeticOps<'r, S>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
+    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB>,
     F: PrimeField + ExtendableField,
     MK: GaloisField,
     BK: GaloisField,

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,11 +4,10 @@ use embed_doc_image::embed_doc_image;
 
 use crate::{
     error::Error,
-    ff::Field,
+    ff::{Field, RefLocalArithmeticOps},
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 #[embed_doc_image("bit_permutation", "images/sort/bit_permutations.png")]
 /// This is an implementation of `GenBitPerm` (Algorithm 3) described in:
@@ -41,7 +40,9 @@ pub async fn bit_permutation<
     ctx: C,
     input: &[S],
 ) -> Result<Vec<S>, Error>
-    where for<'r> &'r S: RefLocalArithmeticOps<'r, S, F> {
+where
+    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+{
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(2 * input.len());
     let share_of_one = S::share_known_value(&ctx, F::ONE);

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,10 +4,11 @@ use embed_doc_image::embed_doc_image;
 
 use crate::{
     error::Error,
-    ff::{Field, RefOps},
+    ff::{Field, },
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 #[embed_doc_image("bit_permutation", "images/sort/bit_permutations.png")]
 /// This is an implementation of `GenBitPerm` (Algorithm 3) described in:

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -41,7 +41,7 @@ pub async fn bit_permutation<
     ctx: C,
     input: &[S],
 ) -> Result<Vec<S>, Error>
-    where for<'r> &'r S: RefLocalArithmeticOps<'r, S> {
+    where for<'r> &'r S: RefLocalArithmeticOps<'r, S, F> {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(2 * input.len());
     let share_of_one = S::share_known_value(&ctx, F::ONE);

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -8,6 +8,7 @@ use crate::{
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 #[embed_doc_image("bit_permutation", "images/sort/bit_permutations.png")]
 /// This is an implementation of `GenBitPerm` (Algorithm 3) described in:
@@ -39,7 +40,8 @@ pub async fn bit_permutation<
 >(
     ctx: C,
     input: &[S],
-) -> Result<Vec<S>, Error> {
+) -> Result<Vec<S>, Error>
+    where for<'r> &'r S: RefLocalArithmeticOps<'r, S> {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(2 * input.len());
     let share_of_one = S::share_known_value(&ctx, F::ONE);
@@ -67,7 +69,7 @@ pub async fn bit_permutation<
     for i in 0..len {
         // we are subtracting "1" from the result since this protocol returns 1-index permutation whereas all other
         // protocols expect 0-indexed permutation
-        let less_one = mult_output[i + len].clone() - &share_of_one;
+        let less_one = &mult_output[i + len] - &share_of_one;
         mult_output[i] = less_one + &mult_output[i];
     }
     mult_output.truncate(len);

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,7 +4,7 @@ use embed_doc_image::embed_doc_image;
 
 use crate::{
     error::Error,
-    ff::{Field, RefLocalArithmeticOps},
+    ff::{Field, RefOps},
     protocol::{context::Context, BasicProtocols, RecordId},
     secret_sharing::Linear as LinearSecretSharing,
 };
@@ -41,7 +41,7 @@ pub async fn bit_permutation<
     input: &[S],
 ) -> Result<Vec<S>, Error>
 where
-    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefOps<'r, S, F>,
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(2 * input.len());

--- a/src/protocol/sort/bit_permutation.rs
+++ b/src/protocol/sort/bit_permutation.rs
@@ -4,11 +4,10 @@ use embed_doc_image::embed_doc_image;
 
 use crate::{
     error::Error,
-    ff::{Field, },
+    ff::Field,
     protocol::{context::Context, BasicProtocols, RecordId},
-    secret_sharing::Linear as LinearSecretSharing,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 #[embed_doc_image("bit_permutation", "images/sort/bit_permutations.png")]
 /// This is an implementation of `GenBitPerm` (Algorithm 3) described in:
@@ -42,7 +41,7 @@ pub async fn bit_permutation<
     input: &[S],
 ) -> Result<Vec<S>, Error>
 where
-    for<'r> &'r S: RefOps<'r, S, F>,
+    for<'r> &'r S: LinearRefOps<'r, S, F>,
 {
     let ctx_ref = &ctx;
     let ctx = ctx.set_total_records(2 * input.len());

--- a/src/query/runner/aggregate.rs
+++ b/src/query/runner/aggregate.rs
@@ -19,11 +19,10 @@ use crate::{
     },
     secret_sharing::{
         replicated::{malicious::DowngradeMalicious, semi_honest::AdditiveShare as Replicated},
-        Linear as LinearSecretSharing,
+        Linear as LinearSecretSharing, LinearRefOps,
     },
     sync::Arc,
 };
-use crate::secret_sharing::RefOps;
 
 pub struct SparseAggregateQuery<F, C, S> {
     config: SparseAggregateQueryConfig,
@@ -54,7 +53,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefOps<'r, S, F>,
+    for<'r> &'r S: LinearRefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>

--- a/src/query/runner/aggregate.rs
+++ b/src/query/runner/aggregate.rs
@@ -5,7 +5,7 @@ use futures_util::TryStreamExt;
 use super::ipa::assert_stream_send;
 use crate::{
     error::Error,
-    ff::{Gf2, Gf8Bit, PrimeField, Serializable},
+    ff::{Gf2, Gf8Bit, PrimeField, RefLocalArithmeticOps, Serializable},
     helpers::{
         query::{QuerySize, SparseAggregateQueryConfig},
         BodyStream, RecordsStream,
@@ -53,6 +53,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
+    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>

--- a/src/query/runner/aggregate.rs
+++ b/src/query/runner/aggregate.rs
@@ -5,7 +5,7 @@ use futures_util::TryStreamExt;
 use super::ipa::assert_stream_send;
 use crate::{
     error::Error,
-    ff::{Gf2, Gf8Bit, PrimeField, RefOps, Serializable},
+    ff::{Gf2, Gf8Bit, PrimeField, Serializable},
     helpers::{
         query::{QuerySize, SparseAggregateQueryConfig},
         BodyStream, RecordsStream,
@@ -23,6 +23,7 @@ use crate::{
     },
     sync::Arc,
 };
+use crate::secret_sharing::RefOps;
 
 pub struct SparseAggregateQuery<F, C, S> {
     config: SparseAggregateQueryConfig,

--- a/src/query/runner/aggregate.rs
+++ b/src/query/runner/aggregate.rs
@@ -5,7 +5,7 @@ use futures_util::TryStreamExt;
 use super::ipa::assert_stream_send;
 use crate::{
     error::Error,
-    ff::{Gf2, Gf8Bit, PrimeField, RefLocalArithmeticOps, Serializable},
+    ff::{Gf2, Gf8Bit, PrimeField, RefOps, Serializable},
     helpers::{
         query::{QuerySize, SparseAggregateQueryConfig},
         BodyStream, RecordsStream,
@@ -53,7 +53,7 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -7,7 +7,7 @@ use futures::{
 
 use crate::{
     error::Error,
-    ff::{Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
+    ff::{Gf2, PrimeField, RefOps, Serializable},
     helpers::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
@@ -55,13 +55,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
+    for<'r> &'r SB: RefOps<'r, SB, Gf2>,
     F: PrimeField,
     Replicated<F>: Serializable + ShareKnownValue<C, F>,
     IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -24,11 +24,10 @@ use crate::{
     report::{EncryptedReport, EventType, InvalidReportError},
     secret_sharing::{
         replicated::{malicious::DowngradeMalicious, semi_honest::AdditiveShare as Replicated},
-        Linear as LinearSecretSharing,
+        Linear as LinearSecretSharing, LinearRefOps,
     },
     sync::Arc,
 };
-use crate::secret_sharing::RefOps;
 
 pub struct IpaQuery<F, C, S> {
     config: IpaQueryConfig,
@@ -56,13 +55,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for<'r> &'r S: RefOps<'r, S, F>,
+    for<'r> &'r S: LinearRefOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for<'r> &'r SB: RefOps<'r, SB, Gf2>,
+    for<'r> &'r SB: LinearRefOps<'r, SB, Gf2>,
     F: PrimeField,
     Replicated<F>: Serializable + ShareKnownValue<C, F>,
     IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -56,13 +56,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'r> &'r S: RefLocalArithmeticOps<'r, S>,
+    for <'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB>,
+    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
     F: PrimeField,
     Replicated<F>: Serializable + ShareKnownValue<C, F>,
     IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -7,7 +7,7 @@ use futures::{
 
 use crate::{
     error::Error,
-    ff::{Gf2, PrimeField, RefOps, Serializable},
+    ff::{Gf2, PrimeField, Serializable},
     helpers::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
@@ -28,6 +28,7 @@ use crate::{
     },
     sync::Arc,
 };
+use crate::secret_sharing::RefOps;
 
 pub struct IpaQuery<F, C, S> {
     config: IpaQueryConfig,

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -7,7 +7,7 @@ use futures::{
 
 use crate::{
     error::Error,
-    ff::{Gf2, PrimeField, Serializable},
+    ff::{Gf2, PrimeField, RefLocalArithmeticOps, Serializable},
     helpers::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
@@ -28,7 +28,6 @@ use crate::{
     },
     sync::Arc,
 };
-use crate::ff::RefLocalArithmeticOps;
 
 pub struct IpaQuery<F, C, S> {
     config: IpaQueryConfig,
@@ -56,13 +55,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
-    for <'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
+    for<'r> &'r S: RefLocalArithmeticOps<'r, S, F>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
-    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
+    for<'r> &'r SB: RefLocalArithmeticOps<'r, SB, Gf2>,
     F: PrimeField,
     Replicated<F>: Serializable + ShareKnownValue<C, F>,
     IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,

--- a/src/query/runner/ipa.rs
+++ b/src/query/runner/ipa.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     sync::Arc,
 };
+use crate::ff::RefLocalArithmeticOps;
 
 pub struct IpaQuery<F, C, S> {
     config: IpaQueryConfig,
@@ -55,11 +56,13 @@ where
         + Serializable
         + DowngradeMalicious<Target = Replicated<F>>
         + 'static,
+    for <'r> &'r S: RefLocalArithmeticOps<'r, S>,
     C::UpgradedContext<Gf2>: UpgradedContext<Gf2, Share = SB>,
     SB: LinearSecretSharing<Gf2>
         + BasicProtocols<C::UpgradedContext<Gf2>, Gf2>
         + DowngradeMalicious<Target = Replicated<Gf2>>
         + 'static,
+    for <'r> &'r SB: RefLocalArithmeticOps<'r, SB>,
     F: PrimeField,
     Replicated<F>: Serializable + ShareKnownValue<C, F>,
     IPAInputRow<F, MatchKey, BreakdownKey>: Serializable,

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -59,7 +59,7 @@ impl<S> BitDecomposed<S> {
         F: PrimeField,
     {
         self.iter().enumerate().fold(S::ZERO, |acc, (i, b)| {
-            acc + &(b.clone() * F::truncate_from(1_u128 << i))
+            acc + (b * F::truncate_from(1_u128 << i))
         })
     }
 }

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -2,9 +2,10 @@ use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     error::Error,
-    ff::{PrimeField, RefOps},
+    ff::{PrimeField, },
     secret_sharing::Linear as LinearSecretSharing,
 };
+use crate::secret_sharing::RefOps;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BitDecomposed<S> {

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     error::Error,
-    ff::{PrimeField, RefLocalArithmeticOps},
+    ff::{PrimeField, RefOps},
     secret_sharing::Linear as LinearSecretSharing,
 };
 
@@ -60,7 +60,7 @@ impl<S> BitDecomposed<S> {
     pub fn to_additive_sharing_in_large_field<F>(&self) -> S
     where
         S: LinearSecretSharing<F>,
-        for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
+        for<'a> &'a S: RefOps<'a, S, F>,
         F: PrimeField,
     {
         self.iter().enumerate().fold(S::ZERO, |acc, (i, b)| {

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -2,10 +2,9 @@ use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     error::Error,
-    ff::{PrimeField, },
-    secret_sharing::Linear as LinearSecretSharing,
+    ff::PrimeField,
+    secret_sharing::{Linear as LinearSecretSharing, LinearRefOps},
 };
-use crate::secret_sharing::RefOps;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BitDecomposed<S> {
@@ -61,7 +60,7 @@ impl<S> BitDecomposed<S> {
     pub fn to_additive_sharing_in_large_field<F>(&self) -> S
     where
         S: LinearSecretSharing<F>,
-        for<'a> &'a S: RefOps<'a, S, F>,
+        for<'a> &'a S: LinearRefOps<'a, S, F>,
         F: PrimeField,
     {
         self.iter().enumerate().fold(S::ZERO, |acc, (i, b)| {

--- a/src/secret_sharing/decomposed.rs
+++ b/src/secret_sharing/decomposed.rs
@@ -1,6 +1,10 @@
 use std::{fmt::Debug, ops::Deref};
 
-use crate::{error::Error, ff::PrimeField, secret_sharing::Linear as LinearSecretSharing};
+use crate::{
+    error::Error,
+    ff::{PrimeField, RefLocalArithmeticOps},
+    secret_sharing::Linear as LinearSecretSharing,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct BitDecomposed<S> {
@@ -56,6 +60,7 @@ impl<S> BitDecomposed<S> {
     pub fn to_additive_sharing_in_large_field<F>(&self) -> S
     where
         S: LinearSecretSharing<F>,
+        for<'a> &'a S: RefLocalArithmeticOps<'a, S, F>,
         F: PrimeField,
     {
         self.iter().enumerate().fold(S::ZERO, |acc, (i, b)| {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -61,23 +61,22 @@ where
 mod tests {
     use crate::ff::{Fp31};
     use crate::secret_sharing::{Linear, SharedValue};
-    use crate::secret_sharing::replicated::semi_honest::AdditiveShare;
+    use crate::secret_sharing::replicated::{malicious, semi_honest};
     use crate::secret_sharing::scheme::RefLocalArithmeticOps;
 
-    #[test]
-    fn arithmetic() {
-        let a = AdditiveShare::<Fp31>::ZERO;
-        let b = AdditiveShare::<Fp31>::ZERO;
+    fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L> {
+        let a = L::ZERO;
+        let b = L::ZERO;
 
-        assert_eq!(AdditiveShare::ZERO, &a + &b);
-        assert_eq!(AdditiveShare::ZERO, a.clone() + &b);
-        assert_eq!(AdditiveShare::ZERO, &a + b.clone());
-        assert_eq!(AdditiveShare::ZERO, a + b);
+        assert_eq!(L::ZERO, &a + &b);
+        assert_eq!(L::ZERO, a.clone() + &b);
+        assert_eq!(L::ZERO, &a + b.clone());
+        assert_eq!(L::ZERO, a + b);
     }
 
-    #[test]
-    fn trait_bounds() {
-        fn sum_owned<S: Linear<Fp31>>(a: S, b: S) -> S {
+    fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L> {
+
+        fn sum_owned<S: Linear<V>, V: SharedValue>(a: S, b: S) -> S {
             a + b
         }
 
@@ -93,9 +92,21 @@ mod tests {
             a + b
         }
 
-        assert_eq!(AdditiveShare::ZERO, sum_owned(AdditiveShare::ZERO, AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_ref(&AdditiveShare::<Fp31>::ZERO, &AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_owned_ref(AdditiveShare::ZERO, &AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_owned(&AdditiveShare::ZERO, AdditiveShare::ZERO))
+        assert_eq!(L::ZERO, sum_owned(L::ZERO, L::ZERO));
+        assert_eq!(L::ZERO, sum_ref_ref(&L::ZERO, &L::ZERO));
+        assert_eq!(L::ZERO, sum_owned_ref(L::ZERO, &L::ZERO));
+        assert_eq!(L::ZERO, sum_ref_owned(&L::ZERO, L::ZERO))
+    }
+
+    #[test]
+    fn semi_honest() {
+        arithmetic::<semi_honest::AdditiveShare<Fp31>, _>();
+        trait_bounds::<semi_honest::AdditiveShare<Fp31>, _>();
+    }
+
+    #[test]
+    fn malicious() {
+        arithmetic::<malicious::AdditiveShare<Fp31>, _>();
+        trait_bounds::<malicious::AdditiveShare<Fp31>, _>();
     }
 }

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -59,7 +59,7 @@ where
 #[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
-        ff::{Fp31, RefLocalArithmeticOps},
+        ff::{Fp31, RefOps},
         secret_sharing::{
             replicated::{malicious, semi_honest},
             Linear, SharedValue,
@@ -68,7 +68,7 @@ mod tests {
 
     fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>()
     where
-        for<'a> &'a L: RefLocalArithmeticOps<'a, L, V>,
+        for<'a> &'a L: RefOps<'a, L, V>,
     {
         let a = L::ZERO;
         let b = L::ZERO;
@@ -81,7 +81,7 @@ mod tests {
 
     fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>()
     where
-        for<'a> &'a L: RefLocalArithmeticOps<'a, L, V>,
+        for<'a> &'a L: RefOps<'a, L, V>,
     {
         fn sum_owned<S: Linear<V>, V: SharedValue>(a: S, b: S) -> S {
             a + b
@@ -91,7 +91,7 @@ mod tests {
         where
             S: Linear<V>,
             V: SharedValue,
-            for<'a> &'a S: RefLocalArithmeticOps<'a, S, V>,
+            for<'a> &'a S: RefOps<'a, S, V>,
         {
             a + b
         }
@@ -104,7 +104,7 @@ mod tests {
         where
             S: Linear<V>,
             V: SharedValue,
-            for<'a> &'a S: RefLocalArithmeticOps<'a, S, V>,
+            for<'a> &'a S: RefOps<'a, S, V>,
         {
             a + b
         }

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -56,14 +56,20 @@ where
     }
 }
 
-
 #[cfg(all(test, unit_test))]
 mod tests {
-    use crate::ff::{Fp31, RefLocalArithmeticOps};
-    use crate::secret_sharing::{Linear, SharedValue};
-    use crate::secret_sharing::replicated::{malicious, semi_honest};
+    use crate::{
+        ff::{Fp31, RefLocalArithmeticOps},
+        secret_sharing::{
+            replicated::{malicious, semi_honest},
+            Linear, SharedValue,
+        },
+    };
 
-    fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L, V> {
+    fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>()
+    where
+        for<'a> &'a L: RefLocalArithmeticOps<'a, L, V>,
+    {
         let a = L::ZERO;
         let b = L::ZERO;
 
@@ -73,13 +79,20 @@ mod tests {
         assert_eq!(L::ZERO, a + b);
     }
 
-    fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L, V> {
-
+    fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>()
+    where
+        for<'a> &'a L: RefLocalArithmeticOps<'a, L, V>,
+    {
         fn sum_owned<S: Linear<V>, V: SharedValue>(a: S, b: S) -> S {
             a + b
         }
 
-        fn sum_ref_ref<S, V>(a: &S, b: &S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S, V> {
+        fn sum_ref_ref<S, V>(a: &S, b: &S) -> S
+        where
+            S: Linear<V>,
+            V: SharedValue,
+            for<'a> &'a S: RefLocalArithmeticOps<'a, S, V>,
+        {
             a + b
         }
 
@@ -87,14 +100,19 @@ mod tests {
             a + b
         }
 
-        fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S, V> {
+        fn sum_ref_owned<S, V>(a: &S, b: S) -> S
+        where
+            S: Linear<V>,
+            V: SharedValue,
+            for<'a> &'a S: RefLocalArithmeticOps<'a, S, V>,
+        {
             a + b
         }
 
         assert_eq!(L::ZERO, sum_owned(L::ZERO, L::ZERO));
         assert_eq!(L::ZERO, sum_ref_ref(&L::ZERO, &L::ZERO));
         assert_eq!(L::ZERO, sum_owned_ref(L::ZERO, &L::ZERO));
-        assert_eq!(L::ZERO, sum_ref_owned(&L::ZERO, L::ZERO))
+        assert_eq!(L::ZERO, sum_ref_owned(&L::ZERO, L::ZERO));
     }
 
     #[test]

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -16,7 +16,7 @@ use rand::{
 };
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
 use replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing};
-pub use scheme::{Bitwise, Linear, SecretSharing};
+pub use scheme::{Bitwise, Linear, SecretSharing, RefOps};
 
 use crate::ff::{ArithmeticOps, Serializable};
 
@@ -58,12 +58,13 @@ where
 #[cfg(all(test, unit_test))]
 mod tests {
     use crate::{
-        ff::{Fp31, RefOps},
+        ff::{Fp31, },
         secret_sharing::{
             replicated::{malicious, semi_honest},
             Linear, SharedValue,
         },
     };
+    use crate::secret_sharing::RefOps;
 
     fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>()
     where

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -59,9 +59,11 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use crate::ff::{Field, Fp31, RefLocalArithmeticOps};
-    use crate::secret_sharing::Linear;
+    use std::ops::Add;
+    use crate::ff::{Field, Fp31};
+    use crate::secret_sharing::{Linear, SharedValue};
     use crate::secret_sharing::replicated::semi_honest::AdditiveShare;
+    use crate::secret_sharing::scheme::RefLocalArithmeticOps;
 
     #[test]
     fn arithmetic() {
@@ -80,7 +82,7 @@ mod tests {
             a + b
         }
 
-        fn sum_ref_ref<S>(a: &S, b: &S) -> S where S: Linear<Fp31>, for <'a> &'a S: RefLocalArithmeticOps<S> {
+        fn sum_ref_ref<S>(a: &S, b: &S) -> S where S: Linear<Fp31>, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
             a + b
         }
 
@@ -88,13 +90,15 @@ mod tests {
             a + b
         }
 
-        fn sum_ref_owned<S>(a: &S, b: S) -> S where S: Linear<Fp31>, for <'a> &'a S: RefLocalArithmeticOps<S> {
-            a + b
-        }
+        // fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<S> {
+        //     a + b
+        // }
 
         assert_eq!(AdditiveShare::ZERO, sum_owned(AdditiveShare::ZERO, AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::ZERO, sum_ref_ref(&AdditiveShare::ZERO, &AdditiveShare::ZERO));
+        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_ref(&AdditiveShare::<Fp31>::ZERO, &AdditiveShare::ZERO));
         assert_eq!(AdditiveShare::ZERO, sum_owned_ref(AdditiveShare::ZERO, &AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::ZERO, sum_ref_owned(&AdditiveShare::ZERO, AdditiveShare::ZERO));
+        // assert_eq!(0, sum_ref_owned(&0_i32, 1));
+        // assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_owned::<AdditiveShare<Fp31>, _>(&AdditiveShare::ZERO, AdditiveShare::ZERO))
+        // assert_eq!(AdditiveShare::ZERO, sum_ref_owned::<AdditiveShare<Fp31>>(&AdditiveShare::ZERO, AdditiveShare::ZERO));
     }
 }

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -27,7 +27,6 @@ pub trait Block: Sized + Copy + Debug {
 }
 
 pub trait SharedValue:
-// TODO: add reference operations
     Clone + Copy + PartialEq + Debug + Send + Sync + Sized + ArithmeticOps + Serializable + 'static
 {
     type Storage: Block;

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::secret_sharing::{Linear, SharedValue};
     use crate::secret_sharing::replicated::{malicious, semi_honest};
 
-    fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L> {
+    fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L, V> {
         let a = L::ZERO;
         let b = L::ZERO;
 
@@ -73,13 +73,13 @@ mod tests {
         assert_eq!(L::ZERO, a + b);
     }
 
-    fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L> {
+    fn trait_bounds<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L, V> {
 
         fn sum_owned<S: Linear<V>, V: SharedValue>(a: S, b: S) -> S {
             a + b
         }
 
-        fn sum_ref_ref<S, V>(a: &S, b: &S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
+        fn sum_ref_ref<S, V>(a: &S, b: &S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S, V> {
             a + b
         }
 
@@ -87,7 +87,7 @@ mod tests {
             a + b
         }
 
-        fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
+        fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S, V> {
             a + b
         }
 

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -59,10 +59,9 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use crate::ff::{Fp31};
+    use crate::ff::{Fp31, RefLocalArithmeticOps};
     use crate::secret_sharing::{Linear, SharedValue};
     use crate::secret_sharing::replicated::{malicious, semi_honest};
-    use crate::secret_sharing::scheme::RefLocalArithmeticOps;
 
     fn arithmetic<L: Linear<V> + PartialEq, V: SharedValue>() where for <'a> &'a L: RefLocalArithmeticOps<'a, L> {
         let a = L::ZERO;

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -59,8 +59,7 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use std::ops::Add;
-    use crate::ff::{Field, Fp31};
+    use crate::ff::{Fp31};
     use crate::secret_sharing::{Linear, SharedValue};
     use crate::secret_sharing::replicated::semi_honest::AdditiveShare;
     use crate::secret_sharing::scheme::RefLocalArithmeticOps;
@@ -82,23 +81,21 @@ mod tests {
             a + b
         }
 
-        fn sum_ref_ref<S>(a: &S, b: &S) -> S where S: Linear<Fp31>, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
+        fn sum_ref_ref<S, V>(a: &S, b: &S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
             a + b
         }
 
-        fn sum_owned_ref<S: Linear<Fp31>>(a: S, b: &S) -> S {
+        fn sum_owned_ref<S: Linear<V>, V: SharedValue>(a: S, b: &S) -> S {
             a + b
         }
 
-        // fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<S> {
-        //     a + b
-        // }
+        fn sum_ref_owned<S, V>(a: &S, b: S) -> S where S: Linear<V>, V: SharedValue, for <'a> &'a S: RefLocalArithmeticOps<'a, S> {
+            a + b
+        }
 
         assert_eq!(AdditiveShare::ZERO, sum_owned(AdditiveShare::ZERO, AdditiveShare::ZERO));
         assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_ref(&AdditiveShare::<Fp31>::ZERO, &AdditiveShare::ZERO));
-        assert_eq!(AdditiveShare::ZERO, sum_owned_ref(AdditiveShare::ZERO, &AdditiveShare::ZERO));
-        // assert_eq!(0, sum_ref_owned(&0_i32, 1));
-        // assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_owned::<AdditiveShare<Fp31>, _>(&AdditiveShare::ZERO, AdditiveShare::ZERO))
-        // assert_eq!(AdditiveShare::ZERO, sum_ref_owned::<AdditiveShare<Fp31>>(&AdditiveShare::ZERO, AdditiveShare::ZERO));
+        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_owned_ref(AdditiveShare::ZERO, &AdditiveShare::ZERO));
+        assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_owned(&AdditiveShare::ZERO, AdditiveShare::ZERO))
     }
 }

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -187,7 +187,7 @@ impl<V: SharedValue + ExtendableField> AddAssign<&Self> for AdditiveShare<V> {
 
 impl<V: SharedValue + ExtendableField> AddAssign<Self> for AdditiveShare<V> {
     fn add_assign(&mut self, rhs: Self) {
-        AddAssign::add_assign(self, &rhs)
+        AddAssign::add_assign(self, &rhs);
     }
 }
 
@@ -246,7 +246,7 @@ impl<V: SharedValue + ExtendableField> SubAssign<&Self> for AdditiveShare<V> {
 
 impl<V: SharedValue + ExtendableField> SubAssign<Self> for AdditiveShare<V> {
     fn sub_assign(&mut self, rhs: Self) {
-        SubAssign::sub_assign(self, &rhs)
+        SubAssign::sub_assign(self, &rhs);
     }
 }
 
@@ -256,7 +256,7 @@ impl<'a, 'b, V: SharedValue + ExtendableField> Mul<&'b V> for &'a AdditiveShare<
     fn mul(self, rhs: &'b V) -> Self::Output {
         AdditiveShare {
             x: &self.x * rhs,
-            rx: &self.rx * &rhs.to_extended()
+            rx: &self.rx * rhs.to_extended(),
         }
     }
 }

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -250,14 +250,22 @@ impl<V: SharedValue + ExtendableField> SubAssign<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Mul<V> for AdditiveShare<V> {
+impl<V: SharedValue + ExtendableField> Mul<&V> for AdditiveShare<V> {
     type Output = Self;
 
-    fn mul(self, rhs: V) -> Self::Output {
+    fn mul(self, rhs: &V) -> Self::Output {
         Self {
             x: self.x * rhs,
             rx: self.rx * rhs.to_extended(),
         }
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Mul<V> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn mul(self, rhs: V) -> Self::Output {
+        Mul::mul(self, &rhs)
     }
 }
 

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -250,19 +250,35 @@ impl<V: SharedValue + ExtendableField> SubAssign<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Mul<&V> for AdditiveShare<V> {
-    type Output = Self;
+impl<'a, 'b, V: SharedValue + ExtendableField> Mul<&'b V> for &'a AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
-    fn mul(self, rhs: &V) -> Self::Output {
-        Self {
-            x: self.x * rhs,
-            rx: self.rx * rhs.to_extended(),
+    fn mul(self, rhs: &'b V) -> Self::Output {
+        AdditiveShare {
+            x: &self.x * rhs,
+            rx: &self.rx * &rhs.to_extended()
         }
     }
 }
 
 impl<V: SharedValue + ExtendableField> Mul<V> for AdditiveShare<V> {
     type Output = Self;
+
+    fn mul(self, rhs: V) -> Self::Output {
+        Mul::mul(&self, &rhs)
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Mul<&V> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn mul(self, rhs: &V) -> Self::Output {
+        Mul::mul(&self, rhs)
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Mul<V> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
     fn mul(self, rhs: V) -> Self::Output {
         Mul::mul(self, &rhs)

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -154,12 +154,27 @@ impl<V: SharedValue + ExtendableField> Add<Self> for &AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Add<&Self> for AdditiveShare<V> {
+impl<V: SharedValue + ExtendableField> Add<Self> for AdditiveShare<V> {
     type Output = Self;
 
-    fn add(mut self, rhs: &Self) -> Self::Output {
-        self += rhs;
-        self
+    fn add(self, rhs: Self) -> Self::Output {
+        Add::add(&self, &rhs)
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Add<AdditiveShare<V>> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
+
+    fn add(self, rhs: AdditiveShare<V>) -> Self::Output {
+        Add::add(self, &rhs)
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Add<&AdditiveShare<V>> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self::Output {
+        Add::add(&self, rhs)
     }
 }
 
@@ -167,6 +182,12 @@ impl<V: SharedValue + ExtendableField> AddAssign<&Self> for AdditiveShare<V> {
     fn add_assign(&mut self, rhs: &Self) {
         self.x += &rhs.x;
         self.rx += &rhs.rx;
+    }
+}
+
+impl<V: SharedValue + ExtendableField> AddAssign<Self> for AdditiveShare<V> {
+    fn add_assign(&mut self, rhs: Self) {
+        AddAssign::add_assign(self, &rhs)
     }
 }
 
@@ -191,12 +212,28 @@ impl<V: SharedValue + ExtendableField> Sub<Self> for &AdditiveShare<V> {
         }
     }
 }
+
+impl<V: SharedValue + ExtendableField> Sub<Self> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Sub::sub(&self, &rhs)
+    }
+}
+
 impl<V: SharedValue + ExtendableField> Sub<&Self> for AdditiveShare<V> {
     type Output = Self;
 
-    fn sub(mut self, rhs: &Self) -> Self::Output {
-        self -= rhs;
-        self
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Sub::sub(&self, rhs)
+    }
+}
+
+impl<V: SharedValue + ExtendableField> Sub<AdditiveShare<V>> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
+
+    fn sub(self, rhs: AdditiveShare<V>) -> Self::Output {
+        Sub::sub(self, &rhs)
     }
 }
 
@@ -204,6 +241,12 @@ impl<V: SharedValue + ExtendableField> SubAssign<&Self> for AdditiveShare<V> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.x -= &rhs.x;
         self.rx -= &rhs.rx;
+    }
+}
+
+impl<V: SharedValue + ExtendableField> SubAssign<Self> for AdditiveShare<V> {
+    fn sub_assign(&mut self, rhs: Self) {
+        SubAssign::sub_assign(self, &rhs)
     }
 }
 

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -143,10 +143,10 @@ impl<V: SharedValue + ExtendableField> AdditiveShare<V> {
     };
 }
 
-impl<V: SharedValue + ExtendableField> Add<Self> for &AdditiveShare<V> {
+impl<'a, 'b, V: SharedValue + ExtendableField> Add<&'b AdditiveShare<V>> for &'a AdditiveShare<V> {
     type Output = AdditiveShare<V>;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: &'b AdditiveShare<V>) -> Self::Output {
         AdditiveShare {
             x: &self.x + &rhs.x,
             rx: &self.rx + &rhs.rx,

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -13,7 +13,6 @@ use crate::{
         SharedValue,
     },
 };
-use crate::secret_sharing::scheme::RefLocalArithmeticOps;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct AdditiveShare<V: SharedValue>(V, V);

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -181,16 +181,32 @@ impl<V: SharedValue> SubAssign<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue> Mul<&V> for AdditiveShare<V> {
-    type Output = Self;
+impl<'a, 'b, V: SharedValue> Mul<&'b V> for &'a AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
-    fn mul(self, rhs: &V) -> Self::Output {
-        Self(self.0 * *rhs, self.1 * *rhs)
+    fn mul(self, rhs: &'b V) -> Self::Output {
+        AdditiveShare(self.0 * *rhs, self.1 * *rhs)
     }
 }
 
 impl<V: SharedValue> Mul<V> for AdditiveShare<V> {
     type Output = Self;
+
+    fn mul(self, rhs: V) -> Self::Output {
+        Mul::mul(&self, &rhs)
+    }
+}
+
+impl<V: SharedValue> Mul<&V> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn mul(self, rhs: &V) -> Self::Output {
+        Mul::mul(&self, rhs)
+    }
+}
+
+impl<V: SharedValue> Mul<V> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
 
     fn mul(self, rhs: V) -> Self::Output {
         Mul::mul(self, &rhs)

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -89,7 +89,7 @@ impl<V: SharedValue> Add<Self> for AdditiveShare<V> {
     }
 }
 
-impl<'a, V: SharedValue> Add<AdditiveShare<V>> for &'a AdditiveShare<V> {
+impl<V: SharedValue> Add<AdditiveShare<V>> for &AdditiveShare<V> {
     type Output = AdditiveShare<V>;
 
     fn add(self, rhs: AdditiveShare<V>) -> Self::Output {
@@ -97,10 +97,10 @@ impl<'a, V: SharedValue> Add<AdditiveShare<V>> for &'a AdditiveShare<V> {
     }
 }
 
-impl<'a, V: SharedValue> Add<&'a AdditiveShare<V>> for AdditiveShare<V> {
+impl<V: SharedValue> Add<&AdditiveShare<V>> for AdditiveShare<V> {
     type Output = Self;
 
-    fn add(self, rhs: &'a Self) -> Self::Output {
+    fn add(self, rhs: &Self) -> Self::Output {
         Add::add(&self, rhs)
     }
 }

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -181,11 +181,19 @@ impl<V: SharedValue> SubAssign<Self> for AdditiveShare<V> {
     }
 }
 
+impl<V: SharedValue> Mul<&V> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn mul(self, rhs: &V) -> Self::Output {
+        Self(self.0 * *rhs, self.1 * *rhs)
+    }
+}
+
 impl<V: SharedValue> Mul<V> for AdditiveShare<V> {
     type Output = Self;
 
     fn mul(self, rhs: V) -> Self::Output {
-        Self(self.0 * rhs, self.1 * rhs)
+        Mul::mul(self, &rhs)
     }
 }
 

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -116,7 +116,7 @@ impl<V: SharedValue> AddAssign<&Self> for AdditiveShare<V> {
 
 impl<V: SharedValue> AddAssign<Self> for AdditiveShare<V> {
     fn add_assign(&mut self, rhs: Self) {
-        AddAssign::add_assign(self, &rhs)
+        AddAssign::add_assign(self, &rhs);
     }
 }
 
@@ -177,7 +177,7 @@ impl<V: SharedValue> SubAssign<&Self> for AdditiveShare<V> {
 
 impl<V: SharedValue> SubAssign<Self> for AdditiveShare<V> {
     fn sub_assign(&mut self, rhs: Self) {
-        SubAssign::sub_assign(self, &rhs)
+        SubAssign::sub_assign(self, &rhs);
     }
 }
 

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -23,8 +23,6 @@ impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
 
 impl<V: SharedValue> LinearSecretSharing<V> for AdditiveShare<V> {}
 
-// impl <'a, V: SharedValue> RefLocalArithmeticOps<'a, Self> for AdditiveShare<V> {}
-
 impl<V: SharedValue + Debug> Debug for AdditiveShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "({:?}, {:?})", self.0, self.1)

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -13,6 +13,7 @@ use crate::{
         SharedValue,
     },
 };
+use crate::secret_sharing::scheme::RefLocalArithmeticOps;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct AdditiveShare<V: SharedValue>(V, V);
@@ -22,6 +23,8 @@ impl<V: SharedValue> SecretSharing<V> for AdditiveShare<V> {
 }
 
 impl<V: SharedValue> LinearSecretSharing<V> for AdditiveShare<V> {}
+
+// impl <'a, V: SharedValue> RefLocalArithmeticOps<'a, Self> for AdditiveShare<V> {}
 
 impl<V: SharedValue + Debug> Debug for AdditiveShare<V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -73,10 +76,10 @@ where
     }
 }
 
-impl<V: SharedValue> Add<Self> for &AdditiveShare<V> {
+impl<'a, 'b, V: SharedValue> Add<&'b AdditiveShare<V>> for &'a AdditiveShare<V> {
     type Output = AdditiveShare<V>;
 
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: &'b AdditiveShare<V>) -> Self::Output {
         AdditiveShare(self.0 + rhs.0, self.1 + rhs.1)
     }
 }
@@ -89,7 +92,7 @@ impl<V: SharedValue> Add<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue> Add<AdditiveShare<V>> for &AdditiveShare<V> {
+impl<'a, V: SharedValue> Add<AdditiveShare<V>> for &'a AdditiveShare<V> {
     type Output = AdditiveShare<V>;
 
     fn add(self, rhs: AdditiveShare<V>) -> Self::Output {
@@ -97,10 +100,10 @@ impl<V: SharedValue> Add<AdditiveShare<V>> for &AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue> Add<&AdditiveShare<V>> for AdditiveShare<V> {
+impl<'a, V: SharedValue> Add<&'a AdditiveShare<V>> for AdditiveShare<V> {
     type Output = Self;
 
-    fn add(self, rhs: &Self) -> Self::Output {
+    fn add(self, rhs: &'a Self) -> Self::Output {
         Add::add(&self, rhs)
     }
 }
@@ -118,11 +121,19 @@ impl<V: SharedValue> AddAssign<Self> for AdditiveShare<V> {
     }
 }
 
+impl<V: SharedValue> Neg for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
+
+    fn neg(self) -> Self::Output {
+        AdditiveShare(-self.0, -self.1)
+    }
+}
+
 impl<V: SharedValue> Neg for AdditiveShare<V> {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        Self(-self.0, -self.1)
+        Neg::neg(&self)
     }
 }
 

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -81,12 +81,27 @@ impl<V: SharedValue> Add<Self> for &AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue> Add<&Self> for AdditiveShare<V> {
+impl<V: SharedValue> Add<Self> for AdditiveShare<V> {
     type Output = Self;
 
-    fn add(mut self, rhs: &Self) -> Self::Output {
-        self += rhs;
-        self
+    fn add(self, rhs: Self) -> Self::Output {
+        Add::add(&self, &rhs)
+    }
+}
+
+impl<V: SharedValue> Add<AdditiveShare<V>> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
+
+    fn add(self, rhs: AdditiveShare<V>) -> Self::Output {
+        Add::add(self, &rhs)
+    }
+}
+
+impl<V: SharedValue> Add<&AdditiveShare<V>> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self::Output {
+        Add::add(&self, rhs)
     }
 }
 
@@ -94,6 +109,12 @@ impl<V: SharedValue> AddAssign<&Self> for AdditiveShare<V> {
     fn add_assign(&mut self, rhs: &Self) {
         self.0 += rhs.0;
         self.1 += rhs.1;
+    }
+}
+
+impl<V: SharedValue> AddAssign<Self> for AdditiveShare<V> {
+    fn add_assign(&mut self, rhs: Self) {
+        AddAssign::add_assign(self, &rhs)
     }
 }
 
@@ -113,12 +134,27 @@ impl<V: SharedValue> Sub<Self> for &AdditiveShare<V> {
     }
 }
 
+impl<V: SharedValue> Sub<Self> for AdditiveShare<V> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Sub::sub(&self, &rhs)
+    }
+}
+
 impl<V: SharedValue> Sub<&Self> for AdditiveShare<V> {
     type Output = Self;
 
-    fn sub(mut self, rhs: &Self) -> Self::Output {
-        self -= rhs;
-        self
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Sub::sub(&self, rhs)
+    }
+}
+
+impl<V: SharedValue> Sub<AdditiveShare<V>> for &AdditiveShare<V> {
+    type Output = AdditiveShare<V>;
+
+    fn sub(self, rhs: AdditiveShare<V>) -> Self::Output {
+        Sub::sub(self, &rhs)
     }
 }
 
@@ -126,6 +162,12 @@ impl<V: SharedValue> SubAssign<&Self> for AdditiveShare<V> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.0 -= rhs.0;
         self.1 -= rhs.1;
+    }
+}
+
+impl<V: SharedValue> SubAssign<Self> for AdditiveShare<V> {
+    fn sub_assign(&mut self, rhs: Self) {
+        SubAssign::sub_assign(self, &rhs)
     }
 }
 

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -12,16 +12,17 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 }
 
 /// Secret share of a secret that has additive and multiplicative properties.
-pub trait Linear<V: SharedValue>: SecretSharing<V>
+pub trait Linear<V: SharedValue>:
+    SecretSharing<V>
     + LocalArithmeticOps
     + LocalAssignOps
     + for<'r> LocalArithmeticOps<&'r Self>
     + for<'r> LocalAssignOps<&'r Self>
-    // TODO: add reference
-    + Mul<V, Output=Self>
+    + Mul<V, Output = Self>
     + for<'r> Mul<&'r V, Output = Self>
-    + Neg<Output=Self>
-{}
+    + Neg<Output = Self>
+{
+}
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::SharedValue;
-use crate::ff::{GaloisField, LocalArithmeticOps, LocalAssignOps};
+use crate::ff::{AddSub, AddSubAssign, GaloisField};
 
 /// Secret sharing scheme i.e. Replicated secret sharing
 pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
@@ -14,10 +14,10 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 /// Secret share of a secret that has additive and multiplicative properties.
 pub trait Linear<V: SharedValue>:
     SecretSharing<V>
-    + LocalArithmeticOps
-    + LocalAssignOps
-    + for<'r> LocalArithmeticOps<&'r Self>
-    + for<'r> LocalAssignOps<&'r Self>
+    + AddSub
+    + AddSubAssign
+    + for<'r> AddSub<&'r Self>
+    + for<'r> AddSubAssign<&'r Self>
     + Mul<V, Output = Self>
     + for<'r> Mul<&'r V, Output = Self>
     + Neg<Output = Self>
@@ -37,19 +37,16 @@ pub trait Linear<V: SharedValue>:
 ///
 /// [`RefNum`]: https://docs.rs/num/0.4.1/num/traits/trait.RefNum.html
 /// [`rust-issue`]: https://github.com/rust-lang/rust/issues/20671
-pub trait RefOps<'a, Base: 'a, R: 'a>:
-LocalArithmeticOps<Base, Base>
-+ LocalArithmeticOps<&'a Base, Base>
-+ Mul<R, Output = Base>
-+ Mul<&'a R, Output = Base>
+pub trait LinearRefOps<'a, Base: 'a, R: 'a>:
+    AddSub<Base, Base> + AddSub<&'a Base, Base> + Mul<R, Output = Base> + Mul<&'a R, Output = Base>
 {
 }
-impl<'a, T, Base: 'a, R: 'a> RefOps<'a, Base, R> for T where
-    T: LocalArithmeticOps<Base, Base>
-    + LocalArithmeticOps<&'a Base, Base>
-    + 'a
-    + Mul<R, Output = Base>
-    + Mul<&'a R, Output = Base>
+impl<'a, T, Base: 'a, R: 'a> LinearRefOps<'a, Base, R> for T where
+    T: AddSub<Base, Base>
+        + AddSub<&'a Base, Base>
+        + 'a
+        + Mul<R, Output = Base>
+        + Mul<&'a R, Output = Base>
 {
 }
 

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -21,8 +21,8 @@ SecretSharing<V>
 + Neg<Output = Self>
 {}
 
-pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<&'a Base, Base> {}
-impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
+pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> {}
+impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> + 'a {}
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -24,5 +24,34 @@ pub trait Linear<V: SharedValue>:
 {
 }
 
+/// The trait for arithmetic operations on references to a secret share, taking the
+/// second operand either by value or by reference. Secret sharings can be added/subtracted and
+/// multiplied by the shared values locally.
+///
+/// The need for this trait is dictated by [`rust-issue`] that causes us not being able to constrain
+/// references to `Self`. Once this issue is fixed, we can simply get rid of it.
+///
+/// This is automatically implemented for types which implement the operators. The idea is borrowed
+/// from [`RefNum`] trait, but I couldn't really make it work with HRTB and secret shares. Primitive
+/// types worked just fine though, so it is possible that it is another compiler issue.
+///
+/// [`RefNum`]: https://docs.rs/num/0.4.1/num/traits/trait.RefNum.html
+/// [`rust-issue`]: https://github.com/rust-lang/rust/issues/20671
+pub trait RefOps<'a, Base: 'a, R: 'a>:
+LocalArithmeticOps<Base, Base>
++ LocalArithmeticOps<&'a Base, Base>
++ Mul<R, Output = Base>
++ Mul<&'a R, Output = Base>
+{
+}
+impl<'a, T, Base: 'a, R: 'a> RefOps<'a, Base, R> for T where
+    T: LocalArithmeticOps<Base, Base>
+    + LocalArithmeticOps<&'a Base, Base>
+    + 'a
+    + Mul<R, Output = Base>
+    + Mul<&'a R, Output = Base>
+{
+}
+
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -20,8 +20,6 @@ pub trait Linear<V: SharedValue>: SecretSharing<V>
     + Neg<Output=Self>
 {}
 
-pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> {}
-impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> + 'a {}
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
-use std::ops::Mul;
+use std::ops::{Mul, Neg};
 
 use super::SharedValue;
-use crate::ff::{GaloisField, LocalArithmeticOps};
+use crate::ff::{GaloisField, LocalArithmeticOps, LocalAssignOps};
 
 /// Secret sharing scheme i.e. Replicated secret sharing
 pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
@@ -13,10 +13,16 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 pub trait Linear<V: SharedValue>:
 SecretSharing<V>
 + LocalArithmeticOps
++ LocalAssignOps
 + for<'r> LocalArithmeticOps<&'r Self>
++ for<'r> LocalAssignOps<&'r Self>
 // TODO: add reference
 + Mul<V, Output = Self>
++ Neg<Output = Self>
 {}
+
+pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<&'a Base, Base> {}
+impl<'a, T, Base: 'a> RefLocalArithmeticOps<'a, Base> for T where T: LocalArithmeticOps<&'a Base, Base> + 'a {}
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -1,5 +1,7 @@
-use std::fmt::Debug;
-use std::ops::{Mul, Neg};
+use std::{
+    fmt::Debug,
+    ops::{Mul, Neg},
+};
 
 use super::SharedValue;
 use crate::ff::{GaloisField, LocalArithmeticOps, LocalAssignOps};
@@ -20,7 +22,6 @@ pub trait Linear<V: SharedValue>: SecretSharing<V>
     + for<'r> Mul<&'r V, Output = Self>
     + Neg<Output=Self>
 {}
-
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -10,15 +10,14 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 }
 
 /// Secret share of a secret that has additive and multiplicative properties.
-pub trait Linear<V: SharedValue>:
-SecretSharing<V>
-+ LocalArithmeticOps
-+ LocalAssignOps
-+ for<'r> LocalArithmeticOps<&'r Self>
-+ for<'r> LocalAssignOps<&'r Self>
-// TODO: add reference
-+ Mul<V, Output = Self>
-+ Neg<Output = Self>
+pub trait Linear<V: SharedValue>: SecretSharing<V>
+    + LocalArithmeticOps
+    + LocalAssignOps
+    + for<'r> LocalArithmeticOps<&'r Self>
+    + for<'r> LocalAssignOps<&'r Self>
+    // TODO: add reference
+    + Mul<V, Output=Self>
+    + Neg<Output=Self>
 {}
 
 pub trait RefLocalArithmeticOps<'a, Base: 'a>: LocalArithmeticOps<Base, Base> + LocalArithmeticOps<&'a Base, Base> {}

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -17,6 +17,7 @@ pub trait Linear<V: SharedValue>: SecretSharing<V>
     + for<'r> LocalAssignOps<&'r Self>
     // TODO: add reference
     + Mul<V, Output=Self>
+    + for<'r> Mul<&'r V, Output = Self>
     + Neg<Output=Self>
 {}
 

--- a/src/secret_sharing/scheme.rs
+++ b/src/secret_sharing/scheme.rs
@@ -1,7 +1,8 @@
 use std::fmt::Debug;
+use std::ops::Mul;
 
 use super::SharedValue;
-use crate::ff::{ArithmeticRefOps, GaloisField};
+use crate::ff::{GaloisField, LocalArithmeticOps};
 
 /// Secret sharing scheme i.e. Replicated secret sharing
 pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
@@ -9,7 +10,13 @@ pub trait SecretSharing<V: SharedValue>: Clone + Debug + Sized + Send + Sync {
 }
 
 /// Secret share of a secret that has additive and multiplicative properties.
-pub trait Linear<V: SharedValue>: SecretSharing<V> + ArithmeticRefOps<V> {}
+pub trait Linear<V: SharedValue>:
+SecretSharing<V>
++ LocalArithmeticOps
++ for<'r> LocalArithmeticOps<&'r Self>
+// TODO: add reference
++ Mul<V, Output = Self>
+{}
 
 /// Secret share of a secret in bits. It has additive and multiplicative properties.
 pub trait Bitwise<V: GaloisField>: SecretSharing<V> + Linear<V> {}


### PR DESCRIPTION
This change brings an extra trait bound for linear secret sharing trait, to allow addition and multiplication on references, rather than owned types. Currently it is only possible to do `a + b` or `a + &b`, but not `&a + b` or `&a + &b`. This change makes it possible.

As usual, it is not all rosy here, because of the compiler issue: https://github.com/rust-lang/rust/issues/20671. There is a need currently to specify the additional trait bound on every function, but I think it is worth it because not every `.clone()` call can be eliminated by the compiler, as it can be seen [here](https://rust.godbolt.org/z/MsoTnaeoc). We're better off helping optimizer here. So it cost us additional trait bound, but gives a much nicer addition/multiplication w/o extra clones and makes us not worry about compiler not being able to optimize it. 

Once (if?) that gnarly issue is fixed, we could probably just add `for <'a, 'b> &'a Self: Add<'b Self>`bound to `ArithmeticOps` trait and eliminate all extra helper traits along with extra bounds on functions. 


## Implementation notes

* I could've probably used a macro to synthesize all extra `Add`/`Sub`/`Mul` implementations, but decided it is not worth it for just two types. Maybe if we had more secret sharing types ....

* I tried hard to mimic `num` trait definition (https://github.com/rust-num/num/pull/283), but ran into an error complaining that `Add` operation is not general enough:

```
error: implementation of `Add` is not general enough
  --> src/secret_sharing/mod.rs:97:49
   |
97 |         assert_eq!(AdditiveShare::<Fp31>::ZERO, sum_ref_ref(&AdditiveShare::<Fp31>::ZERO, &AdditiveShare::ZERO));
   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Add` is not general enough
   |
   = note: `Add<replicated::semi_honest::additive_share::AdditiveShare<fp31::Fp31>>` would have to be implemented for the type `&'0 replicated::semi_honest::additive_share::AdditiveShare<fp31::Fp31>`, for any lifetime `'0`...
   = note: ...but `Add<replicated::semi_honest::additive_share::AdditiveShare<fp31::Fp31>>` is actually implemented for the type `&'1 replicated::semi_honest::additive_share::AdditiveShare<fp31::Fp31>`, for some specific lifetime `'1`
```

it remains a mystery to me, why I was getting it. The same function worked just fine for `u32` and primitive types had the same 4 `Add` overloads with reference ones defined exactly as ours for additive secret shares. 
