### PR TITLE
Remove RecordBinding type parameter from Reshare

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -182,16 +182,14 @@ impl KeyRegistries {
         network: &NetworkConfig,
     ) -> Option<(KeyIdentifier, [&KeyRegistry<PublicKeyOnly>; 3])> {
         // Get the configs, if all three peers have one
-        let Some(configs) = network.peers().iter().try_fold(Vec::new(), |acc, peer| {
+        let configs = network.peers().iter().try_fold(Vec::new(), |acc, peer| {
             if let (mut vec, Some(hpke_config)) = (acc, peer.hpke_config.as_ref()) {
                 vec.push(hpke_config);
                 Some(vec)
             } else {
                 None
             }
-        }) else {
-            return None;
-        };
+        })?;
 
         // Create key registries
         self.0 = configs

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -351,9 +351,7 @@ impl ClientCertRecognizingAcceptor {
         network_config: &NetworkConfig,
         cert_option: Option<&Certificate>,
     ) -> Option<ClientIdentity> {
-        let Some(cert) = cert_option else {
-            return None;
-        };
+        let cert = cert_option?;
         // We currently require an exact match with the peer cert (i.e. we don't support verifying
         // the certificate against a truststore and identifying the peer by the certificate
         // subject). This could be changed if the need arises.

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -19,7 +19,7 @@ pub use sum_of_product::SumOfProducts;
 
 use crate::{
     ff::Field,
-    protocol::{context::Context, RecordId},
+    protocol::context::Context,
     secret_sharing::{
         replicated::semi_honest::AdditiveShare, SecretSharing, SharedValue, Vectorizable,
     },
@@ -34,7 +34,7 @@ use crate::{
 
 pub trait BasicProtocols<C: Context, V: SharedValue + Vectorizable<N>, const N: usize = 1>:
     SecretSharing<V>
-    + Reshare<C, RecordId>
+    + Reshare<C>
     + Reveal<C, N, Output = <V as Vectorizable<N>>::Array>
     + SecureMul<C>
     + ShareKnownValue<C, V>

--- a/ipa-core/src/protocol/modulus_conversion/convert_shares.rs
+++ b/ipa-core/src/protocol/modulus_conversion/convert_shares.rs
@@ -365,9 +365,7 @@ where
     let stream = unfold(
         (ctx, locally_converted, first_record),
         |(ctx, mut locally_converted, record_id)| async move {
-            let Some((triple, residual)) = locally_converted.next().await else {
-                return None;
-            };
+            let (triple, residual) = locally_converted.next().await?;
             let bit_contexts = (0..).map(|i| ctx.narrow(&ConvertSharesStep::ConvertBit(i)));
             let converted =
                 ctx.parallel_join(zip(bit_contexts, triple).map(|(ctx, triple)| async move {


### PR DESCRIPTION
Similar to a recent change to `Reveal`. After removing old IPA we no longer need this implementation of `Reshare` for `Vec`s.