### PR TITLE
Vectorized reveal

### DIFF
--- a/ipa-core/src/protocol/basics/check_zero.rs
+++ b/ipa-core/src/protocol/basics/check_zero.rs
@@ -57,9 +57,11 @@ pub async fn check_zero<C: Context, F: Field + FromRandom>(
     let rv_share = r_sharing
         .multiply(v, ctx.narrow(&Step::MultiplyWithR), record_id)
         .await?;
-    let rv = rv_share
-        .reveal(ctx.narrow(&Step::RevealR), record_id)
-        .await?;
+    let rv = F::from_array(
+        &rv_share
+            .reveal(ctx.narrow(&Step::RevealR), record_id)
+            .await?,
+    );
 
     Ok(rv == F::ZERO)
 }

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -20,7 +20,9 @@ pub use sum_of_product::SumOfProducts;
 use crate::{
     ff::Field,
     protocol::{context::Context, RecordId},
-    secret_sharing::{replicated::semi_honest::AdditiveShare, SecretSharing, SharedValue},
+    secret_sharing::{
+        replicated::semi_honest::AdditiveShare, SecretSharing, SharedValue, Vectorizable,
+    },
 };
 #[cfg(feature = "descriptive-gate")]
 use crate::{
@@ -30,10 +32,10 @@ use crate::{
     },
 };
 
-pub trait BasicProtocols<C: Context, V: SharedValue>:
+pub trait BasicProtocols<C: Context, V: SharedValue + Vectorizable<N>, const N: usize = 1>:
     SecretSharing<V>
     + Reshare<C, RecordId>
-    + Reveal<C, RecordId, Output = V>
+    + Reveal<C, N, Output = <V as Vectorizable<N>>::Array>
     + SecureMul<C>
     + ShareKnownValue<C, V>
     + SumOfProducts<C>

--- a/ipa-core/src/protocol/boolean/comparison.rs
+++ b/ipa-core/src/protocol/boolean/comparison.rs
@@ -82,9 +82,11 @@ where
     let r = rbg.generate(record_id).await?;
 
     // Mask `a` with random `r` and reveal.
-    let b = (r.b_p + a)
-        .reveal(ctx.narrow(&Step::Reveal), record_id)
-        .await?;
+    let b = F::from_array(
+        &(r.b_p + a)
+            .reveal(ctx.narrow(&Step::Reveal), record_id)
+            .await?,
+    );
 
     let RBounds { r_lo, r_hi, invert } = compute_r_bounds(b.as_u128(), c, F::PRIME.into());
 

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -27,6 +27,7 @@ use crate::{
     protocol::basics::Reveal,
     protocol::context::Context,
     protocol::context::{MaliciousContext, UpgradedMaliciousContext},
+    secret_sharing::SharedValue,
     sync::Arc,
 };
 
@@ -229,7 +230,9 @@ impl<'a, F: ExtendableField> Validator<MaliciousContext<'a>, F> for Malicious<'a
             .validate_ctx
             .narrow(&ValidateStep::RevealR)
             .set_total_records(1);
-        let r = self.r_share.reveal(narrow_ctx, RecordId::FIRST).await?;
+        let r = <F as ExtendableField>::ExtendedField::from_array(
+            &self.r_share.reveal(narrow_ctx, RecordId::FIRST).await?,
+        );
         let t = u_share - &(w_share * r);
 
         let check_zero_ctx = self

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -169,10 +169,10 @@ where
     match ctx.role() {
         Role::H1 => Ok(AdditiveShare::<Fp25519>::new(
             Fp25519::from(sh_s.left()).neg(),
-            Fp25519::from(y.unwrap()),
+            Fp25519::from(BA256::from_array(&y.unwrap())),
         )),
         Role::H2 => Ok(AdditiveShare::<Fp25519>::new(
-            Fp25519::from(y.unwrap()),
+            Fp25519::from(BA256::from_array(&y.unwrap())),
             Fp25519::from(sh_r.right()).neg(),
         )),
         Role::H3 => Ok(AdditiveShare::<Fp25519>::new(

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -9,7 +9,10 @@ use crate::{
         prss::SharedRandomness,
         RecordId,
     },
-    secret_sharing::replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+    secret_sharing::{
+        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+        SharedValue,
+    },
 };
 
 #[derive(Step)]
@@ -88,8 +91,8 @@ where
         .await?;
 
     //reconstruct (z,R)
-    let gr: RP25519 = sh_gr.reveal(ctx.narrow(&Step::RevealR), record_id).await?;
-    let z = y.reveal(ctx.narrow(&Step::Revealz), record_id).await?;
+    let gr = RP25519::from_array(&sh_gr.reveal(ctx.narrow(&Step::RevealR), record_id).await?);
+    let z = Fp25519::from_array(&y.reveal(ctx.narrow(&Step::Revealz), record_id).await?);
 
     //compute R^(1/z) to u64
     Ok(u64::from(gr * (z.invert())))

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -112,7 +112,7 @@ where
                                 .await?;
 
                             // desc = true will flip the order of the sort
-                            Ok::<_, Error>(Boolean::from(desc) == comparison)
+                            Ok::<_, Error>(Boolean::from(desc) == Boolean::from_array(&comparison))
                         }
                     }),
             ),


### PR DESCRIPTION
This change also removes the `B: RecordBinding` type parameter on the `Reveal` trait, which is no longer used after removal of IPAv2.

The complexity with vectorized reveal is converting the reveal output from `[T; 1]` to `T` in unvectorized protocols. For general handling of vectorized shares, there are two sets of methods (on the `AdditiveShare` type) -- the existing `new`, `left`, and `right` methods only work for unvectorized shares; the `new_arr`, `left_arr`, and `right_arr` methods return vector shares (even in the case where the vector dimension is one). We could do something similar with reveal, but it would be more complicated because it's traits instead of types. It doesn't seem worth it for the relatively small number of places that we call reveal.