### PR TITLE
Fixing error when running collect steps

### DIFF
--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -152,10 +152,6 @@ async fn run(args: Args) -> Result<(), Error> {
         CappingOrder::CapOldestFirst
     };
 
-    // TODO: Remove the below comment once #844 is landed.
-    // Note that how we apply the attribution window to IPA and OPRF IPA is different.
-    // For IPA, trigger events are considered within the window if [0..window] (upper bound inclusive).
-    // For OPRF, trigger events are considered within the window if [0..window) (upper bound exclusive).
     let expected_results = ipa_in_the_clear(
         &raw_data,
         args.per_user_cap,

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -318,6 +318,17 @@ boolean_array_impl!(
     )
 );
 
+//impl BA4
+boolean_array_impl!(
+    boolean_array_4,
+    BA4,
+    4,
+    1,
+    bitarr ! ( const u8, Lsb0;
+        1, 0, 0, 0
+    )
+);
+
 //impl BA5
 boolean_array_impl!(
     boolean_array_5,
@@ -326,6 +337,28 @@ boolean_array_impl!(
     1,
     bitarr ! ( const u8, Lsb0;
         1, 0, 0, 0, 0
+    )
+);
+
+//impl BA6
+boolean_array_impl!(
+    boolean_array_6,
+    BA6,
+    6,
+    1,
+    bitarr ! ( const u8, Lsb0;
+        1, 0, 0, 0, 0, 0
+    )
+);
+
+//impl BA7
+boolean_array_impl!(
+    boolean_array_7,
+    BA7,
+    7,
+    1,
+    bitarr ! ( const u8, Lsb0;
+        1, 0, 0, 0, 0, 0, 0
     )
 );
 

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -40,7 +40,7 @@ impl<'a> Iterator for BAIterator<'a> {
 
 //macro for implementing Boolean array, only works for a byte size for which Block is defined
 macro_rules! boolean_array_impl {
-    ($modname:ident, $name:ident, $bits:expr, $bytes:expr, $one:expr) => {
+    ($modname:ident, $name:ident, $bits:expr, $bytes:expr, [$($one:expr),+]) => {
         #[allow(clippy::suspicious_arithmetic_impl)]
         #[allow(clippy::suspicious_op_assign_impl)]
         mod $modname {
@@ -128,7 +128,7 @@ macro_rules! boolean_array_impl {
             }
 
             impl Field for $name {
-                const ONE: Self = Self($one);
+                const ONE: Self = Self(bitarr![const u8, Lsb0; $($one),+]);
 
                 fn as_u128(&self) -> u128 {
                     (*self).into()
@@ -308,70 +308,22 @@ store_impl!(U8, 64);
 store_impl!(U32, 256);
 
 //impl BA3
-boolean_array_impl!(
-    boolean_array_3,
-    BA3,
-    3,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_3, BA3, 3, 1, [1, 0, 0]);
 
 //impl BA4
-boolean_array_impl!(
-    boolean_array_4,
-    BA4,
-    4,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_4, BA4, 4, 1, [1, 0, 0, 0]);
 
 //impl BA5
-boolean_array_impl!(
-    boolean_array_5,
-    BA5,
-    5,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_5, BA5, 5, 1, [1, 0, 0, 0, 0]);
 
 //impl BA6
-boolean_array_impl!(
-    boolean_array_6,
-    BA6,
-    6,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_6, BA6, 6, 1, [1, 0, 0, 0, 0, 0]);
 
 //impl BA7
-boolean_array_impl!(
-    boolean_array_7,
-    BA7,
-    7,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_7, BA7, 7, 1, [1, 0, 0, 0, 0, 0, 0]);
 
 //impl BA8
-boolean_array_impl!(
-    boolean_array_8,
-    BA8,
-    8,
-    1,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0, 0
-    )
-);
+boolean_array_impl!(boolean_array_8, BA8, 8, 1, [1, 0, 0, 0, 0, 0, 0, 0]);
 
 //impl BA20
 boolean_array_impl!(
@@ -379,11 +331,7 @@ boolean_array_impl!(
     BA20,
     20,
     3,
-    bitarr ! ( const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0
-    )
+    [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 );
 
 //impl BA32
@@ -392,11 +340,9 @@ boolean_array_impl!(
     BA32,
     32,
     4,
-    bitarr![const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0
+    [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0
     ]
 );
 
@@ -406,15 +352,10 @@ boolean_array_impl!(
     BA64,
     64,
     8,
-    bitarr![const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0
+    [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0
     ]
 );
 
@@ -425,38 +366,15 @@ boolean_array_impl!(
     BA256,
     256,
     32,
-    bitarr![const u8, Lsb0;
-        1, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0
+    [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     ]
 );

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -393,7 +393,7 @@ where
 /// Propagates errors from multiplications
 /// # Panics
 /// Propagates errors from multiplications
-pub async fn attr_cap_aggr<C, BK, TV, TS, SS, S, F>(
+pub async fn attribute_cap_aggregate<C, BK, TV, TS, SS, S, F>(
     sh_ctx: C,
     input_rows: Vec<PrfShardedIpaInputRow<BK, TV, TS>>,
     attribution_window_seconds: Option<NonZeroU32>,
@@ -823,7 +823,7 @@ pub mod tests {
             boolean_array::{BA20, BA3, BA5, BA8},
             CustomArray, Field, Fp32BitPrime,
         },
-        protocol::ipa_prf::prf_sharding::attr_cap_aggr,
+        protocol::ipa_prf::prf_sharding::attribute_cap_aggregate,
         rand::Rng,
         secret_sharing::{
             replicated::semi_honest::AdditiveShare as Replicated, IntoShares, WeakSharedValue,
@@ -1003,9 +1003,15 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attr_cap_aggr::<_, BA5, BA3, BA20, BA5, Replicated<Fp32BitPrime>, Fp32BitPrime>(
-                        ctx, input_rows, None, &histogram,
-                    )
+                    attribute_cap_aggregate::<
+                        _,
+                        BA5,
+                        BA3,
+                        BA20,
+                        BA5,
+                        Replicated<Fp32BitPrime>,
+                        Fp32BitPrime,
+                    >(ctx, input_rows, None, &histogram)
                     .await
                     .unwrap()
                 })
@@ -1051,7 +1057,15 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attr_cap_aggr::<_, BA5, BA3, BA20, BA5, Replicated<Fp32BitPrime>, Fp32BitPrime>(
+                    attribute_cap_aggregate::<
+                        _,
+                        BA5,
+                        BA3,
+                        BA20,
+                        BA5,
+                        Replicated<Fp32BitPrime>,
+                        Fp32BitPrime,
+                    >(
                         ctx,
                         input_rows,
                         NonZeroU32::new(ATTRIBUTION_WINDOW_SECONDS),
@@ -1136,7 +1150,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attr_cap_aggr::<
+                    attribute_cap_aggregate::<
                         _,
                         BA8,
                         BA3,

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -393,7 +393,7 @@ where
 /// Propagates errors from multiplications
 /// # Panics
 /// Propagates errors from multiplications
-pub async fn attribution_and_capping_and_aggregation<C, BK, TV, TS, SS, S, F>(
+pub async fn attr_cap_aggr<C, BK, TV, TS, SS, S, F>(
     sh_ctx: C,
     input_rows: Vec<PrfShardedIpaInputRow<BK, TV, TS>>,
     attribution_window_seconds: Option<NonZeroU32>,
@@ -823,7 +823,7 @@ pub mod tests {
             boolean_array::{BA20, BA3, BA5, BA8},
             CustomArray, Field, Fp32BitPrime,
         },
-        protocol::ipa_prf::prf_sharding::attribution_and_capping_and_aggregation,
+        protocol::ipa_prf::prf_sharding::attr_cap_aggr,
         rand::Rng,
         secret_sharing::{
             replicated::semi_honest::AdditiveShare as Replicated, IntoShares, WeakSharedValue,
@@ -1003,15 +1003,9 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribution_and_capping_and_aggregation::<
-                        _,
-                        BA5,
-                        BA3,
-                        BA20,
-                        BA5,
-                        Replicated<Fp32BitPrime>,
-                        Fp32BitPrime,
-                    >(ctx, input_rows, None, &histogram)
+                    attr_cap_aggr::<_, BA5, BA3, BA20, BA5, Replicated<Fp32BitPrime>, Fp32BitPrime>(
+                        ctx, input_rows, None, &histogram,
+                    )
                     .await
                     .unwrap()
                 })
@@ -1057,15 +1051,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribution_and_capping_and_aggregation::<
-                        _,
-                        BA5,
-                        BA3,
-                        BA20,
-                        BA5,
-                        Replicated<Fp32BitPrime>,
-                        Fp32BitPrime,
-                    >(
+                    attr_cap_aggr::<_, BA5, BA3, BA20, BA5, Replicated<Fp32BitPrime>, Fp32BitPrime>(
                         ctx,
                         input_rows,
                         NonZeroU32::new(ATTRIBUTION_WINDOW_SECONDS),
@@ -1150,7 +1136,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribution_and_capping_and_aggregation::<
+                    attr_cap_aggr::<
                         _,
                         BA8,
                         BA3,

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -17,8 +17,7 @@ use crate::{
         basics::ShareKnownValue,
         context::{UpgradableContext, UpgradedContext},
         ipa_prf::prf_sharding::{
-            attribution_and_capping_and_aggregation, compute_histogram_of_users_with_row_count,
-            PrfShardedIpaInputRow,
+            attr_cap_aggr, compute_histogram_of_users_with_row_count, PrfShardedIpaInputRow,
         },
     },
     report::{EventType, OprfReport},
@@ -98,7 +97,7 @@ where
             .collect::<Vec<_>>();
         // Until then, we convert the output to something next function is happy about.
 
-        attribution_and_capping_and_aggregation::<
+        attr_cap_aggr::<
             C,
             BA8,  // BreakdownKey,
             BA3,  // TriggerValue,

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Error,
     ff::{
         boolean::Boolean,
-        boolean_array::{BA20, BA3, BA5, BA8},
+        boolean_array::{BA20, BA3, BA4, BA5, BA6, BA7, BA8},
         Field, PrimeField, Serializable,
     },
     helpers::{
@@ -17,7 +17,8 @@ use crate::{
         basics::ShareKnownValue,
         context::{UpgradableContext, UpgradedContext},
         ipa_prf::prf_sharding::{
-            attr_cap_aggr, compute_histogram_of_users_with_row_count, PrfShardedIpaInputRow,
+            attribute_cap_aggregate, compute_histogram_of_users_with_row_count,
+            PrfShardedIpaInputRow,
         },
     },
     report::{EventType, OprfReport},
@@ -41,6 +42,7 @@ impl<C, F> OprfIpaQuery<C, F> {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 impl<C, F> OprfIpaQuery<C, F>
 where
     C: UpgradableContext,
@@ -96,21 +98,86 @@ where
             })
             .collect::<Vec<_>>();
         // Until then, we convert the output to something next function is happy about.
-
-        attr_cap_aggr::<
-            C,
-            BA8,  // BreakdownKey,
-            BA3,  // TriggerValue,
-            BA20, // Timestamp,
-            BA5,  // Saturating Sum
-            Replicated<F>,
-            F,
-        >(
-            ctx,
-            sharded_input,
-            config.attribution_window_seconds,
-            ref_to_histogram,
-        )
-        .await
+        match config.per_user_credit_cap {
+            8 => attribute_cap_aggregate::<
+                C,
+                BA8,  // BreakdownKey,
+                BA3,  // TriggerValue,
+                BA20, // Timestamp,
+                BA3,  // Saturating Sum
+                Replicated<F>,
+                F,
+            >(
+                ctx,
+                sharded_input,
+                config.attribution_window_seconds,
+                ref_to_histogram,
+            )
+            .await,
+            16 => attribute_cap_aggregate::<
+                C,
+                BA8,  // BreakdownKey,
+                BA3,  // TriggerValue,
+                BA20, // Timestamp,
+                BA4,  // Saturating Sum
+                Replicated<F>,
+                F,
+            >(
+                ctx,
+                sharded_input,
+                config.attribution_window_seconds,
+                ref_to_histogram,
+            )
+            .await,
+            32 => attribute_cap_aggregate::<
+                C,
+                BA8,  // BreakdownKey,
+                BA3,  // TriggerValue,
+                BA20, // Timestamp,
+                BA5,  // Saturating Sum
+                Replicated<F>,
+                F,
+            >(
+                ctx,
+                sharded_input,
+                config.attribution_window_seconds,
+                ref_to_histogram,
+            )
+            .await,
+            64 => attribute_cap_aggregate::<
+                C,
+                BA8,  // BreakdownKey,
+                BA3,  // TriggerValue,
+                BA20, // Timestamp,
+                BA6,  // Saturating Sum
+                Replicated<F>,
+                F,
+            >(
+                ctx,
+                sharded_input,
+                config.attribution_window_seconds,
+                ref_to_histogram,
+            )
+            .await,
+            128 => attribute_cap_aggregate::<
+                C,
+                BA8,  // BreakdownKey,
+                BA3,  // TriggerValue,
+                BA20, // Timestamp,
+                BA7,  // Saturating Sum
+                Replicated<F>,
+                F,
+            >(
+                ctx,
+                sharded_input,
+                config.attribution_window_seconds,
+                ref_to_histogram,
+            )
+            .await,
+            _ => panic!(
+                "Invalid value specified for per-user cap: {:?}. Must be one of 8, 16, 32, 64, or 128.",
+                config.per_user_credit_cap
+            ),
+        }
     }
 }

--- a/ipa-core/src/test_fixture/ipa.rs
+++ b/ipa-core/src/test_fixture/ipa.rs
@@ -249,7 +249,7 @@ pub async fn test_oprf_ipa<F>(
     use crate::{
         ff::{
             boolean::Boolean,
-            boolean_array::{BA20, BA3, BA5, BA8},
+            boolean_array::{BA20, BA3, BA4, BA5, BA6, BA7, BA8},
             Field,
         },
         protocol::{
@@ -298,22 +298,97 @@ pub async fn test_oprf_ipa<F>(
                     })
                     .collect::<Vec<_>>();
 
-                attribution_and_capping_and_aggregation::<
-                    _,
-                    BA8,  // BreakdownKey,
-                    BA3,  // TriggerValue,
-                    BA20, // Timestamp,
-                    BA5,  // Saturating Sum
-                    Replicated<F>,
-                    F,
-                >(
-                    ctx,
-                    sharded_input,
-                    config.attribution_window_seconds,
-                    ref_to_histogram,
-                )
-                .await
-                .unwrap()
+                if config.per_user_credit_cap == 8 {
+                    attribution_and_capping_and_aggregation::<
+                        _,
+                        BA8,  // BreakdownKey,
+                        BA3,  // TriggerValue,
+                        BA20, // Timestamp,
+                        BA3,  // Saturating Sum
+                        Replicated<F>,
+                        F,
+                    >(
+                        ctx,
+                        sharded_input,
+                        config.attribution_window_seconds,
+                        ref_to_histogram,
+                    )
+                    .await
+                    .unwrap()
+                } else if config.per_user_credit_cap == 16 {
+                    attribution_and_capping_and_aggregation::<
+                        _,
+                        BA8,  // BreakdownKey,
+                        BA3,  // TriggerValue,
+                        BA20, // Timestamp,
+                        BA4,  // Saturating Sum
+                        Replicated<F>,
+                        F,
+                    >(
+                        ctx,
+                        sharded_input,
+                        config.attribution_window_seconds,
+                        ref_to_histogram,
+                    )
+                    .await
+                    .unwrap()
+                } else if config.per_user_credit_cap == 32 {
+                    attribution_and_capping_and_aggregation::<
+                        _,
+                        BA8,  // BreakdownKey,
+                        BA3,  // TriggerValue,
+                        BA20, // Timestamp,
+                        BA5,  // Saturating Sum
+                        Replicated<F>,
+                        F,
+                    >(
+                        ctx,
+                        sharded_input,
+                        config.attribution_window_seconds,
+                        ref_to_histogram,
+                    )
+                    .await
+                    .unwrap()
+                } else if config.per_user_credit_cap == 64 {
+                    attribution_and_capping_and_aggregation::<
+                        _,
+                        BA8,  // BreakdownKey,
+                        BA3,  // TriggerValue,
+                        BA20, // Timestamp,
+                        BA6,  // Saturating Sum
+                        Replicated<F>,
+                        F,
+                    >(
+                        ctx,
+                        sharded_input,
+                        config.attribution_window_seconds,
+                        ref_to_histogram,
+                    )
+                    .await
+                    .unwrap()
+                } else if config.per_user_credit_cap == 128 {
+                    attribution_and_capping_and_aggregation::<
+                        _,
+                        BA8,  // BreakdownKey,
+                        BA3,  // TriggerValue,
+                        BA20, // Timestamp,
+                        BA7,  // Saturating Sum
+                        Replicated<F>,
+                        F,
+                    >(
+                        ctx,
+                        sharded_input,
+                        config.attribution_window_seconds,
+                        ref_to_histogram,
+                    )
+                    .await
+                    .unwrap()
+                } else {
+                    panic!(
+                        "Invalid value specified for per-user cap: {:?}. Must be a power of 2.",
+                        config.per_user_credit_cap
+                    );
+                }
             },
         )
         .await

--- a/ipa-core/src/test_fixture/ipa.rs
+++ b/ipa-core/src/test_fixture/ipa.rs
@@ -235,6 +235,7 @@ pub async fn test_ipa<F>(
 
 /// # Panics
 /// If any of the IPA protocol modules panic
+#[allow(clippy::too_many_lines)]
 #[cfg(feature = "in-memory-infra")]
 pub async fn test_oprf_ipa<F>(
     world: &super::TestWorld,
@@ -255,7 +256,8 @@ pub async fn test_oprf_ipa<F>(
         protocol::{
             basics::ShareKnownValue,
             ipa_prf::prf_sharding::{
-                attr_cap_aggr, compute_histogram_of_users_with_row_count, PrfShardedIpaInputRow,
+                attribute_cap_aggregate, compute_histogram_of_users_with_row_count,
+                PrfShardedIpaInputRow,
             },
         },
         report::EventType,
@@ -299,7 +301,7 @@ pub async fn test_oprf_ipa<F>(
                 let aw = config.attribution_window_seconds;
 
                 match config.per_user_credit_cap {
-                    8 => attr_cap_aggr::<_, BA8, BA3, BA20, BA3, Replicated<F>, F>(
+                    8 => attribute_cap_aggregate::<_, BA8, BA3, BA20, BA3, Replicated<F>, F>(
                         ctx,
                         sharded_input,
                         aw,
@@ -307,7 +309,7 @@ pub async fn test_oprf_ipa<F>(
                     )
                     .await
                     .unwrap(),
-                    16 => attr_cap_aggr::<
+                    16 => attribute_cap_aggregate::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -318,7 +320,7 @@ pub async fn test_oprf_ipa<F>(
                     >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
                     .unwrap(),
-                    32 => attr_cap_aggr::<
+                    32 => attribute_cap_aggregate::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -329,7 +331,7 @@ pub async fn test_oprf_ipa<F>(
                     >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
                     .unwrap(),
-                    64 => attr_cap_aggr::<
+                    64 => attribute_cap_aggregate::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -340,7 +342,7 @@ pub async fn test_oprf_ipa<F>(
                     >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
                     .unwrap(),
-                    128 => attr_cap_aggr::<
+                    128 => attribute_cap_aggregate::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,

--- a/ipa-core/src/test_fixture/ipa.rs
+++ b/ipa-core/src/test_fixture/ipa.rs
@@ -255,8 +255,7 @@ pub async fn test_oprf_ipa<F>(
         protocol::{
             basics::ShareKnownValue,
             ipa_prf::prf_sharding::{
-                attribution_and_capping_and_aggregation, compute_histogram_of_users_with_row_count,
-                PrfShardedIpaInputRow,
+                attr_cap_aggr, compute_histogram_of_users_with_row_count, PrfShardedIpaInputRow,
             },
         },
         report::EventType,
@@ -297,26 +296,18 @@ pub async fn test_oprf_ipa<F>(
                         }
                     })
                     .collect::<Vec<_>>();
+                let aw = config.attribution_window_seconds;
 
-                if config.per_user_credit_cap == 8 {
-                    attribution_and_capping_and_aggregation::<
-                        _,
-                        BA8,  // BreakdownKey,
-                        BA3,  // TriggerValue,
-                        BA20, // Timestamp,
-                        BA3,  // Saturating Sum
-                        Replicated<F>,
-                        F,
-                    >(
+                match config.per_user_credit_cap {
+                    8 => attr_cap_aggr::<_, BA8, BA3, BA20, BA3, Replicated<F>, F>(
                         ctx,
                         sharded_input,
-                        config.attribution_window_seconds,
+                        aw,
                         ref_to_histogram,
                     )
                     .await
-                    .unwrap()
-                } else if config.per_user_credit_cap == 16 {
-                    attribution_and_capping_and_aggregation::<
+                    .unwrap(),
+                    16 => attr_cap_aggr::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -324,16 +315,10 @@ pub async fn test_oprf_ipa<F>(
                         BA4,  // Saturating Sum
                         Replicated<F>,
                         F,
-                    >(
-                        ctx,
-                        sharded_input,
-                        config.attribution_window_seconds,
-                        ref_to_histogram,
-                    )
+                    >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
-                    .unwrap()
-                } else if config.per_user_credit_cap == 32 {
-                    attribution_and_capping_and_aggregation::<
+                    .unwrap(),
+                    32 => attr_cap_aggr::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -341,16 +326,10 @@ pub async fn test_oprf_ipa<F>(
                         BA5,  // Saturating Sum
                         Replicated<F>,
                         F,
-                    >(
-                        ctx,
-                        sharded_input,
-                        config.attribution_window_seconds,
-                        ref_to_histogram,
-                    )
+                    >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
-                    .unwrap()
-                } else if config.per_user_credit_cap == 64 {
-                    attribution_and_capping_and_aggregation::<
+                    .unwrap(),
+                    64 => attr_cap_aggr::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -358,16 +337,10 @@ pub async fn test_oprf_ipa<F>(
                         BA6,  // Saturating Sum
                         Replicated<F>,
                         F,
-                    >(
-                        ctx,
-                        sharded_input,
-                        config.attribution_window_seconds,
-                        ref_to_histogram,
-                    )
+                    >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
-                    .unwrap()
-                } else if config.per_user_credit_cap == 128 {
-                    attribution_and_capping_and_aggregation::<
+                    .unwrap(),
+                    128 => attr_cap_aggr::<
                         _,
                         BA8,  // BreakdownKey,
                         BA3,  // TriggerValue,
@@ -375,19 +348,14 @@ pub async fn test_oprf_ipa<F>(
                         BA7,  // Saturating Sum
                         Replicated<F>,
                         F,
-                    >(
-                        ctx,
-                        sharded_input,
-                        config.attribution_window_seconds,
-                        ref_to_histogram,
-                    )
+                    >(ctx, sharded_input, aw, ref_to_histogram)
                     .await
-                    .unwrap()
-                } else {
+                    .unwrap(),
+                    _ =>
                     panic!(
-                        "Invalid value specified for per-user cap: {:?}. Must be a power of 2.",
+                        "Invalid value specified for per-user cap: {:?}. Must be one of 8, 16, 32, 64, or 128.",
                         config.per_user_credit_cap
-                    );
+                    ),
                 }
             },
         )

--- a/scripts/collect_steps.py
+++ b/scripts/collect_steps.py
@@ -172,7 +172,7 @@ def ipa_steps():
     return output
 
 OPRF_BREAKDOWN_KEY = 256
-OPRF_USER_CAP = [16, 64, 128]
+OPRF_USER_CAP = [8, 16, 32, 64, 128]
 OPRF_SECURITY_MODEL = "semi-honest"
 OPRF_TRIGGER_VALUE = [6, 7]
 


### PR DESCRIPTION
I created another regression in landing #853. 

When running the collect steps script, the outputs do not match the expected values due to differences in how per-user capping is applied.

Unfortunately, now that the per-user cap is a compile-time constant, it's harder to deal with this. I'm not sure how to dynamically select a `type` based on the value of a u32. I'm hopeful that someone can suggest a much better way to do this.

This issue is bigger than just the per-user cap. The number of breakdown keys, the maximum size of a trigger value, everything is a compile time constant now, and we potentially want to choose these things dynamically based on the values provided at runtime.