### PR TITLE
Relax CodeCov targets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,9 +2,9 @@ coverage:
   status:
     project:
       default:
-        target: 89%      # the required coverage value
-        threshold: 0.5%  # the leniency in hitting the target
+        target: 85%      # the required coverage value
+        threshold: 1%  # the leniency in hitting the target
     patch:
       default:
-        target: 90%      # the required coverage value
-        threshold: 0.5%  # the leniency in hitting the target
+        target: 80%      # the required coverage value
+        threshold: 1%  # the leniency in hitting the target


### PR DESCRIPTION
Given that there are plenty of false positives (#920, #919), it does not make sense to keep the target coverage that high.