### PR TITLE
Make Galois multiplication constant time 

### DIFF
--- a/ipa-core/src/ff/galois_field.rs
+++ b/ipa-core/src/ff/galois_field.rs
@@ -331,7 +331,7 @@ macro_rules! bit_array_impl {
             //
             // Since we know that x^8 + x^4 + x^3 + x + 1 = 0, we can distribute out terms of this structure and replace them with zero.
             //
-            // So the result of our multipliation was:
+            // So the result of our multiplication was:
             // 110100011111110
             // which you can think of as:
             // x^14 + x^13 + 0 + x^11 + 0 + 0 + 0 + x^7 + x^6 + x^5 + x^4 + x^3 + x^2 + x + 0


### PR DESCRIPTION
...sort of.  I haven't tried very hard to confound the optimization
routines in the compiler.

This could slow things down, but I believe that it is essential as a
baseline to ensure that we don't leak.

This adds a new test, because I discovered that our Gf20 polynomial was
incorrectly transcribed.