### PR TITLE
Serde is now a non-optional dependency

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -18,7 +18,6 @@ default = [
     "ipa-prf",
 ]
 cli = ["comfy-table", "clap"]
-enable-serde = ["serde", "serde_json"]
 disable-metrics = []
 # TODO move web-app to a separate crate. It adds a lot of build time to people who mostly write protocols
 # TODO Consider moving out benches as well
@@ -28,7 +27,6 @@ web-app = [
     "base64",
     "clap",
     "comfy-table",
-    "enable-serde",
     "hyper",
     "hyper-rustls",
     "rcgen",
@@ -40,7 +38,7 @@ web-app = [
     "tower",
     "tower-http",
 ]
-test-fixture = ["enable-serde", "weak-field"]
+test-fixture = ["weak-field"]
 # Include observability instruments that detect lack of progress inside MPC. If there is a bug that leads to helper
 # miscommunication, this feature helps to detect it. Turning it on has some cost.
 # If "shuttle" feature is enabled, turning this on has no effect.
@@ -134,8 +132,8 @@ rustls-pemfile = { version = "1", optional = true }
 # we can remove pinning
 rustls-webpki = "^0.101.4"
 # TODO consider using zerocopy or serde_bytes or in-house serialization
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 sha2 = "0.10"
 shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
@@ -179,7 +177,7 @@ bench = false
 [[bin]]
 name = "ipa_bench"
 path = "src/bin/ipa_bench/ipa_bench.rs"
-required-features = ["cli", "enable-serde"]
+required-features = ["cli"]
 bench = false
 
 [[bin]]

--- a/ipa-core/src/bin/ipa_bench/config.rs
+++ b/ipa-core/src/bin/ipa_bench/config.rs
@@ -2,14 +2,12 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "enable-serde")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WeightedIndex<T> {
     pub index: T,
     pub weight: f64,
 }
 
-#[cfg(feature = "enable-serde")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
     pub devices_per_user: Vec<WeightedIndex<u8>>,

--- a/ipa-core/src/bin/ipa_bench/models.rs
+++ b/ipa-core/src/bin/ipa_bench/models.rs
@@ -1,15 +1,12 @@
 use std::{
     fmt::{Debug, Formatter},
-    io::{Error as IoError, ErrorKind as IoErrorKind},
     ops::Range,
 };
 
-use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 
 // Type aliases to indicate whether the parameter should be encrypted, secret shared, etc.
 // Underlying types are temporalily assigned for PoC.
-pub type CipherText = Vec<u8>;
 type PlainText = String;
 pub type MatchKey = u64;
 pub type Number = u32;
