### PR TITLE
Change boolean debug representation

### DIFF
--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use bitvec::{
     prelude::{BitArr, Lsb0},
     slice::Iter,
@@ -254,8 +256,14 @@ macro_rules! boolean_array_impl {
     type Store = BitArr!(for $bits, in u8, Lsb0);
 
             /// A Boolean array with $bits bits.
-            #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+            #[derive(Clone, Copy, PartialEq, Eq)]
             pub struct $name(pub(super) Store);
+
+            impl Debug for $name {
+                fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "{}({})", stringify!($name), self.0)
+                }
+            }
 
             impl $name {
                 #[cfg(all(test, unit_test))]

--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -261,7 +261,8 @@ macro_rules! boolean_array_impl {
 
             impl Debug for $name {
                 fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                    write!(f, "{}({})", stringify!($name), self.0)
+                    f.write_str(stringify!($name))?;
+                    self.0.data.fmt(f)
                 }
             }
 
@@ -704,6 +705,13 @@ macro_rules! boolean_array_impl {
                         $name::deserialize(&buf).unwrap(),
                         "Failed to deserialize a valid value: {ba:?}"
                     );
+                }
+
+                #[test]
+                fn debug() {
+                    let expected = format!("{}{:?}", stringify!($name), $name::ZERO.0.data);
+                    let actual = format!("{:?}", $name::ZERO);
+                    assert_eq!(expected, actual);
                 }
             }
         }


### PR DESCRIPTION
The default one is too verbose.

Before:

```
(StdArray([BA32(BitArray<u8, bitvec::order::Lsb0> { addr: 0x12b842774, head: 000, bits: 32 } [1, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1])]), StdArray([BA32(BitArray<u8, bitvec::order::Lsb0> { addr: 0x12b842778, head: 000, bits: 32 } [0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0])]))
```

after

```
(StdArray([BA32([1, 1, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1])]), StdArray([BA32([0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0])]))
```