### PR TITLE
make random event generator generate "min_events_per_user..=max_events_per_user" number of events

### DIFF
--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -782,6 +782,7 @@ pub mod tests {
         const MAX_BREAKDOWN_KEY: u32 = 32;
         const MAX_TRIGGER_VALUE: u32 = 5;
         const NUM_USERS: u32 = 8;
+        const MIN_RECORDS_PER_USER: u32 = 1;
         const MAX_RECORDS_PER_USER: u32 = 8;
         const NUM_MULTI_BITS: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
@@ -803,6 +804,7 @@ pub mod tests {
                 u64::from(NUM_USERS),
                 MAX_TRIGGER_VALUE,
                 MAX_BREAKDOWN_KEY,
+                MIN_RECORDS_PER_USER,
                 MAX_RECORDS_PER_USER,
             ),
         )

--- a/src/protocol/step/compact.rs
+++ b/src/protocol/step/compact.rs
@@ -34,15 +34,17 @@ impl Debug for Compact {
 }
 
 const ROOT_STATE: u16 = 0;
-const PRSS_EXCHANGE_STATE: u16 = 65531;
 const QUERY_TYPE_SEMIHONEST_STATE: u16 = 65533;
 const QUERY_TYPE_MALICIOUS_STATE: u16 = 65532;
+const PRSS_EXCHANGE_STATE: u16 = 65531;
+const QUERY_TYPE_OPRF_STATE: u16 = 65530;
 
 impl StepNarrow<QueryType> for Compact {
     fn narrow(&self, step: &QueryType) -> Self {
         match step {
             QueryType::SemiHonestIpa(_) => Self(QUERY_TYPE_SEMIHONEST_STATE),
             QueryType::MaliciousIpa(_) => Self(QUERY_TYPE_MALICIOUS_STATE),
+            QueryType::OprfIpa(_) => Self(QUERY_TYPE_OPRF_STATE),
             _ => panic!("cannot narrow from the invalid step {}", step.as_ref()),
         }
     }
@@ -60,6 +62,7 @@ fn static_reverse_state_map(state: u16) -> &'static str {
         ROOT_STATE => "run-0",
         QUERY_TYPE_SEMIHONEST_STATE => QueryType::SEMIHONEST_IPA_STR,
         QUERY_TYPE_MALICIOUS_STATE => QueryType::MALICIOUS_IPA_STR,
+        QUERY_TYPE_OPRF_STATE => QueryType::OPRF_IPA_STR,
         PRSS_EXCHANGE_STATE => PrssExchangeStep.as_ref(),
         _ => panic!("cannot as_ref() from the invalid state {state}"),
     }
@@ -72,6 +75,8 @@ fn static_deserialize_state_map(s: &str) -> u16 {
         return QUERY_TYPE_SEMIHONEST_STATE;
     } else if s == QueryType::MALICIOUS_IPA_STR {
         return QUERY_TYPE_MALICIOUS_STATE;
+    } else if s == QueryType::OPRF_IPA_STR {
+        return QUERY_TYPE_OPRF_STATE;
     } else if s == PrssExchangeStep.as_ref() {
         return PRSS_EXCHANGE_STATE;
     }

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -37,6 +37,8 @@ pub enum ReportFilter {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct Config {
+    /// Number of unique users per event generator. The generator will generate events
+    /// for at most this many users.
     #[cfg_attr(feature = "clap", arg(long, default_value = "1000000000000"))]
     pub user_count: NonZeroU64,
     #[cfg_attr(feature = "clap", arg(long, default_value = "5"))]
@@ -97,6 +99,8 @@ impl Config {
         }
     }
 
+    /// Returns the number of unique users per event generator. The generator will generate
+    /// events for at most this many users.
     fn user_count(&self) -> usize {
         usize::try_from(self.user_count.get()).unwrap()
     }


### PR DESCRIPTION
OPRF steps depend on the maximum number of rows of all given users. In order to generate steps for the `Compact` gate, we need to be able to specify exactly how many **user(s)** and **events** we want to generate from the `EventGenerator`.

The current `EventGenerator` randomly generates events between `[1..=max_events_per_user]` per user, for up to `max_user_id` users (the name is confusing. I renamed it to `user_count`). It allows us to control the total number of events to generate, but not the number of events per user.

This is a quick change to fixate the number of events users can produce. We lose the randomness, but for the testing purpose I don't think that is a big deal as the randomness doesn't follow a real-world distribution anyway. Ideally, callers of the generator should be able to pass in a distribution of events-per-user.

This fixes other issues mentioned in #830. There's another issue with the generated timestamps exceeding the current 20 bits limit. I'll make another PR for that.