### PR TITLE
Allow zero spare space in `OrderingSender`

### DIFF
--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -575,10 +575,7 @@ mod tests {
 
     #[tokio::test]
     async fn can_consume_ordering_sender() {
-        let tx = Arc::new(OrderingSender::new(
-            NonZeroUsize::new(2).unwrap(),
-            NonZeroUsize::new(2).unwrap(),
-        ));
+        let tx = Arc::new(OrderingSender::new(NonZeroUsize::new(2).unwrap(), 2));
         let rx = Arc::clone(&tx).as_rc_stream();
         let network = InMemoryNetwork::default();
         let transport1 = network.transport(HelperIdentity::ONE);


### PR DESCRIPTION
Prompted by https://github.com/private-attribution/ipa/pull/852/files#r1464197048.

I compromised the quality of the assertion in `State::write` a little. It may not be as effective in catching broken configurations, but it should still prevent reaching a deadlock.

There are two ways I can see revising this:
* Get rid of the notion of spare entirely, and just require that messages are uniformly sized (less work).
* Use an enum to track the mode (spare capacity vs. uniform message size), and the observed message size in the uniform case. This would restore the quality of the assertion, but would be a bit more work to implement.