### PR TITLE
Generate valid field elements, and other fixes for RecordsStream proptest

### DIFF
--- a/ipa-core/src/ff/prime_field.rs
+++ b/ipa-core/src/ff/prime_field.rs
@@ -225,11 +225,25 @@ macro_rules! field_impl {
 
         #[cfg(all(test, unit_test))]
         mod common_tests {
+            use std::ops::Range;
+
             use generic_array::GenericArray;
-            use proptest::proptest;
+            use proptest::{
+                prelude::{prop, Arbitrary, Strategy},
+                proptest,
+            };
 
             use super::*;
             use crate::ff::Serializable;
+
+            impl Arbitrary for $field {
+                type Parameters = ();
+                type Strategy = prop::strategy::Map<Range<u128>, fn(u128) -> Self>;
+
+                fn arbitrary_with(_args: ()) -> Self::Strategy {
+                    (0..u128::from(Self::PRIME)).prop_map($field::truncate_from as _)
+                }
+            }
 
             #[test]
             fn zero() {


### PR DESCRIPTION
Fixes a bug in `random_chunks` that showed up with `TestField = Fp31`, makes empty streams a candidate input, and fixes the greater-than-prime error in #931. The combination of `arb_size_in_bytes` and `arb_aligned_bytes` into `arb_expected_and_chunked_body` is not to fix a bug, it just seemed unnecessarily complicated. 

I got failures in Fp32BitPrime twice within 10-15 minutes, but I think I was lucky and O(hours) is a more realistic time frame. You can also change the TestField to Fp31 to get a failure immediately.

Fixes #931.