### PR TITLE
Remove compact gate tests from basic checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,9 +67,6 @@ jobs:
       - name: Run Web Tests
         run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture descriptive-gate"
 
-      - name: Run compact gate tests
-        run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
-
   release:
     name: Release builds and tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Its great that we run them twice, but it is probably [too much](https://github.com/private-attribution/ipa/actions/runs/6789188348/job/18458850996). Run them once as part of additional checks step

[Here is the step where we run it](https://github.com/private-attribution/ipa/blob/main/.github/workflows/check.yml#L140)