### PR TITLE
UnorderedReceiver can be closed now

### DIFF
--- a/src/helpers/buffers/unordered_receiver.rs
+++ b/src/helpers/buffers/unordered_receiver.rs
@@ -238,12 +238,14 @@ where
                     }
                 }
 
+                self.wake_next();
                 Poll::Ready(Ok(m))
             }
             None => loop {
                 match ready!(self.stream.as_mut().poll_next(cx)) {
                     Some(bytes) => {
                         if let Some(m) = self.spare.extend(bytes.as_ref()) {
+                            self.wake_next();
                             break Poll::Ready(Ok(m));
                         }
                     }
@@ -255,10 +257,6 @@ where
                 }
             },
         };
-
-        if next.is_ready() {
-            self.wake_next();
-        }
 
         next
     }

--- a/src/helpers/gateway/transport.rs
+++ b/src/helpers/gateway/transport.rs
@@ -50,10 +50,8 @@ impl<T: Transport> RoleResolvingTransport<T> {
         );
 
         UnorderedReceiver::new(
-            Box::pin(
-                self.inner
-                    .receive(peer, (self.query_id, channel_id.gate.clone())),
-            ),
+            self.inner
+                .receive(peer, (self.query_id, channel_id.gate.clone())),
             self.config.active_work(),
         )
     }


### PR DESCRIPTION
This is required to properly implement resource cleanup and install debugging infrastructure to Gateway.

One issue we noticed while working on it, is that it is impossible to distinguish between messages awaiting receive and streams that have been fully exhausted.

After this change, observers can check `is_closed` status and exclude this stream.

In the future, when resource cleanup will be a thing, such receivers can be safely removed from the channel map.