### PR TITLE
First building blocks for Sharding API: ShardIndex and TransportIdentity

### DIFF
--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -6,7 +6,7 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{report::InvalidReportError, task::JoinError};
+use crate::{helpers::Role, report::InvalidReportError, sharding::ShardIndex, task::JoinError};
 
 /// An error raised by the IPA protocol.
 ///
@@ -52,8 +52,10 @@ pub enum Error {
     #[error("failed to parse json: {0}")]
     #[cfg(feature = "enable-serde")]
     Serde(#[from] serde_json::Error),
-    #[error("Infrastructure error: {0}")]
-    InfraError(#[from] crate::helpers::Error),
+    #[error("MPC Infrastructure error: {0}")]
+    MpcInfraError(#[from] crate::helpers::Error<Role>),
+    #[error("Shard Infrastructure error: {0}")]
+    ShardInfraError(#[from] crate::helpers::Error<ShardIndex>),
     #[error("Value truncation error: {0}")]
     FieldValueTruncation(String),
     #[error("Invalid query parameter: {0}")]

--- a/ipa-core/src/helpers/buffers/unordered_receiver.rs
+++ b/ipa-core/src/helpers/buffers/unordered_receiver.rs
@@ -11,7 +11,7 @@ use generic_array::GenericArray;
 use typenum::Unsigned;
 
 use crate::{
-    helpers::{Error, Message},
+    helpers::{Error, Message, Role},
     protocol::RecordId,
     sync::{Arc, Mutex},
 };
@@ -160,7 +160,7 @@ pub enum ReceiveError<M: Message> {
     #[error("Error deserializing {0:?} record: {1}")]
     DeserializationError(RecordId, #[source] M::DeserializationError),
     #[error(transparent)]
-    InfraError(#[from] Error),
+    InfraError(#[from] Error<Role>),
 }
 
 impl<S, C> OperatingState<S, C>

--- a/ipa-core/src/helpers/error.rs
+++ b/ipa-core/src/helpers/error.rs
@@ -2,25 +2,13 @@ use thiserror::Error;
 
 use crate::{
     error::BoxError,
-    helpers::{ChannelId, HelperChannelId, HelperIdentity, Role, TotalRecords, TransportIdentity},
-    protocol::{step::Gate, RecordId},
+    helpers::{ChannelId, TotalRecords, TransportIdentity},
+    protocol::RecordId,
 };
 
 /// An error raised by the IPA supporting infrastructure.
 #[derive(Error, Debug)]
 pub enum Error<I: TransportIdentity> {
-    #[error("An error occurred while sending data to {channel:?}: {inner}")]
-    SendError {
-        channel: ChannelId<I>,
-
-        #[source]
-        inner: BoxError,
-    },
-    #[error("An error occurred while sending data to unknown helper: {inner}")]
-    PollSendError {
-        #[source]
-        inner: BoxError,
-    },
     #[error("An error occurred while receiving data from {source:?}/{step}: {inner}")]
     ReceiveError {
         source: I,
@@ -33,15 +21,6 @@ pub enum Error<I: TransportIdentity> {
         // TODO(mt): add more fields, like step and role.
         record_id: RecordId,
     },
-    #[error("An error occurred while serializing or deserializing data for {record_id:?} and step {step}: {inner}")]
-    SerializationError {
-        record_id: RecordId,
-        step: String,
-        #[source]
-        inner: BoxError,
-    },
-    #[error("Encountered unknown identity {0:?}")]
-    UnknownIdentity(HelperIdentity),
     #[error("record ID {record_id:?} is out of range for {channel_id:?} (expected {total_records:?} records)")]
     TooManyRecords {
         record_id: RecordId,
@@ -49,30 +28,3 @@ pub enum Error<I: TransportIdentity> {
         total_records: TotalRecords,
     },
 }
-
-impl Error<Role> {
-    pub fn send_error<E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>>(
-        channel: HelperChannelId,
-        inner: E,
-    ) -> Self {
-        Self::SendError {
-            channel,
-            inner: inner.into(),
-        }
-    }
-
-    #[must_use]
-    pub fn serialization_error<E: Into<BoxError>>(
-        record_id: RecordId,
-        gate: &Gate,
-        inner: E,
-    ) -> Self {
-        Self::SerializationError {
-            record_id,
-            step: String::from(gate.as_ref()),
-            inner: inner.into(),
-        }
-    }
-}
-
-pub type Result<T> = std::result::Result<T, Error<Role>>;

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 /// To avoid proliferation of type parameters, most code references this concrete type alias, rather
 /// than a type parameter `T: Transport`.
 #[cfg(feature = "in-memory-infra")]
-pub type TransportImpl = super::transport::InMemoryTransport;
+pub type TransportImpl = super::transport::InMemoryTransport<HelperIdentity>;
 
 #[cfg(feature = "real-world-infra")]
 pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -15,10 +15,12 @@ pub(super) use stall_detection::InstrumentedGateway;
 
 use crate::{
     helpers::{
+        buffers::UnorderedReceiver,
         gateway::{
             receive::GatewayReceivers, send::GatewaySenders, transport::RoleResolvingTransport,
         },
-        ChannelId, Message, Role, RoleAssignment, TotalRecords, Transport,
+        HelperChannelId, HelperIdentity, Message, Role, RoleAssignment, RouteId, TotalRecords,
+        Transport,
     },
     protocol::QueryId,
 };
@@ -33,12 +35,13 @@ pub type TransportImpl = super::transport::InMemoryTransport;
 #[cfg(feature = "real-world-infra")]
 pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
 
-pub type TransportError = <TransportImpl as Transport>::Error;
+pub type TransportError = <TransportImpl as Transport<HelperIdentity>>::Error;
 
 /// Gateway into IPA Network infrastructure. It allows helpers send and receive messages.
 pub struct Gateway {
     config: GatewayConfig,
     transport: RoleResolvingTransport,
+    query_id: QueryId,
     #[cfg(feature = "stall-detection")]
     inner: crate::sync::Arc<State>,
     #[cfg(not(feature = "stall-detection"))]
@@ -74,12 +77,11 @@ impl Gateway {
     ) -> Self {
         #[allow(clippy::useless_conversion)] // not useless in stall-detection build
         Self {
+            query_id,
             config,
             transport: RoleResolvingTransport {
-                query_id,
                 roles,
                 inner: transport,
-                config,
             },
             inner: State::default().into(),
         }
@@ -87,7 +89,7 @@ impl Gateway {
 
     #[must_use]
     pub fn role(&self) -> Role {
-        self.transport.role()
+        self.transport.identity()
     }
 
     #[must_use]
@@ -101,7 +103,7 @@ impl Gateway {
     #[must_use]
     pub fn get_sender<M: Message>(
         &self,
-        channel_id: &ChannelId,
+        channel_id: &HelperChannelId,
         total_records: TotalRecords,
     ) -> send::SendingEnd<M> {
         let (tx, maybe_stream) = self.inner.senders.get_or_create::<M>(
@@ -113,10 +115,15 @@ impl Gateway {
             tokio::spawn({
                 let channel_id = channel_id.clone();
                 let transport = self.transport.clone();
+                let query_id = self.query_id;
                 async move {
                     // TODO(651): In the HTTP case we probably need more robust error handling here.
                     transport
-                        .send(&channel_id, stream)
+                        .send(
+                            channel_id.peer,
+                            (RouteId::Records, query_id, channel_id.gate),
+                            stream,
+                        )
                         .await
                         .expect("{channel_id:?} receiving end should be accepted by transport");
                 }
@@ -127,12 +134,21 @@ impl Gateway {
     }
 
     #[must_use]
-    pub fn get_receiver<M: Message>(&self, channel_id: &ChannelId) -> receive::ReceivingEnd<M> {
+    pub fn get_receiver<M: Message>(
+        &self,
+        channel_id: &HelperChannelId,
+    ) -> receive::ReceivingEnd<M> {
         receive::ReceivingEnd::new(
             channel_id.clone(),
-            self.inner
-                .receivers
-                .get_or_create(channel_id, || self.transport.receive(channel_id)),
+            self.inner.receivers.get_or_create(channel_id, || {
+                UnorderedReceiver::new(
+                    Box::pin(
+                        self.transport
+                            .receive(channel_id.peer, (self.query_id, channel_id.gate.clone())),
+                    ),
+                    self.config.active_work(),
+                )
+            }),
         )
     }
 }

--- a/ipa-core/src/helpers/gateway/transport.rs
+++ b/ipa-core/src/helpers/gateway/transport.rs
@@ -1,64 +1,94 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use async_trait::async_trait;
+use futures::Stream;
+
 use crate::{
     helpers::{
-        buffers::UnorderedReceiver,
-        gateway::{receive::UR, send::GatewaySendStream},
-        ChannelId, GatewayConfig, Role, RoleAssignment, RouteId, Transport, TransportImpl,
+        HelperIdentity, NoResourceIdentifier, QueryIdBinding, Role, RoleAssignment, RouteId,
+        RouteParams, StepBinding, Transport, TransportImpl,
     },
-    protocol::QueryId,
+    protocol::{step::Gate, QueryId},
 };
+
+#[derive(Debug, thiserror::Error)]
+#[error("Failed to send to {0:?}: {1:?}")]
+pub struct SendToRoleError(Role, <TransportImpl as Transport<HelperIdentity>>::Error);
+
+/// This struct exists to hide the generic type used to index streams internally.
+#[pin_project::pin_project]
+pub struct RoleRecordsStream(#[pin] <TransportImpl as Transport<HelperIdentity>>::RecordsStream);
 
 /// Transport adapter that resolves [`Role`] -> [`HelperIdentity`] mapping. As gateways created
 /// per query, it is not ambiguous.
 ///
 /// [`HelperIdentity`]: crate::helpers::HelperIdentity
 #[derive(Clone)]
-pub(super) struct RoleResolvingTransport {
-    pub query_id: QueryId,
-    pub roles: RoleAssignment,
-    pub config: GatewayConfig,
-    pub inner: TransportImpl,
+pub struct RoleResolvingTransport {
+    pub(super) roles: RoleAssignment,
+    pub(super) inner: TransportImpl,
 }
 
-impl RoleResolvingTransport {
-    pub(crate) async fn send(
+impl Stream for RoleRecordsStream {
+    type Item = Vec<u8>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().0.poll_next(cx)
+    }
+}
+
+#[async_trait]
+impl Transport<Role> for RoleResolvingTransport {
+    type RecordsStream = RoleRecordsStream;
+    type Error = SendToRoleError;
+
+    fn identity(&self) -> Role {
+        let helper_identity = self.inner.identity();
+        self.roles.role(helper_identity)
+    }
+
+    async fn send<
+        D: Stream<Item = Vec<u8>> + Send + 'static,
+        Q: QueryIdBinding,
+        S: StepBinding,
+        R: RouteParams<RouteId, Q, S>,
+    >(
         &self,
-        channel_id: &ChannelId,
-        data: GatewaySendStream,
-    ) -> Result<(), <TransportImpl as Transport>::Error> {
-        let dest_identity = self.roles.identity(channel_id.role);
+        dest: Role,
+        route: R,
+        data: D,
+    ) -> Result<(), Self::Error>
+    where
+        Option<QueryId>: From<Q>,
+        Option<Gate>: From<S>,
+    {
+        let dest_helper = self.roles.identity(dest);
         assert_ne!(
-            dest_identity,
+            dest_helper,
             self.inner.identity(),
             "can't send message to itself"
         );
-
         self.inner
-            .send(
-                dest_identity,
-                (RouteId::Records, self.query_id, channel_id.gate.clone()),
-                data,
-            )
+            .send(dest_helper, route, data)
             .await
+            .map_err(|e| SendToRoleError(dest, e))
     }
 
-    pub(crate) fn receive(&self, channel_id: &ChannelId) -> UR {
-        let peer = self.roles.identity(channel_id.role);
+    fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
+        &self,
+        from: Role,
+        route: R,
+    ) -> Self::RecordsStream {
+        let origin_helper = self.roles.identity(from);
         assert_ne!(
-            peer,
+            origin_helper,
             self.inner.identity(),
             "can't receive message from itself"
         );
 
-        UnorderedReceiver::new(
-            Box::pin(
-                self.inner
-                    .receive(peer, (self.query_id, channel_id.gate.clone())),
-            ),
-            self.config.active_work(),
-        )
-    }
-
-    pub(crate) fn role(&self) -> Role {
-        self.roles.role(self.inner.identity())
+        RoleRecordsStream(self.inner.receive(origin_helper, route))
     }
 }

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -49,9 +49,10 @@ pub use prss_protocol::negotiate as negotiate_prss;
 #[cfg(feature = "web-app")]
 pub use transport::WrappedAxumBodyStream;
 pub use transport::{
-    callbacks::*, query, BodyStream, BytesStream, LengthDelimitedStream, LogErrors,
-    NoResourceIdentifier, QueryIdBinding, ReceiveRecords, RecordsStream, RouteId, RouteParams,
-    StepBinding, StreamCollection, StreamKey, Transport, WrappedBoxBodyStream,
+    callbacks::*, query, BodyStream, BytesStream, Identity as TransportIdentity,
+    LengthDelimitedStream, LogErrors, NoResourceIdentifier, QueryIdBinding, ReceiveRecords,
+    RecordsStream, RouteId, RouteParams, StepBinding, StreamCollection, StreamKey, Transport,
+    WrappedBoxBodyStream,
 };
 #[cfg(feature = "in-memory-infra")]
 pub use transport::{InMemoryNetwork, InMemoryTransport};
@@ -405,23 +406,25 @@ impl TryFrom<[Role; 3]> for RoleAssignment {
 /// Combination of helper role and step that uniquely identifies a single channel of communication
 /// between two helpers.
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ChannelId {
-    pub role: Role,
+pub struct ChannelId<I: transport::Identity> {
+    pub peer: I,
     // TODO: step could be either reference or owned value. references are convenient to use inside
     // gateway , owned values can be used inside lookup tables.
     pub gate: Gate,
 }
 
-impl ChannelId {
+pub type HelperChannelId = ChannelId<Role>;
+
+impl<I: transport::Identity> ChannelId<I> {
     #[must_use]
-    pub fn new(role: Role, gate: Gate) -> Self {
-        Self { role, gate }
+    pub fn new(peer: I, gate: Gate) -> Self {
+        Self { peer, gate }
     }
 }
 
-impl Debug for ChannelId {
+impl<I: transport::Identity> Debug for ChannelId<I> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "channel[{:?},{:?}]", self.role, self.gate.as_ref())
+        write!(f, "channel[{:?},{:?}]", self.peer, self.gate.as_ref())
     }
 }
 

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -17,7 +17,7 @@ use std::ops::{Index, IndexMut};
 /// to validate that transport can actually send streams of this type
 #[cfg(test)]
 pub use buffers::OrderingSender;
-pub use error::{Error, Result};
+pub use error::Error;
 
 #[cfg(feature = "stall-detection")]
 mod gateway_exports {

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -407,6 +407,7 @@ impl TryFrom<[Role; 3]> for RoleAssignment {
 /// between two helpers.
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct ChannelId<I: transport::Identity> {
+    /// Entity we are talking to through this channel. It can be a source or a destination.
     pub peer: I,
     // TODO: step could be either reference or owned value. references are convenient to use inside
     // gateway , owned values can be used inside lookup tables.

--- a/ipa-core/src/helpers/prss_protocol.rs
+++ b/ipa-core/src/helpers/prss_protocol.rs
@@ -3,7 +3,7 @@ use rand_core::{CryptoRng, RngCore};
 use x25519_dalek::PublicKey;
 
 use crate::{
-    helpers::{ChannelId, Direction, Error, Gateway, TotalRecords},
+    helpers::{ChannelId, Direction, Error, Gateway, Role, TotalRecords},
     protocol::{
         prss,
         step::{Gate, Step, StepNarrow},
@@ -28,7 +28,7 @@ pub async fn negotiate<R: RngCore + CryptoRng>(
     gateway: &Gateway,
     gate: &Gate,
     rng: &mut R,
-) -> Result<prss::Endpoint, Error> {
+) -> Result<prss::Endpoint, Error<Role>> {
     // setup protocol to exchange prss public keys. This protocol sends one message per peer.
     // Each message contains this helper's public key. At the end of this protocol, all helpers
     // have completed key exchange and each of them have established a shared secret with each peer.

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -151,7 +151,7 @@ impl InMemoryTransport {
 }
 
 #[async_trait]
-impl Transport for Weak<InMemoryTransport> {
+impl Transport<HelperIdentity> for Weak<InMemoryTransport> {
     type RecordsStream = ReceiveRecords<InMemoryStream>;
     type Error = Error;
 

--- a/ipa-core/src/helpers/transport/stream/collection.rs
+++ b/ipa-core/src/helpers/transport/stream/collection.rs
@@ -7,14 +7,14 @@ use std::{
 use futures::Stream;
 
 use crate::{
-    helpers::HelperIdentity,
+    helpers::TransportIdentity,
     protocol::{step::Gate, QueryId},
     sync::{Arc, Mutex},
 };
 
 /// Each stream is indexed by query id, the identity of helper where stream is originated from
 /// and step.
-pub type StreamKey = (QueryId, HelperIdentity, Gate);
+pub type StreamKey<I> = (QueryId, I, Gate);
 
 /// Thread-safe append-only collection of homogeneous record streams.
 /// Streams are indexed by [`StreamKey`] and the lifecycle of each stream is described by the
@@ -22,11 +22,11 @@ pub type StreamKey = (QueryId, HelperIdentity, Gate);
 ///
 /// Each stream can be inserted and taken away exactly once, any deviation from this behaviour will
 /// result in panic.
-pub struct StreamCollection<S> {
-    inner: Arc<Mutex<HashMap<StreamKey, StreamState<S>>>>,
+pub struct StreamCollection<I, S> {
+    inner: Arc<Mutex<HashMap<StreamKey<I>, StreamState<S>>>>,
 }
 
-impl<S> Default for StreamCollection<S> {
+impl<I, S> Default for StreamCollection<I, S> {
     fn default() -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::default())),
@@ -34,7 +34,7 @@ impl<S> Default for StreamCollection<S> {
     }
 }
 
-impl<S> Clone for StreamCollection<S> {
+impl<I, S> Clone for StreamCollection<I, S> {
     fn clone(&self) -> Self {
         Self {
             inner: Arc::clone(&self.inner),
@@ -42,12 +42,12 @@ impl<S> Clone for StreamCollection<S> {
     }
 }
 
-impl<S: Stream> StreamCollection<S> {
+impl<I: TransportIdentity, S: Stream> StreamCollection<I, S> {
     /// Adds a new stream associated with the given key.
     ///
     /// ## Panics
     /// If there was another stream associated with the same key some time in the past.
-    pub fn add_stream(&self, key: StreamKey, stream: S) {
+    pub fn add_stream(&self, key: StreamKey<I>, stream: S) {
         let mut streams = self.inner.lock().unwrap();
         match streams.entry(key) {
             Entry::Occupied(mut entry) => match entry.get_mut() {
@@ -77,7 +77,7 @@ impl<S: Stream> StreamCollection<S> {
     ///
     /// ## Panics
     /// If [`Waker`] that exists already inside this collection will not wake the given one.
-    pub fn add_waker(&self, key: &StreamKey, waker: &Waker) -> Option<S> {
+    pub fn add_waker(&self, key: &StreamKey<I>, waker: &Waker) -> Option<S> {
         let mut streams = self.inner.lock().unwrap();
 
         match streams.entry(key.clone()) {

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -33,6 +33,7 @@ mod exact;
 mod seq_join;
 #[cfg(feature = "enable-serde")]
 mod serde;
+mod sharding;
 
 pub use app::{HelperApp, Setup as AppSetup};
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -33,7 +33,7 @@ pub struct HttpTransport {
     clients: [MpcHelperClient; 3],
     // TODO(615): supporting multiple queries likely require a hashmap here. It will be ok if we
     // only allow one query at a time.
-    record_streams: StreamCollection<LogHttpErrors>,
+    record_streams: StreamCollection<HelperIdentity, LogHttpErrors>,
 }
 
 impl HttpTransport {
@@ -124,7 +124,7 @@ impl HttpTransport {
 
 #[async_trait]
 impl Transport<HelperIdentity> for Arc<HttpTransport> {
-    type RecordsStream = ReceiveRecords<LogHttpErrors>;
+    type RecordsStream = ReceiveRecords<HelperIdentity, LogHttpErrors>;
     type Error = Error;
 
     fn identity(&self) -> HelperIdentity {

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -123,7 +123,7 @@ impl HttpTransport {
 }
 
 #[async_trait]
-impl Transport for Arc<HttpTransport> {
+impl Transport<HelperIdentity> for Arc<HttpTransport> {
     type RecordsStream = ReceiveRecords<LogHttpErrors>;
     type Error = Error;
 

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -33,7 +33,7 @@ pub trait ShardConfiguration {
             "Current shard index '{this}' >= '{max}' (total number of shards)"
         );
 
-        max.preceding().filter(move |&v| v != this)
+        max.iter().filter(move |&v| v != this)
     }
 }
 
@@ -41,7 +41,7 @@ impl ShardIndex {
     pub const FIRST: Self = Self(0);
 
     /// Returns an iterator over all shard indices that precede this one, excluding this one.
-    pub fn preceding(self) -> impl Iterator<Item = Self> {
+    pub fn iter(self) -> impl Iterator<Item = Self> {
         (0..self.0).map(Self)
     }
 }
@@ -71,8 +71,8 @@ mod tests {
 
     #[test]
     fn iter() {
-        assert!(ShardIndex::FIRST.preceding().eq(empty()));
-        assert!(shards([0, 1, 2]).eq(ShardIndex::from(3).preceding()));
+        assert!(ShardIndex::FIRST.iter().eq(empty()));
+        assert!(shards([0, 1, 2]).eq(ShardIndex::from(3).iter()));
     }
 
     /// It is often useful to keep a collection of elements indexed by shard.

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -21,7 +21,7 @@ pub trait ShardConfiguration {
     fn shard_count(&self) -> ShardIndex;
 
     /// Returns an iterator that yields shard indices for all shards present in the system, except
-    /// this once. Shards are yielded in ascending order.
+    /// this one. Shards are yielded in ascending order.
     ///
     /// ## Panics
     /// if current shard index is greater or equal to the total number of shards.

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -14,7 +14,7 @@ impl Display for ShardIndex {
 /// the total number of shards in the system.
 pub trait ShardConfiguration {
     /// Returns the index of the current shard.
-    fn shard_index(&self) -> ShardIndex;
+    fn shard_id(&self) -> ShardIndex;
 
     /// Total number of shards present on this helper. It is expected that all helpers have the
     /// same number of shards.
@@ -26,7 +26,7 @@ pub trait ShardConfiguration {
     /// ## Panics
     /// if current shard index is greater or equal to the total number of shards.
     fn peer_shards(&self) -> impl Iterator<Item = ShardIndex> {
-        let this = self.shard_index();
+        let this = self.shard_id();
         let max = self.shard_count();
         assert!(
             this < max,
@@ -87,7 +87,7 @@ mod tests {
 
         struct StaticConfig(u32, u32);
         impl ShardConfiguration for StaticConfig {
-            fn shard_index(&self) -> ShardIndex {
+            fn shard_id(&self) -> ShardIndex {
                 self.0.into()
             }
 

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -1,0 +1,116 @@
+use std::fmt::{Display, Formatter};
+
+/// A unique zero-based index of the helper shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ShardIndex(u32);
+
+impl Display for ShardIndex {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// Shard-specific configuration required by sharding API. Each shard must know its own index and
+/// the total number of shards in the system.
+pub trait ShardConfiguration {
+    /// Returns the index of the current shard.
+    fn shard_index(&self) -> ShardIndex;
+
+    /// Total number of shards present on this helper. It is expected that all helpers have the
+    /// same number of shards.
+    fn shard_count(&self) -> ShardIndex;
+
+    /// Returns an iterator that yields shard indices for all shards present in the system, except
+    /// this once. Shards are yielded in ascending order.
+    ///
+    /// ## Panics
+    /// if current shard index is greater or equal to the total number of shards.
+    fn peer_shards(&self) -> impl Iterator<Item = ShardIndex> {
+        let this = self.shard_index();
+        let max = self.shard_count();
+        assert!(
+            this < max,
+            "Current shard index '{this}' >= '{max}' (total number of shards)"
+        );
+
+        max.preceding().filter(move |&v| v != this)
+    }
+}
+
+impl ShardIndex {
+    pub const FIRST: Self = Self(0);
+
+    /// Returns an iterator over all shard indices that precede this one, excluding this one.
+    pub fn preceding(self) -> impl Iterator<Item = Self> {
+        (0..self.0).map(Self)
+    }
+}
+
+impl From<u32> for ShardIndex {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl From<ShardIndex> for usize {
+    fn from(value: ShardIndex) -> Self {
+        usize::try_from(value.0).unwrap()
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use std::iter::empty;
+
+    use crate::sharding::ShardIndex;
+
+    fn shards<I: IntoIterator<Item = u32>>(input: I) -> impl Iterator<Item = ShardIndex> {
+        input.into_iter().map(ShardIndex)
+    }
+
+    #[test]
+    fn iter() {
+        assert!(ShardIndex::FIRST.preceding().eq(empty()));
+        assert!(shards([0, 1, 2]).eq(ShardIndex::from(3).preceding()));
+    }
+
+    /// It is often useful to keep a collection of elements indexed by shard.
+    #[test]
+    fn indexing() {
+        let arr = [0, 1, 2];
+        assert_eq!(0, arr[usize::from(ShardIndex::FIRST)]);
+    }
+
+    mod conf {
+        use crate::sharding::{tests::shards, ShardConfiguration, ShardIndex};
+
+        struct StaticConfig(u32, u32);
+        impl ShardConfiguration for StaticConfig {
+            fn shard_index(&self) -> ShardIndex {
+                self.0.into()
+            }
+
+            fn shard_count(&self) -> ShardIndex {
+                self.1.into()
+            }
+        }
+
+        #[test]
+        fn excludes_this_shard() {
+            assert!(shards([0, 1, 2, 4]).eq(StaticConfig(3, 5).peer_shards()));
+        }
+
+        #[test]
+        #[should_panic(expected = "Current shard index '5' >= '5' (total number of shards)")]
+        fn shard_index_eq_shard_count() {
+            let _ = StaticConfig(5, 5).peer_shards();
+        }
+
+        #[test]
+        #[should_panic(expected = "Current shard index '7' >= '5' (total number of shards)")]
+        fn shard_index_gt_shard_count() {
+            let _ = StaticConfig(7, 5).peer_shards();
+        }
+    }
+}

--- a/ipa-core/src/test_fixture/app.rs
+++ b/ipa-core/src/test_fixture/app.rs
@@ -8,7 +8,7 @@ use crate::{
     ff::Serializable,
     helpers::{
         query::{QueryConfig, QueryInput},
-        InMemoryNetwork, InMemoryTransport,
+        HelperIdentity, InMemoryNetwork,
     },
     protocol::QueryId,
     query::QueryStatus,
@@ -50,7 +50,7 @@ where
 /// [`TestWorld`]: crate::test_fixture::TestWorld
 pub struct TestApp {
     drivers: [HelperApp; 3],
-    network: InMemoryNetwork,
+    network: InMemoryNetwork<HelperIdentity>,
 }
 
 fn unzip_tuple_array<T, U>(input: [(T, U); 3]) -> ([T; 3], [U; 3]) {
@@ -68,7 +68,7 @@ impl Default for TestApp {
             .transports()
             .iter()
             .zip(setup)
-            .map(|(t, s)| s.connect(<InMemoryTransport as Clone>::clone(t)))
+            .map(|(t, s)| s.connect(Clone::clone(t)))
             .collect::<Vec<_>>()
             .try_into()
             .map_err(|_| "infallible")

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -8,7 +8,7 @@ use rand_core::{RngCore, SeedableRng};
 use tracing::{Instrument, Level, Span};
 
 use crate::{
-    helpers::{Gateway, GatewayConfig, InMemoryNetwork, Role, RoleAssignment},
+    helpers::{Gateway, GatewayConfig, HelperIdentity, InMemoryNetwork, Role, RoleAssignment},
     protocol::{
         context::{
             Context, MaliciousContext, SemiHonestContext, UpgradableContext, UpgradeContext,
@@ -49,7 +49,7 @@ pub struct TestWorld {
     participants: [PrssEndpoint; 3],
     executions: AtomicUsize,
     metrics_handle: MetricsHandle,
-    _network: InMemoryNetwork,
+    _network: InMemoryNetwork<HelperIdentity>,
 }
 
 #[derive(Clone)]
@@ -112,7 +112,7 @@ impl TestWorld {
         let network = InMemoryNetwork::default();
         let role_assignment = config
             .role_assignment
-            .unwrap_or_else(|| RoleAssignment::new(network.helper_identities()));
+            .unwrap_or_else(|| RoleAssignment::new(network.identities()));
 
         let mut gateways = [None, None, None];
         for i in 0..3 {


### PR DESCRIPTION
See #969 for overall approach.

This change introduces two fundamental concepts for horizontal scaling - `ShardIndex` and `Transportidentity`. 

The former will be used the same way as `HelperIdentity` is used nowadays - unique identifier of a peer we are communicating with. Having in mind 200B events, we may need more than 65k shards, thus 4 byte identifier usage. 

`TransportIdentity` is a generalization for peer identifiers used at transport layer.  Two fundamental structs implement it: `HelperIdentity` and `ShardIndex` to allow communication via MPC and shard channels.

`Role` is used at the Gateway/Context layer for communication purposes and `RoleResolvingTransport` is a convenient abstraction, so it also implements `TransportIdentity`.

`Transport` trait became generic over `TransportIdentity` - I tested it in my private branch where I have a complete implementation, so this approach works. 

I also did a bit of a refactoring and made `RoleResolvingTransport` to implement the `Transport` trait because it can now.

 