### PR TITLE
Print helper role inside `TestWorld` spans

### DIFF
--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -193,10 +193,12 @@ impl TestWorld {
     {
         let input_shares = input.share_with(&mut thread_rng());
         #[allow(clippy::disallowed_methods)] // It's just 3 items.
-        let output =
-            join_all(zip(contexts, input_shares).map(|(ctx, shares)| helper_fn(ctx, shares)))
-                .instrument(span)
-                .await;
+        let output = join_all(zip(contexts, input_shares).map(|(ctx, shares)| {
+            let role = ctx.role();
+            helper_fn(ctx, shares).instrument(tracing::trace_span!("", role = ?role))
+        }))
+        .instrument(span)
+        .await;
         <[_; 3]>::try_from(output).unwrap()
     }
 }


### PR DESCRIPTION
When running unit tests, logs from all 3 helpers are grouped together. It makes it hard to see which helper is running the computation that caused a given log line.

This change instruments helper function with a span that contains current helper's role.

```text
TRACE {role=H3}:attribute_cap_aggregate:receive{i=9 from=H2 gate="protocol/run-0/prime_field_validator/modulus_convert_breakdown_key_bits_and_trigger_values/convert_bit7/xor2"}: ipa_core::helpers::buffers::unordered_receiver: Receiver::poll i=9
```