### PR TITLE
Remove cpu=native flag from release checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,8 +73,6 @@ jobs:
   release:
     name: Release builds and tests
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -C target-cpu=native
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We started getting compile errors from `curve25519-dalek` recently: https://github.com/private-attribution/ipa/actions/runs/6769658075/job/18396480025?pr=834

would be great to know the root cause, but nothing has been reported in their repo.