### PR TITLE
Clean up GH runners for CodeCov and Sanitize actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -156,6 +156,7 @@ jobs:
       TARGET: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/rm
       - uses: dtolnay/rust-toolchain@nightly
       - name: Add Rust sources
         run: rustup component add rust-src
@@ -168,6 +169,7 @@ jobs:
       TARGET: x86_64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v3
+    - uses: ./.github/actions/rm
     - uses: dtolnay/rust-toolchain@nightly
     - name: Add Miri
       run: rustup component add miri
@@ -184,6 +186,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: ./.github/actions/rm
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
We've started getting "no space left on device" [errors](https://github.com/private-attribution/ipa/actions/runs/7777348395/job/21205786323?pr=939) for these actions