### PR TITLE
#[dynamic] attribute takes an integer literal to specify the max number of steps

### DIFF
--- a/src/protocol/attribution/mod.rs
+++ b/src/protocol/attribution/mod.rs
@@ -438,7 +438,7 @@ pub(in crate::protocol) enum Step {
 
 #[derive(Step)]
 pub(crate) enum InteractionPatternStep {
-    #[dynamic]
+    #[dynamic(64)]
     Depth(usize),
 }
 

--- a/src/protocol/context/upgrade.rs
+++ b/src/protocol/context/upgrade.rs
@@ -165,7 +165,7 @@ where
 
 #[derive(Step)]
 pub(crate) enum Upgrade2DVectors {
-    #[dynamic]
+    #[dynamic(64)]
     Upgrade2d(usize),
 }
 

--- a/src/protocol/modulus_conversion/convert_shares.rs
+++ b/src/protocol/modulus_conversion/convert_shares.rs
@@ -51,7 +51,7 @@ use crate::{
 
 #[derive(Step)]
 pub(crate) enum ConvertSharesStep {
-    #[dynamic]
+    #[dynamic(64)]
     ConvertBit(u32),
     Upgrade,
     Xor1,

--- a/src/protocol/prf_sharding/feature_label_dot_product.rs
+++ b/src/protocol/prf_sharding/feature_label_dot_product.rs
@@ -117,7 +117,7 @@ impl InputsRequiredFromPrevRow {
 
 #[derive(Step)]
 pub enum UserNthRowStep {
-    #[dynamic]
+    #[dynamic(64)]
     Row(usize),
 }
 

--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -183,7 +183,7 @@ pub struct CappedAttributionOutputs {
 
 #[derive(Step)]
 pub enum UserNthRowStep {
-    #[dynamic]
+    #[dynamic(64)]
     Row(usize),
 }
 
@@ -195,7 +195,7 @@ impl From<usize> for UserNthRowStep {
 
 #[derive(Step)]
 pub enum BinaryTreeDepthStep {
-    #[dynamic]
+    #[dynamic(64)]
     Depth(usize),
 }
 

--- a/src/protocol/sort/apply_sort/shuffle.rs
+++ b/src/protocol/sort/apply_sort/shuffle.rs
@@ -18,7 +18,7 @@ use crate::{
 
 #[derive(Step)]
 pub(crate) enum InnerVectorElementStep {
-    #[dynamic]
+    #[dynamic(64)]
     Elem(usize),
 }
 

--- a/src/protocol/sort/mod.rs
+++ b/src/protocol/sort/mod.rs
@@ -25,7 +25,7 @@ pub(crate) enum SortStep {
     Compose,
     ShuffleRevealPermutation,
     SortKeys,
-    #[dynamic]
+    #[dynamic(64)]
     MultiApplyInv(u32),
 }
 

--- a/src/protocol/step/mod.rs
+++ b/src/protocol/step/mod.rs
@@ -53,7 +53,7 @@ impl Step for str {}
 /// updated with a new step scheme.
 #[derive(Step)]
 pub enum BitOpStep {
-    #[dynamic]
+    #[dynamic(64)]
     Bit(usize),
 }
 
@@ -79,6 +79,6 @@ impl From<usize> for BitOpStep {
 #[derive(Step)]
 pub(crate) enum IpaProtocolStep {
     /// Sort shares by the match key
-    #[dynamic]
+    #[dynamic(64)]
     Sort(usize),
 }


### PR DESCRIPTION
Unblocking @richajaindce for her sparse attribution-aggregation code testing. Dynamic steps can be extended beyond 64. I set the upper limit to 1024 to prevent the IDE from freezing by accidentally writing a huge number and the macro generating gigantic code.