### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ enable-serde = ["serde", "serde_json"]
 disable-metrics = []
 # TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
 # TODO Consider moving out benches as well
-web-app = ["axum", "axum-server", "base64", "clap", "comfy-table", "enable-serde", "hyper", "hyper-rustls", "rcgen", "rustls-pemfile", "time", "tokio-rustls", "toml", "tower", "tower-http"]
+web-app = ["axum", "axum-server", "base64", "clap", "comfy-table", "enable-serde", "hyper", "hyper-rustls", "rcgen", "rustls", "rustls-pemfile", "time", "tokio-rustls", "toml", "tower", "tower-http"]
 test-fixture = ["enable-serde", "weak-field"]
 shuttle = ["shuttle-crate", "test-fixture"]
 debug-trace = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
@@ -43,7 +43,6 @@ compact-gate = ["ipa-macros/compact-gate"]
 aggregate-circuit = []
 
 [dependencies]
-ipa-macros = { version = "*", path = "./ipa-macros" }
 aes = "0.8.3"
 async-trait = "0.1.68"
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
@@ -60,13 +59,14 @@ dhat = "0.3.2"
 embed-doc-image = "0.1.4"
 futures = "0.3.28"
 futures-util = "0.3.28"
-generic-array = "0.14.7"
+generic-array = "1.0.0"
 hex = { version = "0.4", features = ["serde"] }
 hkdf = "0.12.3"
-hpke = { version = "0.10.0", default-features = false, features = ["std", "x25519-dalek"] }
+hpke = { version = "0.11.0", default-features = false, features = ["std", "x25519"] }
 hyper = { version = "0.14.26", optional = true, features = ["client", "h2", "stream", "runtime"] }
-hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
+hyper-rustls = { version = "0.24.1", optional = true, features = ["http2"] }
 iai = { version = "0.1.1", optional = true }
+ipa-macros = { version = "*", path = "./ipa-macros" }
 metrics = "0.21.0"
 metrics-tracing-context = "0.14.0"
 metrics-util = { version = "0.15.0" }
@@ -74,27 +74,31 @@ once_cell = "1.18"
 pin-project = "1.0"
 rand = "0.8"
 rand_core = "0.6"
-rcgen = { version = "0.10", optional = true }
-rustls = "0.21.5"
+rcgen = { version = "0.11.3", optional = true }
+rustls = { version = "0.21", optional = true }
 rustls-pemfile = { version = "1", optional = true }
+# TODO: https://rustsec.org/advisories/RUSTSEC-2023-0053. tokio-rustls and hyper-rustls need to be upgraded first, before
+# we can remove pinning
+rustls-webpki = "^0.101.4"
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
-sha2 = "0.10.6"
+sha2 = "0.10"
 shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.28", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-rustls = { version = "0.24.0", optional = true }
+# TODO: axum-server holds onto 0.24 and we can't upgrade until they do. Or we move away from axum-server
+tokio-rustls = { version = "0.24", optional = true }
 tokio-stream = "0.1.14"
