### PR TITLE
quick fix for overflow

### DIFF
--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -138,7 +138,7 @@ macro_rules! boolean_array_impl {
                     let v = v.into();
                     let mut val = Self::ZERO;
                     for i in 0..$bits {
-                        val.set(i, Boolean::from(v <= 128 && (v >> i & 1) == 1));
+                        val.set(i, Boolean::from(i < 128 && (v >> i & 1) == 1));
                     }
 
                     val

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -137,8 +137,8 @@ macro_rules! boolean_array_impl {
                 fn truncate_from<T: Into<u128>>(v: T) -> Self {
                     let v = v.into();
                     let mut val = Self::ZERO;
-                    for i in 0..$bits {
-                        val.set(i, Boolean::from(i < 128 && (v >> i & 1) == 1));
+                    for i in 0..std::cmp::min(128, $bits) {
+                        val.set(i, Boolean::from((v >> i & 1) == 1));
                     }
 
                     val

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -138,7 +138,7 @@ macro_rules! boolean_array_impl {
                     let v = v.into();
                     let mut val = Self::ZERO;
                     for i in 0..$bits {
-                        val.set(i, Boolean::from((v >> i & 1) == 1));
+                        val.set(i, Boolean::from(v <= 128 && (v >> i & 1) == 1));
                     }
 
                     val
@@ -257,7 +257,6 @@ macro_rules! boolean_array_impl {
 
                 use super::*;
 
-                #[ignore]
                 #[test]
                 fn set_boolean_array() {
                     let mut rng = thread_rng();

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -260,7 +260,6 @@ mod tests {
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
 
-    #[ignore]
     #[test]
     fn semi_honest_convert_into_fp25519() {
         run(|| async move {


### PR DESCRIPTION
quick fix for overflow issue when using BA256 with new truncate function. 2 tests failed (doesn't seem related to PR): 

test protocol::ipa_prf::prf_sharding::tests::capping_bugfix ... FAILED
test protocol::ipa_prf::prf_sharding::tests::semi_honest_aggregation_capping_attribution_with_attribution_window ... FAILED

new truncate leads to insecure PRSS for BA256, will get fixed when issue https://github.com/private-attribution/ipa/issues/812 is addressed