### PR TITLE
Enable sanitizers again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -141,8 +141,6 @@ jobs:
 
   # sanitizers currently require nightly https://github.com/rust-lang/rust/issues/39699
   sanitize:
-    # disabled due to https://github.com/private-attribution/ipa/issues/837
-    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixes https://github.com/private-attribution/ipa/issues/837 because the underlying issue https://github.com/rust-lang/rust/pull/117542 is fixed

Sanitizers are green again: https://github.com/akoshelev/raw-ipa/actions/runs/6828379933/job/18572392843