### PR TITLE
Include tokio fs feature

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -132,7 +132,7 @@ sha2 = "0.10"
 shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
-tokio = { version = "1.28", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.28", features = ["fs", "rt", "rt-multi-thread", "macros"] }
 # TODO: axum-server holds onto 0.24 and we can't upgrade until they do. Or we move away from axum-server
 tokio-rustls = { version = "0.24", optional = true }
 tokio-stream = "0.1.14"


### PR DESCRIPTION
We use it in one place where we read the encryption keys for match keys.

The reason why it was working before: `axum-server` [brought](https://github.com/programatik29/axum-server/blob/9d5adb28bfa483bda401714ad43f5f5c8d12cb61/Cargo.toml#L16) it.