### PR TITLE
[DRAFT] Bump config dependency

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -87,7 +87,7 @@ bitvec = "1.0"
 bytes = "1.4"
 clap = { version = "4.3.2", optional = true, features = ["derive"] }
 comfy-table = { version = "7.0", optional = true }
-config = "0.13.2"
+config = "0.14"
 criterion = { version = "0.5.1", optional = true, default-features = false, features = [
     "async_tokio",
     "plotters",


### PR DESCRIPTION
This should help with https://github.com/private-attribution/ipa/actions/runs/7806487945/job/21292951289?pr=898 but I am not sure until I see the CI results

Related issue: https://github.com/tkaitchuck/aHash/issues/200

before bump:

```bash
> cargo tree -i ahash
error: There are multiple `ahash` packages in your project, and the specification `ahash` is ambiguous.
Please re-run this command with one of the following specifications:
  ahash@0.7.7
  ahash@0.8.6

> cargo tree -i ahash@0.7.7
ahash v0.7.7
└── hashbrown v0.12.3
    ├── indexmap v1.9.3
    │   └── metrics-util v0.15.1
    │       ├── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
    │       └── metrics-tracing-context v0.14.0
    │           └── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
    └── ordered-multimap v0.4.3
        └── rust-ini v0.18.0
            └── config v0.13.4
                └── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
```

after bump:

```bash
 cargo tree -i ahash      
ahash v0.8.6
├── hashbrown v0.13.2
│   ├── metrics-util v0.15.0
│   │   ├── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
│   │   └── metrics-tracing-context v0.14.0
│   │       └── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
│   └── ordered-multimap v0.6.0
│       └── rust-ini v0.19.0
│           └── config v0.14.0
│               └── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
└── metrics v0.21.1
    ├── ipa-core v0.1.0 (/Users/koshelev/workspace/rmstuff/ipa/ipa-core)
    ├── metrics-tracing-context v0.14.0 (*)
    └── metrics-util v0.15.0 (*)
```