### PR TITLE
Vectorization of boolean arrays

### DIFF
--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -91,7 +91,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 pub type Res<T> = Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct LengthError {
     pub expected: usize,
     pub actual: usize,

--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -215,10 +215,20 @@ impl FieldVectorizable<256> for Boolean {
 #[cfg(all(test, unit_test))]
 mod test {
     use generic_array::GenericArray;
+    use proptest::prelude::{prop, Arbitrary, Strategy};
     use rand::{thread_rng, Rng};
     use typenum::U1;
 
     use crate::ff::{boolean::Boolean, Serializable};
+
+    impl Arbitrary for Boolean {
+        type Parameters = <bool as Arbitrary>::Parameters;
+        type Strategy = prop::strategy::Map<<bool as Arbitrary>::Strategy, fn(bool) -> Self>;
+
+        fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            <bool>::arbitrary_with(args).prop_map(Boolean)
+        }
+    }
 
     ///test serialize and deserialize
     #[test]

--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -196,6 +196,22 @@ impl FromRandomU128 for Boolean {
     }
 }
 
+impl Vectorizable<64> for Boolean {
+    type Array = crate::ff::boolean_array::BA64;
+}
+
+impl FieldVectorizable<64> for Boolean {
+    type ArrayAlias = crate::ff::boolean_array::BA64;
+}
+
+impl Vectorizable<256> for Boolean {
+    type Array = crate::ff::boolean_array::BA256;
+}
+
+impl FieldVectorizable<256> for Boolean {
+    type ArrayAlias = crate::ff::boolean_array::BA256;
+}
+
 #[cfg(all(test, unit_test))]
 mod test {
     use generic_array::GenericArray;

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -6,6 +6,7 @@ use generic_array::GenericArray;
 use typenum::{U14, U2, U32, U8};
 
 use crate::{
+    error::LengthError,
     ff::{boolean::Boolean, ArrayAccess, ArrayBuilder, Field, Serializable},
     protocol::prss::{FromRandom, FromRandomU128},
     secret_sharing::{Block, FieldVectorizable, SharedValue, StdArray, Vectorizable},
@@ -487,12 +488,15 @@ macro_rules! boolean_array_impl {
             }
 
             impl TryFrom<Vec<Boolean>> for $name {
-                type Error = ();
+                type Error = LengthError;
                 fn try_from(value: Vec<Boolean>) -> Result<Self, Self::Error> {
                     if value.len() == $bits {
                         Ok(value.into_iter().collect::<Self>())
                     } else {
-                        Err(())
+                        Err(LengthError {
+                            expected: $bits,
+                            actual: value.len(),
+                        })
                     }
                 }
             }

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -11,6 +11,7 @@ mod galois_field;
 mod prime_field;
 
 use std::{
+    borrow::Borrow,
     convert::Infallible,
     ops::{Add, AddAssign, Sub, SubAssign},
 };
@@ -93,6 +94,24 @@ pub trait ArrayAccess {
     fn iter(&self) -> Self::Iter<'_>;
 }
 
+pub trait ArrayAccessRef {
+    type Element;
+    type Ref<'a>: Borrow<Self::Element> + Clone
+    where
+        Self: 'a;
+    type Iter<'a>: Iterator<Item = Self::Ref<'a>> + ExactSizeIterator + Send
+    where
+        Self: 'a;
+
+    fn get(&self, index: usize) -> Option<Self::Ref<'_>>;
+
+    fn set(&mut self, index: usize, e: Self::Ref<'_>);
+
+    fn iter(&self) -> Self::Iter<'_>;
+
+    fn make_ref(src: &Self::Element) -> Self::Ref<'_>;
+}
+
 pub trait Expand {
     type Input;
 
@@ -105,7 +124,9 @@ pub trait Expand {
 /// supports `FromIterator` to collect an iterator of elements back into the original type
 pub trait CustomArray
 where
-    Self: ArrayAccess<Output = Self::Element> + Expand<Input = Self::Element>,
+    Self: ArrayAccess<Output = Self::Element>
+        + Expand<Input = Self::Element>
+        + ArrayBuild<Input = Self::Element>,
 {
     type Element;
 }
@@ -113,7 +134,30 @@ where
 /// impl Custom Array for all compatible structs
 impl<S> CustomArray for S
 where
-    S: ArrayAccess + Expand<Input = <S as ArrayAccess>::Output>,
+    S: ArrayAccess
+        + Expand<Input = <S as ArrayAccess>::Output>
+        + ArrayBuild<Input = <S as ArrayAccess>::Output>,
 {
     type Element = <S as ArrayAccess>::Output;
+}
+
+pub trait ArrayBuild {
+    type Input;
+    type Builder: ArrayBuilder<Element = Self::Input, Array = Self>;
+
+    fn builder() -> Self::Builder;
+}
+
+pub trait ArrayBuilder: Send + Sized {
+    type Element;
+    type Array;
+
+    #[must_use]
+    fn with_capacity(self, _capacity: usize) -> Self {
+        self
+    }
+
+    fn push(&mut self, value: Self::Element);
+
+    fn build(self) -> Self::Array;
 }

--- a/ipa-core/src/protocol/basics/mul/semi_honest.rs
+++ b/ipa-core/src/protocol/basics/mul/semi_honest.rs
@@ -62,7 +62,7 @@ where
     } else {
         debug_assert_eq!(
             a.left_arr().clone() * b.right_arr() + a.right_arr().clone() * b.left_arr(),
-            <<F as Vectorizable<N>>::Array as SharedValueArray<F>>::ZERO
+            <<F as Vectorizable<N>>::Array as SharedValueArray<F>>::ZERO_ARRAY
         );
     }
     // Add randomness to this value whether we sent or not, depending on whether the

--- a/ipa-core/src/protocol/basics/mul/sparse.rs
+++ b/ipa-core/src/protocol/basics/mul/sparse.rs
@@ -121,14 +121,14 @@ impl ZeroPositions {
             let flags = <[bool; 3]>::from(self);
             if flags[role as usize] {
                 assert_eq!(
-                    &<V as Vectorizable<N>>::Array::ZERO,
+                    &<V as Vectorizable<N>>::Array::ZERO_ARRAY,
                     v.left_arr(),
                     "expected a zero on the left for input {which}"
                 );
             }
             if flags[role.peer(Right) as usize] {
                 assert_eq!(
-                    &<V as Vectorizable<N>>::Array::ZERO,
+                    &<V as Vectorizable<N>>::Array::ZERO_ARRAY,
                     v.right_arr(),
                     "expected a zero on the right for input {which}"
                 );

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -228,6 +228,7 @@ where
 }
 
 #[cfg(all(test, unit_test))]
+#[cfg_attr(coverage, allow(unused_imports))]
 mod test {
     use std::{
         array,
@@ -390,6 +391,7 @@ mod test {
         });
     }
 
+    #[cfg(not(coverage))]
     const BENCH_COUNT: usize = 131_072;
 
     #[test]

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -394,6 +394,7 @@ mod test {
 
     #[test]
     #[ignore] // benchmark
+    #[cfg(not(coverage))]
     fn semi_honest_compare_gt_novec() {
         run(|| async move {
             let world = TestWorld::default();
@@ -440,6 +441,7 @@ mod test {
 
     #[test]
     #[ignore] // benchmark
+    #[cfg(not(coverage))]
     fn semi_honest_compare_gt_vec() {
         run(|| async move {
             const N: usize = 256;

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -1,18 +1,29 @@
+//! Bitwise subtraction and comparison protocols
+//!
+//! Implementations in this module require that if the bit-width of the second (y) operand exceeds
+//! the bit-width of the first (x) operand, then the excess bits of y must be zero. This condition
+//! is abbreviated below as `length(x) >= log2(y)`.
+
+use std::{borrow::Borrow, iter::repeat, ops::Not};
+
 #[cfg(all(test, unit_test))]
 use ipa_macros::Step;
 
-#[cfg(all(test, unit_test))]
-use crate::ff::Expand;
 use crate::{
     error::Error,
-    ff::{ArrayAccess, CustomArray, Field},
+    ff::{ArrayAccessRef, ArrayBuild, ArrayBuilder, Field},
     protocol::{
         basics::{SecureMul, ShareKnownValue},
         context::Context,
         step::BitOpStep,
         RecordId,
     },
-    secret_sharing::{replicated::semi_honest::AdditiveShare, SharedValue},
+    secret_sharing::{replicated::semi_honest::AdditiveShare, FieldSimd},
+};
+#[cfg(all(test, unit_test))]
+use crate::{
+    ff::{CustomArray, Expand},
+    secret_sharing::SharedValue,
 };
 
 #[cfg(all(test, unit_test))]
@@ -23,80 +34,82 @@ pub(crate) enum Step {
 }
 
 /// Comparison operation
-/// outputs x>=y
+///
+/// Outputs x>=y for length(x) >= log2(y).
 /// # Errors
-/// propagates errors from multiply
+/// Propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn compare_geq<C, XS, YS>(
+pub async fn compare_geq<C, F, XS, YS>(
     ctx: C,
     record_id: RecordId,
-    x: &AdditiveShare<XS>,
-    y: &AdditiveShare<YS>,
-) -> Result<AdditiveShare<XS::Element>, Error>
+    x: &XS,
+    y: &YS,
+) -> Result<AdditiveShare<F>, Error>
 where
     C: Context,
-    YS: SharedValue + CustomArray<Element = XS::Element>,
-    XS: SharedValue + CustomArray + Field,
-    XS::Element: Field,
-    AdditiveShare<XS::Element>: std::ops::Not<Output = AdditiveShare<XS::Element>>,
+    F: Field,
+    XS: ArrayAccessRef<Element = AdditiveShare<F>> + ArrayBuild<Input = AdditiveShare<F>>,
+    YS: ArrayAccessRef<Element = AdditiveShare<F>>,
+    AdditiveShare<F>: SecureMul<C> + Not<Output = AdditiveShare<F>>,
 {
     // we need to initialize carry to 1 for x>=y,
-    let mut carry = AdditiveShare::<XS::Element>::share_known_value(&ctx, XS::Element::ONE);
-    // we don't care about the subtraction, we just want the carry
-    let _ = subtraction_circuit(ctx, record_id, x, y, &mut carry).await;
+    let mut carry = AdditiveShare::<F>::share_known_value(&ctx, F::ONE);
+    // We don't care about the subtraction, we just want the carry
+    subtraction_circuit(ctx, record_id, x, y, &mut carry).await?;
     Ok(carry)
 }
 
 /// Comparison operation
-/// outputs x>y
+
+/// Outputs x>y for length(x) >= log2(y).
 /// # Errors
 /// propagates errors from multiply
-pub async fn compare_gt<C, XS, YS>(
+pub async fn compare_gt<C, F, XS, YS, const N: usize>(
     ctx: C,
     record_id: RecordId,
-    x: &AdditiveShare<XS>,
-    y: &AdditiveShare<YS>,
-) -> Result<AdditiveShare<XS::Element>, Error>
+    x: &XS,
+    y: &YS,
+) -> Result<AdditiveShare<F, N>, Error>
 where
     C: Context,
-    YS: SharedValue + CustomArray<Element = XS::Element>,
-    XS: SharedValue + CustomArray + Field,
-    XS::Element: Field,
-    AdditiveShare<XS::Element>: std::ops::Not<Output = AdditiveShare<XS::Element>>,
+    F: Field + FieldSimd<N>,
+    XS: ArrayAccessRef<Element = AdditiveShare<F, N>> + ArrayBuild<Input = AdditiveShare<F, N>>,
+    YS: ArrayAccessRef<Element = AdditiveShare<F, N>>,
+    AdditiveShare<F, N>: SecureMul<C> + Not<Output = AdditiveShare<F, N>>,
 {
     // we need to initialize carry to 0 for x>y
-    let mut carry = AdditiveShare::<XS::Element>::ZERO;
-    // we don't care about the subtraction, we just want the carry
-    let _ = subtraction_circuit(ctx, record_id, x, y, &mut carry).await;
+    let mut carry = AdditiveShare::<F, N>::ZERO;
+    subtraction_circuit(ctx, record_id, x, y, &mut carry).await?;
     Ok(carry)
 }
 
 /// non-saturated unsigned integer subtraction
-/// subtracts y from x, Output has same length as x (carries and indices of y too large for x are ignored)
-/// when y>x, it computes `(x+"XS::MaxValue")-y`
+/// subtracts y from x, Output has same length as x (carries and indices of y too large for x are ignored).
+/// When y>x, it computes `(x+"XS::MaxValue"+1)-y`, considering only the least-significant
+/// length(x) bits of y.
 /// # Errors
 /// propagates errors from multiply
-pub async fn integer_sub<C, XS, YS>(
+pub async fn integer_sub<C, F, XS, YS>(
     ctx: C,
     record_id: RecordId,
-    x: &AdditiveShare<XS>,
-    y: &AdditiveShare<YS>,
-) -> Result<AdditiveShare<XS>, Error>
+    x: &XS,
+    y: &YS,
+) -> Result<XS, Error>
 where
     C: Context,
-    YS: SharedValue + CustomArray<Element = XS::Element>,
-    XS: SharedValue + CustomArray + Field,
-    XS::Element: Field,
-    AdditiveShare<XS::Element>: std::ops::Not<Output = AdditiveShare<XS::Element>>,
+    F: Field,
+    XS: ArrayAccessRef<Element = AdditiveShare<F>> + ArrayBuild<Input = AdditiveShare<F>>,
+    YS: ArrayAccessRef<Element = AdditiveShare<F>>,
+    AdditiveShare<F>: SecureMul<C> + Not<Output = AdditiveShare<F>>,
 {
     // we need to initialize carry to 1 for a subtraction
-    let mut carry = AdditiveShare::<XS::Element>::share_known_value(&ctx, XS::Element::ONE);
+    let mut carry = AdditiveShare::<F>::share_known_value(&ctx, F::ONE);
     subtraction_circuit(ctx, record_id, x, y, &mut carry).await
 }
 
 /// saturated unsigned integer subtraction
-/// subtracts y from x, Output has same length as x (we dont seem to need support for different length)
-/// when y>x, it outputs 0
+/// subtracts y from x, Output has same length as x (we dont seem to need support for different length).
+/// when y>x, it outputs 0. Only correct when length(x) >= log2(y).
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
@@ -108,9 +121,12 @@ pub async fn integer_sat_sub<C, S>(
 ) -> Result<AdditiveShare<S>, Error>
 where
     C: Context,
-    S: CustomArray + Field,
     S::Element: Field,
-    AdditiveShare<S::Element>: std::ops::Not<Output = AdditiveShare<S::Element>>,
+    S: SharedValue + CustomArray + Expand<Input = S::Element>,
+    AdditiveShare<S>: SecureMul<C>
+        + ArrayAccessRef<Element = AdditiveShare<S::Element>>
+        + ArrayBuild<Input = AdditiveShare<S::Element>>,
+    AdditiveShare<S::Element>: SecureMul<C> + Not<Output = AdditiveShare<S::Element>>,
 {
     let mut carry = AdditiveShare::<S::Element>::share_known_value(&ctx, S::Element::ONE);
     let result = subtraction_circuit(
@@ -131,41 +147,48 @@ where
 }
 
 /// subtraction using bit subtractor
-/// subtracts y from x, Output has same length as x (carries and indices of y too large for x are ignored)
-/// implementing `https://encrypto.de/papers/KSS09.pdf` from Section 3.1/3.2
+/// subtracts y from x, Output has same length as x (carries and indices of y too large for x are ignored,
+/// so only correct when length(x) >= log2(y)).
+/// Implements `https://encrypto.de/papers/KSS09.pdf` from Section 3.1/3.2
 ///
 /// # Errors
 /// propagates errors from multiply
-async fn subtraction_circuit<C, XS, YS>(
+async fn subtraction_circuit<C, F, XS, YS, const N: usize>(
     ctx: C,
     record_id: RecordId,
-    x: &AdditiveShare<XS>,
-    y: &AdditiveShare<YS>,
-    carry: &mut AdditiveShare<XS::Element>,
-) -> Result<AdditiveShare<XS>, Error>
+    x: &XS,
+    y: &YS,
+    carry: &mut AdditiveShare<F, N>,
+) -> Result<XS, Error>
 where
     C: Context,
-    XS: SharedValue + CustomArray,
-    YS: SharedValue + CustomArray<Element = XS::Element>,
-    XS::Element: Field,
-    AdditiveShare<XS::Element>: std::ops::Not<Output = AdditiveShare<XS::Element>>,
+    F: Field + FieldSimd<N>,
+    XS: ArrayAccessRef<Element = AdditiveShare<F, N>> + ArrayBuild<Input = AdditiveShare<F, N>>,
+    YS: ArrayAccessRef<Element = AdditiveShare<F, N>>,
+    AdditiveShare<F, N>: SecureMul<C> + Not<Output = AdditiveShare<F, N>>,
 {
-    let mut result = AdditiveShare::<XS>::ZERO;
-    for (i, v) in x.iter().enumerate() {
-        result.set(
-            i,
+    let x = x.iter();
+    let y = y.iter();
+
+    let mut result = XS::builder().with_capacity(x.len());
+
+    for (i, (xb, yb)) in x
+        .zip(y.chain(repeat(YS::make_ref(&AdditiveShare::<F, N>::ZERO))))
+        .enumerate()
+    {
+        result.push(
             bit_subtractor(
                 ctx.narrow(&BitOpStep::from(i)),
                 record_id,
-                &v,
-                y.get(i).as_ref(),
+                xb.borrow(),
+                yb.borrow(),
                 carry,
             )
             .await?,
         );
     }
 
-    Ok(result)
+    Ok(result.build())
 }
 
 /// This improved one-bit subtractor that only requires a single multiplication was taken from:
@@ -182,27 +205,23 @@ where
 ///
 /// # Errors
 /// propagates errors from multiply
-async fn bit_subtractor<C, S>(
+async fn bit_subtractor<C, F, const N: usize>(
     ctx: C,
     record_id: RecordId,
-    x: &AdditiveShare<S>,
-    y: Option<&AdditiveShare<S>>,
-    carry: &mut AdditiveShare<S>,
-) -> Result<AdditiveShare<S>, Error>
+    x: &AdditiveShare<F, N>,
+    y: &AdditiveShare<F, N>,
+    carry: &mut AdditiveShare<F, N>,
+) -> Result<AdditiveShare<F, N>, Error>
 where
     C: Context,
-    S: Field,
-    AdditiveShare<S>: std::ops::Not<Output = AdditiveShare<S>>,
+    F: Field + FieldSimd<N>,
+    AdditiveShare<F, N>: SecureMul<C> + Not<Output = AdditiveShare<F, N>>,
 {
-    let output = x + !(y.unwrap_or(&AdditiveShare::<S>::ZERO) + &*carry);
+    let output = x + !(y + &*carry);
 
     *carry = &*carry
         + (x + &*carry)
-            .multiply(
-                &(!(y.unwrap_or(&AdditiveShare::<S>::ZERO) + &*carry)),
-                ctx,
-                record_id,
-            )
+            .multiply(&(!(y + &*carry)), ctx, record_id)
             .await?;
 
     Ok(output)
@@ -210,6 +229,14 @@ where
 
 #[cfg(all(test, unit_test))]
 mod test {
+    use std::{
+        array,
+        iter::{repeat, repeat_with, zip, Iterator},
+        time::Instant,
+    };
+
+    use futures::stream::iter as stream_iter;
+    use futures_util::TryStreamExt;
     use rand::Rng;
 
     use crate::{
@@ -224,14 +251,16 @@ mod test {
             ipa_prf::boolean_ops::comparison_and_subtraction_sequential::{
                 compare_geq, compare_gt, integer_sat_sub, integer_sub,
             },
+            RecordId,
         },
         rand::thread_rng,
         secret_sharing::{
             replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
-            SharedValue,
+            BitDecomposed, SharedValue,
         },
+        seq_join::{seq_join, SeqJoin},
         test_executor::run,
-        test_fixture::{Reconstruct, Runner, TestWorld},
+        test_fixture::{Reconstruct, ReconstructArr, Runner, TestWorld},
     };
 
     /// testing correctness of Not
@@ -282,7 +311,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
-                    compare_geq::<_, BA64, BA64>(
+                    compare_geq(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -298,7 +327,7 @@ mod test {
 
             let result2 = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    compare_geq::<_, BA64, BA64>(
+                    compare_geq(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -329,7 +358,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
-                    compare_gt::<_, BA64, BA64>(
+                    compare_gt::<_, _, AdditiveShare<BA64>, AdditiveShare<BA64>, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -346,7 +375,7 @@ mod test {
             // check that x is not greater than itself
             let result2 = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    compare_gt::<_, BA64, BA64>(
+                    compare_gt::<_, _, AdditiveShare<BA64>, AdditiveShare<BA64>, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -358,6 +387,133 @@ mod test {
                 .await
                 .reconstruct();
             assert_eq!(result2, <Boolean>::from(false));
+        });
+    }
+
+    const BENCH_COUNT: usize = 131_072;
+
+    #[test]
+    #[ignore] // benchmark
+    fn semi_honest_compare_gt_novec() {
+        run(|| async move {
+            let world = TestWorld::default();
+
+            let mut rng = thread_rng();
+
+            let x = repeat_with(|| rng.gen())
+                .take(BENCH_COUNT)
+                .collect::<Vec<BA64>>();
+            let x_int = x.iter().map(Field::as_u128).collect::<Vec<_>>();
+            let y: BA64 = rng.gen::<BA64>();
+            let y_int = y.as_u128();
+
+            let expected = x_int.iter().map(|x| *x > y_int).collect::<Vec<_>>();
+
+            let result = world
+                .semi_honest((x.clone().into_iter(), y), |ctx, (x, y)| async move {
+                    let begin = Instant::now();
+                    let ctx = ctx.set_total_records(x.len());
+                    let res = seq_join(
+                        ctx.active_work(),
+                        stream_iter(x.into_iter().zip(repeat((ctx, y))).enumerate().map(
+                            |(i, (x, (ctx, y)))| async move {
+                                compare_gt(ctx, RecordId::from(i), &x, &y).await
+                            },
+                        )),
+                    )
+                    .try_collect::<Vec<AdditiveShare<Boolean>>>()
+                    .await
+                    .unwrap();
+                    tracing::info!("Execution time: {:?}", begin.elapsed());
+                    res
+                })
+                .await
+                .reconstruct();
+
+            let results_iter = zip(result, expected);
+            assert_eq!(results_iter.len(), BENCH_COUNT);
+            for (observed, expected) in results_iter {
+                assert_eq!(observed, <Boolean>::from(expected));
+            }
+        });
+    }
+
+    #[test]
+    #[ignore] // benchmark
+    fn semi_honest_compare_gt_vec() {
+        run(|| async move {
+            const N: usize = 256;
+            const CMP_BITS: usize = 64;
+
+            let world = TestWorld::default();
+
+            let mut rng = thread_rng();
+
+            let x = repeat_with(|| rng.gen())
+                .take(BENCH_COUNT)
+                .collect::<Vec<BA64>>();
+            let x_int: Vec<u64> = x
+                .iter()
+                .map(|x| x.as_u128().try_into().unwrap())
+                .collect::<Vec<_>>();
+            let y: BA64 = rng.gen::<BA64>();
+            let y_int: u64 = y.as_u128().try_into().unwrap();
+            let xa: Vec<BitDecomposed<[Boolean; N]>> = x_int
+                .chunks(N)
+                .map(|x| {
+                    BitDecomposed::decompose(CMP_BITS, move |bit| {
+                        array::from_fn(|rec| {
+                            if (x[rec] >> bit) & 1 == 1 {
+                                Boolean::TRUE
+                            } else {
+                                Boolean::FALSE
+                            }
+                        })
+                    })
+                })
+                .collect::<Vec<_>>();
+            let ya: BitDecomposed<[Boolean; N]> = BitDecomposed::decompose(CMP_BITS, |i| {
+                if (y_int >> i) & 1 == 1 {
+                    [Boolean::TRUE; N]
+                } else {
+                    [Boolean::FALSE; N]
+                }
+            });
+
+            let expected = x_int.iter().map(|x| *x > y_int).collect::<Vec<_>>();
+
+            let xa_iter = xa.clone().into_iter();
+            let result = world
+                .semi_honest((xa_iter, ya.clone()), |ctx, (x, y)| async move {
+                    println!("Processing {} records", x.len());
+                    let begin = Instant::now();
+                    let ctx = ctx.set_total_records(x.len());
+                    let res = seq_join(
+                        ctx.active_work(),
+                        stream_iter(x.into_iter().zip(repeat((ctx, y))).enumerate().map(
+                            |(i, (x, (ctx, y)))| async move {
+                                compare_gt(ctx, RecordId::from(i), &x, &y).await
+                            },
+                        )),
+                    )
+                    .try_collect::<Vec<AdditiveShare<Boolean, N>>>()
+                    .await
+                    .unwrap();
+                    tracing::info!("Execution time: {:?}", begin.elapsed());
+                    res
+                })
+                .await;
+
+            let [r0, r1, r2] = result;
+            let observed = (0..r0.len())
+                .flat_map(|i| [r0[i].clone(), r1[i].clone(), r2[i].clone()].reconstruct_arr())
+                .collect::<Vec<_>>();
+
+            let results_iter = zip(observed, expected);
+            assert_eq!(results_iter.len(), BENCH_COUNT);
+            for (observed, expected) in results_iter {
+                assert_eq!(observed, <Boolean>::from(expected));
+            }
         });
     }
 
@@ -378,7 +534,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    integer_sub::<_, BA64, BA64>(
+                    integer_sub(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -468,7 +624,7 @@ mod test {
 
             let result = world
                 .semi_honest(records, |ctx, x_y| async move {
-                    integer_sub::<_, BA64, BA32>(
+                    integer_sub(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y.0,

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -198,6 +198,11 @@ impl<
                 ctx.narrow(&Step::IsSaturatedAndPrevRowNotSaturated),
                 record_id,
             ),
+            // It is okay that we are calling `integer_sub` with length(y) > length(x) here.
+            // `difference_to_cap` only needs to be accurate in the case where the next row will
+            // overflow. When that is the case, `updated_sum` must be within `2^TV::BITS` of the
+            // cap, and a `TV::BITS` subtraction of the `TV::BITS` least significant bits of
+            // `updated_sum` from zero will correctly compute the difference to the cap.
             integer_sub(
                 ctx.narrow(&Step::ComputeDifferenceToCap),
                 record_id,

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -9,7 +9,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, CustomArray, Field},
+    ff::{boolean::Boolean, ArrayAccess, ArrayBuild, CustomArray, Field},
     protocol::{
         basics::Reveal, context::Context,
         ipa_prf::boolean_ops::comparison_and_subtraction_sequential::compare_gt, RecordId,
@@ -61,6 +61,7 @@ where
     S: Send + Sync,
     F: Fn(&S) -> &AdditiveShare<K> + Sync + Send + Copy,
     K: SharedValue + Field + CustomArray<Element = Boolean>,
+    AdditiveShare<K>: ArrayAccess + ArrayBuild<Input = AdditiveShare<Boolean>>,
 {
     assert!(!ranges_to_sort.iter().any(Range::is_empty));
 

--- a/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
@@ -75,10 +75,10 @@ where
 // This function converts AdditiveShare obtained from shuffle protocol to OprfReport
 pub fn shuffled_to_oprfreport<YS, BK, TV, TS>(input: &AdditiveShare<YS>) -> OprfReport<BK, TV, TS>
 where
-    YS: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
-    BK: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
-    TV: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
-    TS: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
+    YS: SharedValue + CustomArray<Element = Boolean>,
+    BK: SharedValue + CustomArray<Element = Boolean>,
+    TV: SharedValue + CustomArray<Element = Boolean>,
+    TS: SharedValue + CustomArray<Element = Boolean>,
 {
     let match_key = extract_from_shared_array::<YS, BA64>(input, 0);
 

--- a/ipa-core/src/secret_sharing/array.rs
+++ b/ipa-core/src/secret_sharing/array.rs
@@ -63,7 +63,7 @@ impl<V: SharedValue, const N: usize> SharedValueArray<V> for StdArray<V, N>
 where
     Self: Sendable,
 {
-    const ZERO: Self = Self([V::ZERO; N]);
+    const ZERO_ARRAY: Self = Self([V::ZERO; N]);
 
     fn from_fn<F: FnMut(usize) -> V>(f: F) -> Self {
         Self(array::from_fn(f))
@@ -91,7 +91,7 @@ where
     Self: Sendable, // required for `<Self as SharedValueArray>::ZERO`
 {
     fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
-        let mut res = Self::ZERO;
+        let mut res = Self::ZERO_ARRAY;
         let mut iter = iter.into_iter();
 
         for i in 0..N {

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -247,6 +247,7 @@ pub trait SharedValueArray<V>:
 pub trait FieldArray<F: SharedValue>:
     SharedValueArray<F>
     + FromRandom
+    + for<'a> Mul<F, Output = Self>
     + for<'a> Mul<&'a F, Output = Self>
     + for<'a> Mul<&'a Self, Output = Self>
 {

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -70,7 +70,7 @@ pub use scheme::{Bitwise, Linear, LinearRefOps, SecretSharing};
 
 use crate::{
     error::LengthError,
-    ff::{AddSub, AddSubAssign, Field, Fp32BitPrime, Serializable},
+    ff::{boolean::Boolean, AddSub, AddSubAssign, Field, Fp32BitPrime, Serializable},
     protocol::prss::FromRandom,
 };
 
@@ -211,6 +211,10 @@ impl<F: Field> FieldSimd<1> for F {}
 
 impl FieldSimd<32> for Fp32BitPrime {}
 
+impl FieldSimd<64> for Boolean {}
+
+impl FieldSimd<256> for Boolean {}
+
 pub trait SharedValueArray<V>:
     Clone
     + Eq
@@ -232,7 +236,7 @@ pub trait SharedValueArray<V>:
     + SubAssign<Self>
     + for<'a> SubAssign<&'a Self>
 {
-    const ZERO: Self;
+    const ZERO_ARRAY: Self;
 
     fn from_fn<F: FnMut(usize) -> V>(f: F) -> Self;
 }


### PR DESCRIPTION
Builds on #852.

Adds support for vectorization of bitwise protocols, and adds vectorized version of `compare_gt` (used by quicksort).

Unvectorized bitwise protocols operate on `AdditiveShare<BA>`, as before (bits of the BA are different bits of multi-bit values associated with a particular record). Vectorized bitwise protocols operate on `BitDecomposed<AdditiveShare<BA>>`, where the elements of the outer `BitDecomposed` are different bits of multi-bit values associated with a particular record, and bits of the inner BA are the values of a particular bit position for a stripe of records. Adds an `ArrayAccessRef` variant of the `ArrayAccess` trait that is implemented for both kinds of inputs, and an `ArrayBuilder` trait that is implemented for both kinds of outputs.

## Performance

`compare_gt` benchmark. Generates 131,072 64-bit values and compares each of them to a single 64-bit threshold. This is a proxy for quicksort.

* Unvectorized: 39.6 s 🐢
* Vectorized x256, bitvec version (what is in this PR): 320 ms
* Vectorized x256, raw array version (see #928): 200 ms
* Vectorized x1024, raw array version: 100 ms
* Vectorized x4096, raw array version: 84 ms 🔥