### PR TITLE
Fix some (all?) concurrency issues inside infrastructure

### DIFF
--- a/src/helpers/buffers/ordering_sender.rs
+++ b/src/helpers/buffers/ordering_sender.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Borrow,
     cmp::Ordering,
     collections::VecDeque,
-    fmt::{Debug, Formatter},
+    fmt::Debug,
     mem::drop,
     num::NonZeroUsize,
     pin::Pin,
@@ -217,7 +217,7 @@ impl Waiting {
     ///
     /// ## Errors
     /// If `current` is behind the current position recorded in this shard.
-    fn add(&self, current: usize, i: usize, w: &Waker) -> Result<(), WakerRejected> {
+    fn add(&self, current: usize, i: usize, w: &Waker) -> Result<(), ()> {
         self.shard(i).add(current, i, w)
     }
 

--- a/src/helpers/buffers/ordering_sender.rs
+++ b/src/helpers/buffers/ordering_sender.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO remove
-
 use std::{
     borrow::Borrow,
     cmp::Ordering,
@@ -7,9 +5,9 @@ use std::{
     mem::drop,
     num::NonZeroUsize,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+use std::fmt::{Debug, Formatter};
 
 use futures::{task::Waker, Future, Stream};
 use generic_array::GenericArray;
@@ -116,6 +114,7 @@ impl State {
 }
 
 /// An saved waker for a given index.
+#[derive(Debug)]
 struct WakerItem {
     /// The index.
     i: usize,
@@ -124,37 +123,82 @@ struct WakerItem {
 }
 
 /// A collection of saved wakers.
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct WaitingShard {
+    /// The maximum index that was used to wake a task that belongs to this shard.
+    /// Updates to this shard will be rejected if th supplied index is less than this value.
+    /// See [`Add`] for more details.
+    ///
+    /// [`Add`]: WaitingShard::add
+    woken_at: usize,
     /// The saved wakers.  These are sorted on insert (see `add`) and
     /// presumably removed constantly, so a circular buffer is used.
     wakers: VecDeque<WakerItem>,
 }
 
+struct WakerRejected(usize, usize);
+
+impl WakerRejected {
+    fn new(expected_pos: usize, actual_pos: usize) -> Self {
+        Self(expected_pos, actual_pos)
+    }
+}
+
+impl std::fmt::Display for WakerRejected {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl Debug for WakerRejected {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Adding waker is rejected because the expected position {} is behind actual {}. \
+        Refresh your view and try again.", self.0, self.1)
+    }
+}
+
+impl std::error::Error for WakerRejected {}
+
 impl WaitingShard {
-    fn add(&mut self, i: usize, w: Waker) {
+    /// Add a waker that will be used to wake up a write to `i`.
+    ///
+    /// ## Errors
+    /// If `current` is behind the current position recorded in this shard.
+    fn add(&mut self, current: usize, i: usize, w: &Waker) -> Result<(), WakerRejected> {
+        if current < self.woken_at {
+            // this means this thread is out of sync and there was an update to channel's current
+            // position. Accepting a waker could mean it will never be awakened. Rejecting this operation
+            // will let the current thread to read the position again.
+            Err(WakerRejected::new(current, self.woken_at))?
+        }
+
         // Each new addition will tend to have a larger index, so search backwards and
         // replace an equal index or insert after a smaller index.
         // TODO: consider a binary search if the item cannot be added to the end.
-        let item = WakerItem { i, w };
+        let item = WakerItem { i, w: w.clone() };
         for j in (0..self.wakers.len()).rev() {
             match self.wakers[j].i.cmp(&i) {
                 Ordering::Greater => (),
                 Ordering::Equal => {
                     assert!(item.w.will_wake(&self.wakers[j].w));
                     self.wakers[j] = item;
-                    return;
+                    return Ok(());
                 }
                 Ordering::Less => {
                     self.wakers.insert(j + 1, item);
-                    return;
+                    return Ok(());
                 }
             }
         }
         self.wakers.insert(0, item);
+        Ok(())
     }
 
     fn wake(&mut self, i: usize) {
+        // Waking thread may have lost the race and got the lock after the successful write
+        // to the next element. Moving `woken_at` back will introduce a concurrency bug.
+        self.woken_at = std::cmp::max(self.woken_at, i);
+
         if let Some(idx) = self
             .wakers
             .iter()
@@ -192,8 +236,8 @@ impl Waiting {
         self.shards[idx].lock().unwrap()
     }
 
-    fn add(&self, i: usize, w: Waker) {
-        self.shard(i).add(i, w);
+    fn add(&self, curr: usize, i: usize, w: &Waker) -> Result<(), WakerRejected> {
+        self.shard(i).add(curr, i, w)
     }
 
     fn wake(&self, i: usize) {
@@ -276,26 +320,43 @@ impl OrderingSender {
     {
         // This load here is on the hot path.
         // Don't acquire the state mutex unless this test passes.
-        match self.next.load(Acquire).cmp(&i) {
-            Ordering::Greater => {
-                panic!("attempt to write/close at index {i} twice");
-            }
-            Ordering::Equal => {
-                // OK, now it is our turn, so we need to hold a lock.
-                // No one else should be incrementing this atomic, so
-                // there should be no contention on this lock except for
-                // any calls to `take()`, which is tolerable.
-                let res = f(&mut self.state.lock().unwrap());
-                if res.is_ready() {
-                    let curr = self.next.fetch_add(1, AcqRel);
-                    debug_assert_eq!(i, curr, "we just checked this");
+        loop {
+            let curr = self.next.load(Acquire);
+            match curr.cmp(&i) {
+                Ordering::Greater => {
+                    panic!("attempt to write/close at index {i} twice");
                 }
-                res
-            }
-            Ordering::Less => {
-                // This is the hot path. Wait our turn.
-                self.waiting.add(i, cx.waker().clone());
-                Poll::Pending
+                Ordering::Equal => {
+                    // OK, now it is our turn, so we need to hold a lock.
+                    // No one else should be incrementing this atomic, so
+                    // there should be no contention on this lock except for
+                    // any calls to `take()`, which is tolerable.
+                    let res = f(&mut self.state.lock().unwrap());
+                    if res.is_ready() {
+                        let curr = self.next.fetch_add(1, AcqRel);
+                        debug_assert_eq!(i, curr, "we just checked this");
+                    }
+                    break res
+                }
+                Ordering::Less => {
+                    // This is the hot path. Wait our turn. If our view of the world is obsolete
+                    // we won't be able to add a waker and need to read the atomic again.
+                    //
+                    // Here is why it works:
+                    // * The only thread updating the atomic is the one that is writing to `i`.
+                    // * If the write to `i` is successful, it wakes up the thread waiting to write `i` + 1.
+                    // * Adding a waker and waking it is within a critical section.
+                    //
+                    // There are two possible scenarios for two threads competing for `i` + 1 waker.
+                    // * Waiting thread adds a waker before writer thread attempts to wake it. This is a normal case
+                    // scenario and things work as expected
+                    // * Waiting thread attempts to add a waker after writer tried to wake it. This attempt will
+                    // be rejected because writer has moved the waiting shard position ahead and it won't match
+                    // the value of `self.next` read by the waiting thread.
+                    if let Ok(()) = self.waiting.add(curr, i, cx.waker()) {
+                        break Poll::Pending
+                    }
+                }
             }
         }
     }
@@ -309,7 +370,8 @@ impl OrderingSender {
         let mut b = self.state.lock().unwrap();
 
         if let Poll::Ready(v) = b.take(cx) {
-            self.waiting.wake(self.next.load(Acquire));
+            let curr = self.next.load(Acquire);
+            self.waiting.wake(curr);
             Poll::Ready(Some(v))
         } else if b.closed {
             Poll::Ready(None)
@@ -322,11 +384,13 @@ impl OrderingSender {
     /// The stream interface requires a mutable reference to the stream itself.
     /// That's not possible here as we create a ton of immutable references to this.
     /// This wrapper takes a trivial reference so that we can implement `Stream`.
-    pub(crate) fn as_stream(&self) -> OrderedStream<&Self> {
+    #[cfg(test)]
+    fn as_stream(&self) -> OrderedStream<&Self> {
         OrderedStream { sender: self }
     }
 
-    pub(crate) fn as_rc_stream(self: Arc<Self>) -> OrderedStream<Arc<Self>> {
+    #[cfg(test)]
+    pub(crate) fn as_rc_stream(self: crate::sync::Arc<Self>) -> OrderedStream<crate::sync::Arc<Self>> {
         OrderedStream { sender: self }
     }
 }
@@ -417,6 +481,7 @@ mod test {
         sync::Arc,
         test_executor::run,
     };
+    use crate::test_fixture::logging;
 
     fn sender() -> Arc<OrderingSender> {
         Arc::new(OrderingSender::new(
@@ -588,7 +653,8 @@ mod test {
     /// This test is supposed to eventually hang if there is a concurrency bug inside `OrderingSender`.
     #[test]
     fn parallel_send() {
-        const PARALLELISM: usize = 1000;
+        logging::setup();
+        const PARALLELISM: usize = 100;
         run(|| async {
             let sender = Arc::new(OrderingSender::new(
                 NonZeroUsize::new(PARALLELISM * <Fp31 as Serializable>::Size::USIZE).unwrap(),

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -252,7 +252,7 @@ mod tests {
                     .narrow("send_contention")
                     .set_total_records(TOTAL_RECORDS);
 
-                tokio::spawn({
+                let receive_handle = tokio::spawn({
                     let ctx = ctx.clone();
                     async move {
                         for record in 0..TOTAL_RECORDS {
@@ -262,6 +262,7 @@ mod tests {
                                 .receive(record.into())
                                 .await
                                 .unwrap();
+
                             assert_eq!(v, r, "Bad value for record {record}");
                         }
                     }
@@ -278,6 +279,8 @@ mod tests {
                 }))
                 .await
                 .unwrap();
+
+                receive_handle.await.unwrap();
             })
         }))
         .await

--- a/src/helpers/gateway/mod.rs
+++ b/src/helpers/gateway/mod.rs
@@ -149,12 +149,13 @@ impl GatewayConfig {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use futures_util::future::{join, try_join};
+    use std::iter::{repeat, zip};
 
-    use super::*;
+    use futures_util::future::{join, try_join, try_join_all};
+
     use crate::{
         ff::{Field, Fp31, Fp32BitPrime, Gf2},
-        helpers::{Direction, GatewayConfig, SendingEnd},
+        helpers::{Direction, GatewayConfig, Role, SendingEnd},
         protocol::{context::Context, RecordId},
         test_fixture::{Runner, TestWorld, TestWorldConfig},
     };
@@ -236,5 +237,108 @@ mod tests {
         );
         spawned.await.unwrap();
         let _world = unsafe { Box::from_raw(world_ptr) };
+    }
+
+    /// this test requires quite a few threads to simulate send contention and will panic if
+    /// there is more than one sender channel created per step.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 20)]
+    pub async fn send_contention() {
+        let (world, world_ptr) = make_world();
+
+        try_join_all(world.contexts().map(|ctx| {
+            tokio::spawn(async move {
+                const TOTAL_RECORDS: usize = 10;
+                let ctx = ctx
+                    .narrow("send_contention")
+                    .set_total_records(TOTAL_RECORDS);
+
+                tokio::spawn({
+                    let ctx = ctx.clone();
+                    async move {
+                        for record in 0..TOTAL_RECORDS {
+                            let v = Fp31::truncate_from(u128::try_from(record).unwrap());
+                            let r = ctx
+                                .recv_channel::<Fp31>(ctx.role().peer(Direction::Left))
+                                .receive(record.into())
+                                .await
+                                .unwrap();
+                            assert_eq!(v, r, "Bad value for record {record}");
+                        }
+                    }
+                });
+
+                try_join_all(zip(0..TOTAL_RECORDS, repeat(ctx)).map(|(record, ctx)| {
+                    tokio::spawn(async move {
+                        let r = Fp31::truncate_from(u128::try_from(record).unwrap());
+                        ctx.send_channel(ctx.role().peer(Direction::Right))
+                            .send(RecordId::from(record), r)
+                            .await
+                            .unwrap();
+                    })
+                }))
+                .await
+                .unwrap();
+            })
+        }))
+        .await
+        .unwrap();
+
+        let _world = unsafe { Box::from_raw(world_ptr) };
+    }
+
+    /// This test should hang if receiver channel is not created atomically. It may occasionally
+    /// pass, but it will not give false negatives.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 20)]
+    pub async fn receive_contention() {
+        let (world, world_ptr) = make_world();
+        let contexts = world.contexts();
+
+        try_join_all(contexts.map(|ctx| {
+            tokio::spawn(async move {
+                const TOTAL_RECORDS: u32 = 20;
+                let ctx = ctx
+                    .narrow("receive_contention")
+                    .set_total_records(usize::try_from(TOTAL_RECORDS).unwrap());
+
+                tokio::spawn({
+                    let ctx = ctx.clone();
+                    async move {
+                        for record in 0..TOTAL_RECORDS {
+                            ctx.send_channel(ctx.role().peer(Direction::Right))
+                                .send(RecordId::from(record), Fp31::truncate_from(record))
+                                .await
+                                .unwrap();
+                        }
+                    }
+                });
+
+                try_join_all((0..TOTAL_RECORDS).zip(repeat(ctx)).map(|(record, ctx)| {
+                    tokio::spawn(async move {
+                        let r = ctx
+                            .recv_channel::<Fp31>(ctx.role().peer(Direction::Left))
+                            .receive(RecordId::from(record))
+                            .await
+                            .unwrap();
+                        assert_eq!(
+                            Fp31::truncate_from(record),
+                            r,
+                            "received bad value for record {record}"
+                        );
+                    })
+                }))
+                .await
+                .unwrap();
+            })
+        }))
+        .await
+        .unwrap();
+
+        let _world = unsafe { Box::from_raw(world_ptr) };
+    }
+
+    fn make_world() -> (&'static TestWorld, *mut TestWorld) {
+        let world = Box::leak(Box::<TestWorld>::default());
+        let world_ptr = world as *mut _;
+        (world, world_ptr)
     }
 }

--- a/src/helpers/gateway/send.rs
+++ b/src/helpers/gateway/send.rs
@@ -7,7 +7,6 @@ use std::{
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::Stream;
-use tracing::Instrument;
 use typenum::Unsigned;
 
 use crate::{
@@ -100,11 +99,7 @@ impl<M: Message> SendingEnd<M> {
     ///
     /// [`set_total_records`]: crate::protocol::context::Context::set_total_records
     pub async fn send(&self, record_id: RecordId, msg: M) -> Result<(), Error> {
-        let r = self
-            .inner
-            .send(record_id, msg)
-            .instrument(tracing::info_span!( "send", my_role = ?self.sender_role))
-            .await;
+        let r = self.inner.send(record_id, msg).await;
         metrics::increment_counter!(RECORDS_SENT,
             STEP => self.channel_id.gate.as_ref().to_string(),
             ROLE => self.sender_role.as_static_str()


### PR DESCRIPTION
So far I've discovered three:

1) Contention when creating a sender
2) Contention when creating a receiver

Those were easy to fix, just use the entry API that provides atomic `check-and-insert`. It costs us a clone but correctness is more important.

3) Race inside `OrderingSender`

This was not that easy to find and fix. Essentially what was happening is two threads (write to `i` and write to `i+1`) both read the same value from `next` atomic ( = `i`). Then, thread `i` won the race and blocked `waiting` shard trying to wake the waker for `i+1`. Obviously there was no waker yet, so it released the lock to let `i+1` thread put its waker there. After that, there was no action that could lead to calling that waker and the whole program stalled. 

I considered a brute force fix (to extend the critical section), but it seems that there was a more efficient way to deal with it. It works similarly to MVCC and versioning checks. We keep a version (last number seen) on each shard that gets updated each time someone tries to wake `i`. This version is a monotonically increasing number. 

Whenever a thread attempts to add its waker, it must supply its own view of the `next` atomic value. If it is lower than the value this shard has seen so far, this operation will get rejected and thread will read the `next` value again and retry. In this case, it will discover that `next` actually moved and it does not need to store a waker anymore.

I tested it with both shuttle (discovered that bug) and flaky tester - both pass.