### PR TITLE
Require that `SharedValue: Eq`

### DIFF
--- a/ipa-core/src/ff/curve_points.rs
+++ b/ipa-core/src/ff/curve_points.rs
@@ -25,7 +25,7 @@ impl Block for CompressedRistretto {
 /// since we always generate curve points from scalars (elements in Fp25519) and
 /// only deserialize previously serialized valid points, panics will not occur
 /// However, we still added a debug assert to deserialize since values are sent by other servers
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct RP25519(CompressedRistretto);
 
 /// Implementing trait for secret sharing

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -15,7 +15,7 @@ impl Block for Scalar {
 
 ///implements the Scalar field for elliptic curve 25519
 /// we use elements in Fp25519 to generate curve points and operate on the curve
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Fp25519(<Self as SharedValue>::Storage);
 
 impl Fp25519 {

--- a/ipa-core/src/ff/prime_field.rs
+++ b/ipa-core/src/ff/prime_field.rs
@@ -33,7 +33,7 @@ macro_rules! field_impl {
         use super::*;
         use crate::ff::FieldType;
 
-        #[derive(Clone, Copy, PartialEq)]
+        #[derive(Clone, Copy, PartialEq, Eq)]
         pub struct $field(<Self as SharedValue>::Storage);
 
         impl SharedValue for $field {

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -57,7 +57,7 @@ pub trait Block: Sized + Copy + Debug {
 /// (capable of supporting addition and multiplication) is desired, the `Field` trait extends
 /// `SharedValue` to require multiplication.
 pub trait SharedValue:
-    Clone + Copy + PartialEq + Debug + Send + Sync + Sized + Additive + Serializable + 'static
+    Clone + Copy + Eq + Debug + Send + Sync + Sized + Additive + Serializable + 'static
 {
     type Storage: Block;
 


### PR DESCRIPTION
The compiler is smart enough to conditionally derive `Eq` on `AdditiveShare<V: SharedValue>` depending on whether `V: Eq`. However, when the picture gets more complicated for vectorization, there are cases where the compiler can't figure out the Eq / non-Eq variants. Requiring that `SharedValue`s are always `Eq` will simplify things.

(I don't really think there's anywhere that the Eq vs. PartialEq distinction for these types really matters, so we could probably address this by removing any use of `Eq` `AdditiveShare`s, but my impression is that would be a bigger change.)

The only case where I can see this being potentially controversial is `RP25519(CompressedRistretto)`. However, since `CompressedRistretto` (which comes from the curve25519_dalek crate) is `Eq`, it seems safe to make our wrapper type `Eq` as well.