### PR TITLE
Remove public access to `AdditiveShare` members

### DIFF
--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -16,6 +16,16 @@ impl Block for bool {
 #[derive(Clone, Copy, PartialEq, Debug, Eq)]
 pub struct Boolean(bool);
 
+impl Boolean {
+    pub const TRUE: Boolean = Self(true);
+    pub const FALSE: Boolean = Self(false);
+
+    #[must_use]
+    pub fn as_u128(&self) -> u128 {
+        bool::from(*self).into()
+    }
+}
+
 impl ExtendableField for Boolean {
     type ExtendedField = Gf32Bit;
 
@@ -139,7 +149,7 @@ impl Field for Boolean {
     const ONE: Boolean = Boolean(true);
 
     fn as_u128(&self) -> u128 {
-        bool::from(*self).into()
+        Boolean::as_u128(self)
     }
 
     fn truncate_from<T: Into<u128>>(v: T) -> Self {

--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -22,7 +22,7 @@ impl Boolean {
 
     #[must_use]
     pub fn as_u128(&self) -> u128 {
-        bool::from(*self).into()
+        u128::from(bool::from(*self))
     }
 }
 

--- a/ipa-core/src/ff/galois_field.rs
+++ b/ipa-core/src/ff/galois_field.rs
@@ -687,5 +687,11 @@ bit_array_impl!(
                 v
             }
         }
+
+        impl From<Gf2> for bool {
+            fn from(value: Gf2) -> Self {
+                value != Gf2::ZERO
+            }
+        }
     }
 );

--- a/ipa-core/src/protocol/basics/share_known_value.rs
+++ b/ipa-core/src/protocol/basics/share_known_value.rs
@@ -12,6 +12,10 @@ use crate::{
     },
 };
 
+/// Produce a share of some pre-determined constant.
+///
+/// The context is only used to determine the helper role. It is not used for communication or PRSS,
+/// and it is not necessary to use a uniquely narrowed context.
 pub trait ShareKnownValue<C: Context, V: SharedValue> {
     fn share_known_value(ctx: &C, value: V) -> Self;
 }

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -122,16 +122,16 @@ where
         // sh_s: H1: (r1,0), H2: (0,0), H3: (0, r1)
         match ctx.role() {
             Role::H1 => (
-                AdditiveShare(<BA256 as SharedValue>::ZERO, <BA256 as SharedValue>::ZERO),
-                AdditiveShare(r.0, <BA256 as SharedValue>::ZERO),
+                AdditiveShare::new(<BA256 as SharedValue>::ZERO, <BA256 as SharedValue>::ZERO),
+                AdditiveShare::new(r.left(), <BA256 as SharedValue>::ZERO),
             ),
             Role::H2 => (
-                AdditiveShare(<BA256 as SharedValue>::ZERO, r.1),
-                AdditiveShare(<BA256 as SharedValue>::ZERO, <BA256 as SharedValue>::ZERO),
+                AdditiveShare::new(<BA256 as SharedValue>::ZERO, r.right()),
+                AdditiveShare::new(<BA256 as SharedValue>::ZERO, <BA256 as SharedValue>::ZERO),
             ),
             Role::H3 => (
-                AdditiveShare(r.0, <BA256 as SharedValue>::ZERO),
-                AdditiveShare(<BA256 as SharedValue>::ZERO, r.1),
+                AdditiveShare::new(r.left(), <BA256 as SharedValue>::ZERO),
+                AdditiveShare::new(<BA256 as SharedValue>::ZERO, r.right()),
             ),
         }
     };
@@ -162,22 +162,22 @@ where
             .await?;
 
     // this leaks information, but with negligible probability
