### PR TITLE
Use checkout@v4 action in CI consistently

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
@@ -78,7 +78,7 @@ jobs:
     env:
       RUSTFLAGS: -C target-cpu=native
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/rm
 
       - uses: dtolnay/rust-toolchain@stable
@@ -155,7 +155,7 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/rm
       - uses: dtolnay/rust-toolchain@nightly
       - name: Add Rust sources
@@ -168,7 +168,7 @@ jobs:
     env:
       TARGET: x86_64-unknown-linux-gnu
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ./.github/actions/rm
     - uses: dtolnay/rust-toolchain@nightly
     - name: Add Miri


### PR DESCRIPTION
checkout@v3 triggers a warning: https://github.com/private-attribution/ipa/actions/runs/7777716103