### PR TITLE
Add asan and leak sanitizers and tidy up GH

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,6 +70,37 @@ jobs:
       - name: Run compact gate tests
         run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
 
+  release:
+    name: Release builds and tests
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -C target-cpu=native
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Release Build
+        run: cargo build --release
+
+      - name: Build concurrency tests
+        run: cargo build --release --features shuttle
+
+      - name: Run concurrency tests
+        run: cargo test --release --features shuttle
+
   extra:
     name: Additional Builds and Concurrency Tests
     env:
@@ -94,20 +125,11 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      - name: Release Build
-        run: cargo build --release
-
       - name: Build benchmarks
         run: cargo build --benches --no-default-features --features "enable-benches descriptive-gate"
 
-      - name: Build concurrency tests
-        run: cargo build --release --features shuttle
-
       - name: Build concurrency tests (debug mode)
         run: cargo build --features shuttle
-
-      - name: Run concurrency tests
-        run: cargo test --release --features shuttle
 
       - name: Run IPA bench
         run: cargo bench --bench oneshot_ipa --no-default-features --features "enable-benches descriptive-gate"
@@ -118,42 +140,20 @@ jobs:
       - name: Run compact gate tests
         run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
 
-  aggregate:
-    name: Build and test aggregate circuit
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy,rustfmt
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-
-      - name: Web Tests
-        run: cargo test --no-default-features --features "aggregate-circuit cli web-app real-world-infra test-fixture descriptive-gate"
+  # sanitizers currently require nightly https://github.com/rust-lang/rust/issues/39699
   sanitize:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [ address, leak, memory, thread ]
+        sanitizer: [ address, leak ]
+    env:
+      TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
-        # https://github.com/rust-lang/rust/issues/39699
       - uses: dtolnay/rust-toolchain@nightly
-      - name: Add rust source
+      - name: Add Rust sources
         run: rustup component add rust-src
       - name: Run tests with sanitizer
-        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test --target x86_64-unknown-linux-gnu
+        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test -Z build-std --target $TARGET --no-default-features --features "cli web-app real-world-infra test-fixture descriptive-gate"
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,7 @@ on:
       - "src/**/*"
       - "benches/**/*"
       - "tests/**/*"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -140,4 +140,19 @@ jobs:
 
       - name: Web Tests
         run: cargo test --no-default-features --features "aggregate-circuit cli web-app real-world-infra test-fixture descriptive-gate"
+  sanitize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [ address, leak, memory, thread ]
+    steps:
+      - uses: actions/checkout@v3
+        # https://github.com/rust-lang/rust/issues/39699
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Add rust source
+        run: rustup component add rust-src
+      - name: Run tests with sanitizer
+        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test --target x86_64-unknown-linux-gnu
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -188,8 +188,7 @@ pub fn test_multiply(config_dir: &Path, https: bool) {
 }
 
 pub fn test_network(https: bool) {
-    // set to true to always keep the temp dir after test finishes
-    let dir = TempDir::new(false);
+    let dir = TempDir::new_delete_on_drop();
     let path = dir.path();
 
     println!("generating configuration in {}", path.display());
@@ -206,7 +205,7 @@ pub fn test_ipa(mode: IpaSecurityModel, https: bool) {
 pub fn test_ipa_with_config(mode: IpaSecurityModel, https: bool, config: IpaQueryConfig) {
     const INPUT_SIZE: usize = 10;
     // set to true to always keep the temp dir after test finishes
-    let dir = TempDir::new(false);
+    let dir = TempDir::new_delete_on_drop();
     let path = dir.path();
 
     println!("generating configuration in {}", path.display());

--- a/tests/common/tempdir.rs
+++ b/tests/common/tempdir.rs
@@ -1,4 +1,4 @@
-use std::{mem, path::Path, thread};
+use std::{path::Path, thread};
 
 use tempfile::tempdir;
 
@@ -12,16 +12,16 @@ pub struct TempDir {
 }
 
 impl TempDir {
-    /// Creates a new temporary directory. If `delete` is set to `false`, then it won't be cleaned up
-    /// after drop.
+    /// Creates a new temporary directory that will be deleted when this instance is dropped.
+    /// There is an exception if thread is panicking, then it won't be.
     ///
     /// ## Panics
     /// Panics if a new temp dir cannot be created.
     #[must_use]
-    pub fn new(delete: bool) -> Self {
+    pub fn new_delete_on_drop() -> Self {
         Self {
             inner: Some(tempdir().expect("Can create temp directory")),
-            delete,
+            delete: true,
         }
     }
 
@@ -37,7 +37,7 @@ impl Drop for TempDir {
     fn drop(&mut self) {
         if !self.delete || thread::panicking() {
             let td = self.inner.take().unwrap();
-            mem::forget(td);
+            let _ = td.into_path();
         }
     }
 }

--- a/tests/helper_networks.rs
+++ b/tests/helper_networks.rs
@@ -39,7 +39,7 @@ fn https_semi_honest_ipa() {
 #[test]
 #[cfg(all(test, web_test))]
 fn keygen_confgen() {
-    let dir = TempDir::new(false);
+    let dir = TempDir::new_delete_on_drop();
     let path = dir.path();
 
     let sockets: [_; 3] = array::from_fn(|_| TcpListener::bind("127.0.0.1:0").unwrap());


### PR DESCRIPTION
* Adding ASAN led to a leak discovery, fixed it inside integration tests
* Tried hard to onboard MSAN and TSAN, both don't really work. Opened an issue for MSAN: #800
* "Additional tests" section in our CI grew big and now failing with "no space left on device error". Did not have enough time to investigate, just decided to split it into release and debug builds


Motivation for adding sanitizers: we are preparing for adding unsafe parallelism to simulate structured concurrency and it is crucial to have some guardrails around that mechanism