-    let y = AdditiveShare::<BA256>(sh_y.left(), sh_y.right())
+    let y = AdditiveShare::<BA256>::new(sh_y.left(), sh_y.right())
         .partial_reveal(ctx.narrow(&Step::RevealY), record_id, Role::H3)
         .await?;
 
     match ctx.role() {
-        Role::H1 => Ok(AdditiveShare::<Fp25519>(
-            Fp25519::from(sh_s.0).neg(),
+        Role::H1 => Ok(AdditiveShare::<Fp25519>::new(
+            Fp25519::from(sh_s.left()).neg(),
             Fp25519::from(y.unwrap()),
         )),
-        Role::H2 => Ok(AdditiveShare::<Fp25519>(
+        Role::H2 => Ok(AdditiveShare::<Fp25519>::new(
             Fp25519::from(y.unwrap()),
-            Fp25519::from(sh_r.1).neg(),
+            Fp25519::from(sh_r.right()).neg(),
         )),
-        Role::H3 => Ok(AdditiveShare::<Fp25519>(
-            Fp25519::from(sh_r.0).neg(),
-            Fp25519::from(sh_s.1).neg(),
+        Role::H3 => Ok(AdditiveShare::<Fp25519>::new(
+            Fp25519::from(sh_r.left()).neg(),
+            Fp25519::from(sh_s.right()).neg(),
         )),
     }
 }
@@ -236,25 +236,6 @@ where
     y
 }
 
-/// inserts a smaller array into a larger
-/// allows share conversion between secret shared Boolean Array types like 'BA64' and 'BA256'
-/// only used for testing purposes
-#[cfg(all(test, unit_test))]
-pub fn expand_shared_array<XS, YS>(
-    x: &AdditiveShare<XS>,
-    offset: Option<usize>,
-) -> AdditiveShare<YS>
-where
-    XS: CustomArray + SharedValue,
-    YS: CustomArray<Element = XS::Element> + SharedValue,
-    XS::Element: SharedValue,
-{
-    AdditiveShare::<YS>(
-        expand_array(&x.left(), offset),
-        expand_array(&x.right(), offset),
-    )
-}
-
 #[cfg(all(test, unit_test))]
 mod tests {
     use curve25519_dalek::Scalar;
@@ -272,12 +253,10 @@ mod tests {
         protocol,
         protocol::{
             context::Context,
-            ipa_prf::boolean_ops::share_conversion_aby::{
-                convert_to_fp25519, expand_array, expand_shared_array,
-            },
+            ipa_prf::boolean_ops::share_conversion_aby::{convert_to_fp25519, expand_array},
         },
         rand::thread_rng,
-        secret_sharing::{replicated::semi_honest::AdditiveShare, SharedValue},
+        secret_sharing::SharedValue,
         test_executor::run,
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
@@ -319,20 +298,12 @@ mod tests {
 
         let a = rng.gen::<BA64>();
 
-        let shared_a = AdditiveShare::<BA64>(rng.gen::<BA64>(), rng.gen::<BA64>());
-
         let b = expand_array::<_, BA256>(&a, None);
-
-        let shared_b = expand_shared_array::<_, BA256>(&shared_a, None);
 
         for i in 0..BA256::BITS as usize {
             assert_eq!(
                 (i, b.get(i).unwrap_or(Boolean::ZERO)),
                 (i, a.get(i).unwrap_or(Boolean::ZERO))
-            );
-            assert_eq!(
-                (i, shared_b.get(i).unwrap_or(AdditiveShare::<Boolean>::ZERO)),
-                (i, shared_a.get(i).unwrap_or(AdditiveShare::<Boolean>::ZERO))
             );
         }
     }

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -74,8 +74,7 @@ where
         );
         let mut offset = BA7::BITS as usize;
 
-        self.sort_key.0.set(offset, self.is_trigger_bit.left());
-        self.sort_key.1.set(offset, self.is_trigger_bit.right());
+        self.sort_key.set(offset, self.is_trigger_bit.clone());
 
         offset += 1;
         expand_shared_array_in_place(&mut self.sort_key, &self.timestamp, offset);
@@ -262,15 +261,15 @@ impl<
         if i < bk_bits {
             BitConversionTriple::new(
                 role,
-                self.attributed_breakdown_key_bits.0.get(i).unwrap() == Boolean::ONE,
-                self.attributed_breakdown_key_bits.1.get(i).unwrap() == Boolean::ONE,
+                self.attributed_breakdown_key_bits.get(i).unwrap().left() == Boolean::ONE,
+                self.attributed_breakdown_key_bits.get(i).unwrap().right() == Boolean::ONE,
             )
         } else {
             let i = i - bk_bits;
             BitConversionTriple::new(
                 role,
-                self.capped_attributed_trigger_value.0.get(i).unwrap() == Boolean::ONE,
-                self.capped_attributed_trigger_value.1.get(i).unwrap() == Boolean::ONE,
+                self.capped_attributed_trigger_value.get(i).unwrap().left() == Boolean::ONE,
+                self.capped_attributed_trigger_value.get(i).unwrap().right() == Boolean::ONE,
             )
         }
     }

--- a/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
@@ -57,8 +57,7 @@ where
 
     let mut offset = BA64::BITS as usize;
 
-    y.0.set(offset, input.is_trigger.left());
-    y.1.set(offset, input.is_trigger.right());
+    y.set(offset, input.is_trigger.clone());
 
     offset += 1;
 

--- a/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct AdditiveShare<V: SharedValue>(pub V, pub V);
+pub struct AdditiveShare<V: SharedValue>(V, V);
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct ASIterator<T: Iterator>(pub T, pub T);


### PR DESCRIPTION
Making the members of `AdditiveShare` private reduces the number of things that will need to be updated for vectorization.

In cases where there is both horizontal and vertical vectorization, my plan is that the vertical (across records) is the inner vectorization, and the horizontal (vector-type values within one record) is the outer. My plan is that values of this sort will be stored in `BitDecomposed<AdditiveShare<BitVec>>`. (The most likely candidate for `BitVec` is a Boolean array, although for vertical vectorization, it should rarely be necessary to access individual elements of the vector, and disallowing such access except through special pack/unpack primitives may catch some bugs.)