### PR TITLE
TestWorld for sharded environments

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -35,7 +35,7 @@ pub type TransportImpl = super::transport::InMemoryTransport<HelperIdentity>;
 #[cfg(feature = "real-world-infra")]
 pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
 
-pub type TransportError = <TransportImpl as Transport<HelperIdentity>>::Error;
+pub type TransportError = <TransportImpl as Transport>::Error;
 
 /// Gateway into IPA Network infrastructure. It allows helpers send and receive messages.
 pub struct Gateway {

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -19,8 +19,7 @@ use crate::{
         gateway::{
             receive::GatewayReceivers, send::GatewaySenders, transport::RoleResolvingTransport,
         },
-        HelperChannelId, HelperIdentity, Message, Role, RoleAssignment, RouteId, TotalRecords,
-        Transport,
+        HelperChannelId, Message, Role, RoleAssignment, RouteId, TotalRecords, Transport,
     },
     protocol::QueryId,
 };
@@ -30,7 +29,7 @@ use crate::{
 /// To avoid proliferation of type parameters, most code references this concrete type alias, rather
 /// than a type parameter `T: Transport`.
 #[cfg(feature = "in-memory-infra")]
-pub type TransportImpl = super::transport::InMemoryTransport<HelperIdentity>;
+pub type TransportImpl = super::transport::InMemoryTransport<crate::helpers::HelperIdentity>;
 
 #[cfg(feature = "real-world-infra")]
 pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;

--- a/ipa-core/src/helpers/gateway/receive.rs
+++ b/ipa-core/src/helpers/gateway/receive.rs
@@ -25,8 +25,8 @@ pub(super) struct GatewayReceivers {
 }
 
 pub(super) type UR = UnorderedReceiver<
-    <RoleResolvingTransport as Transport<Role>>::RecordsStream,
-    <<RoleResolvingTransport as Transport<Role>>::RecordsStream as Stream>::Item,
+    <RoleResolvingTransport as Transport>::RecordsStream,
+    <<RoleResolvingTransport as Transport>::RecordsStream as Stream>::Item,
 >;
 
 impl<M: Message> ReceivingEnd<M> {

--- a/ipa-core/src/helpers/gateway/transport.rs
+++ b/ipa-core/src/helpers/gateway/transport.rs
@@ -8,19 +8,19 @@ use futures::Stream;
 
 use crate::{
     helpers::{
-        HelperIdentity, NoResourceIdentifier, QueryIdBinding, Role, RoleAssignment, RouteId,
-        RouteParams, StepBinding, Transport, TransportImpl,
+        NoResourceIdentifier, QueryIdBinding, Role, RoleAssignment, RouteId, RouteParams,
+        StepBinding, Transport, TransportImpl,
     },
     protocol::{step::Gate, QueryId},
 };
 
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to send to {0:?}: {1:?}")]
-pub struct SendToRoleError(Role, <TransportImpl as Transport<HelperIdentity>>::Error);
+pub struct SendToRoleError(Role, <TransportImpl as Transport>::Error);
 
 /// This struct exists to hide the generic type used to index streams internally.
 #[pin_project::pin_project]
-pub struct RoleRecordsStream(#[pin] <TransportImpl as Transport<HelperIdentity>>::RecordsStream);
+pub struct RoleRecordsStream(#[pin] <TransportImpl as Transport>::RecordsStream);
 
 /// Transport adapter that resolves [`Role`] -> [`HelperIdentity`] mapping. As gateways created
 /// per query, it is not ambiguous.
@@ -41,7 +41,8 @@ impl Stream for RoleRecordsStream {
 }
 
 #[async_trait]
-impl Transport<Role> for RoleResolvingTransport {
+impl Transport for RoleResolvingTransport {
+    type Identity = Role;
     type RecordsStream = RoleRecordsStream;
     type Error = SendToRoleError;
 

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -57,7 +57,7 @@ pub use transport::{
     WrappedBoxBodyStream,
 };
 #[cfg(feature = "in-memory-infra")]
-pub use transport::{InMemoryNetwork, InMemoryTransport};
+pub use transport::{InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};
 use typenum::{Unsigned, U8};
 use x25519_dalek::PublicKey;
 
@@ -350,6 +350,14 @@ impl<T> IndexMut<Role> for Vec<T> {
 }
 
 impl RoleAssignment {
+    pub const DEFAULT: Self = Self {
+        helper_roles: [
+            HelperIdentity::ONE,
+            HelperIdentity::TWO,
+            HelperIdentity::THREE,
+        ],
+    };
+
     #[must_use]
     pub fn new(helper_roles: [HelperIdentity; 3]) -> Self {
         Self { helper_roles }
@@ -402,6 +410,12 @@ impl TryFrom<[Role; 3]> for RoleAssignment {
             (HelperIdentity::TWO, value[1]),
             (HelperIdentity::THREE, value[2]),
         ])
+    }
+}
+
+impl Default for RoleAssignment {
+    fn default() -> Self {
+        Self::DEFAULT
     }
 }
 

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -350,16 +350,8 @@ impl<T> IndexMut<Role> for Vec<T> {
 }
 
 impl RoleAssignment {
-    pub const DEFAULT: Self = Self {
-        helper_roles: [
-            HelperIdentity::ONE,
-            HelperIdentity::TWO,
-            HelperIdentity::THREE,
-        ],
-    };
-
     #[must_use]
-    pub fn new(helper_roles: [HelperIdentity; 3]) -> Self {
+    pub const fn new(helper_roles: [HelperIdentity; 3]) -> Self {
         Self { helper_roles }
     }
 
@@ -410,12 +402,6 @@ impl TryFrom<[Role; 3]> for RoleAssignment {
             (HelperIdentity::TWO, value[1]),
             (HelperIdentity::THREE, value[2]),
         ])
-    }
-}
-
-impl Default for RoleAssignment {
-    fn default() -> Self {
-        Self::DEFAULT
     }
 }
 

--- a/ipa-core/src/helpers/transport/in_memory/handlers.rs
+++ b/ipa-core/src/helpers/transport/in_memory/handlers.rs
@@ -1,0 +1,102 @@
+use std::{collections::HashSet, future::Future};
+
+use crate::{
+    helpers::{
+        query::{PrepareQuery, QueryConfig},
+        transport::in_memory::{routing::Addr, transport::Error, InMemoryTransport},
+        HelperIdentity, RouteId, Transport, TransportCallbacks, TransportIdentity,
+    },
+    protocol::QueryId,
+    sharding::ShardIndex,
+};
+
+///
+pub trait RequestHandler<I: TransportIdentity>: Send {
+    fn handle(
+        &mut self,
+        transport: InMemoryTransport<I>,
+        addr: Addr<I>,
+    ) -> impl Future<Output = Result<(), Error<I>>> + Send;
+}
+
+/// Helper trait to bind in-memory request handlers to transport identity.
+pub trait IdentityHandlerExt: TransportIdentity {
+    type Handler: RequestHandler<Self>;
+}
+
+impl IdentityHandlerExt for HelperIdentity {
+    type Handler = HelperRequestHandler;
+}
+
+impl IdentityHandlerExt for ShardIndex {
+    type Handler = ();
+}
+
+impl RequestHandler<ShardIndex> for () {
+    async fn handle(
+        &mut self,
+        _transport: InMemoryTransport<ShardIndex>,
+        addr: Addr<ShardIndex>,
+    ) -> Result<(), Error<ShardIndex>> {
+        panic!(
+            "Shards can only process {:?} requests, got {:?}",
+            RouteId::Records,
+            addr.route
+        )
+    }
+}
+
+/// Handler that keeps track of running queries and
+/// routes [`RouteId::PrepareQuery`] and [`RouteId::ReceiveQuery`] requests to the stored
+/// callback instance. This handler works for MPC networks, for sharding network see
+/// [`RequestHandler<ShardIndex>`]
+pub struct HelperRequestHandler {
+    active_queries: HashSet<QueryId>,
+    callbacks: TransportCallbacks<InMemoryTransport<HelperIdentity>>,
+}
+
+impl From<TransportCallbacks<InMemoryTransport<HelperIdentity>>> for HelperRequestHandler {
+    fn from(callbacks: TransportCallbacks<InMemoryTransport<HelperIdentity>>) -> Self {
+        Self {
+            active_queries: HashSet::default(),
+            callbacks,
+        }
+    }
+}
+
+impl RequestHandler<HelperIdentity> for HelperRequestHandler {
+    async fn handle(
+        &mut self,
+        transport: InMemoryTransport<HelperIdentity>,
+        addr: Addr<HelperIdentity>,
+    ) -> Result<(), Error<HelperIdentity>> {
+        let dest = transport.identity();
+        match addr.route {
+            RouteId::ReceiveQuery => {
+                let qc = addr.into::<QueryConfig>();
+                (self.callbacks.receive_query)(Transport::clone_ref(&transport), qc)
+                    .await
+                    .map(|query_id| {
+                        assert!(
+                            self.active_queries.insert(query_id),
+                            "the same query id {query_id:?} is generated twice"
+                        );
+                    })
+                    .map_err(|e| Error::Rejected {
+                        dest,
+                        inner: Box::new(e),
+                    })
+            }
+            RouteId::PrepareQuery => {
+                let input = addr.into::<PrepareQuery>();
+                (self.callbacks.prepare_query)(Transport::clone_ref(&transport), input)
+                    .await
+                    .map_err(|e| Error::Rejected {
+                        dest,
+                        inner: Box::new(e),
+                    })
+            }
+            RouteId::Records => unreachable!(),
+        }
+    }
+}

--- a/ipa-core/src/helpers/transport/in_memory/handlers.rs
+++ b/ipa-core/src/helpers/transport/in_memory/handlers.rs
@@ -10,7 +10,10 @@ use crate::{
     sharding::ShardIndex,
 };
 
+/// Trait for in-memory request handlers. MPC handlers need to be able to process query requests,
+/// while shard traffic does not need to and therefore does not make use of it.
 ///
+/// See [`HelperRequestHandler`].
 pub trait RequestHandler<I: TransportIdentity>: Send {
     fn handle(
         &mut self,

--- a/ipa-core/src/helpers/transport/in_memory/handlers.rs
+++ b/ipa-core/src/helpers/transport/in_memory/handlers.rs
@@ -19,19 +19,6 @@ pub trait RequestHandler<I: TransportIdentity>: Send {
     ) -> impl Future<Output = Result<(), Error<I>>> + Send;
 }
 
-/// Helper trait to bind in-memory request handlers to transport identity.
-pub trait IdentityHandlerExt: TransportIdentity {
-    type Handler: RequestHandler<Self>;
-}
-
-impl IdentityHandlerExt for HelperIdentity {
-    type Handler = HelperRequestHandler;
-}
-
-impl IdentityHandlerExt for ShardIndex {
-    type Handler = ();
-}
-
 impl RequestHandler<ShardIndex> for () {
     async fn handle(
         &mut self,

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -1,21 +1,25 @@
+mod handlers;
+mod routing;
+mod sharding;
 mod transport;
 
+pub use sharding::InMemoryShardNetwork;
 pub use transport::Setup;
 
 use crate::{
-    helpers::{HelperIdentity, TransportCallbacks, TransportIdentity},
+    helpers::{HelperIdentity, TransportCallbacks},
     sync::{Arc, Weak},
 };
 
 pub type InMemoryTransport<I> = Weak<transport::InMemoryTransport<I>>;
 
-/// Container for all active transports
+/// Container for all active MPC communication channels
 #[derive(Clone)]
-pub struct InMemoryNetwork<I> {
-    pub transports: [Arc<transport::InMemoryTransport<I>>; 3],
+pub struct InMemoryMpcNetwork {
+    pub transports: [Arc<transport::InMemoryTransport<HelperIdentity>>; 3],
 }
 
-impl Default for InMemoryNetwork<HelperIdentity> {
+impl Default for InMemoryMpcNetwork {
     fn default() -> Self {
         Self::new([
             TransportCallbacks::default(),
@@ -25,11 +29,26 @@ impl Default for InMemoryNetwork<HelperIdentity> {
     }
 }
 
-#[allow(dead_code)]
-impl<I: TransportIdentity> InMemoryNetwork<I> {
+impl InMemoryMpcNetwork {
+    #[must_use]
+    pub fn new(callbacks: [TransportCallbacks<InMemoryTransport<HelperIdentity>>; 3]) -> Self {
+        let [mut first, mut second, mut third]: [_; 3] =
+            HelperIdentity::make_three().map(Setup::new);
+
+        first.connect(&mut second);
+        second.connect(&mut third);
+        third.connect(&mut first);
+
+        let [cb1, cb2, cb3] = callbacks;
+
+        Self {
+            transports: [first.start(cb1), second.start(cb2), third.start(cb3)],
+        }
+    }
+
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn identities(&self) -> [I; 3] {
+    pub fn identities(&self) -> [HelperIdentity; 3] {
         self.transports
             .iter()
             .map(|t| t.identity())
@@ -43,7 +62,7 @@ impl<I: TransportIdentity> InMemoryNetwork<I> {
     /// ## Panics
     /// If [`HelperIdentity`] is somehow points to a non-existent helper, which shouldn't happen.
     #[must_use]
-    pub fn transport(&self, id: I) -> InMemoryTransport<I> {
+    pub fn transport(&self, id: HelperIdentity) -> InMemoryTransport<HelperIdentity> {
         self.transports
             .iter()
             .find(|t| t.identity() == id)
@@ -52,7 +71,7 @@ impl<I: TransportIdentity> InMemoryNetwork<I> {
 
     #[allow(clippy::missing_panics_doc)]
     #[must_use]
-    pub fn transports(&self) -> [InMemoryTransport<I>; 3] {
+    pub fn transports(&self) -> [InMemoryTransport<HelperIdentity>; 3] {
         let transports: [InMemoryTransport<_>; 3] = self
             .transports
             .iter()
@@ -68,24 +87,6 @@ impl<I: TransportIdentity> InMemoryNetwork<I> {
     pub fn reset(&self) {
         for t in &self.transports {
             t.reset();
-        }
-    }
-}
-
-impl InMemoryNetwork<HelperIdentity> {
-    #[must_use]
-    pub fn new(callbacks: [TransportCallbacks<InMemoryTransport<HelperIdentity>>; 3]) -> Self {
-        let [mut first, mut second, mut third]: [_; 3] =
-            HelperIdentity::make_three().map(Setup::new);
-
-        first.connect(&mut second);
-        second.connect(&mut third);
-        third.connect(&mut first);
-
-        let [cb1, cb2, cb3] = callbacks;
-
-        Self {
-            transports: [first.start(cb1), second.start(cb2), third.start(cb3)],
         }
     }
 }

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -7,7 +7,7 @@ pub use sharding::InMemoryShardNetwork;
 pub use transport::Setup;
 
 use crate::{
-    helpers::{HelperIdentity, TransportCallbacks},
+    helpers::{transport::in_memory::transport::ListenerSetup, HelperIdentity, TransportCallbacks},
     sync::{Arc, Weak},
 };
 

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -46,17 +46,6 @@ impl InMemoryMpcNetwork {
         }
     }
 
-    #[must_use]
-    #[allow(clippy::missing_panics_doc)]
-    pub fn identities(&self) -> [HelperIdentity; 3] {
-        self.transports
-            .iter()
-            .map(|t| t.identity())
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap()
-    }
-
     /// Returns the transport to communicate with the given helper.
     ///
     /// ## Panics

--- a/ipa-core/src/helpers/transport/in_memory/routing.rs
+++ b/ipa-core/src/helpers/transport/in_memory/routing.rs
@@ -1,0 +1,65 @@
+use std::{
+    borrow::Borrow,
+    fmt::{Debug, Formatter},
+};
+
+use serde::de::DeserializeOwned;
+
+use crate::{
+    helpers::{QueryIdBinding, RouteId, RouteParams, StepBinding, TransportIdentity},
+    protocol::{step::Gate, QueryId},
+};
+
+/// The header/metadata of the incoming request.
+pub(super) struct Addr<I> {
+    pub route: RouteId,
+    pub origin: Option<I>,
+    pub query_id: Option<QueryId>,
+    pub gate: Option<Gate>,
+    pub params: String,
+}
+
+impl<I: TransportIdentity> Addr<I> {
+    #[allow(clippy::needless_pass_by_value)] // to avoid using double-reference at callsites
+    pub fn from_route<Q: QueryIdBinding, S: StepBinding, R: RouteParams<RouteId, Q, S>>(
+        origin: I,
+        route: R,
+    ) -> Self
+    where
+        Option<QueryId>: From<Q>,
+        Option<Gate>: From<S>,
+    {
+        Self {
+            route: route.resource_identifier(),
+            origin: Some(origin),
+            query_id: route.query_id().into(),
+            gate: route.gate().into(),
+            params: route.extra().borrow().to_string(),
+        }
+    }
+
+    pub fn into<T: DeserializeOwned>(self) -> T {
+        serde_json::from_str(&self.params).unwrap()
+    }
+
+    #[cfg(all(test, unit_test))]
+    pub fn records(from: I, query_id: QueryId, gate: Gate) -> Self {
+        Self {
+            route: RouteId::Records,
+            origin: Some(from),
+            query_id: Some(query_id),
+            gate: Some(gate),
+            params: String::new(),
+        }
+    }
+}
+
+impl<I: Debug> Debug for Addr<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Addr[route={:?}, from={:?}, query_id={:?}, step={:?}, params={}]",
+            self.route, self.origin, self.query_id, self.gate, self.params
+        )
+    }
+}

--- a/ipa-core/src/helpers/transport/in_memory/routing.rs
+++ b/ipa-core/src/helpers/transport/in_memory/routing.rs
@@ -1,7 +1,4 @@
-use std::{
-    borrow::Borrow,
-    fmt::{Debug, Formatter},
-};
+use std::{borrow::Borrow, fmt::Debug};
 
 use serde::de::DeserializeOwned;
 
@@ -11,6 +8,7 @@ use crate::{
 };
 
 /// The header/metadata of the incoming request.
+#[derive(Debug)]
 pub(super) struct Addr<I> {
     pub route: RouteId,
     pub origin: Option<I>,
@@ -51,15 +49,5 @@ impl<I: TransportIdentity> Addr<I> {
             gate: Some(gate),
             params: String::new(),
         }
-    }
-}
-
-impl<I: Debug> Debug for Addr<I> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Addr[route={:?}, from={:?}, query_id={:?}, step={:?}, params={}]",
-            self.route, self.origin, self.query_id, self.gate, self.params
-        )
     }
 }

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -1,0 +1,148 @@
+use crate::{
+    helpers::{
+        transport::in_memory::transport::{InMemoryTransport, Setup},
+        HelperIdentity,
+    },
+    sharding::ShardIndex,
+    sync::{Arc, Weak},
+};
+
+/// Container for shard-to-shard communication channels set up for each helper. Each shard is connected
+/// to every other shard within the same helper and these connections are stored here. MPC connections
+/// for each individual shard are created and stored inside [`super::InMemoryMpcNetwork`].
+///
+/// This structure helps to have a single entry point for in-memory runs. Dropping it causes all
+/// connections to be destroyed. To obtain a sending end of shard communication channel, use
+/// [`transport`] method.
+///
+/// [`transport`]: InMemoryShardNetwork::transport
+pub struct InMemoryShardNetwork {
+    pub shard_network: [Box<[Arc<InMemoryTransport<ShardIndex>>]>; 3],
+}
+
+impl InMemoryShardNetwork {
+    pub fn with_shards<I: Into<ShardIndex>>(shard_count: I) -> Self {
+        let shard_count = shard_count.into();
+        let shard_network: [_; 3] = HelperIdentity::make_three().map(|h| {
+            let mut shard_connections = shard_count.iter().map(Setup::new).collect::<Vec<_>>();
+            for i in 0..shard_connections.len() {
+                let (lhs, rhs) = shard_connections.split_at_mut(i);
+                if let Some((a, _)) = lhs.split_last_mut() {
+                    for b in rhs {
+                        Setup::connect(a, b);
+                    }
+                }
+            }
+
+            shard_connections
+                .into_iter()
+                .map(|s| tracing::info_span!("", ?h).in_scope(|| s.start(())))
+                .collect::<Vec<_>>()
+                .into()
+        });
+
+        Self { shard_network }
+    }
+
+    pub fn transport<I: Into<ShardIndex>>(
+        &self,
+        id: HelperIdentity,
+        shard_id: I,
+    ) -> Weak<InMemoryTransport<ShardIndex>> {
+        Arc::downgrade(&self.shard_network[id][usize::from(shard_id.into())])
+    }
+
+    pub fn shard_transports<I: Into<ShardIndex>>(
+        &self,
+        shard_id: I,
+    ) -> [Weak<InMemoryTransport<ShardIndex>>; 3] {
+        let shard_id = usize::from(shard_id.into());
+        // see #121
+        [
+            Arc::downgrade(&self.shard_network[0][shard_id]),
+            Arc::downgrade(&self.shard_network[1][shard_id]),
+            Arc::downgrade(&self.shard_network[2][shard_id]),
+        ]
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+
+    use futures_util::StreamExt;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    use crate::{
+        helpers::{transport::in_memory::InMemoryShardNetwork, HelperIdentity, RouteId, Transport},
+        protocol::{step::Gate, QueryId},
+        sharding::ShardIndex,
+        test_executor::run,
+        test_fixture::logging,
+    };
+
+    fn shard_pairs<I: Into<ShardIndex>>(
+        shard_count: I,
+    ) -> impl Iterator<Item = (ShardIndex, ShardIndex)> {
+        let shard_count = shard_count.into();
+        shard_count.iter().flat_map(move |a| {
+            shard_count
+                .iter()
+                .filter_map(move |b| (a != b).then_some((a, b)))
+        })
+    }
+
+    #[test]
+    fn shards_talk_to_each_other() {
+        logging::setup();
+        run(|| async {
+            let shard_count = 5;
+            let shard_network = InMemoryShardNetwork::with_shards(shard_count);
+            let mut sum: u32 = 0;
+
+            for identity in HelperIdentity::make_three() {
+                for (a, b) in shard_pairs(shard_count) {
+                    let (tx, rx) = mpsc::channel(1);
+                    shard_network
+                        .transport(identity, a)
+                        .send(
+                            b,
+                            (RouteId::Records, QueryId, Gate::default()),
+                            ReceiverStream::new(rx),
+                        )
+                        .await
+                        .unwrap();
+                    tx.send(vec![1]).await.unwrap();
+                }
+
+                for (a, b) in shard_pairs(shard_count) {
+                    sum += shard_network
+                        .transport(identity, a)
+                        .receive(b, (QueryId, Gate::default()))
+                        .collect::<Vec<_>>()
+                        .await
+                        .into_iter()
+                        .flatten()
+                        .map(u32::from)
+                        .sum::<u32>();
+                }
+            }
+
+            // total number of messages sent by each shard: N - 1
+            assert_eq!(3 * shard_count * (shard_count - 1), sum);
+        });
+    }
+
+    #[test]
+    fn network_owns_transports() {
+        run(|| async {
+            let shard_network = InMemoryShardNetwork::with_shards(3);
+            let [h1, h2, h3] =
+                HelperIdentity::make_three().map(|identity| shard_network.transport(identity, 0));
+            drop(shard_network);
+            assert!(h1.upgrade().is_none());
+            assert!(h2.upgrade().is_none());
+            assert!(h3.upgrade().is_none());
+        });
+    }
+}

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -1,6 +1,6 @@
 use crate::{
     helpers::{
-        transport::in_memory::transport::{InMemoryTransport, Setup},
+        transport::in_memory::transport::{InMemoryTransport, ListenerSetup, Setup},
         HelperIdentity,
     },
     sharding::ShardIndex,

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -133,7 +133,8 @@ impl<I: IdentityHandlerExt> InMemoryTransport<I> {
 }
 
 #[async_trait]
-impl<I: IdentityHandlerExt> Transport<I> for Weak<InMemoryTransport<I>> {
+impl<I: IdentityHandlerExt> Transport for Weak<InMemoryTransport<I>> {
+    type Identity = I;
     type RecordsStream = ReceiveRecords<I, InMemoryStream>;
     type Error = Error<I>;
 

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -16,7 +16,7 @@ mod receive;
 mod stream;
 
 #[cfg(feature = "in-memory-infra")]
-pub use in_memory::{InMemoryNetwork, InMemoryTransport};
+pub use in_memory::{InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};
 pub use receive::{LogErrors, ReceiveRecords};
 #[cfg(feature = "web-app")]
 pub use stream::WrappedAxumBodyStream;

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -25,7 +25,10 @@ pub use stream::{
     WrappedBoxBodyStream,
 };
 
-use crate::{helpers::Role, sharding::ShardIndex};
+use crate::{
+    helpers::{Role, TransportIdentity},
+    sharding::ShardIndex,
+};
 
 /// An identity of a peer that can be communicated with using [`Transport`]. There are currently two
 /// types of peers - helpers and shards.
@@ -138,16 +141,22 @@ impl RouteParams<RouteId, QueryId, Gate> for (RouteId, QueryId, Gate) {
 
 /// Transport that supports per-query,per-step channels
 #[async_trait]
-pub trait Transport<I: Identity>: Clone + Send + Sync + 'static {
+pub trait Transport: Clone + Send + Sync + 'static {
+    type Identity: TransportIdentity;
     type RecordsStream: Stream<Item = Vec<u8>> + Send + Unpin;
     type Error: std::fmt::Debug;
 
-    fn identity(&self) -> I;
+    fn identity(&self) -> Self::Identity;
 
     /// Sends a new request to the given destination helper party.
     /// Depending on the specific request, it may or may not require acknowledgment by the remote
     /// party
-    async fn send<D, Q, S, R>(&self, dest: I, route: R, data: D) -> Result<(), Self::Error>
+    async fn send<D, Q, S, R>(
+        &self,
+        dest: Self::Identity,
+        route: R,
+        data: D,
+    ) -> Result<(), Self::Error>
     where
         Option<QueryId>: From<Q>,
         Option<Gate>: From<S>,
@@ -160,7 +169,7 @@ pub trait Transport<I: Identity>: Clone + Send + Sync + 'static {
     /// and step
     fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
         &self,
-        from: I,
+        from: Self::Identity,
         route: R,
     ) -> Self::RecordsStream;
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -123,7 +123,8 @@ impl HttpTransport {
 }
 
 #[async_trait]
-impl Transport<HelperIdentity> for Arc<HttpTransport> {
+impl Transport for Arc<HttpTransport> {
+    type Identity = HelperIdentity;
     type RecordsStream = ReceiveRecords<HelperIdentity, LogHttpErrors>;
     type Error = Error;
 

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -32,6 +32,7 @@ use crate::{
         ReplicatedSecretSharing,
     },
     seq_join::SeqJoin,
+    sharding::NoSharding,
     sync::Arc,
 };
 
@@ -43,7 +44,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     pub fn new(participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self {
-            inner: Base::new(participant, gateway),
+            inner: Base::new(participant, gateway, NoSharding),
         }
     }
 
@@ -182,6 +183,7 @@ impl<'a, F: ExtendableField> Upgraded<'a, F> {
             self.inner.gateway,
             self.gate.clone(),
             self.total_records,
+            NoSharding,
         )
     }
 }

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -32,7 +32,7 @@ use crate::{
         ReplicatedSecretSharing,
     },
     seq_join::SeqJoin,
-    sharding::NoSharding,
+    sharding::NotSharded,
     sync::Arc,
 };
 
@@ -44,7 +44,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     pub fn new(participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self {
-            inner: Base::new(participant, gateway, NoSharding),
+            inner: Base::new(participant, gateway, NotSharded),
         }
     }
 
@@ -183,7 +183,7 @@ impl<'a, F: ExtendableField> Upgraded<'a, F> {
             self.inner.gateway,
             self.gate.clone(),
             self.total_records,
-            NoSharding,
+            NotSharded,
         )
     }
 }

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -164,6 +164,9 @@ pub struct Base<'a, B: ShardBinding = NoSharding> {
     inner: Inner<'a>,
     gate: Gate,
     total_records: TotalRecords,
+    /// This indicates whether the system uses sharding or no. It's not ideal that we keep it here
+    /// because it gets cloned often, a potential solution to that, if this shows up on flame graph,
+    /// would be to move it to [`Inner`] struct.
     sharding: B,
 }
 
@@ -290,36 +293,11 @@ struct Inner<'a> {
     pub gateway: &'a Gateway,
 }
 
-// #[derive(Clone)]
-// struct WithShardInfo<'a> {
-//     base: Inner<'a>,
-//     shard: Shard,
-// }
-//
 impl<'a> Inner<'a> {
     fn new(prss: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
         Self { prss, gateway }
     }
 }
-//
-// impl<'a> WithShardInfo<'a> {
-//     fn new(prss: &'a PrssEndpoint, gateway: &'a Gateway, shard: Shard) -> Self {
-//         Self {
-//             base: Inner::new(prss, gateway),
-//             shard,
-//         }
-//     }
-// }
-
-// impl ShardConfiguration for WithShardInfo<'_> {
-//     fn shard_index(&self) -> ShardIndex {
-//         self.shard.shard_id
-//     }
-//
-//     fn shard_count(&self) -> ShardIndex {
-//         self.shard.shard_count
-//     }
-// }
 
 #[cfg(all(test, unit_test))]
 mod tests {

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -18,8 +18,8 @@ use prss::{InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRand
 pub use semi_honest::Upgraded as UpgradedSemiHonestContext;
 pub use upgrade::{UpgradeContext, UpgradeToMalicious};
 pub use validator::Validator;
-pub type SemiHonestContext<'a, B = NoSharding> = semi_honest::Context<'a, B>;
-pub type ShardedSemiHonestContext<'a> = semi_honest::Context<'a, Shard>;
+pub type SemiHonestContext<'a, B = NotSharded> = semi_honest::Context<'a, B>;
+pub type ShardedSemiHonestContext<'a> = semi_honest::Context<'a, Sharded>;
 
 use crate::{
     error::Error,
@@ -35,7 +35,7 @@ use crate::{
         SecretSharing,
     },
     seq_join::SeqJoin,
-    sharding::{NoSharding, Shard, ShardBinding, ShardConfiguration, ShardIndex},
+    sharding::{NotSharded, ShardBinding, ShardConfiguration, ShardIndex, Sharded},
 };
 
 /// Context used by each helper to perform secure computation. Provides access to shared randomness
@@ -160,7 +160,7 @@ pub trait SpecialAccessToUpgradedContext<F: ExtendableField>: UpgradedContext<F>
 /// Context for protocol executions suitable for semi-honest security model, i.e. secure against
 /// honest-but-curious adversary parties.
 #[derive(Clone)]
-pub struct Base<'a, B: ShardBinding = NoSharding> {
+pub struct Base<'a, B: ShardBinding = NotSharded> {
     inner: Inner<'a>,
     gate: Gate,
     total_records: TotalRecords,
@@ -269,7 +269,7 @@ impl<'a, B: ShardBinding> Context for Base<'a, B> {
 /// via [`ShardConfiguration`] trait.
 pub trait ShardedContext: Context + ShardConfiguration {}
 
-impl ShardConfiguration for Base<'_, Shard> {
+impl ShardConfiguration for Base<'_, Sharded> {
     fn shard_id(&self) -> ShardIndex {
         self.sharding.shard_id
     }
@@ -279,7 +279,7 @@ impl ShardConfiguration for Base<'_, Shard> {
     }
 }
 
-impl<'a> ShardedContext for Base<'a, Shard> {}
+impl<'a> ShardedContext for Base<'a, Sharded> {}
 
 impl<'a, B: ShardBinding> SeqJoin for Base<'a, B> {
     fn active_work(&self) -> NonZeroUsize {

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -27,14 +27,14 @@ use crate::{
         malicious::ExtendableField, semi_honest::AdditiveShare as Replicated,
     },
     seq_join::SeqJoin,
-    sharding::{NoSharding, Shard, ShardBinding, ShardConfiguration, ShardIndex},
+    sharding::{NotSharded, ShardBinding, ShardConfiguration, ShardIndex, Sharded},
 };
 
 #[derive(Clone)]
 pub struct Context<'a, B: ShardBinding> {
     inner: Base<'a, B>,
 }
-impl ShardConfiguration for Context<'_, Shard> {
+impl ShardConfiguration for Context<'_, Sharded> {
     fn shard_id(&self) -> ShardIndex {
         self.inner.shard_id()
     }
@@ -52,14 +52,18 @@ impl<'a, B: ShardBinding> Context<'a, B> {
     }
 }
 
-impl<'a> Context<'a, NoSharding> {
+impl<'a> Context<'a, NotSharded> {
     pub fn new(participant: &'a PrssEndpoint, gateway: &'a Gateway) -> Self {
-        Self::new_complete(participant, gateway, NoSharding)
+        Self::new_complete(participant, gateway, NotSharded)
     }
 }
 
-impl<'a> Context<'a, Shard> {
-    pub fn new_sharded(participant: &'a PrssEndpoint, gateway: &'a Gateway, shard: Shard) -> Self {
+impl<'a> Context<'a, Sharded> {
+    pub fn new_sharded(
+        participant: &'a PrssEndpoint,
+        gateway: &'a Gateway,
+        shard: Sharded,
+    ) -> Self {
         Self::new_complete(participant, gateway, shard)
     }
 }

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -322,7 +322,7 @@ mod tests {
         ff::FieldType,
         helpers::{
             query::{PrepareQuery, QueryConfig, QueryType::TestMultiply},
-            HelperIdentity, InMemoryNetwork, PrepareQueryCallback, RoleAssignment, Transport,
+            HelperIdentity, InMemoryMpcNetwork, PrepareQueryCallback, RoleAssignment, Transport,
             TransportCallbacks,
         },
         protocol::QueryId,
@@ -368,7 +368,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let network = InMemoryNetwork::new([TransportCallbacks::default(), cb2, cb3]);
+        let network = InMemoryMpcNetwork::new([TransportCallbacks::default(), cb2, cb3]);
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
@@ -406,7 +406,7 @@ mod tests {
             prepare_query: prepare_query_callback(|_, _| async { Ok(()) }),
             ..Default::default()
         });
-        let network = InMemoryNetwork::new(cb);
+        let network = InMemoryMpcNetwork::new(cb);
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
@@ -433,7 +433,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let network = InMemoryNetwork::new([TransportCallbacks::default(), cb2, cb3]);
+        let network = InMemoryMpcNetwork::new([TransportCallbacks::default(), cb2, cb3]);
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
@@ -456,7 +456,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let network = InMemoryNetwork::new([TransportCallbacks::default(), cb2, cb3]);
+        let network = InMemoryMpcNetwork::new([TransportCallbacks::default(), cb2, cb3]);
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
@@ -482,7 +482,7 @@ mod tests {
 
         #[tokio::test]
         async fn happy_case() {
-            let network = InMemoryNetwork::default();
+            let network = InMemoryMpcNetwork::default();
             let identities = HelperIdentity::make_three();
             let req = prepare_query(identities);
             let transport = network.transport(identities[1]);
@@ -501,7 +501,7 @@ mod tests {
 
         #[tokio::test]
         async fn rejects_if_coordinator() {
-            let network = InMemoryNetwork::default();
+            let network = InMemoryMpcNetwork::default();
             let identities = HelperIdentity::make_three();
             let req = prepare_query(identities);
             let transport = network.transport(identities[0]);
@@ -515,7 +515,7 @@ mod tests {
 
         #[tokio::test]
         async fn rejects_if_query_exists() {
-            let network = InMemoryNetwork::default();
+            let network = InMemoryMpcNetwork::default();
             let identities = HelperIdentity::make_three();
             let req = prepare_query(identities);
             let transport = network.transport(identities[1]);

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -8,12 +8,12 @@ use std::{
 pub struct ShardIndex(u32);
 
 #[derive(Debug, Copy, Clone)]
-pub struct Shard {
+pub struct Sharded {
     pub shard_id: ShardIndex,
     pub shard_count: ShardIndex,
 }
 
-impl ShardConfiguration for Shard {
+impl ShardConfiguration for Sharded {
     fn shard_id(&self) -> ShardIndex {
         self.shard_id
     }
@@ -59,10 +59,10 @@ pub trait ShardConfiguration {
 pub trait ShardBinding: Debug + Send + Sync + Clone {}
 
 #[derive(Debug, Copy, Clone)]
-pub struct NoSharding;
+pub struct NotSharded;
 
-impl ShardBinding for NoSharding {}
-impl ShardBinding for Shard {}
+impl ShardBinding for NotSharded {}
+impl ShardBinding for Sharded {}
 
 impl ShardIndex {
     pub const FIRST: Self = Self(0);

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -79,12 +79,6 @@ impl From<u32> for ShardIndex {
     }
 }
 
-impl From<ShardIndex> for u32 {
-    fn from(value: ShardIndex) -> Self {
-        value.0
-    }
-}
-
 impl From<ShardIndex> for u64 {
     fn from(value: ShardIndex) -> Self {
         u64::from(value.0)

--- a/ipa-core/src/test_fixture/app.rs
+++ b/ipa-core/src/test_fixture/app.rs
@@ -8,7 +8,7 @@ use crate::{
     ff::Serializable,
     helpers::{
         query::{QueryConfig, QueryInput},
-        HelperIdentity, InMemoryNetwork,
+        InMemoryMpcNetwork,
     },
     protocol::QueryId,
     query::QueryStatus,
@@ -50,7 +50,7 @@ where
 /// [`TestWorld`]: crate::test_fixture::TestWorld
 pub struct TestApp {
     drivers: [HelperApp; 3],
-    network: InMemoryNetwork<HelperIdentity>,
+    network: InMemoryMpcNetwork,
 }
 
 fn unzip_tuple_array<T, U>(input: [(T, U); 3]) -> ([T; 3], [U; 3]) {
@@ -63,7 +63,7 @@ impl Default for TestApp {
         let (setup, callbacks) =
             unzip_tuple_array([AppSetup::new(), AppSetup::new(), AppSetup::new()]);
 
-        let network = InMemoryNetwork::new(callbacks);
+        let network = InMemoryMpcNetwork::new(callbacks);
         let drivers = network
             .transports()
             .iter()

--- a/ipa-core/src/test_fixture/sharing.rs
+++ b/ipa-core/src/test_fixture/sharing.rs
@@ -152,6 +152,10 @@ where
     }
 }
 
+impl Reconstruct<()> for [(); 3] {
+    fn reconstruct(&self) {}
+}
+
 #[cfg(feature = "descriptive-gate")]
 impl<F, S> Reconstruct<F> for [crate::protocol::boolean::RandomBitsShare<F, S>; 3]
 where

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -10,8 +10,8 @@ use tracing::{Instrument, Level, Span};
 
 use crate::{
     helpers::{
-        Gateway, GatewayConfig, InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport, Role,
-        RoleAssignment,
+        Gateway, GatewayConfig, HelperIdentity, InMemoryMpcNetwork, InMemoryShardNetwork,
+        InMemoryTransport, Role, RoleAssignment,
     },
     protocol::{
         context::{
@@ -283,9 +283,12 @@ impl TestWorldConfig {
 
     #[must_use]
     pub fn role_assignment(&self) -> &RoleAssignment {
-        self.role_assignment
-            .as_ref()
-            .unwrap_or(&RoleAssignment::DEFAULT)
+        const DEFAULT_ASSIGNMENT: RoleAssignment = RoleAssignment::new([
+            HelperIdentity::ONE,
+            HelperIdentity::TWO,
+            HelperIdentity::THREE,
+        ]);
+        self.role_assignment.as_ref().unwrap_or(&DEFAULT_ASSIGNMENT)
     }
 }
 

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -60,8 +60,8 @@ pub trait ShardingScheme {
 
 /// Helper trait to parametrize [`Runner`] trait based on the sharding scheme chosen. The whole
 /// purpose of it is to be able to say for sharded runs, the input must be in a form of a [`Vec`]
-pub trait RunnerInput<W: ShardingScheme, A: Send>: Send {
-    fn share(self) -> [W::Container<A>; 3];
+pub trait RunnerInput<S: ShardingScheme, A: Send>: Send {
+    fn share(self) -> [S::Container<A>; 3];
 }
 
 /// This indicates how many shards need to be created in test environment.
@@ -210,7 +210,7 @@ impl TestWorld<NoSharding> {
     }
 }
 
-impl<W: ShardingScheme> Drop for TestWorld<W> {
+impl<S: ShardingScheme> Drop for TestWorld<S> {
     fn drop(&mut self) {
         if tracing::span_enabled!(Level::DEBUG) {
             let metrics = self.metrics_handle.snapshot();

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -170,7 +170,8 @@ impl<const SHARDS: usize> TestWorld<WithShards<SHARDS>> {
             .iter()
             .collect::<Vec<_>>()
             .try_into()
-            .unwrap_or_else(|_| unreachable!())
+            .ok()
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
This change introduces the ability to run very simple circuits on multiple shards in parallel. It is not possible to communicate between shards yet, but it is possible to use the same test infrastructure to create multiple shards and use PRSS inside them as well as provide the input for each shard and consume their output.

The next and hopefully final change will bring the ability to communicate across shards.