### PR TITLE
Max out the number of rows for OPRF step generation

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -115,16 +115,10 @@ async fn run(args: Args) -> Result<(), Error> {
     // Note that this is a temporary solution. If the max number of rows become too
     // large, we need a better way to generate the steps, likely by synthesizing the
     // steps in the `Step` derive macro.
-    let (max_number_of_users, query_size) = if cfg!(feature = "step-trace") && args.oprf {
-        (
-            NonZeroU32::new(1).unwrap(),
-            usize::try_from(args.records_per_user).unwrap(),
-        )
+    let (single_user_mode, query_size) = if cfg!(feature = "step-trace") && args.oprf {
+        (true, usize::try_from(args.records_per_user).unwrap())
     } else {
-        (
-            EventGeneratorConfig::default().max_number_of_users,
-            args.query_size,
-        )
+        (false, args.query_size)
     };
 
     let seed = args.random_seed.unwrap_or_else(|| random());
@@ -139,7 +133,7 @@ async fn run(args: Args) -> Result<(), Error> {
             max_trigger_value: NonZeroU32::try_from(args.max_trigger_value).unwrap(),
             max_breakdown_key: NonZeroU32::try_from(args.breakdown_keys).unwrap(),
             max_events_per_user: NonZeroU32::try_from(args.records_per_user).unwrap(),
-            max_number_of_users,
+            single_user_mode,
             ..Default::default()
         },
     )

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -149,6 +149,7 @@ def extract_intermediate_steps(steps):
 
     return steps
 
+
 def ipa_steps():
     output = set()
     for c in PER_USER_CAP:
@@ -171,10 +172,13 @@ def ipa_steps():
                     output.update(collect_steps(args))
     return output
 
+
 OPRF_BREAKDOWN_KEY = 256
 OPRF_USER_CAP = [16, 64, 128]
 OPRF_SECURITY_MODEL = "semi-honest"
 OPRF_TRIGGER_VALUE = [6, 7]
+OPRF_USER_NTH_ROW_STEP_MAX = 64
+
 
 def oprf_steps():
     output = set()
@@ -194,11 +198,14 @@ def oprf_steps():
                     OPRF_SECURITY_MODEL,
                     "-t",
                     str(tv),
-                    "-o"
-            ]
+                    "-o",
+                    "-u",
+                    str(OPRF_USER_NTH_ROW_STEP_MAX),
+                ]
             print(" ".join(args), file=sys.stderr)
             output.update(collect_steps(args))
     return output
+
 
 if __name__ == "__main__":
     steps = set()

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -785,6 +785,7 @@ pub mod tests {
         const MAX_RECORDS_PER_USER: u32 = 8;
         const NUM_MULTI_BITS: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
+        const MAX_NUMBER_OF_USERS: u32 = 10;
         type TestField = Fp32BitPrime;
         logging::setup();
 
@@ -804,6 +805,7 @@ pub mod tests {
                 MAX_TRIGGER_VALUE,
                 MAX_BREAKDOWN_KEY,
                 MAX_RECORDS_PER_USER,
+                MAX_NUMBER_OF_USERS,
             ),
         )
         .take(usize::try_from(max_events).unwrap())

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -785,7 +785,6 @@ pub mod tests {
         const MAX_RECORDS_PER_USER: u32 = 8;
         const NUM_MULTI_BITS: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
-        const MAX_NUMBER_OF_USERS: u32 = 10;
         type TestField = Fp32BitPrime;
         logging::setup();
 
@@ -805,7 +804,6 @@ pub mod tests {
                 MAX_TRIGGER_VALUE,
                 MAX_BREAKDOWN_KEY,
                 MAX_RECORDS_PER_USER,
-                MAX_NUMBER_OF_USERS,
             ),
         )
         .take(usize::try_from(max_events).unwrap())

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -73,7 +73,7 @@ fn validate_probability(value: &str) -> Result<f32, String> {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new(1_000_000_000_000, 5, 20, 50, 10)
+        Self::new(1_000_000_000_000, 5, 20, 50)
     }
 }
 
@@ -88,7 +88,6 @@ impl Config {
         max_trigger_value: u32,
         max_breakdown_key: u32,
         max_events_per_user: u32,
-        number_of_users_in_flight: u32,
     ) -> Self {
         Self {
             max_user_id: NonZeroU64::try_from(max_user_id).unwrap(),
@@ -97,7 +96,7 @@ impl Config {
             max_events_per_user: NonZeroU32::try_from(max_events_per_user).unwrap(),
             report_filter: ReportFilter::All,
             conversion_probability: None,
-            number_of_users_in_flight: NonZeroU32::try_from(number_of_users_in_flight).unwrap(),
+            number_of_users_in_flight: NonZeroU32::try_from(10).unwrap(),
             single_user_mode: false,
         }
     }
@@ -381,16 +380,9 @@ mod tests {
                 1..u32::MAX,
                 1..u32::MAX,
                 report_filter_strategy(),
-                1..u32::MAX,
             )
                 .prop_map(
-                    |(
-                        max_trigger_value,
-                        max_breakdown_key,
-                        max_events_per_user,
-                        report_filter,
-                        number_of_users_in_flight,
-                    )| {
+                    |(max_trigger_value, max_breakdown_key, max_events_per_user, report_filter)| {
                         Config {
                             max_user_id: NonZeroU64::new(10_000).unwrap(),
                             max_trigger_value: NonZeroU32::new(max_trigger_value).unwrap(),
@@ -401,9 +393,7 @@ mod tests {
                                 ReportFilter::TriggerOnly => Some(0.02),
                                 _ => None,
                             },
-                            number_of_users_in_flight: NonZeroU32::new(number_of_users_in_flight)
-                                .unwrap(),
-                            single_user_mode: false,
+                            ..Default::default()
                         }
                     },
                 )


### PR DESCRIPTION
OPRF protocol step generation needed to run #822. `ipa::protocol::prf_sharding::UserNthPerStep` depends on the maximum number of rows of any users in the input. In order to generate all possible combinations of the steps, we need to generate the max allowable number of rows for a user. The max allowable number should be the number specified by `#[dynamic(...)]` in `UserNthRowStep` enum. For now, we use `records_per_user` which can be specified when running the benchmark.

Note that this is a temporary solution. If the max number of rows become too large, we need a better way to generate the steps, likely by synthesizing the steps in the `Step` derive macro.