@@ -19,104 +16,6 @@ pub type Epoch = u8;
 
 /// An offset in seconds into a given epoch. Using an 32-bit value > 20-bit > 604,800 seconds.
 pub type Offset = u32;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SecretShare {
-    ss: [CipherText; 3],
-}
-
-impl SecretShare {
-    fn combine(&self) -> Vec<u8> {
-        let mut result = Vec::new();
-
-        assert!(self.ss[0].len() == self.ss[1].len());
-        assert!(self.ss[0].len() == self.ss[2].len());
-
-        for i in 0..self.ss[0].len() {
-            result.push(self.ss[0][i] ^ self.ss[1][i] ^ self.ss[2][i]);
-        }
-
-        result
-    }
-
-    // TODO: Add Shamir's SS
-
-    fn xor<R: RngCore + CryptoRng>(data: &[u8], rng: &mut R) -> Self {
-        let mut ss = [Vec::new(), Vec::new(), Vec::new()];
-
-        for x in data {
-            let ss1 = rng.gen::<u8>();
-            let ss2 = rng.gen::<u8>();
-            let ss3 = ss1 ^ ss2 ^ x;
-
-            ss[0].push(ss1);
-            ss[1].push(ss2);
-            ss[2].push(ss3);
-        }
-
-        SecretShare { ss }
-    }
-}
-
-pub trait SecretSharable {
-    /// Splits the number into secret shares
-    fn xor_split<R: RngCore + CryptoRng>(&self, rng: &mut R) -> SecretShare;
-
-    /// Combines the given secret shares back to [Self]
-    /// # Errors
-    /// if the combined data overflows [Self]
-    fn combine(data: &SecretShare) -> Result<Self, IoError>
-    where
-        Self: Sized;
-}
-
-impl SecretSharable for u32 {
-    fn xor_split<R: RngCore + CryptoRng>(&self, rng: &mut R) -> SecretShare {
-        SecretShare::xor(&self.to_be_bytes(), rng)
-    }
-
-    fn combine(data: &SecretShare) -> Result<Self, IoError> {
-        let ss = data.combine();
-
-        let mut high = ss[0..ss.len() - 4].to_vec();
-        high.retain(|x| *x != 0);
-
-        if ss.len() > 4 && !high.is_empty() {
-            return Err(IoError::from(IoErrorKind::InvalidData));
-        }
-
-        let mut bytes = [0u8; 4];
-        for (i, v) in ss[ss.len() - 4..].iter().enumerate() {
-            bytes[i] = *v;
-        }
-
-        Ok(u32::from_be_bytes(bytes))
-    }
-}
-
-impl SecretSharable for u64 {
-    fn xor_split<R: RngCore + CryptoRng>(&self, rng: &mut R) -> SecretShare {
-        SecretShare::xor(&self.to_be_bytes(), rng)
-    }
-
-    fn combine(data: &SecretShare) -> Result<Self, IoError> {
-        let ss = data.combine();
-
-        let mut high = ss[0..ss.len() - 8].to_vec();
-        high.retain(|x| *x != 0);
-
-        if ss.len() > 8 && !high.is_empty() {
-            return Err(IoError::from(IoErrorKind::InvalidData));
-        }
-
-        let mut bytes = [0u8; 8];
-        for (i, v) in ss[ss.len() - 8..].iter().enumerate() {
-            bytes[i] = *v;
-        }
-
-        Ok(u64::from_be_bytes(bytes))
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// A timestamp of a source/trigger report represented by epoch and offset.
@@ -313,8 +212,7 @@ impl Debug for TriggerFanoutQuery {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::EventTimestamp;
-    use crate::models::Epoch;
+    use super::{EventTimestamp, Epoch};
 
     #[test]
     fn event_timestamp_new() {

--- a/ipa-core/src/bin/ipa_bench/models.rs
+++ b/ipa-core/src/bin/ipa_bench/models.rs
@@ -20,8 +20,7 @@ pub type Epoch = u8;
 /// An offset in seconds into a given epoch. Using an 32-bit value > 20-bit > 604,800 seconds.
 pub type Offset = u32;
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretShare {
     ss: [CipherText; 3],
 }
@@ -119,8 +118,7 @@ impl SecretSharable for u64 {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// A timestamp of a source/trigger report represented by epoch and offset.
 ///
 /// Internally, the time is stored in `u32`, but the value is capped at `(Epoch::MAX + 1) * SECONDS_IN_EPOCH - 1`.
@@ -206,8 +204,7 @@ impl From<EventTimestamp> for u32 {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Event {
     // An identifier, set in the user agent, which identifies an individual person. This must never be released (beyond
     /// the match key provider) to any party in unencrypted form. For the purpose of this tool, however, the value is in
@@ -222,8 +219,7 @@ pub struct Event {
     pub timestamp: EventTimestamp,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum GenericReport {
     /// An event produced on websites/apps when a user interacts with an ad (i.e. impression, click).
     Source {
@@ -242,22 +238,20 @@ pub enum GenericReport {
     },
 }
 
-// TODO(taiki): Implement Serialize/Deserialize
-
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 enum QueryType {
     SourceFanout,
     TriggerFanout,
 }
 
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 enum Node {
     Helper1,
     Helper2,
     Helper3,
 }
 
-#[cfg_attr(feature = "enable-serde", derive(Serialize))]
+#[derive(Serialize)]
 struct IPAQuery {
     /// Caller authentication token.
     auth_token: PlainText,
@@ -278,7 +272,7 @@ struct IPAQuery {
     reports: Vec<GenericReport>,
 }
 
-#[cfg_attr(feature = "enable-serde", derive(Serialize))]
+#[derive(Serialize)]
 struct SourceFanoutQuery {
     query: IPAQuery,
 
@@ -299,7 +293,7 @@ impl Debug for SourceFanoutQuery {
     }
 }
 
-#[cfg_attr(feature = "enable-serde", derive(Serialize))]
+#[derive(Serialize)]
 struct TriggerFanoutQuery {
     query: IPAQuery,
 

--- a/ipa-core/src/bin/ipa_bench/models.rs
+++ b/ipa-core/src/bin/ipa_bench/models.rs
@@ -212,7 +212,7 @@ impl Debug for TriggerFanoutQuery {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use super::{EventTimestamp, Epoch};
+    use super::{Epoch, EventTimestamp};
 
     #[test]
     fn event_timestamp_new() {

--- a/ipa-core/src/cli/ipa_output.rs
+++ b/ipa-core/src/cli/ipa_output.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
+
 use crate::helpers::query::{IpaQueryConfig, QuerySize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/ipa-core/src/cli/ipa_output.rs
+++ b/ipa-core/src/cli/ipa_output.rs
@@ -1,9 +1,8 @@
 use std::time::Duration;
-
+use serde::{Deserialize, Serialize};
 use crate::helpers::query::{IpaQueryConfig, QuerySize};
 
-#[derive(Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct QueryResult {
     pub input_size: QuerySize,
     pub config: IpaQueryConfig,

--- a/ipa-core/src/cli/mod.rs
+++ b/ipa-core/src/cli/mod.rs
@@ -13,7 +13,6 @@ pub mod playbook;
 #[cfg(feature = "web-app")]
 mod test_setup;
 mod verbosity;
-
 #[cfg(feature = "web-app")]
 pub use clientconf::{setup as client_config_setup, ConfGenArgs};
 pub use csv::Serializer as CsvSerializer;

--- a/ipa-core/src/cli/noise.rs
+++ b/ipa-core/src/cli/noise.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::{Debug, Display, Formatter},
 };
 
+use serde::{Deserialize, Serialize};
 use clap::Args;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
@@ -30,8 +31,7 @@ pub struct ApplyDpArgs {
     cap: u32,
 }
 
-#[derive(Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct NoisyOutput {
     /// Aggregated breakdowns with noise applied. It is important to use unsigned values here
     /// to avoid bias/mean skew
@@ -45,11 +45,10 @@ pub struct NoisyOutput {
 #[derive(Debug, Copy, Clone)]
 pub struct EpsilonBits(f64);
 
-#[cfg(feature = "enable-serde")]
-impl serde::Serialize for EpsilonBits {
+impl Serialize for EpsilonBits {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         serializer.serialize_str(&self.0.to_string())
     }

--- a/ipa-core/src/cli/noise.rs
+++ b/ipa-core/src/cli/noise.rs
@@ -7,7 +7,7 @@ use std::{
 use clap::Args;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::protocol::dp::InsecureDiscreteDp;
 

--- a/ipa-core/src/cli/noise.rs
+++ b/ipa-core/src/cli/noise.rs
@@ -4,10 +4,10 @@ use std::{
     fmt::{Debug, Display, Formatter},
 };
 
-use serde::{Deserialize, Serialize};
 use clap::Args;
 use rand::rngs::StdRng;
 use rand_core::SeedableRng;
+use serde::{Deserialize, Serialize};
 
 use crate::protocol::dp::InsecureDiscreteDp;
 

--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -50,7 +50,6 @@ pub enum Error {
     #[error("runtime error")]
     RuntimeError(JoinError),
     #[error("failed to parse json: {0}")]
-    #[cfg(feature = "enable-serde")]
     Serde(#[from] serde_json::Error),
     #[error("MPC Infrastructure error: {0}")]
     MpcInfraError(#[from] crate::helpers::Error<Role>),

--- a/ipa-core/src/ff/field.rs
+++ b/ipa-core/src/ff/field.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use typenum::{U1, U4};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     protocol::prss::FromRandom,
@@ -37,8 +38,7 @@ pub trait Field:
     const ONE: Self;
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum FieldType {
     #[cfg(any(test, feature = "weak-field"))]

--- a/ipa-core/src/ff/field.rs
+++ b/ipa-core/src/ff/field.rs
@@ -3,8 +3,8 @@ use std::{
     ops::{Mul, MulAssign},
 };
 
-use typenum::{U1, U4};
 use serde::{Deserialize, Serialize};
+use typenum::{U1, U4};
 
 use crate::{
     protocol::prss::FromRandom,

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -13,7 +13,7 @@ mod gateway;
 pub(crate) mod prss_protocol;
 pub mod stream;
 mod transport;
-
+use serde::{Deserialize, Serialize, Serializer};
 use std::ops::{Index, IndexMut};
 
 /// to validate that transport can actually send streams of this type
@@ -81,22 +81,18 @@ pub const MESSAGE_PAYLOAD_SIZE_BYTES: usize = MessagePayloadArrayLen::USIZE;
 /// represents a helper's role within an MPC protocol, which may be different per protocol.
 /// `HelperIdentity` will be established at startup and then never change. Components that want to
 /// resolve this identifier into something (Uri, encryption keys, etc) must consult configuration
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "enable-serde",
-    derive(serde::Deserialize),
-    serde(try_from = "usize")
-)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Deserialize)]
+#[serde(try_from = "usize")]
 pub struct HelperIdentity {
     id: u8,
 }
 
 // Serialize as `serde(transparent)` would. Don't see how to enable that
 // for only one of (de)serialization.
-impl serde::Serialize for HelperIdentity {
+impl Serialize for HelperIdentity {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         self.id.serialize(serializer)
     }
@@ -219,26 +215,18 @@ impl<T> IndexMut<HelperIdentity> for Vec<T> {
 /// may be `H2` or `H3`.
 /// Each helper instance must be able to take any role, but once the role is assigned, it cannot
 /// be changed for the remainder of the query.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
-#[cfg_attr(
-    feature = "enable-serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(into = "&'static str", try_from = "&str")
-)]
+#[serde(into = "&'static str", try_from = "&str")]
 pub enum Role {
     H1 = 0,
     H2 = 1,
     H3 = 2,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[cfg_attr(
-    feature = "enable-serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(transparent)
-)]
+#[serde(transparent)]
 pub struct RoleAssignment {
     helper_roles: [HelperIdentity; 3],
 }

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -13,7 +13,6 @@ mod gateway;
 pub(crate) mod prss_protocol;
 pub mod stream;
 mod transport;
-use serde::{Deserialize, Serialize, Serializer};
 use std::ops::{Index, IndexMut};
 
 /// to validate that transport can actually send streams of this type
@@ -21,6 +20,7 @@ use std::ops::{Index, IndexMut};
 pub use buffers::OrderingSender;
 pub use error::Error;
 pub use futures::MaybeFuture;
+use serde::{Deserialize, Serialize, Serializer};
 
 #[cfg(feature = "stall-detection")]
 mod gateway_exports {

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -122,7 +122,6 @@ impl RouteParams<RouteId, NoQueryId, NoStep> for &QueryConfig {
     fn extra(&self) -> Self::Params {
         serde_json::to_string(self).unwrap()
     }
-
 }
 
 impl From<&QueryConfig> for GatewayConfig {
@@ -171,7 +170,6 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
     fn extra(&self) -> Self::Params {
         serde_json::to_string(self).unwrap()
     }
-
 }
 
 pub struct QueryInput {

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -1,5 +1,3 @@
-pub mod oprf_shuffle;
-
 use std::{
     fmt::{Debug, Display, Formatter},
     num::NonZeroU32,
@@ -310,20 +308,5 @@ impl Default for ContributionBits {
 impl std::fmt::Display for ContributionBits {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SparseAggregateQueryConfig {
-    pub contribution_bits: ContributionBits,
-    pub num_contributions: u32,
-}
-
-impl Default for SparseAggregateQueryConfig {
-    fn default() -> Self {
-        Self {
-            contribution_bits: ContributionBits::default(),
-            num_contributions: 8,
-        }
     }
 }

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -16,15 +16,13 @@ use crate::{
     protocol::{step::Step, QueryId},
 };
 
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize))]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize)]
 pub struct QuerySize(u32);
 
 impl QuerySize {
     pub const MAX: u32 = 1_000_000_000;
 }
 
-#[cfg(feature = "enable-serde")]
 impl<'de> Deserialize<'de> for QuerySize {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -84,9 +82,8 @@ impl From<QuerySize> for usize {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct QueryConfig {
     pub size: QuerySize,
     pub field_type: FieldType,
@@ -99,9 +96,8 @@ pub enum QueryConfigError {
     BadQuerySize(#[from] BadQuerySizeError),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct PrepareQuery {
     pub query_id: QueryId,
     pub config: QueryConfig,
@@ -123,15 +119,10 @@ impl RouteParams<RouteId, NoQueryId, NoStep> for &QueryConfig {
         NoStep
     }
 
-    #[cfg(feature = "enable-serde")]
     fn extra(&self) -> Self::Params {
         serde_json::to_string(self).unwrap()
     }
 
-    #[cfg(not(feature = "enable-serde"))]
-    fn extra(&self) -> Self::Params {
-        unimplemented!()
-    }
 }
 
 impl From<&QueryConfig> for GatewayConfig {
@@ -177,15 +168,10 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
         NoStep
     }
 
-    #[cfg(feature = "enable-serde")]
     fn extra(&self) -> Self::Params {
         serde_json::to_string(self).unwrap()
     }
 
-    #[cfg(not(feature = "enable-serde"))]
-    fn extra(&self) -> Self::Params {
-        unimplemented!()
-    }
 }
 
 pub struct QueryInput {
@@ -199,8 +185,7 @@ impl Debug for QueryInput {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum QueryType {
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
     TestMultiply,
@@ -225,8 +210,7 @@ impl AsRef<str> for QueryType {
 
 impl Step for QueryType {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::Args))]
 pub struct IpaQueryConfig {
     #[cfg_attr(feature = "clap", arg(long, default_value = "8"))]
@@ -331,8 +315,7 @@ impl std::fmt::Display for ContributionBits {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SparseAggregateQueryConfig {
     pub contribution_bits: ContributionBits,
     pub num_contributions: u32,

--- a/ipa-core/src/helpers/transport/query/oprf_shuffle.rs
+++ b/ipa-core/src/helpers/transport/query/oprf_shuffle.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct QueryConfig {}

--- a/ipa-core/src/helpers/transport/query/oprf_shuffle.rs
+++ b/ipa-core/src/helpers/transport/query/oprf_shuffle.rs
@@ -1,4 +1,0 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct QueryConfig {}

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -9,7 +9,7 @@
 
 #[cfg(any(feature = "cli", feature = "web-app"))]
 pub mod cli;
-#[cfg( feature = "web-app")]
+#[cfg(feature = "web-app")]
 pub mod config;
 pub mod error;
 pub mod ff;

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -9,7 +9,7 @@
 
 #[cfg(any(feature = "cli", feature = "web-app"))]
 pub mod cli;
-#[cfg(all(feature = "enable-serde", feature = "web-app"))]
+#[cfg( feature = "web-app")]
 pub mod config;
 pub mod error;
 pub mod ff;
@@ -29,7 +29,6 @@ pub mod test_fixture;
 
 mod app;
 mod seq_join;
-#[cfg(feature = "enable-serde")]
 mod serde;
 mod sharding;
 

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -8,12 +8,12 @@ pub mod echo {
 
     use async_trait::async_trait;
     use axum::extract::{FromRequest, Query, RequestParts};
+    use serde::{Deserialize, Serialize};
     use hyper::http::uri;
 
     use crate::net::Error;
 
-    #[derive(Debug, Default, Clone, PartialEq, Eq)]
-    #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct Request {
         pub query_params: HashMap<String, String>,
         pub headers: HashMap<String, String>,
@@ -54,7 +54,6 @@ pub mod echo {
         }
     }
 
-    #[cfg(feature = "enable-serde")]
     #[async_trait]
     impl<B: Send> FromRequest<B> for Request {
         type Rejection = Error;
@@ -80,6 +79,7 @@ pub mod echo {
 }
 
 pub mod query {
+    use serde::Deserialize;
     use std::fmt::{Display, Formatter};
 
     use async_trait::async_trait;
@@ -108,7 +108,7 @@ pub mod query {
         type Rejection = Error;
 
         async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
-            #[derive(serde::Deserialize)]
+            #[derive(Deserialize)]
             struct QueryTypeParam {
                 size: QuerySize,
                 field_type: FieldType,
@@ -173,6 +173,8 @@ pub mod query {
     pub const BASE_AXUM_PATH: &str = "/query";
 
     pub mod create {
+        
+        use serde::{Deserialize, Serialize};
         use async_trait::async_trait;
         use axum::extract::{FromRequest, RequestParts};
         use hyper::http::uri;
@@ -224,7 +226,7 @@ pub mod query {
             }
         }
 
-        #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+        #[derive(Serialize, Deserialize)]
         pub struct ResponseBody {
             pub query_id: QueryId,
         }
@@ -233,6 +235,7 @@ pub mod query {
     }
 
     pub mod prepare {
+        use serde::{Deserialize, Serialize};
         use async_trait::async_trait;
         use axum::{
             extract::{FromRequest, Path, RequestParts},
@@ -303,7 +306,7 @@ pub mod query {
             }
         }
 
-        #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+        #[derive(Serialize, Deserialize)]
         struct RequestBody {
             roles: RoleAssignment,
         }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -8,8 +8,8 @@ pub mod echo {
 
     use async_trait::async_trait;
     use axum::extract::{FromRequest, Query, RequestParts};
-    use serde::{Deserialize, Serialize};
     use hyper::http::uri;
+    use serde::{Deserialize, Serialize};
 
     use crate::net::Error;
 
@@ -79,11 +79,11 @@ pub mod echo {
 }
 
 pub mod query {
-    use serde::Deserialize;
     use std::fmt::{Display, Formatter};
 
     use async_trait::async_trait;
     use axum::extract::{FromRequest, Query, RequestParts};
+    use serde::Deserialize;
 
     use crate::{
         ff::FieldType,
@@ -173,11 +173,11 @@ pub mod query {
     pub const BASE_AXUM_PATH: &str = "/query";
 
     pub mod create {
-        
-        use serde::{Deserialize, Serialize};
+
         use async_trait::async_trait;
         use axum::extract::{FromRequest, RequestParts};
         use hyper::http::uri;
+        use serde::{Deserialize, Serialize};
 
         use crate::{
             helpers::query::QueryConfig,
@@ -235,7 +235,6 @@ pub mod query {
     }
 
     pub mod prepare {
-        use serde::{Deserialize, Serialize};
         use async_trait::async_trait;
         use axum::{
             extract::{FromRequest, Path, RequestParts},
@@ -243,6 +242,7 @@ pub mod query {
             Json,
         };
         use hyper::header::CONTENT_TYPE;
+        use serde::{Deserialize, Serialize};
 
         use crate::{
             helpers::{query::PrepareQuery, RoleAssignment},

--- a/ipa-core/src/protocol/mod.rs
+++ b/ipa-core/src/protocol/mod.rs
@@ -12,8 +12,9 @@ use std::{
     hash::Hash,
     ops::{Add, AddAssign},
 };
-use serde::{Deserialize, Serialize};
+
 pub use basics::BasicProtocols;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     error::Error,

--- a/ipa-core/src/protocol/mod.rs
+++ b/ipa-core/src/protocol/mod.rs
@@ -12,7 +12,7 @@ use std::{
     hash::Hash,
     ops::{Add, AddAssign},
 };
-
+use serde::{Deserialize, Serialize};
 pub use basics::BasicProtocols;
 
 use crate::{
@@ -30,12 +30,8 @@ pub type Timestamp = Gf20Bit;
 /// them collaborating on constructing this unique id. These details haven't been flushed out yet,
 /// so for now it is just an empty struct. Once we know more about it, we will make necessary
 /// amendments to it
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(into = "&'static str", try_from = "&str")
-)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(into = "&'static str", try_from = "&str")]
 pub struct QueryId;
 
 impl Display for QueryId {
@@ -78,8 +74,7 @@ impl TryFrom<&str> for QueryId {
 
 /// Unique identifier of the record inside the query. Support up to `$2^32$` max records because
 /// of the assumption that the maximum input is 1B records per query.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct RecordId(u32);
 
 impl Display for RecordId {

--- a/ipa-core/src/protocol/step/compact.rs
+++ b/ipa-core/src/protocol/step/compact.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use ipa_macros::Gate;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use super::StepNarrow;
 use crate::helpers::{prss_protocol::PrssExchangeStep, query::QueryType};

--- a/ipa-core/src/protocol/step/compact.rs
+++ b/ipa-core/src/protocol/step/compact.rs
@@ -1,16 +1,12 @@
 use std::fmt::{Debug, Display, Formatter};
 
 use ipa_macros::Gate;
-
+use serde::{Deserialize, Serialize};
 use super::StepNarrow;
 use crate::helpers::{prss_protocol::PrssExchangeStep, query::QueryType};
 
-#[derive(Gate, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
-#[cfg_attr(
-    feature = "enable-serde",
-    derive(serde::Deserialize),
-    serde(from = "&str")
-)]
+#[derive(Gate, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize)]
+#[serde(from = "&str")]
 pub struct Compact(pub u16);
 
 // serde::Deserialize requires From<&str> implementation

--- a/ipa-core/src/protocol/step/compact.rs
+++ b/ipa-core/src/protocol/step/compact.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Display, Formatter};
 
 use ipa_macros::Gate;
 use serde::{Deserialize, Serialize};
+
 use super::StepNarrow;
 use crate::helpers::{prss_protocol::PrssExchangeStep, query::QueryType};
 

--- a/ipa-core/src/protocol/step/descriptive.rs
+++ b/ipa-core/src/protocol/step/descriptive.rs
@@ -1,5 +1,5 @@
 use std::fmt::{Debug, Display, Formatter};
-
+use serde::{Deserialize};
 use super::{Step, StepNarrow};
 #[cfg(feature = "step-trace")]
 use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};
@@ -22,12 +22,8 @@ use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};
 /// Step "a" would be executed with a context identifier of "protocol/a", which it
 ///  would `narrow()` into "protocol/a/x" and "protocol/a/y" to produce a final set
 /// of identifiers: ".../a/x", ".../a/y", ".../b", and ".../c".
-#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "enable-serde",
-    derive(serde::Deserialize),
-    serde(from = "&str")
-)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(from = "&str")]
 pub struct Descriptive {
     id: String,
 }

--- a/ipa-core/src/protocol/step/descriptive.rs
+++ b/ipa-core/src/protocol/step/descriptive.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
-use serde::{Deserialize};
+
+use serde::Deserialize;
+
 use super::{Step, StepNarrow};
 #[cfg(feature = "step-trace")]
 use crate::telemetry::{labels::STEP, metrics::STEP_NARROWED};


### PR DESCRIPTION
Removed the `enable-serde` flag and made Serde a non-optional dependency. Removed the `cfg` attributes that depended on the feature since now the library is included by default.

### Testing
Both unit tests and `./pre-commit` pass.

closes private-attribution/ipa#588

