### PR TITLE
Use sequential join to compute PRF

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -124,16 +124,16 @@ where
 
     let prf_key = gen_prf_key(&convert_ctx);
 
-    ctx.parallel_join(input_rows.into_iter().enumerate().map(|(idx, record)| {
+    ctx.try_join(input_rows.into_iter().enumerate().map(|(idx, record)| {
         let convert_ctx = convert_ctx.clone();
         let eval_ctx = eval_ctx.clone();
-        let prf_key = prf_key.clone();
+        let prf_key = &prf_key;
         async move {
             let record_id = RecordId::from(idx);
             let elliptic_curve_pt =
                 convert_to_fp25519::<_, BA64>(convert_ctx, record_id, &record.match_key).await?;
             let elliptic_curve_pt =
-                eval_dy_prf(eval_ctx, record_id, &prf_key, &elliptic_curve_pt).await?;
+                eval_dy_prf(eval_ctx, record_id, prf_key, &elliptic_curve_pt).await?;
 
             Ok::<_, Error>(PrfShardedIpaInputRow {
                 prf_of_match_key: elliptic_curve_pt,

--- a/ipa-core/src/report.rs
+++ b/ipa-core/src/report.rs
@@ -69,7 +69,7 @@ impl Serializable for EventType {
         match buf[0] {
             0 => EventType::Trigger,
             1 => EventType::Source,
-            2_u8..=u8::MAX => panic!("Unreachable code"),
+            v @ 2_u8..=u8::MAX => panic!("Unrecognized event type: {v}"),
         }
     }
 }


### PR DESCRIPTION
Running it with tracing enabled to debug #867 made it quite obvious that we attempt to send 1M records without having a chance to succeed.

I also included some minor fixes to improve diagnostics for event type deserialization 