### PR TITLE
Clean up `Field` trait

### DIFF
--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -197,22 +197,6 @@ impl FromRandomU128 for Boolean {
     }
 }
 
-impl Vectorizable<64> for Boolean {
-    type Array = crate::ff::boolean_array::BA64;
-}
-
-impl FieldVectorizable<64> for Boolean {
-    type ArrayAlias = crate::ff::boolean_array::BA64;
-}
-
-impl Vectorizable<256> for Boolean {
-    type Array = crate::ff::boolean_array::BA256;
-}
-
-impl FieldVectorizable<256> for Boolean {
-    type ArrayAlias = crate::ff::boolean_array::BA256;
-}
-
 #[cfg(all(test, unit_test))]
 mod test {
     use generic_array::GenericArray;

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -180,8 +180,6 @@ macro_rules! impl_serializable_trait {
 
         #[cfg(all(test, unit_test))]
         mod fallible_serialization_tests {
-            use rand::{thread_rng, Rng};
-
             use super::*;
 
             /// [`https://github.com/private-attribution/ipa/issues/911`]
@@ -197,8 +195,6 @@ macro_rules! impl_serializable_trait {
                     "Padding only makes sense for lengths that are not multiples of 8."
                 );
 
-                let mut rng = thread_rng();
-
                 let mut non_zero_padding = $name::ZERO.0;
                 non_zero_padding.set($bits, true);
                 assert_eq!(
@@ -212,10 +208,6 @@ macro_rules! impl_serializable_trait {
                 let mut max_value = $name::ZERO.0;
                 max_value[..$bits].fill(true);
                 deserialize(max_value).unwrap();
-
-                let mut rnd_value = $name::ZERO.0;
-                rnd_value[..$bits].fill_with(|_| rng.gen());
-                deserialize(rnd_value).unwrap();
             }
         }
     };

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -1,5 +1,5 @@
 use bitvec::{
-    prelude::{bitarr, BitArr, Lsb0},
+    prelude::{BitArr, Lsb0},
     slice::Iter,
 };
 use generic_array::GenericArray;
@@ -9,7 +9,7 @@ use crate::{
     error::LengthError,
     ff::{boolean::Boolean, ArrayAccess, ArrayBuilder, Field, Serializable, U128Conversions},
     protocol::prss::{FromRandom, FromRandomU128},
-    secret_sharing::{Block, FieldVectorizable, SharedValue, StdArray, Vectorizable},
+    secret_sharing::{Block, SharedValue, StdArray, Vectorizable},
 };
 
 /// The implementation below cannot be constrained without breaking Rust's
@@ -78,63 +78,10 @@ where
     }
 }
 
