### PR TITLE
Update aes crate and enable intrinsics on aarch64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-apple-darwin]
+rustflags = ["--cfg", "aes_armv8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ aggregate-circuit = []
 
 [dependencies]
 ipa-macros = { version = "*", path = "./ipa-macros" }
-aes = "0.8"
+aes = "0.8.3"
 async-trait = "0.1.68"
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
 axum-server = { version = "0.5.1", optional = true, features = ["rustls", "rustls-pemfile", "tls-rustls"] }


### PR DESCRIPTION
This used to require the nightly compiler, but as of https://github.com/RustCrypto/block-ciphers/pull/365 no longer does.

Before:
sort benchmark BATCHSIZE 100 NUM_MULTI_BITS 3 complete after 0.15205078s
After:
sort benchmark BATCHSIZE 100 NUM_MULTI_BITS 3 complete after 0.07513808s