### PR TITLE
Add OPRF root step to compact

### DIFF
--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -37,12 +37,14 @@ const ROOT_STATE: u16 = 0;
 const PRSS_EXCHANGE_STATE: u16 = 65531;
 const QUERY_TYPE_SEMIHONEST_STATE: u16 = 65533;
 const QUERY_TYPE_MALICIOUS_STATE: u16 = 65532;
+const QUERY_TYPE_OPRF_STATE: u16 = 65531;
 
 impl StepNarrow<QueryType> for Compact {
     fn narrow(&self, step: &QueryType) -> Self {
         match step {
             QueryType::SemiHonestIpa(_) => Self(QUERY_TYPE_SEMIHONEST_STATE),
             QueryType::MaliciousIpa(_) => Self(QUERY_TYPE_MALICIOUS_STATE),
+            QueryType::OprfIpa(_) => Self(QUERY_TYPE_OPRF_STATE),
             _ => panic!("cannot narrow from the invalid step {}", step.as_ref()),
         }
     }
@@ -60,6 +62,7 @@ fn static_reverse_state_map(state: u16) -> &'static str {
         ROOT_STATE => "run-0",
         QUERY_TYPE_SEMIHONEST_STATE => QueryType::SEMIHONEST_IPA_STR,
         QUERY_TYPE_MALICIOUS_STATE => QueryType::MALICIOUS_IPA_STR,
+        QUERY_TYPE_OPRF_STATE => QueryType::OPRF_IPA_STR,
         PRSS_EXCHANGE_STATE => PrssExchangeStep.as_ref(),
         _ => panic!("cannot as_ref() from the invalid state {state}"),
     }
@@ -72,6 +75,8 @@ fn static_deserialize_state_map(s: &str) -> u16 {
         return QUERY_TYPE_SEMIHONEST_STATE;
     } else if s == QueryType::MALICIOUS_IPA_STR {
         return QUERY_TYPE_MALICIOUS_STATE;
+    } else if s == QUERY_TYPE_OPRF_STATE {
+        return QUERY_TYPE_OPRF_STATE;
     } else if s == PrssExchangeStep.as_ref() {
         return PRSS_EXCHANGE_STATE;
     }

--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -75,7 +75,7 @@ fn static_deserialize_state_map(s: &str) -> u16 {
         return QUERY_TYPE_SEMIHONEST_STATE;
     } else if s == QueryType::MALICIOUS_IPA_STR {
         return QUERY_TYPE_MALICIOUS_STATE;
-    } else if s == QUERY_TYPE_OPRF_STATE {
+    } else if s == QueryType::OPRF_IPA_STR {
         return QUERY_TYPE_OPRF_STATE;
     } else if s == PrssExchangeStep.as_ref() {
         return PRSS_EXCHANGE_STATE;

--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -34,10 +34,10 @@ impl Debug for Compact {
 }
 
 const ROOT_STATE: u16 = 0;
-const PRSS_EXCHANGE_STATE: u16 = 65531;
 const QUERY_TYPE_SEMIHONEST_STATE: u16 = 65533;
 const QUERY_TYPE_MALICIOUS_STATE: u16 = 65532;
-const QUERY_TYPE_OPRF_STATE: u16 = 65531;
+const PRSS_EXCHANGE_STATE: u16 = 65531;
+const QUERY_TYPE_OPRF_STATE: u16 = 65530;
 
 impl StepNarrow<QueryType> for Compact {
     fn narrow(&self, step: &QueryType) -> Self {


### PR DESCRIPTION
was getting an error running OPRF IPA with compact steps enabled

```
cannot narrow from the invalid step oprf_ipa
stack trace:
```

there is still another issue that I don't know how to fix yet

```
thread 'tokio-runtime-worker' panicked at src/protocol/prf_sharding/mod.rs:219:10:
Invalid state transition: 8815 -> row3
```