### PR TITLE
fixing busted stuff

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -159,7 +159,6 @@ pub mod tests {
     };
 
     #[test]
-    #[ignore]
     fn semi_honest() {
         const EXPECTED: &[u128] = &[0, 2, 5, 0, 0, 0, 0, 0];
 

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -355,21 +355,26 @@ where
     TS: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
 {
     let mut histogram = vec![];
-    let mut last_prf = input[0].get_grouping_key();
+    let mut last_prf = 0;
     let mut cur_count = 0;
     let mut start = 0;
     let mut ranges = vec![];
-    for (idx, row) in input.iter_mut().enumerate().skip(1) {
-        if row.get_grouping_key() == last_prf {
+    for (idx, row) in input.iter_mut().enumerate() {
+        if idx != 0 && row.get_grouping_key() == last_prf {
             cur_count += 1;
         } else {
-            ranges.push(start..idx);
+            if idx > 0 {
+                ranges.push(start..idx);
+            }
             start = idx;
             cur_count = 0;
             last_prf = row.get_grouping_key();
         }
+
         row.compute_sort_key(cur_count.try_into().unwrap());
-        histogram.resize(cur_count + 1, 0);
+        if histogram.len() <= cur_count {
+            histogram.push(0);
+        }
         histogram[cur_count] += 1;
     }
     ranges.push(start..input.len());

--- a/pre-commit
+++ b/pre-commit
@@ -99,9 +99,8 @@ check "Concurrency tests" \
 check "IPA benchmark" \
     cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches descriptive-gate" -- -n 62
 
-# https://github.com/private-attribution/ipa/issues/899
-#check "IPA OPRF benchmark" \
-#    cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches descriptive-gate" -- -n 62 --oprf -c 16
+check "IPA OPRF benchmark" \
+    cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches descriptive-gate" -- -n 62 --oprf -c 16
 
 check "Arithmetic circuit benchmark" \
     cargo bench --bench oneshot_arithmetic --no-default-features --features "enable-benches descriptive-gate"


### PR DESCRIPTION
While #900 unblocked the build, it did so in a way that broke the way the "histogram" was computed. This reverts those changes, while continuing to ensure that it doesn't generate any invalid ranges like 0..0 - so now the tests pass.