### PR TITLE
Reject paddings != 0 for boolean arrays

### DIFF
--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -261,7 +261,7 @@ macro_rules! boolean_array_impl {
                     SharedValue,
                 },
             };
-            // formatting does not set the indent properly
+
     type Store = BitArr!(for $bits, in u8, Lsb0);
 
             /// A Boolean array with $bits bits.

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -206,19 +206,22 @@ macro_rules! impl_serializable_trait {
                     $bits % 8,
                     "Padding only makes sense for lengths that are not multiples of 8."
                 );
+
                 let mut non_zero_padding: Store = $name::ZERO.0;
                 non_zero_padding.set($bits, true);
-                let min_value: Store = $name::ZERO.0;
-                let one = $name::ONE.0;
-                let mut max_value = $name::ZERO.0;
-                max_value[..$bits].fill(true);
-
                 assert_eq!(
                     non_zero_padding,
                     deserialize(non_zero_padding).unwrap_err().0
                 );
+
+                let min_value: Store = $name::ZERO.0;
                 deserialize(min_value).unwrap();
+
+                let one = $name::ONE.0;
                 deserialize(one).unwrap();
+
+                let mut max_value = $name::ZERO.0;
+                max_value[..$bits].fill(true);
                 deserialize(max_value).unwrap();
             }
         }


### PR DESCRIPTION
Addresses #911 by returning a `NonZeroPadding` error for bit arrays that don't have infallible conversions. 

I had to change the awesome Martin's macro in order to be able to generate a bit array with all ones. Unfortunately, for bit arrays that are not multiples of 8, `bitarr!` macro generate a byte array with all `1`s. So for 20 bit wide array, `bitarr[1; 20]` generates a [u8::MAX; 3], instead of `100000h`. 

Unfortunately, macros can't do math, so we need to specify explicitly whether deserializing a  BAXX is fallible or no. Infallible deserialization has a compile-time check for multiples of 8, so we don't accidentally set it for wrong boolean arrays