### PR TITLE
Set timestamp upper limit in EventGenerator's config

### DIFF
--- a/benches/oneshot/ipa.rs
+++ b/benches/oneshot/ipa.rs
@@ -129,7 +129,7 @@ async fn run(args: Args) -> Result<(), Error> {
                 args.query_size,
             )
         };
-    let raw_data = EventGenerator::with_config(
+    let mut raw_data = EventGenerator::with_config(
         rng,
         EventGeneratorConfig {
             user_count,
@@ -142,6 +142,9 @@ async fn run(args: Args) -> Result<(), Error> {
     )
     .take(query_size)
     .collect::<Vec<_>>();
+    // EventGenerator produces events in random order, but IPA requires them to be sorted by
+    // timestamp.
+    raw_data.sort_by_key(|e| e.timestamp);
 
     let order = if args.oprf {
         CappingOrder::CapMostRecentFirst

--- a/src/bin/report_collector.rs
+++ b/src/bin/report_collector.rs
@@ -182,7 +182,10 @@ fn gen_inputs(
     let rng = seed
         .map(StdRng::seed_from_u64)
         .unwrap_or_else(|| StdRng::from_entropy());
-    let event_gen = EventGenerator::with_config(rng, args).take(count as usize);
+    let mut event_gen = EventGenerator::with_config(rng, args)
+        .take(count as usize)
+        .collect::<Vec<_>>();
+    event_gen.sort_by_key(|e| e.timestamp);
     let mut writer: Box<dyn Write> = if let Some(path) = output_file {
         Box::new(OpenOptions::new().write(true).create_new(true).open(path)?)
     } else {

--- a/src/protocol/ipa/mod.rs
+++ b/src/protocol/ipa/mod.rs
@@ -784,6 +784,7 @@ pub mod tests {
         const NUM_USERS: u32 = 8;
         const MIN_RECORDS_PER_USER: u32 = 1;
         const MAX_RECORDS_PER_USER: u32 = 8;
+        const MAX_TIMESTAMP: u32 = 604_800;
         const NUM_MULTI_BITS: u32 = 3;
         const ATTRIBUTION_WINDOW_SECONDS: Option<NonZeroU32> = NonZeroU32::new(86_400);
         type TestField = Fp32BitPrime;
@@ -798,7 +799,7 @@ pub mod tests {
         } else {
             NUM_USERS * MAX_RECORDS_PER_USER
         };
-        let raw_data = EventGenerator::with_config(
+        let mut raw_data = EventGenerator::with_config(
             rand::thread_rng(),
             EventGeneratorConfig::new(
                 u64::from(NUM_USERS),
@@ -806,10 +807,12 @@ pub mod tests {
                 MAX_BREAKDOWN_KEY,
                 MIN_RECORDS_PER_USER,
                 MAX_RECORDS_PER_USER,
+                MAX_TIMESTAMP,
             ),
         )
         .take(usize::try_from(max_events).unwrap())
         .collect::<Vec<_>>();
+        raw_data.sort_by_key(|e| e.timestamp);
 
         for per_user_cap in [1, 3] {
             let expected_results = ipa_in_the_clear(

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -91,8 +91,6 @@ impl Config {
         max_events_per_user: u32,
         max_timestamp: u32,
     ) -> Self {
-        const TIMESTAMP_BITS: u32 = 20;
-        assert!(max_timestamp < (1 << TIMESTAMP_BITS));
         assert!(min_events_per_user < max_events_per_user);
         Self {
             user_count: NonZeroU64::try_from(user_count).unwrap(),

--- a/src/test_fixture/event_gen.rs
+++ b/src/test_fixture/event_gen.rs
@@ -45,6 +45,9 @@ pub struct Config {
     pub max_trigger_value: NonZeroU32,
     #[cfg_attr(feature = "clap", arg(long, default_value = "20"))]
     pub max_breakdown_key: NonZeroU32,
+    #[cfg_attr(feature = "clap", arg(long, hide = true, default_value = "604800"))]
+    // 7 days < 20 bits
+    pub max_timestamp: NonZeroU32,
     #[cfg_attr(feature = "clap", arg(long, default_value = "10"))]
     pub max_events_per_user: NonZeroU32,
     #[cfg_attr(feature = "clap", arg(long, default_value = "1"))]
@@ -70,7 +73,7 @@ fn validate_probability(value: &str) -> Result<f32, String> {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new(1_000_000_000_000, 5, 20, 1, 50)
+        Self::new(1_000_000_000_000, 5, 20, 1, 50, 604_800)
     }
 }
 
@@ -86,12 +89,16 @@ impl Config {
         max_breakdown_key: u32,
         min_events_per_user: u32,
         max_events_per_user: u32,
+        max_timestamp: u32,
     ) -> Self {
+        const TIMESTAMP_BITS: u32 = 20;
+        assert!(max_timestamp < (1 << TIMESTAMP_BITS));
         assert!(min_events_per_user < max_events_per_user);
         Self {
             user_count: NonZeroU64::try_from(user_count).unwrap(),
             max_trigger_value: NonZeroU32::try_from(max_trigger_value).unwrap(),
             max_breakdown_key: NonZeroU32::try_from(max_breakdown_key).unwrap(),
+            max_timestamp: NonZeroU32::try_from(max_timestamp).unwrap(),
             min_events_per_user: NonZeroU32::try_from(min_events_per_user).unwrap(),
             max_events_per_user: NonZeroU32::try_from(max_events_per_user).unwrap(),
             report_filter: ReportFilter::All,
@@ -149,7 +156,6 @@ pub struct EventGenerator<R: Rng> {
     users: Vec<UserStats>,
     // even bit vector takes too long to initialize. Need a sparse structure here
     used: HashSet<UserId>,
-    current_ts: u64,
 }
 
 impl<R: Rng> EventGenerator<R> {
@@ -163,24 +169,21 @@ impl<R: Rng> EventGenerator<R> {
             rng,
             users: vec![],
             used: HashSet::new(),
-            current_ts: 0,
         }
     }
 
     fn gen_event(&mut self, user_id: UserId) -> TestRawDataRecord {
-        if self.rng.gen() {
-            // The next event would have timestamp upto 60 seconds after the previous
-            // event generated. On an average, we should be able to start seeing spacing
-            // of 7 days in query size of 100k or greater.
-            self.current_ts += self.rng.gen_range(1..=60);
-        }
+        // Generate a new random timestamp between [0..`max_timestamp`).
+        // This means the generated events must be sorted by timestamp before being
+        // fed into the IPA protocols.
+        let current_ts = self.rng.gen_range(0..self.config.max_timestamp.get());
 
         match self.config.report_filter {
             ReportFilter::All => {
                 if self.rng.gen() {
-                    self.gen_trigger(user_id)
+                    self.gen_trigger(user_id, current_ts)
                 } else {
-                    self.gen_source(user_id)
+                    self.gen_source(user_id, current_ts)
                 }
             }
             ReportFilter::TriggerOnly => {
@@ -191,30 +194,30 @@ impl<R: Rng> EventGenerator<R> {
                     } else {
                         UserId::EPHEMERAL
                     };
-                self.gen_trigger(user_id)
+                self.gen_trigger(user_id, current_ts)
             }
-            ReportFilter::SourceOnly => self.gen_source(user_id),
+            ReportFilter::SourceOnly => self.gen_source(user_id, current_ts),
         }
     }
 
-    fn gen_trigger(&mut self, user_id: UserId) -> TestRawDataRecord {
+    fn gen_trigger(&mut self, user_id: UserId, timestamp: u32) -> TestRawDataRecord {
         let trigger_value = self.rng.gen_range(1..self.config.max_trigger_value.get());
 
         TestRawDataRecord {
             user_id: user_id.into(),
-            timestamp: self.current_ts,
+            timestamp: timestamp.into(),
             is_trigger_report: true,
             breakdown_key: 0,
             trigger_value,
         }
     }
 
-    fn gen_source(&mut self, user_id: UserId) -> TestRawDataRecord {
+    fn gen_source(&mut self, user_id: UserId, timestamp: u32) -> TestRawDataRecord {
         let breakdown_key = self.rng.gen_range(0..self.config.max_breakdown_key.get());
 
         TestRawDataRecord {
             user_id: user_id.into(),
-            timestamp: self.current_ts,
+            timestamp: timestamp.into(),
             is_trigger_report: false,
             breakdown_key,
             trigger_value: 0,
@@ -391,6 +394,7 @@ mod tests {
                             user_count: NonZeroU64::new(10_000).unwrap(),
                             max_trigger_value: NonZeroU32::new(max_trigger_value).unwrap(),
                             max_breakdown_key: NonZeroU32::new(max_breakdown_key).unwrap(),
+                            max_timestamp: NonZeroU32::new(604_800).unwrap(),
                             min_events_per_user: NonZeroU32::new(min_events_per_user).unwrap(),
                             max_events_per_user: NonZeroU32::new(max_events_per_user).unwrap(),
                             report_filter,
@@ -409,7 +413,6 @@ mod tests {
 
             let gen = EventGenerator::with_config(StdRng::seed_from_u64(rng_seed), config.clone());
             let mut events_per_users = HashMap::<_, u32>::new();
-            let mut last_ts = 0;
             for event in gen.take(total_events) {
                 let counter = events_per_users.entry(event.user_id).or_default();
                 *counter += 1_u32;
@@ -422,14 +425,10 @@ mod tests {
                     "Generated breakdown key greater than {max_breakdown}"
                 );
 
-                // basic correctness checks
-                assert!(
-                    event.timestamp >= last_ts,
-                    "Found an event with timestamp preceding the previous event timestamp"
-                );
+                // Basic correctness checks. timestamps are not checked as the order of events
+                // is not guaranteed. The caller must sort the events by timestamp before
+                // feeding them into IPA.
                 config.is_valid(&event);
-
-                last_ts = event.timestamp;
             }
         }
 


### PR DESCRIPTION
Our protocols expect timestamps to be within a fixed bit length (i.e., Gf20Bit), but the event generator may generate events that are outside this bound. This change adds a new config parameter to bind the timestamps to be within a given value.