### PR TITLE
A draft API for validation of replicated shares

### DIFF
--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     MaliciousSecurityCheckFailed,
     #[error("malicious reveal failed")]
     MaliciousRevealFailed,
+    #[error("share values were inconsistent between helpers")]
+    InconsistentShares,
     #[error("problem during IO: {0}")]
     Io(#[from] std::io::Error),
     // TODO remove if this https://github.com/awslabs/shuttle/pull/109 gets approved

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -7,6 +7,7 @@ mod reshare;
 mod reveal;
 mod share_known_value;
 pub mod sum_of_product;
+pub mod validate;
 
 pub use check_zero::check_zero;
 pub use if_else::if_else;

--- a/ipa-core/src/protocol/basics/validate.rs
+++ b/ipa-core/src/protocol/basics/validate.rs
@@ -58,7 +58,7 @@ impl From<HashFunction> for HashValue {
 }
 
 struct ReplicatedValidatorFinalization {
-    f: Pin<Box<dyn Future<Output = Result<(), Error>>>>,
+    f: Pin<Box<(dyn Future<Output = Result<(), Error>> + Send)>>,
 }
 
 impl ReplicatedValidatorFinalization {

--- a/ipa-core/src/protocol/basics/validate.rs
+++ b/ipa-core/src/protocol/basics/validate.rs
@@ -1,0 +1,218 @@
+use std::{
+    convert::Infallible,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
+
+use futures::{
+    future::try_join,
+    stream::{Fuse, Stream, StreamExt},
+    Future, FutureExt,
+};
+use generic_array::GenericArray;
+use pin_project::pin_project;
+use sha2::{
+    digest::{typenum::Unsigned, FixedOutput, OutputSizeUser},
+    Digest, Sha256,
+};
+
+use crate::{
+    error::Error,
+    ff::Serializable,
+    helpers::{Direction, Message},
+    protocol::{context::Context, RecordId},
+    secret_sharing::{replicated::ReplicatedSecretSharing, SharedValue},
+};
+
+type HashFunction = Sha256;
+type HashSize = <HashFunction as OutputSizeUser>::OutputSize;
+type HashOutputArray = [u8; <HashSize as Unsigned>::USIZE];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HashValue(GenericArray<u8, HashSize>);
+
+impl Serializable for HashValue {
+    type Size = HashSize;
+    type DeserializationError = Infallible;
+
+    fn serialize(&self, buf: &mut GenericArray<u8, Self::Size>) {
+        buf.copy_from_slice(self.0.as_slice())
+    }
+
+    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Result<Self, Self::DeserializationError> {
+        Ok(Self(buf.to_owned()))
+    }
+}
+
+impl Message for HashValue {}
+
+struct ReplicatedValidatorFinalization<C> {
+    f: Pin<Box<dyn Future<Output = Result<(), Error>>>>,
+    ctx: C,
+}
+
+impl<C: Context + 'static> ReplicatedValidatorFinalization<C> {
+    fn new(active: ReplicatedValidatorActive<C>) -> Self {
+        let ReplicatedValidatorActive {
+            ctx,
+            left_hash,
+            right_hash,
+        } = active;
+        // Ugh: The version of sha2 we currently use doesn't use the same GenericArray version as we do.
+        let left_hash = HashValue(GenericArray::from(<HashOutputArray>::from(
+            left_hash.finalize_fixed(),
+        )));
+        let right_hash = HashValue(GenericArray::from(<HashOutputArray>::from(
+            right_hash.finalize_fixed(),
+        )));
+        let left_peer = ctx.role().peer(Direction::Left);
+        let right_peer = ctx.role().peer(Direction::Left);
+        let ctx_ref = &ctx;
+
+        let f = Box::pin(async move {
+            try_join(
+                ctx_ref
+                    .send_channel(left_peer)
+                    .send(RecordId::FIRST, left_hash.clone()),
+                ctx_ref
+                    .send_channel(right_peer)
+                    .send(RecordId::FIRST, right_hash.clone()),
+            )
+            .await?;
+            let (left_recvd, right_recvd) = try_join(
+                ctx_ref.recv_channel(left_peer).receive(RecordId::FIRST),
+                ctx_ref.recv_channel(right_peer).receive(RecordId::FIRST),
+            )
+            .await?;
+            if left_hash == left_recvd && right_hash == right_recvd {
+                Ok(())
+            } else {
+                Err(Error::Internal) // TODO add a code
+            }
+        });
+        Self { f, ctx }
+    }
+
+    fn poll(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Error>> {
+        self.f.poll_unpin(cx)
+    }
+}
+
+struct ReplicatedValidatorActive<C> {
+    ctx: C,
+    left_hash: Sha256,
+    right_hash: Sha256,
+}
+
+impl<C: Context + 'static> ReplicatedValidatorActive<C> {
+    fn new(ctx: C) -> Self {
+        Self {
+            ctx,
+            left_hash: HashFunction::new(),
+            right_hash: HashFunction::new(),
+        }
+    }
+
+    fn update<S, V>(&mut self, s: &S)
+    where
+        S: ReplicatedSecretSharing<V>,
+        V: SharedValue,
+    {
+        let mut buf = GenericArray::default(); // ::<u8, <V as Serializable>::Size>
+        s.left().serialize(&mut buf);
+        self.left_hash.update(buf.as_slice());
+        s.right().serialize(&mut buf);
+        self.right_hash.update(buf.as_slice());
+    }
+
+    fn finalize(self) -> ReplicatedValidatorFinalization<C> {
+        ReplicatedValidatorFinalization::new(self)
+    }
+}
+
+enum ReplicatedValidatorState<C> {
+    /// While the validator is waiting, it holds a context reference.
+    Pending(Option<ReplicatedValidatorActive<C>>),
+    /// After the validator has taken all of its inputs, it holds a future.
+    Finalizing(ReplicatedValidatorFinalization<C>),
+}
+
+impl<C: Context + 'static> ReplicatedValidatorState<C> {
+    /// # Panics
+    /// This panics if it is called after `finalize()`.
+    fn update<S, V>(&mut self, s: &S)
+    where
+        S: ReplicatedSecretSharing<V>,
+        V: SharedValue,
+    {
+        if let Self::Pending(Some(a)) = self {
+            a.update(s);
+        } else {
+            panic!();
+        }
+    }
+
+    fn poll(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Error>> {
+        match self {
+            Self::Pending(ref mut active) => {
+                let mut f = active.take().unwrap().finalize();
+                let res = f.poll(cx);
+                *self = ReplicatedValidatorState::Finalizing(f);
+                res
+            }
+            Self::Finalizing(f) => f.poll(cx),
+        }
+    }
+}
+
+#[pin_project]
+struct ReplicatedValidator<C, T: Stream, S, V> {
+    #[pin]
+    input: Fuse<T>,
+    state: ReplicatedValidatorState<C>,
+    _marker: PhantomData<(S, V)>,
+}
+
+impl<C: Context + 'static, T: Stream, S, V> ReplicatedValidator<C, T, S, V> {
+    pub fn new(ctx: C, s: T) -> Self {
+        Self {
+            input: s.fuse(),
+            state: ReplicatedValidatorState::Pending(Some(ReplicatedValidatorActive::new(ctx))),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C, T, S, V> Stream for ReplicatedValidator<C, T, S, V>
+where
+    C: Context + 'static,
+    T: Stream<Item = Result<S, Error>>,
+    S: ReplicatedSecretSharing<V>,
+    V: SharedValue,
+{
+    type Item = Result<S, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.input.poll_next(cx) {
+            Poll::Ready(Some(v)) => match v {
+                Ok(v) => {
+                    this.state.update(&v);
+                    Poll::Ready(Some(Ok(v)))
+                }
+                Err(e) => Poll::Ready(Some(Err(e))),
+            },
+            Poll::Ready(None) => match this.state.poll(cx) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Ok(())) => Poll::Ready(None),
+                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            },
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}

--- a/ipa-core/src/protocol/basics/validate.rs
+++ b/ipa-core/src/protocol/basics/validate.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // Not wired in yet.
+
 use std::{
     convert::Infallible,
     marker::PhantomData,
@@ -57,16 +59,18 @@ impl From<HashFunction> for HashValue {
     }
 }
 
-struct ReplicatedValidatorFinalization {
-    f: Pin<Box<(dyn Future<Output = Result<(), Error>> + Send)>>,
+/// The finalizing state for the validator.
+struct ReplicatedValidatorFinalization<'a> {
+    f: Pin<Box<(dyn Future<Output = Result<(), Error>> + Send + 'a)>>,
 }
 
-impl ReplicatedValidatorFinalization {
-    fn new<C: Context + 'static>(active: ReplicatedValidatorActive<C>) -> Self {
+impl<'a> ReplicatedValidatorFinalization<'a> {
+    fn new<C: Context + 'a>(active: ReplicatedValidatorActive<'a, C>) -> Self {
         let ReplicatedValidatorActive {
             ctx,
             left_hash,
             right_hash,
+            ..
         } = active;
         let left_hash = HashValue::from(left_hash);
         let right_hash = HashValue::from(right_hash);
@@ -89,7 +93,7 @@ impl ReplicatedValidatorFinalization {
             if left_hash == left_recvd && right_hash == right_recvd {
                 Ok(())
             } else {
-                Err(Error::Internal) // TODO add a code
+                Err(Error::InconsistentShares)
             }
         }));
         Self { f }
@@ -100,18 +104,21 @@ impl ReplicatedValidatorFinalization {
     }
 }
 
-struct ReplicatedValidatorActive<C> {
+/// The active state for the validator.
+struct ReplicatedValidatorActive<'a, C: 'a> {
     ctx: C,
     left_hash: Sha256,
     right_hash: Sha256,
+    _marker: PhantomData<&'a ()>,
 }
 
-impl<C: Context + 'static> ReplicatedValidatorActive<C> {
+impl<'a, C: Context + 'a> ReplicatedValidatorActive<'a, C> {
     fn new(ctx: C) -> Self {
         Self {
             ctx,
             left_hash: HashFunction::new(),
             right_hash: HashFunction::new(),
+            _marker: PhantomData,
         }
     }
 
@@ -127,19 +134,19 @@ impl<C: Context + 'static> ReplicatedValidatorActive<C> {
         self.right_hash.update(buf.as_slice());
     }
 
-    fn finalize(self) -> ReplicatedValidatorFinalization {
+    fn finalize(self) -> ReplicatedValidatorFinalization<'a> {
         ReplicatedValidatorFinalization::new(self)
     }
 }
 
-enum ReplicatedValidatorState<C> {
+enum ReplicatedValidatorState<'a, C: 'a> {
     /// While the validator is waiting, it holds a context reference.
-    Pending(Option<Box<ReplicatedValidatorActive<C>>>),
+    Pending(Option<Box<ReplicatedValidatorActive<'a, C>>>),
     /// After the validator has taken all of its inputs, it holds a future.
-    Finalizing(ReplicatedValidatorFinalization),
+    Finalizing(ReplicatedValidatorFinalization<'a>),
 }
 
-impl<C: Context + 'static> ReplicatedValidatorState<C> {
+impl<'a, C: Context + 'a> ReplicatedValidatorState<'a, C> {
     /// # Panics
     /// This panics if it is called after `finalize()`.
     fn update<S, V>(&mut self, s: &S)
@@ -167,29 +174,37 @@ impl<C: Context + 'static> ReplicatedValidatorState<C> {
     }
 }
 
+/// A `ReplicatedValidator` takes a stream of replicated shares of anything
+/// and produces a stream of the same values, without modifying them.
+/// The only thing it does is check that the values are consistent across
+/// all three helpers using the provided context.
+/// To do this, it sends a single message.
+///
+/// If validation passes, the stream is completely transparent.
+/// If validation fails, the stream will error before it closes.
 #[pin_project]
-struct ReplicatedValidator<C, T: Stream, S, V> {
+struct ReplicatedValidator<'a, C: 'a, T: Stream, S, V> {
     #[pin]
     input: Fuse<T>,
-    state: ReplicatedValidatorState<C>,
+    state: ReplicatedValidatorState<'a, C>,
     _marker: PhantomData<(S, V)>,
 }
 
-impl<C: Context + 'static, T: Stream, S, V> ReplicatedValidator<C, T, S, V> {
-    pub fn new(ctx: C, s: T) -> Self {
+impl<'a, C: Context + 'a, T: Stream, S, V> ReplicatedValidator<'a, C, T, S, V> {
+    pub fn new(ctx: &C, s: T) -> Self {
         Self {
             input: s.fuse(),
             state: ReplicatedValidatorState::Pending(Some(Box::new(
-                ReplicatedValidatorActive::new(ctx),
+                ReplicatedValidatorActive::new(ctx.set_total_records(1)),
             ))),
             _marker: PhantomData,
         }
     }
 }
 
-impl<C, T, S, V> Stream for ReplicatedValidator<C, T, S, V>
+impl<'a, C, T, S, V> Stream for ReplicatedValidator<'a, C, T, S, V>
 where
-    C: Context + 'static,
+    C: Context + 'a,
     T: Stream<Item = Result<S, Error>>,
     S: ReplicatedSecretSharing<V>,
     V: SharedValue,
@@ -220,7 +235,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 mod test {
     use std::iter::repeat_with;
 
@@ -228,8 +243,8 @@ mod test {
 
     use crate::{
         error::Error,
-        ff::Fp31,
-        helpers::Direction,
+        ff::{Field, Fp31},
+        helpers::{Direction, Role},
         protocol::{basics::validate::ReplicatedValidator, context::Context, RecordId},
         rand::{thread_rng, Rng},
         secret_sharing::{
@@ -256,14 +271,14 @@ mod test {
             .collect::<Vec<_>>();
         let result = world
             .semi_honest(input.into_iter(), |ctx, shares| async move {
-                let ctx = ctx.set_total_records(shares.len());
-                let s = stream_iter(shares).map(|x| Ok(x));
-                let vs = ReplicatedValidator::new(ctx.narrow("validate"), s);
+                let s = stream_iter(shares).map(Ok);
+                let vs = ReplicatedValidator::new(&ctx.narrow("validate"), s);
                 let sum = assert_stream(vs)
                     .try_fold(Fp31::ZERO, |sum, value| async move {
                         Ok(sum + value.left() - value.right())
                     })
                     .await?;
+                let ctx = ctx.set_total_records(1);
                 // This value should sum to zero now, so replicate the value.
                 // (We don't care here that this reveals our share to other helpers, it's just a test.)
                 ctx.send_channel(ctx.role().peer(Direction::Right))
@@ -280,5 +295,50 @@ mod test {
             .reconstruct();
 
         assert_eq!(Fp31::ZERO, result);
+    }
+
+    #[tokio::test]
+    pub async fn inconsistent() {
+        let mut rng = thread_rng();
+        let world = TestWorld::default();
+
+        let damage = |role| {
+            let mut tweak = role == Role::H3;
+            move |v: SemiHonestReplicated<Fp31>| -> SemiHonestReplicated<Fp31> {
+                if tweak {
+                    tweak = false;
+                    SemiHonestReplicated::new(v.left(), v.right() + Fp31::ONE)
+                } else {
+                    v
+                }
+            }
+        };
+
+        let input = repeat_with(|| rng.gen::<Fp31>())
+            .take(10)
+            .collect::<Vec<_>>();
+        let result = world
+            .semi_honest(input.into_iter(), |ctx, shares| async move {
+                let s = stream_iter(shares).map(damage(ctx.role())).map(Ok);
+                let vs = ReplicatedValidator::new(&ctx.narrow("validate"), s);
+                let sum = assert_stream(vs)
+                    .try_fold(Fp31::ZERO, |sum, value| async move {
+                        Ok(sum + value.left() - value.right())
+                    })
+                    .await?;
+                Ok(sum) // This will be not be reached by 2/3 helpers.
+            })
+            .await;
+
+        // With just one error having been introduced, two of three helpers will error out.
+        assert!(matches!(
+            result[0].as_ref().unwrap_err(),
+            Error::InconsistentShares
+        ));
+        assert!(result[1].is_ok());
+        assert!(matches!(
+            result[2].as_ref().unwrap_err(),
+            Error::InconsistentShares
+        ));
     }
 }

--- a/ipa-macros/src/parser.rs
+++ b/ipa-macros/src/parser.rs
@@ -71,7 +71,10 @@ pub(crate) fn read_steps_file(file_path: &str) -> Vec<String> {
     let mut file = std::fs::File::open(path).expect("Could not open the steps file");
     let mut contents = String::new();
     file.read_to_string(&mut contents).unwrap();
-    contents.lines().map(|s| s.to_owned()).collect::<Vec<_>>()
+    contents
+        .lines()
+        .map(std::borrow::ToOwned::to_owned)
+        .collect::<Vec<_>>()
 }
 
 /// Constructs a tree structure with nodes that contain the `Step` instances.
@@ -109,10 +112,15 @@ pub(crate) fn construct_tree(steps: Vec<StepMetaData>) -> Node<StepMetaData> {
 /// Split a single substep full path into the module path and the step's name.
 ///
 /// # Example
+/// ```ignore
 /// input = "ipa::protocol::modulus_conversion::convert_shares::Step::xor1"
 /// output = ("ipa::protocol::modulus_conversion::convert_shares::Step", "xor1")
+/// ```
 pub(crate) fn split_step_module_and_name(input: &str) -> (String, String) {
-    let mod_parts = input.split("::").map(|s| s.to_owned()).collect::<Vec<_>>();
+    let mod_parts = input
+        .split("::")
+        .map(std::borrow::ToOwned::to_owned)
+        .collect::<Vec<_>>();
     let (substep_name, path) = mod_parts.split_last().unwrap();
     (path.join("::"), substep_name.to_owned())
 }
@@ -123,8 +131,8 @@ pub(crate) fn split_step_module_and_name(input: &str) -> (String, String) {
 /// # Example
 /// Let say we have the following steps:
 ///
-/// - StepA::A1
-/// - StepC::C1/StepD::D1/StepA::A2
+/// - `StepA::A1`
+/// - `StepC::C1/StepD::D1/StepA::A2`
 ///
 /// If we generate code for each node while traversing, we will end up with the following:
 ///


### PR DESCRIPTION
This is a simple stream adapter that performs inline validation of anything that is replicated.  It will error at the end of the stream if it finds a mismatch.  (Future work might include periodic checkpoints.)

The reason I'm putting this up is that it is a great example of how our borrowed contexts are a giant pain in the posterior.  I'm starting to think that we need to think about moving to something with Arc so we can avoid this lifetime business.  It's a real drag.