### PR TITLE
Clean up runner space before running actions

### DIFF
--- a/.github/actions/rm/action.yml
+++ b/.github/actions/rm/action.yml
@@ -1,0 +1,19 @@
+# this name is currently not visible on GitHub due to https://github.com/actions/runner/issues/1877
+name: "Free disk space"
+description: "Frees up disk space on GitHub Ubuntu runners"
+runs:
+  using: "composite"
+  steps:
+    - uses: jlumbroso/free-disk-space@main
+      with:
+
+        # These 5 options give back ~32Gb. If that's not enough, the remaining flags can be set to `true` at the expense
+        # of this action taking longer to finish
+        android: true
+        dotnet: true
+        haskell: true
+        docker-images: true
+        swap-storage: true
+
+        large-packages: false
+        tool-cache: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,11 +26,11 @@ jobs:
     name: Basic Checks
     env:
       CARGO_INCREMENTAL: 0
-
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -74,6 +74,7 @@ jobs:
       RUSTFLAGS: -C target-cpu=native
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -107,6 +108,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
14Gb default space is probably not enough for us [anymore](https://github.com/private-attribution/ipa/actions/runs/6797444345/job/18479569860?pr=840)

```
[ec2-user@ip-172-31-49-57 ipa]$ du -sh target/
36G     target/
```

see the discussion here
https://github.com/actions/runner-images/issues/2875

A successful run: https://github.com/akoshelev/raw-ipa/actions/runs/6802955694