-toml = { version = "0.7", optional = true }
+toml = { version = "0.8", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4.0", optional = true, features = ["trace"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 typenum = "1.16"
 # hpke is pinned to it
-x25519-dalek = "2.0.0-pre.0"
+x25519-dalek = "2.0.0-rc.3"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5.0"
@@ -107,8 +111,8 @@ command-fds = "0.2.2"
 hex = "0.4"
 permutation = "0.4.1"
 proptest = "1"
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
 tempfile = "3"
-tokio-rustls = { version = "0.24.0", features = ["dangerous_configuration"] }
 
 [profile.release]
 incremental = true

--- a/src/bin/test_mpc.rs
+++ b/src/bin/test_mpc.rs
@@ -103,7 +103,7 @@ async fn multiply_in_field<F: Field>(args: &Args, helper_clients: &[MpcHelperCli
 where
     F: Field + IntoShares<AdditiveShare<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
-    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength<u8>,
+    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength,
 {
     let input = InputSource::from(&args.input);
     let input_rows = input.iter::<(F, F)>().collect::<Vec<_>>();

--- a/src/cli/keygen.rs
+++ b/src/cli/keygen.rs
@@ -9,7 +9,7 @@ use rand::{thread_rng, Rng};
 use rand_core::CryptoRng;
 use rcgen::{
     Certificate, CertificateParams, DistinguishedName, ExtendedKeyUsagePurpose, IsCa,
-    KeyUsagePurpose, SanType, PKCS_ECDSA_P256_SHA256,
+    KeyUsagePurpose, SanType, SerialNumber, PKCS_ECDSA_P256_SHA256,
 };
 use time::{Duration, OffsetDateTime};
 
@@ -75,7 +75,9 @@ pub fn keygen_tls<R: Rng + CryptoRng>(args: &KeygenArgs, rng: &mut R) -> Result<
     ];
     params.not_before = OffsetDateTime::now_utc() - Duration::days(1);
     params.not_after = params.not_before + Duration::days(91);
-    params.serial_number = Some(rng.gen_range(0..=i64::MAX.try_into().unwrap()));
+    params.serial_number = Some(SerialNumber::from(
+        rng.gen_range(0..=i64::MAX.try_into().unwrap()),
+    ));
 
     let mut name = DistinguishedName::new();
     name.push(rcgen::DnType::CommonName, args.name.clone());

--- a/src/cli/playbook/multiply.rs
+++ b/src/cli/playbook/multiply.rs
@@ -27,7 +27,7 @@ pub async fn secure_mul<F>(
 where
     F: Field + IntoShares<Replicated<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
-    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength<u8>,
+    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength,
 {
     // prepare inputs
     let inputs = input.into_iter().share().map(|vec| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,10 +9,10 @@ use std::{
 };
 
 use hyper::{client::Builder, http::uri::Scheme, Uri};
+use rustls::Certificate;
 use rustls_pemfile::Item;
 use serde::{Deserialize, Deserializer, Serialize};
 use tokio::fs;
-use tokio_rustls::rustls::Certificate;
 
 use crate::{
     error::BoxError,

--- a/src/ff/mod.rs
+++ b/src/ff/mod.rs
@@ -38,7 +38,7 @@ impl<T, Rhs> AddSubAssign<Rhs> for T where T: AddAssign<Rhs> + SubAssign<Rhs> {}
 /// Trait for items that have fixed-byte length representation.
 pub trait Serializable: Sized {
     /// Required number of bytes to store this message on disk/network
-    type Size: ArrayLength<u8>;
+    type Size: ArrayLength;
 
     /// Serialize this message to a mutable slice. It is enforced at compile time or on the caller
     /// side that this slice is sized to fit this instance. Implementations do not need to check

--- a/src/hpke/mod.rs
+++ b/src/hpke/mod.rs
@@ -31,12 +31,13 @@ type IpaKdf = hpke::kdf::HkdfSha256;
 
 pub type IpaPublicKey = <IpaKem as hpke::kem::Kem>::PublicKey;
 pub type IpaPrivateKey = <IpaKem as hpke::kem::Kem>::PrivateKey;
+pub type IpaEncappedKey = <IpaKem as hpke::kem::Kem>::EncappedKey;
 
 pub use hpke::{Deserializable, Serializable};
 
 pub trait FieldShareCrypt: GaloisField + IpaSerializable {
-    type EncapKeySize: ArrayLength<u8>;
-    type CiphertextSize: ArrayLength<u8>;
+    type EncapKeySize: ArrayLength;
+    type CiphertextSize: ArrayLength;
     type SemiHonestShares: IpaSerializable + Clone + Debug + Eq;
 }
 
@@ -50,7 +51,7 @@ where
     AdditiveShare<F>: IpaSerializable + Clone + Debug + Eq,
     AeadTag<IpaAead>: Serializable<OutputSize = U16>,
     <AdditiveShare<F> as IpaSerializable>::Size: Add<U16>,
-    <<AdditiveShare<F> as IpaSerializable>::Size as Add<U16>>::Output: ArrayLength<u8>,
+    <<AdditiveShare<F> as IpaSerializable>::Size as Add<U16>>::Output: ArrayLength,
 {
     type EncapKeySize = <<IpaKem as hpke::Kem>::EncappedKey as Serializable>::OutputSize;
     type CiphertextSize = <<AdditiveShare<F> as IpaSerializable>::Size as Add<U16>>::Output;

--- a/src/hpke/registry.rs
+++ b/src/hpke/registry.rs
@@ -123,12 +123,12 @@ impl PublicKeyRegistry for KeyRegistry<PublicKeyOnly> {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use hpke::{kem::EncappedKey, HpkeError, OpModeR, OpModeS};
+    use hpke::{HpkeError, OpModeR, OpModeS};
     use rand::rngs::StdRng;
     use rand_core::{CryptoRng, RngCore, SeedableRng};
 
     use super::*;
-    use crate::hpke::{IpaAead, IpaKdf, IpaKem};
+    use crate::hpke::{IpaAead, IpaEncappedKey, IpaKdf, IpaKem};
 
     const INFO_STR: &[u8] = b"This is an INFO string.";
     const AAD: &[u8] = b"This is AAD.";
@@ -137,7 +137,7 @@ mod tests {
         pk: &IpaPublicKey,
         pt: &[u8],
         r: &mut R,
-    ) -> (EncappedKey, Vec<u8>) {
+    ) -> (IpaEncappedKey, Vec<u8>) {
         let (encapsulated_key, mut encryption_context) =
             hpke::setup_sender::<IpaAead, IpaKdf, IpaKem, _>(&OpModeS::Base, pk, INFO_STR, r)
                 .expect("Can setup the sender.");
@@ -152,7 +152,7 @@ mod tests {
 
     fn decrypt<I: AsRef<[u8]>>(
         sk: &IpaPrivateKey,
-        payload: &(EncappedKey, I),
+        payload: &(IpaEncappedKey, I),
     ) -> Result<Vec<u8>, HpkeError> {
         let (encap_key, ct) = payload;
         let mut decryption_context = hpke::setup_receiver::<IpaAead, IpaKdf, IpaKem>(

--- a/src/net/client/mod.rs
+++ b/src/net/client/mod.rs
@@ -16,10 +16,7 @@ use hyper::{
 };
 use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
 use pin_project::pin_project;
-use tokio_rustls::{
-    rustls,
-    rustls::{Certificate, PrivateKey, RootCertStore},
-};
+use rustls::{Certificate, PrivateKey, RootCertStore};
 use tracing::error;
 
 use crate::{

--- a/src/net/server/mod.rs
+++ b/src/net/server/mod.rs
@@ -30,16 +30,13 @@ use futures::{
 };
 use hyper::{header::HeaderName, server::conn::AddrStream, Request};
 use metrics::increment_counter;
+use rustls::{
+    server::AllowAnyAnonymousOrAuthenticatedClient, Certificate, PrivateKey, RootCertStore,
+};
 use rustls_pemfile::Item;
 #[cfg(all(feature = "shuttle", test))]
 use shuttle::future as tokio;
-use tokio_rustls::{
-    rustls::{
-        server::AllowAnyAnonymousOrAuthenticatedClient, Certificate, PrivateKey, RootCertStore,
-        ServerConfig as RustlsServerConfig,
-    },
-    server::TlsStream,
-};
+use tokio_rustls::server::TlsStream;
 use tower::{layer::layer_fn, Service};
 use tower_http::trace::TraceLayer;
 use tracing::{error, Span};
@@ -306,7 +303,7 @@ async fn rustls_config(
     }
     let verifier = AllowAnyAnonymousOrAuthenticatedClient::new(trusted_certs);
 
-    let mut config = RustlsServerConfig::builder()
+    let mut config = rustls::ServerConfig::builder()
         .with_safe_defaults()
         .with_client_cert_verifier(verifier.boxed())
         .with_single_cert(cert, key)?;
@@ -488,12 +485,9 @@ mod e2e_tests {
     use hyper::{client::HttpConnector, http::uri, StatusCode, Version};
     use hyper_rustls::HttpsConnector;
     use metrics_util::debugging::Snapshotter;
-    use tokio_rustls::{
-        rustls,
-        rustls::{
-            client::{ServerCertVerified, ServerCertVerifier},
-            ServerName,
-        },
+    use rustls::{
+        client::{ServerCertVerified, ServerCertVerifier},
+        ServerName,
     };
     use tracing::Level;
 

--- a/src/net/test.rs
+++ b/src/net/test.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
+use rustls::Certificate;
 use tokio::task::JoinHandle;
-use tokio_rustls::rustls::Certificate;
 
 use crate::{
     config::{

--- a/src/protocol/aggregation/input.rs
+++ b/src/protocol/aggregation/input.rs
@@ -21,7 +21,7 @@ where
     Replicated<BK>: Serializable,
     <Replicated<CV> as Serializable>::Size: Add<<Replicated<BK> as Serializable>::Size>,
     <<Replicated<CV> as Serializable>::Size as Add<<Replicated<BK> as Serializable>::Size>>::Output:
-        ArrayLength<u8>,
+        ArrayLength,
 {
     type Size = <<Replicated<CV> as Serializable>::Size as Add<
         <Replicated<BK> as Serializable>::Size,

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -104,7 +104,7 @@ where
                 >>::Output,
             >>::Output,
         >>::Output,
-    >>::Output: ArrayLength<u8>,
+    >>::Output: ArrayLength,
 {
     type Size = <<Replicated<F> as Serializable>::Size as Add<
         <<Replicated<MK> as Serializable>::Size as Add<

--- a/src/protocol/prss/crypto.rs
+++ b/src/protocol/prss/crypto.rs
@@ -101,7 +101,7 @@ pub struct KeyExchange {
 impl KeyExchange {
     pub fn new<R: RngCore + CryptoRng>(r: &mut R) -> Self {
         Self {
-            sk: EphemeralSecret::new(r),
+            sk: EphemeralSecret::random_from_rng(r),
         }
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -256,7 +256,7 @@ where
         .unwrap(); // validated on construction
 
         let mut ciphertext: GenericArray<u8, <Gf40Bit as FieldShareCrypt>::CiphertextSize> =
-            GenericArray::clone_from_slice(self.match_key_ciphertext());
+            *GenericArray::from_slice(self.match_key_ciphertext());
         let plaintext = open_in_place(key_registry, self.encap_key(), &mut ciphertext, &info)?;
 
         Ok(Report {

--- a/src/secret_sharing/mod.rs
+++ b/src/secret_sharing/mod.rs
@@ -45,7 +45,7 @@ impl<T, Rhs, Output> Arithmetic<Rhs, Output> for T where
 // Trait for primitive integer types used to represent the underlying type for shared values
 pub trait Block: Sized + Copy + Debug {
     /// Size of a block in bytes big enough to hold the shared value. `Size * 8 >= VALID_BIT_LENGTH`.
-    type Size: ArrayLength<u8>;
+    type Size: ArrayLength;
 }
 
 pub trait SharedValue:

--- a/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -294,7 +294,7 @@ where
         Add<<SemiHonestAdditiveShare<V::ExtendedField> as Serializable>::Size>,
     <<SemiHonestAdditiveShare<V> as Serializable>::Size as Add<
         <SemiHonestAdditiveShare<V::ExtendedField> as Serializable>::Size,
-    >>::Output: ArrayLength<u8>,
+    >>::Output: ArrayLength,
 {
     type Size = <<SemiHonestAdditiveShare<V> as Serializable>::Size as Add<
         <SemiHonestAdditiveShare<V::ExtendedField> as Serializable>::Size,

--- a/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -220,7 +220,7 @@ impl<V: SharedValue> From<(V, V)> for AdditiveShare<V> {
 impl<V: SharedValue> Serializable for AdditiveShare<V>
 where
     V::Size: Add<V::Size>,
-    <V::Size as Add<V::Size>>::Output: ArrayLength<u8>,
+    <V::Size as Add<V::Size>>::Output: ArrayLength,
 {
     type Size = <V::Size as Add<V::Size>>::Output;
 


### PR DESCRIPTION
Notable bumps

* GenericArray to 1.0
* HPKE changed a lot, moving from 0.10 to 0.11
* Explicit dependency on 'rust-webpki' due to https://rustsec.org/advisories/RUSTSEC-2023-0053
* Use native `rustls` types rather than their proxies defined in `tokio-rustls`