### PR TITLE
Hack to avoid stall

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -21,13 +21,13 @@ pub use basics::BasicProtocols;
 
 use crate::{
     error::Error,
-    ff::{Gf20Bit, Gf3Bit, Gf40Bit, Gf8Bit},
+    ff::{Gf3Bit, Gf40Bit, Gf8Bit, Gf32Bit},
 };
 
 pub type MatchKey = Gf40Bit;
 pub type BreakdownKey = Gf8Bit;
 pub type TriggerValue = Gf3Bit;
-pub type Timestamp = Gf20Bit;
+pub type Timestamp = Gf32Bit;
 
 /// Unique identifier of the MPC query requested by report collectors
 /// TODO(615): Generating this unique id may be tricky as it may involve communication between helpers and

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -21,7 +21,7 @@ pub use basics::BasicProtocols;
 
 use crate::{
     error::Error,
-    ff::{Gf3Bit, Gf40Bit, Gf8Bit, Gf32Bit},
+    ff::{Gf32Bit, Gf3Bit, Gf40Bit, Gf8Bit},
 };
 
 pub type MatchKey = Gf40Bit;


### PR DESCRIPTION
There is an issue where sequential join limits the number of Futures that are spawned...

...this interacts poorly with our infra which is waiting for a sufficiently large batch to perform any communication...

...which leads to this deadlock where you're just stuck, and no progress is made...

This is a hack which allows the code to actually run for input sizes > 1000. I do not like this code, but I'll put it up here just to stimulate a conversation about how to move forward. I think I'd prefer a different solution, where we increase the number of futures that can spawn to more than the minimum batch size, so that progress can be made. 

- Running IPA for 10000 records took 27.914203637s
- Running IPA for 100000 records took 308.087942399s
- Running IPA for 1000000 records took 2865.641394015s

One more hack: the random events generator is making timestamps that are larger than 2^20 so I can't use the correct type.