### PR TITLE
Fix OPRF attribution and capping circuit

### DIFF
--- a/src/protocol/prf_sharding/mod.rs
+++ b/src/protocol/prf_sharding/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         },
         BitDecomposed, Linear as LinearSecretSharing, SharedValue,
     },
-    seq_join::{seq_join, seq_try_join_all},
+    seq_join::seq_join,
 };
 
 pub mod bucket;
@@ -381,7 +381,7 @@ where
             attribution_window_seconds,
         ));
     }
-    let outputs_chunked_by_user = seq_try_join_all(sh_ctx.active_work(), futures).await?;
+    let outputs_chunked_by_user = sh_ctx.parallel_join(futures).await?;
     Ok(outputs_chunked_by_user
         .into_iter()
         .flatten()


### PR DESCRIPTION
It was using sequential join that limits number of futures driven concurrently to completion. This circuit requires all user-level circuits to be polled, so `parallel_join` is more appropriate

There may be other places where parallel join must be used, I did not check those, this got me to 10k rows.

```
     Running `target/debug/report_collector --network test_data/network.toml --input-file /tmp/events-10000.txt --output-file output.txt --disable-https oprf-ipa --max-breakdown-key 256 --per-user-credit-cap 16 --plaintext-match-keys`
2023-10-31T21:04:37.643906Z  INFO ipa::cli::verbosity: Logging setup at level info
2023-10-31T21:04:38.406898Z  INFO ipa::cli::playbook::ipa: Starting query for OPRF
2023-10-31T21:07:11.873166Z  INFO ipa::cli::playbook::ipa: Running IPA for 10000 records took 153.46518s
2023-10-31T21:07:11.873315Z  WARN report_collector: output.txt file exists, renaming to "output-e13qo"
2023-10-31T21:07:11.875135Z  INFO report_collector: IpaQueryConfig { per_user_credit_cap: 16, max_breakdown_key: 256, attribution_window_seconds: None, num_multi_bits: 3, plaintext_match_keys: true }
```