-/// A value of ONE has a one in the first element of the bit array, followed by `$bits-1` zeros.
-/// This macro uses a bit of recursive repetition to produce those zeros.
-///
-/// The longest call is 8 bits, which involves `2(n+1)` macro expansions in addition to `bitarr!`.
-macro_rules! bitarr_one {
-
-    // The binary value of `$bits-1` is expanded in MSB order for each of the values we care about.
-    // e.g., 20 =(-1)=> 19 =(binary)=> 0b10011 =(expand)=> 1 0 0 1 1
-
-    (2) => { bitarr_one!(1) };
-    (3) => { bitarr_one!(1 0) };
-    (4) => { bitarr_one!(1 1) };
-    (5) => { bitarr_one!(1 0 0) };
-    (6) => { bitarr_one!(1 0 1) };
-    (7) => { bitarr_one!(1 1 0) };
-    (8) => { bitarr_one!(1 1 1) };
-    (20) => { bitarr_one!(1 0 0 1 1) };
-    (32) => { bitarr_one!(1 1 1 1 1) };
-    (64) => { bitarr_one!(1 1 1 1 1 1) };
-    (112) => { bitarr_one!(1 1 0 1 1 1 1) };
-    (256) => { bitarr_one!(1 1 1 1 1 1 1 1) };
-
-    // Incrementally convert 1 or 0 into `[0,]` or `[]` as needed for the recursion step.
-    // This also reverses the bit order so that the MSB comes last, as needed for recursion.
-
-    // This passes a value back once the conversion is done.
-    ($([$($x:tt)*])*) => { bitarr_one!(@r $([$($x)*])*) };
-    // This converts one 1 into `[0,]`.
-    ($([$($x:tt)*])* 1 $($y:tt)*) => { bitarr_one!([0,] $([$($x)*])* $($y)*) };
-    // This converts one 0 into `[]`.
-    ($([$($x:tt)*])* 0 $($y:tt)*) => { bitarr_one!([] $([$($x)*])* $($y)*) };
-
-    // Recursion step.
-
-    // This is where recursion ends with a `BitArray`.
-    (@r [$($x:tt)*]) => { bitarr![const u8, Lsb0; 1, $($x)*] };
-    // This is the recursion workhorse.  It takes a list of lists.  The outer lists are bracketed.
-    // The inner lists contain any form that can be repeated and concatenated, which probably
-    // means comma-separated values with a trailing comma.
-    // The first value is repeated once.
-    // The second value is repeated twice and merged into the first value.
-    // The third and subsequent values are repeated twice and shifted along one place.
-    // One-valued bits are represented as `[0,]`, zero-valued bits as `[]`.
-    (@r [$($x:tt)*] [$($y:tt)*] $([$($z:tt)*])*) => { bitarr_one!(@r [$($x)* $($y)* $($y)*] $([$($z)* $($z)*])*) };
-}
-
 // Macro for boolean arrays <= 128 bits.
 macro_rules! boolean_array_impl_small {
     ($modname:ident, $name:ident, $bits:tt, $deser_type:tt) => {
         boolean_array_impl!($modname, $name, $bits, $deser_type);
-
-        // TODO(812): remove this impl; BAs are not field elements.
-        impl Field for $name {
-            const NAME: &'static str = stringify!($name);
-
-            const ONE: Self = Self(bitarr_one!($bits));
-        }
 
         impl U128Conversions for $name {
             fn truncate_from<T: Into<u128>>(v: T) -> Self {
@@ -193,10 +140,6 @@ macro_rules! boolean_array_impl_small {
                 Self::truncate_from(src)
             }
         }
-
-        impl FieldVectorizable<1> for $name {
-            type ArrayAlias = StdArray<$name, 1>;
-        }
     };
 }
 
@@ -237,6 +180,8 @@ macro_rules! impl_serializable_trait {
 
         #[cfg(all(test, unit_test))]
         mod fallible_serialization_tests {
+            use rand::{thread_rng, Rng};
+
             use super::*;
 
             /// [`https://github.com/private-attribution/ipa/issues/911`]
@@ -252,6 +197,8 @@ macro_rules! impl_serializable_trait {
                     "Padding only makes sense for lengths that are not multiples of 8."
                 );
 
+                let mut rng = thread_rng();
+
                 let mut non_zero_padding = $name::ZERO.0;
                 non_zero_padding.set($bits, true);
                 assert_eq!(
@@ -262,12 +209,13 @@ macro_rules! impl_serializable_trait {
                 let min_value = $name::ZERO.0;
                 deserialize(min_value).unwrap();
 
-                let one = $name::ONE.0;
-                deserialize(one).unwrap();
-
                 let mut max_value = $name::ZERO.0;
                 max_value[..$bits].fill(true);
                 deserialize(max_value).unwrap();
+
+                let mut rnd_value = $name::ZERO.0;
+                rnd_value[..$bits].fill_with(|_| rng.gen());
+                deserialize(rnd_value).unwrap();
             }
         }
     };

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -2,14 +2,12 @@ use std::convert::Infallible;
 
 use curve25519_dalek::scalar::Scalar;
 use generic_array::GenericArray;
-use hkdf::Hkdf;
-use sha2::Sha256;
-use typenum::U32;
+use typenum::{U2, U32};
 
 use crate::{
-    ff::{boolean_array::BA256, Field, Serializable, U128Conversions},
+    ff::{boolean_array::BA256, Field, Serializable},
     impl_shared_value_common,
-    protocol::prss::FromRandomU128,
+    protocol::prss::FromRandom,
     secret_sharing::{Block, FieldVectorizable, SharedValue, StdArray, Vectorizable},
 };
 
@@ -193,43 +191,17 @@ impl Field for Fp25519 {
     const ONE: Fp25519 = Fp25519::ONE;
 }
 
-// TODO(812): remove these impls
-impl U128Conversions for Fp25519 {
-    ///both following methods are based on hashing and do not allow to actually convert elements in Fp25519
-    /// from or into u128. However it is sufficient to generate random elements in Fp25519
-    fn as_u128(&self) -> u128 {
-        unimplemented!()
-    }
+impl FromRandom for Fp25519 {
+    type SourceLength = U2;
 
-    ///PRSS uses `truncate_from function`, we need to expand the u128 using a PRG (Sha256) to a [u8;32]
-    fn truncate_from<T: Into<u128>>(_v: T) -> Self {
-        unimplemented!()
+    fn from_random(src: GenericArray<u128, Self::SourceLength>) -> Self {
+        let mut src_bytes = [0u8; 32];
+        src_bytes[0..16].copy_from_slice(&src[0].to_le_bytes());
+        src_bytes[16..32].copy_from_slice(&src[1].to_le_bytes());
+        // Reduces mod order
+        Fp25519::deserialize_infallible(<&GenericArray<u8, U32>>::from(&src_bytes))
     }
 }
-
-impl FromRandomU128 for Fp25519 {
-    fn from_random_u128(v: u128) -> Self {
-        let hk = Hkdf::<Sha256>::new(None, &v.to_le_bytes());
-        let mut okm = [0u8; 32];
-        //error invalid length from expand only happens when okm is very large
-        hk.expand(&[], &mut okm).unwrap();
-        Fp25519::deserialize_infallible(&okm.into())
-    }
-}
-
-///implement `TryFrom` since required by Field
-impl TryFrom<u128> for Fp25519 {
-    type Error = crate::error::Error;
-
-    fn try_from(v: u128) -> Result<Self, Self::Error> {
-        let mut bits = [0u8; 32];
-        bits[..].copy_from_slice(&v.to_le_bytes());
-        let f: Fp25519 = Fp25519::ONE;
-        f.serialize((&mut bits).into());
-        Ok(f)
-    }
-}
-// TODO(812): end remove impls
 
 #[cfg(all(test, unit_test))]
 mod test {

--- a/ipa-core/src/ff/field.rs
+++ b/ipa-core/src/ff/field.rs
@@ -6,8 +6,7 @@ use std::{
 use typenum::{U1, U4};
 
 use crate::{
-    error,
-    protocol::prss::FromRandomU128,
+    protocol::prss::FromRandom,
     secret_sharing::{Block, FieldVectorizable, SharedValue, Vectorizable},
 };
 
@@ -26,8 +25,7 @@ pub trait Field:
     SharedValue
     + Mul<Self, Output = Self>
     + MulAssign<Self>
-    + FromRandomU128
-    + TryFrom<u128, Error = error::Error>
+    + FromRandom
     + Into<Self::Storage>
     + Vectorizable<1>
     + FieldVectorizable<1, ArrayAlias = <Self as Vectorizable<1>>::Array>

--- a/ipa-core/src/protocol/basics/check_zero.rs
+++ b/ipa-core/src/protocol/basics/check_zero.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::{
         basics::{reveal::Reveal, SecureMul},
         context::Context,
-        prss::SharedRandomness,
+        prss::{FromRandom, SharedRandomness},
         RecordId,
     },
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
@@ -47,7 +47,7 @@ pub(crate) enum Step {
 /// ## Errors
 /// Lots of things may go wrong here, from timeouts to bad output. They will be signalled
 /// back via the error response
-pub async fn check_zero<C: Context, F: Field>(
+pub async fn check_zero<C: Context, F: Field + FromRandom>(
     ctx: C,
     record_id: RecordId,
     v: &Replicated<F>,

--- a/ipa-core/src/protocol/basics/if_else.rs
+++ b/ipa-core/src/protocol/basics/if_else.rs
@@ -2,7 +2,10 @@ use crate::{
     error::Error,
     ff::{boolean::Boolean, Field},
     protocol::{
-        basics::{mul::BooleanArrayMul, SecureMul},
+        basics::{
+            mul::{boolean_array_multiply, BooleanArrayMul},
+            SecureMul,
+        },
         context::Context,
         RecordId,
     },
@@ -84,7 +87,9 @@ where
     //     false_value + condition * (true_value - false_value)
     //   = false_value + 0
     //   = false_value
-    let product = B::multiply(ctx, record_id, &condition, &(true_value - &false_value)).await?;
+    let product =
+        boolean_array_multiply::<_, B>(ctx, record_id, &condition, &(true_value - &false_value))
+            .await?;
 
     Ok((false_value + &product).into())
 }

--- a/ipa-core/src/protocol/basics/if_else.rs
+++ b/ipa-core/src/protocol/basics/if_else.rs
@@ -75,9 +75,9 @@ where
     C: Context,
     B: Clone + BooleanArrayMul,
 {
-    let false_value = false_value.clone().into();
-    let true_value = true_value.clone().into();
-    let condition = B::expand(condition).into();
+    let false_value = B::Vectorized::from(false_value.clone());
+    let true_value = B::Vectorized::from(true_value.clone());
+    let condition = B::Vectorized::from(B::expand(condition));
     // If `condition` is a share of 1 (true), then
     //     false_value + condition * (true_value - false_value)
     //   = false_value + true_value - false_value

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -10,8 +10,8 @@ pub mod sum_of_product;
 
 #[cfg(feature = "descriptive-gate")]
 pub use check_zero::check_zero;
-pub use if_else::if_else;
-pub use mul::{MultiplyZeroPositions, SecureMul, ZeroPositions};
+pub use if_else::{if_else, select};
+pub use mul::{BooleanArrayMul, MultiplyZeroPositions, SecureMul, ZeroPositions};
 pub use reshare::Reshare;
 pub use reveal::Reveal;
 pub use share_known_value::ShareKnownValue;

--- a/ipa-core/src/protocol/basics/mul/mod.rs
+++ b/ipa-core/src/protocol/basics/mul/mod.rs
@@ -58,13 +58,12 @@ use semi_honest::multiply as semi_honest_mul;
 // breakdown key type BK is BA8) can invoke vectorized multiply. Without this trait, those
 // implementations would need to specify the `N` const parameter, which is tricky, because you
 // can't supply an expression involving a type parameter (BK::BITS) as a const parameter.
-pub trait BooleanArrayMul:
-    Expand<Input = Replicated<Boolean>> + From<Self::Vectorized> + Into<Self::Vectorized>
-{
-    type Vectorized: Send
-        + Sync
+pub trait BooleanArrayMul: Expand<Input = Replicated<Boolean>> + From<Self::Vectorized> {
+    type Vectorized: From<Self>
         + for<'a> Add<&'a Self::Vectorized, Output = Self::Vectorized>
         + for<'a> Sub<&'a Self::Vectorized, Output = Self::Vectorized>
+        + Send
+        + Sync
         + 'static;
 
     fn multiply<'fut, C>(

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -1,6 +1,8 @@
 #[cfg(all(test, unit_test))]
 use ipa_macros::Step;
 
+#[cfg(all(test, unit_test))]
+use crate::secret_sharing::{FieldSimd, FieldVectorizable};
 use crate::{
     error::Error,
     ff::{ArrayAccess, CustomArray, Field},
@@ -46,19 +48,20 @@ where
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn integer_sat_add<C, S>(
+pub async fn integer_sat_add<F, C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     x: &AdditiveShare<S>,
     y: &AdditiveShare<S>,
 ) -> Result<AdditiveShare<S>, Error>
 where
+    F: Field + FieldSimd<N> + FieldVectorizable<N, ArrayAlias = S>,
     C: Context,
-    S: CustomArray + Field,
-    S::Element: Field,
+    S: SharedValue + CustomArray<Element = F>,
+    AdditiveShare<S>: From<AdditiveShare<F, N>> + Into<AdditiveShare<F, N>>,
 {
     use crate::{ff::Expand, protocol::basics::if_else};
-    let mut carry = AdditiveShare::<S::Element>::ZERO;
+    let mut carry = AdditiveShare::<F>::ZERO;
     let result = addition_circuit(
         ctx.narrow(&Step::SaturatedAddition),
         record_id,
@@ -66,10 +69,11 @@ where
         y,
         &mut carry,
     )
-    .await?;
+    .await?
+    .into();
 
     // expand carry bit to array
-    let carry_array = AdditiveShare::<S>::expand(&carry);
+    let carry_array = AdditiveShare::<S>::expand(&carry).into();
 
     // if carry_array==1 then {carry_array} else {result}:
     if_else(
@@ -80,6 +84,7 @@ where
         &result,
     )
     .await
+    .map(Into::into)
 }
 
 /// addition using bit adder
@@ -237,7 +242,7 @@ mod test {
 
             let result = world
                 .semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
-                    integer_sat_add::<_, BA64>(
+                    integer_sat_add::<_, _, _, 64>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y.0,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -9,6 +9,8 @@ use std::{borrow::Borrow, iter::repeat, ops::Not};
 #[cfg(all(test, unit_test))]
 use ipa_macros::Step;
 
+#[cfg(all(test, unit_test))]
+use crate::secret_sharing::FieldVectorizable;
 use crate::{
     error::Error,
     ff::{ArrayAccessRef, ArrayBuild, ArrayBuilder, Field},
@@ -113,22 +115,22 @@ where
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn integer_sat_sub<C, S>(
+pub async fn integer_sat_sub<F, C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     x: &AdditiveShare<S>,
     y: &AdditiveShare<S>,
 ) -> Result<AdditiveShare<S>, Error>
 where
+    F: Field + FieldSimd<N> + FieldVectorizable<N, ArrayAlias = S>,
     C: Context,
-    S::Element: Field,
-    S: SharedValue + CustomArray + Expand<Input = S::Element>,
-    AdditiveShare<S>: SecureMul<C>
-        + ArrayAccessRef<Element = AdditiveShare<S::Element>>
-        + ArrayBuild<Input = AdditiveShare<S::Element>>,
-    AdditiveShare<S::Element>: SecureMul<C> + Not<Output = AdditiveShare<S::Element>>,
+    S: SharedValue + CustomArray<Element = F>,
+    AdditiveShare<S>:
+        ArrayAccessRef<Element = AdditiveShare<F>> + ArrayBuild<Input = AdditiveShare<F>>,
+    AdditiveShare<F>: SecureMul<C> + Not<Output = AdditiveShare<F>>,
+    AdditiveShare<S>: From<AdditiveShare<F, N>> + Into<AdditiveShare<F, N>>,
 {
-    let mut carry = AdditiveShare::<S::Element>::share_known_value(&ctx, S::Element::ONE);
+    let mut carry = AdditiveShare::<F>::share_known_value(&ctx, F::ONE);
     let result = subtraction_circuit(
         ctx.narrow(&Step::SaturatedSubtraction),
         record_id,
@@ -136,14 +138,17 @@ where
         y,
         &mut carry,
     )
-    .await?;
+    .await?
+    .into();
 
     // carry computes carry=(x>=y)
     // if carry==0 {all 0 array, i.e. Array[carry]} else {result}:
     // compute (1-carry)*Array[carry]+carry*result =carry*result
     AdditiveShare::<S>::expand(&carry)
+        .into()
         .multiply(&result, ctx.narrow(&Step::MultiplyWithCarry), record_id)
         .await
+        .map(Into::into)
 }
 
 /// subtraction using bit subtractor
@@ -569,7 +574,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    integer_sat_sub::<_, BA64>(
+                    integer_sat_sub::<_, _, _, 64>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Error,
     ff::{
         boolean::Boolean, boolean_array::BA256, ec_prime_field::Fp25519, ArrayAccess, CustomArray,
-        Expand, Field,
+        Expand,
     },
     helpers::Role,
     protocol::{
@@ -99,7 +99,7 @@ pub async fn convert_to_fp25519<C, B>(
 ) -> Result<AdditiveShare<Fp25519>, Error>
 where
     C: Context,
-    B: SharedValue + CustomArray<Element = Boolean> + Field,
+    B: SharedValue + CustomArray<Element = Boolean>,
 {
     // generate sh_r = (0, 0, sh_r) and sh_s = (sh_s, 0, 0)
     // the two highest bits are set to 0 to allow carries for two additions

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -8,10 +8,11 @@ use self::{quicksort::quicksort_ranges_by_key_insecure, shuffle::shuffle_inputs}
 use crate::{
     error::{Error, UnwrapInfallible},
     ff::{
-        boolean::Boolean, boolean_array::BA64, CustomArray, Field, PrimeField, Serializable,
+        boolean::Boolean, boolean_array::BA64, CustomArray, PrimeField, Serializable,
         U128Conversions,
     },
     protocol::{
+        basics::BooleanArrayMul,
         context::{UpgradableContext, UpgradedContext},
         ipa_prf::{
             boolean_ops::convert_to_fp25519,
@@ -171,10 +172,13 @@ where
     C: UpgradableContext,
     C::UpgradedContext<Boolean>: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
     C::UpgradedContext<F>: UpgradedContext<F, Share = Replicated<F>>,
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<BK>: BooleanArrayMul,
+    Replicated<TS>: BooleanArrayMul,
+    Replicated<TV>: BooleanArrayMul,
     F: PrimeField + ExtendableField,
     Replicated<F>: Serializable,
 {
@@ -212,9 +216,9 @@ where
     C: UpgradableContext,
     C::UpgradedContext<Boolean>: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
     C::UpgradedContext<F>: UpgradedContext<F, Share = Replicated<F>>,
-    BK: SharedValue + CustomArray<Element = Boolean> + Field,
-    TV: SharedValue + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + CustomArray<Element = Boolean>,
+    TV: SharedValue + CustomArray<Element = Boolean>,
+    TS: SharedValue + CustomArray<Element = Boolean>,
     F: PrimeField + ExtendableField,
     Replicated<F>: Serializable,
 {

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -6,9 +6,9 @@ use ipa_macros::Step;
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, CustomArray, Expand, Field, PrimeField, Serializable},
+    ff::{boolean::Boolean, CustomArray, Field, PrimeField, Serializable},
     protocol::{
-        basics::{if_else, SecureMul, ShareKnownValue},
+        basics::{select, BooleanArrayMul, SecureMul, ShareKnownValue},
         boolean::or::or,
         context::{Context, UpgradableContext, UpgradedContext, Validator},
         modulus_conversion::convert_bits,
@@ -57,7 +57,8 @@ impl InputsRequiredFromPrevRow {
     ) -> Result<Replicated<FV>, Error>
     where
         C: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
-        FV: CustomArray<Element = Boolean> + Field,
+        FV: SharedValue + CustomArray<Element = Boolean>,
+        Replicated<FV>: BooleanArrayMul,
     {
         let share_of_one = Replicated::share_known_value(&ctx, Boolean::ONE);
         let is_source_event = &share_of_one - &input_row.is_trigger_bit;
@@ -92,11 +93,10 @@ impl InputsRequiredFromPrevRow {
         )
         .await?;
 
-        let capped_label_vector = Replicated::<FV>::expand(&capped_label);
-        let capped_attributed_feature_vector = if_else(
+        let capped_attributed_feature_vector = select(
             ctx.narrow(&Step::ComputedCappedFeatureVector),
             record_id,
-            &capped_label_vector,
+            &capped_label,
             &input_row.feature_vector,
             &Replicated::<FV>::ZERO,
         )
@@ -223,7 +223,8 @@ where
     C::UpgradedContext<Boolean>: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
     C::UpgradedContext<F>: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + Serializable + SecureMul<C::UpgradedContext<F>>,
-    FV: CustomArray<Element = Boolean> + Field,
+    FV: SharedValue + CustomArray<Element = Boolean>,
+    Replicated<FV>: BooleanArrayMul,
     F: PrimeField + ExtendableField,
 {
     assert!(<FV as SharedValue>::BITS > 0);
@@ -300,7 +301,8 @@ async fn evaluate_per_user_attribution_circuit<C, FV>(
 ) -> Result<Vec<Replicated<FV>>, Error>
 where
     C: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
-    FV: CustomArray<Element = Boolean> + Field,
+    FV: SharedValue + CustomArray<Element = Boolean>,
+    Replicated<FV>: BooleanArrayMul,
 {
     assert!(!rows_for_user.is_empty());
     if rows_for_user.len() == 1 {

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     helpers::Role,
     protocol::{
-        basics::{if_else, SecureMul, ShareKnownValue},
+        basics::{select, BooleanArrayMul, SecureMul, ShareKnownValue},
         boolean::or::or,
         context::{Context, UpgradableContext, UpgradedContext, Validator},
         ipa_prf::boolean_ops::{
@@ -102,10 +102,13 @@ struct InputsRequiredFromPrevRow<BK: SharedValue, TV: SharedValue, TS: SharedVal
 
 impl<BK, TV, TS, SS> InputsRequiredFromPrevRow<BK, TV, TS, SS>
 where
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<BK>: BooleanArrayMul,
+    Replicated<TS>: BooleanArrayMul,
+    Replicated<TV>: BooleanArrayMul,
 {
     ///
     /// This function contains the main logic for the per-user attribution circuit.
@@ -466,10 +469,13 @@ where
     C::UpgradedContext<Boolean>: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
     C::UpgradedContext<F>: UpgradedContext<F, Share = S>,
     S: LinearSecretSharing<F> + Serializable + SecureMul<C::UpgradedContext<F>>,
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<BK>: BooleanArrayMul,
+    Replicated<TS>: BooleanArrayMul,
+    Replicated<TV>: BooleanArrayMul,
     F: PrimeField + ExtendableField,
 {
     // Get the validator and context to use for Boolean multiplication operations
@@ -572,10 +578,13 @@ async fn evaluate_per_user_attribution_circuit<C, BK, TV, TS, SS>(
 ) -> Result<Vec<CappedAttributionOutputs<BK, TV>>, Error>
 where
     C: Context,
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<BK>: BooleanArrayMul,
+    Replicated<TS>: BooleanArrayMul,
+    Replicated<TV>: BooleanArrayMul,
 {
     assert!(!rows_for_user.is_empty());
     if rows_for_user.len() == 1 {
@@ -644,14 +653,13 @@ async fn breakdown_key_of_most_recent_source_event<C, BK>(
 ) -> Result<Replicated<BK>, Error>
 where
     C: Context,
-    BK: SharedValue + CustomArray<Element = Boolean> + Field,
+    BK: SharedValue + CustomArray<Element = Boolean>,
+    Replicated<BK>: BooleanArrayMul,
 {
-    let is_trigger_bit_array = Replicated::<BK>::expand(is_trigger_bit);
-
-    if_else(
+    select(
         ctx,
         record_id,
-        &is_trigger_bit_array,
+        is_trigger_bit,
         prev_row_breakdown_key_bits,
         cur_row_breakdown_key_bits,
     )
@@ -670,17 +678,16 @@ async fn timestamp_of_most_recent_source_event<C, TS>(
 ) -> Result<Replicated<TS>, Error>
 where
     C: Context,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<TS>: BooleanArrayMul,
 {
     match attribution_window_seconds {
         None => Ok(prev_row_timestamp_bits.clone()),
         Some(_) => {
-            let is_trigger_bit_array = Replicated::<TS>::expand(is_trigger_bit);
-
-            if_else(
+            select(
                 ctx,
                 record_id,
-                &is_trigger_bit_array,
+                is_trigger_bit,
                 prev_row_timestamp_bits,
                 cur_row_timestamp_bits,
             )
@@ -711,8 +718,9 @@ async fn zero_out_trigger_value_unless_attributed<C, TV, TS>(
 ) -> Result<Replicated<TV>, Error>
 where
     C: Context,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<TV>: BooleanArrayMul,
 {
     let (did_trigger_get_attributed, is_trigger_within_window) = try_join(
         is_trigger_bit.multiply(
@@ -740,12 +748,10 @@ where
         did_trigger_get_attributed.clone()
     };
 
-    let zero_out_flag_array = Replicated::<TV>::expand(&zero_out_flag);
-
-    if_else(
+    select(
         ctx,
         record_id,
-        &zero_out_flag_array,
+        &zero_out_flag,
         trigger_value,
         &Replicated::<TV>::ZERO,
     )
@@ -765,7 +771,7 @@ async fn is_trigger_event_within_attribution_window<C, TS>(
 ) -> Result<Replicated<Boolean>, Error>
 where
     C: Context,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         let time_delta_bits = integer_sub(
@@ -821,29 +827,25 @@ async fn compute_capped_trigger_value<C, TV>(
 ) -> Result<Replicated<TV>, Error>
 where
     C: Context,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    Replicated<TV>: BooleanArrayMul,
 {
     let narrowed_ctx1 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueNotSaturatedCase);
     let narrowed_ctx2 = ctx.narrow(&Step::ComputedCappedAttributedTriggerValueJustSaturatedCase);
 
-    let is_saturated_array = Replicated::<TV>::expand(is_saturated);
-
-    let is_saturated_and_prev_row_not_saturated_array =
-        Replicated::<TV>::expand(is_saturated_and_prev_row_not_saturated);
-
-    let attributed_trigger_value_or_zero = if_else(
+    let attributed_trigger_value_or_zero = select(
         narrowed_ctx1,
         record_id,
-        &is_saturated_array,
+        is_saturated,
         &Replicated::new(<TV as SharedValue>::ZERO, <TV as SharedValue>::ZERO),
         attributed_trigger_value,
     )
     .await?;
 
-    if_else(
+    select(
         narrowed_ctx2,
         record_id,
-        &is_saturated_and_prev_row_not_saturated_array,
+        is_saturated_and_prev_row_not_saturated,
         prev_row_diff_to_cap,
         &attributed_trigger_value_or_zero,
     )
@@ -885,7 +887,7 @@ pub mod tests {
         trigger_value: u8,
     ) -> PreShardedAndSortedOPRFTestInput<BK, BA3, BA20>
     where
-        BK: SharedValue + U128Conversions + Field,
+        BK: SharedValue + U128Conversions,
     {
         oprf_test_input_with_timestamp(
             prf_of_match_key,
@@ -904,7 +906,7 @@ pub mod tests {
         timestamp: u32,
     ) -> PreShardedAndSortedOPRFTestInput<BK, BA3, BA20>
     where
-        BK: SharedValue + U128Conversions + Field,
+        BK: SharedValue + U128Conversions,
     {
         let is_trigger_bit = if is_trigger {
             Boolean::ONE
@@ -981,8 +983,8 @@ pub mod tests {
     impl<BK, TV> Reconstruct<PreAggregationTestOutputInDecimal>
         for [&CappedAttributionOutputs<BK, TV>; 3]
     where
-        BK: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
-        TV: SharedValue + U128Conversions + CustomArray<Element = Boolean> + Field,
+        BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+        TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     {
         fn reconstruct(&self) -> PreAggregationTestOutputInDecimal {
             let [s0, s1, s2] = self;

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -155,7 +155,10 @@ where
 
 #[cfg(all(test, unit_test))]
 pub mod tests {
-    use std::cmp::Ordering;
+    use std::{
+        cmp::Ordering,
+        iter::{repeat, repeat_with},
+    };
 
     use ipa_macros::Step;
     use rand::Rng;
@@ -163,7 +166,7 @@ pub mod tests {
     use crate::{
         ff::{
             boolean_array::{BA20, BA64},
-            Field, U128Conversions,
+            U128Conversions,
         },
         protocol::{context::Context, ipa_prf::quicksort::quicksort_ranges_by_key_insecure},
         rand::thread_rng,
@@ -188,8 +191,7 @@ pub mod tests {
 
             for desc in bools {
                 // generate vector of random values
-                let mut records: Vec<BA64> = vec![<BA64>::ONE; 20];
-                records.iter_mut().for_each(|x| *x = rng.gen::<BA64>());
+                let records: Vec<BA64> = repeat_with(|| rng.gen()).take(20).collect();
 
                 // convert expected into more readable format
                 let mut expected: Vec<u128> =
@@ -236,10 +238,8 @@ pub mod tests {
             let bools = vec![false, true];
 
             for desc in bools {
-                // generate vector of random values
-                let element = rng.gen::<BA64>();
-                let mut records: Vec<BA64> = vec![<BA64>::ONE; 20];
-                records.iter_mut().for_each(|x| *x = element);
+                // generate vector of 20 copies of same random value
+                let records: Vec<BA64> = repeat(rng.gen()).take(20).collect();
 
                 // convert expected into more readable format
                 let mut expected: Vec<u128> =
@@ -334,8 +334,7 @@ pub mod tests {
 
             for desc in bools {
                 // generate vector of random values
-                let mut records: Vec<BA64> = vec![<BA64>::ONE; 20];
-                records.iter_mut().for_each(|x| *x = rng.gen::<BA64>());
+                let records: Vec<BA64> = repeat_with(|| rng.gen()).take(20).collect();
 
                 // convert expected into more readable format
                 let mut expected: Vec<u128> =

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -140,7 +140,7 @@ pub trait SharedRandomness {
     // Equivalent functionality could be obtained by defining an `Unreplicated<F>` type that
     // implements `FromPrss`.
     #[must_use]
-    fn zero<V: SharedValue + FromRandomU128, I: Into<PrssIndex>>(&self, index: I) -> V {
+    fn zero<V: SharedValue + FromRandom, I: Into<PrssIndex>>(&self, index: I) -> V {
         let (l, r): (V, V) = self.generate(index);
         l - r
     }

--- a/ipa-core/src/secret_sharing/array.rs
+++ b/ipa-core/src/secret_sharing/array.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use generic_array::{ArrayLength, GenericArray};
-use typenum::{U1, U32};
+use typenum::U32;
 
 use crate::{
     error::LengthError,
@@ -270,9 +270,9 @@ impl<V: SharedValue + Not<Output = V>, const N: usize> Not for StdArray<V, N> {
     }
 }
 
-impl<F: SharedValue + FromRandom<SourceLength = U1>> FromRandom for StdArray<F, 1> {
-    type SourceLength = U1;
-    fn from_random(src: GenericArray<u128, U1>) -> Self {
+impl<F: SharedValue + FromRandom> FromRandom for StdArray<F, 1> {
+    type SourceLength = <F as FromRandom>::SourceLength;
+    fn from_random(src: GenericArray<u128, Self::SourceLength>) -> Self {
         Self([F::from_random(src)])
     }
 }

--- a/ipa-core/src/test_fixture/input/sharing.rs
+++ b/ipa-core/src/test_fixture/input/sharing.rs
@@ -1,7 +1,7 @@
 use std::iter::{repeat, zip};
 
 use crate::{
-    ff::{boolean::Boolean, boolean_array::BA64, Field, U128Conversions},
+    ff::{boolean::Boolean, boolean_array::BA64, U128Conversions},
     protocol::ipa_prf::OPRFIPAInputRow,
     rand::Rng,
     report::{EventType, OprfReport},
@@ -67,9 +67,9 @@ where
 
 impl<BK, TV, TS> IntoShares<OPRFIPAInputRow<BK, TV, TS>> for TestRawDataRecord
 where
-    BK: SharedValue + Field + IntoShares<Replicated<BK>>,
-    TV: SharedValue + Field + IntoShares<Replicated<TV>>,
-    TS: SharedValue + Field + IntoShares<Replicated<TS>>,
+    BK: SharedValue + U128Conversions + IntoShares<Replicated<BK>>,
+    TV: SharedValue + U128Conversions + IntoShares<Replicated<TV>>,
+    TS: SharedValue + U128Conversions + IntoShares<Replicated<TS>>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [OPRFIPAInputRow<BK, TV, TS>; 3] {
         let is_trigger = Replicated::new(


### PR DESCRIPTION
* Remove `Field` trait impl from Boolean arrays.
* Remove u128 conversions from `Fp25519`.
* Add `select` variant of `if_else`. `select` is bus multiplexer with a single-bit control input. `if_else` is a vectorizable multiplexer, with condition input the same width as the data inputs.
* Remove `Field` (or replace with `SharedValue`) in various trait bounds.
* Implement `Vectorizable` and related traits for more boolean arrays.
