### PR TITLE
Use `BytesStream` inside `Transport` trait

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -20,7 +20,7 @@ use crate::{
             receive::GatewayReceivers, send::GatewaySenders, transport::RoleResolvingTransport,
         },
         transport::routing::RouteId,
-        HelperChannelId, Message, Role, RoleAssignment, TotalRecords, Transport,
+        HelperChannelId, LogErrors, Message, Role, RoleAssignment, TotalRecords, Transport,
     },
     protocol::QueryId,
 };
@@ -142,10 +142,10 @@ impl Gateway {
             channel_id.clone(),
             self.inner.receivers.get_or_create(channel_id, || {
                 UnorderedReceiver::new(
-                    Box::pin(
-                        self.transport
-                            .receive(channel_id.peer, (self.query_id, channel_id.gate.clone())),
-                    ),
+                    Box::pin(LogErrors::new(self.transport.receive(
+                        channel_id.peer,
+                        (self.query_id, channel_id.gate.clone()),
+                    ))),
                     self.config.active_work(),
                 )
             }),

--- a/ipa-core/src/helpers/gateway/receive.rs
+++ b/ipa-core/src/helpers/gateway/receive.rs
@@ -1,12 +1,13 @@
 use std::marker::PhantomData;
 
+use bytes::Bytes;
 use dashmap::{mapref::entry::Entry, DashMap};
-use futures::Stream;
 
 use crate::{
+    error::BoxError,
     helpers::{
         buffers::UnorderedReceiver, gateway::transport::RoleResolvingTransport, Error,
-        HelperChannelId, Message, Role, Transport,
+        HelperChannelId, LogErrors, Message, Role, Transport,
     },
     protocol::RecordId,
 };
@@ -25,8 +26,8 @@ pub(super) struct GatewayReceivers {
 }
 
 pub(super) type UR = UnorderedReceiver<
-    <RoleResolvingTransport as Transport>::RecordsStream,
-    <<RoleResolvingTransport as Transport>::RecordsStream as Stream>::Item,
+    LogErrors<<RoleResolvingTransport as Transport>::RecordsStream, Bytes, BoxError>,
+    Vec<u8>,
 >;
 
 impl<M: Message> ReceivingEnd<M> {

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -122,6 +122,7 @@ mod tests {
                     sum += shard_network
                         .transport(identity, a)
                         .receive(b, (QueryId, Gate::default()))
+                        .into_bytes_stream()
                         .collect::<Vec<_>>()
                         .await
                         .into_iter()

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -163,7 +163,7 @@ impl RouteParams<RouteId, QueryId, NoStep> for (RouteId, QueryId) {
 #[async_trait]
 pub trait Transport: Clone + Send + Sync + 'static {
     type Identity: TransportIdentity;
-    type RecordsStream: Stream<Item = Vec<u8>> + Send + Unpin;
+    type RecordsStream: BytesStream;
     type Error: std::fmt::Debug;
 
     fn identity(&self) -> Self::Identity;

--- a/ipa-core/src/helpers/transport/receive.rs
+++ b/ipa-core/src/helpers/transport/receive.rs
@@ -84,6 +84,17 @@ impl<I, S> ReceiveRecords<I, S> {
     }
 }
 
+#[cfg(all(test, any(unit_test, web_test)))]
+impl<I: TransportIdentity, S: crate::helpers::BytesStream> ReceiveRecords<I, S> {
+    /// Converts this into a stream that yields owned byte chunks.
+    ///
+    /// ## Panics
+    /// If inner stream yields an [`Err`] chunk.
+    pub(crate) fn into_bytes_stream(self) -> impl Stream<Item = Vec<u8>> {
+        self.inner.map(Result::unwrap).map(Into::into)
+    }
+}
+
 impl<I: TransportIdentity, S: Stream> Stream for ReceiveRecords<I, S> {
     type Item = S::Item;
 

--- a/ipa-core/src/helpers/transport/stream/box_body.rs
+++ b/ipa-core/src/helpers/transport/stream/box_body.rs
@@ -6,7 +6,7 @@ use std::{
 use bytes::Bytes;
 use futures::{stream::StreamExt, Stream};
 
-use crate::helpers::transport::stream::BoxBytesStream;
+use crate::helpers::{transport::stream::BoxBytesStream, BytesStream};
 
 pub struct WrappedBoxBodyStream(BoxBytesStream);
 
@@ -20,6 +20,10 @@ impl WrappedBoxBodyStream {
 
     pub fn from_infallible<S: Stream<Item = Box<[u8]>> + Send + 'static>(input: S) -> Self {
         Self(Box::pin(input.map(Bytes::from).map(Ok)))
+    }
+
+    pub fn from_bytes_stream<S: BytesStream + 'static>(input: S) -> Self {
+        Self(Box::pin(input))
     }
 
     #[must_use]

--- a/ipa-core/src/helpers/transport/stream/input.rs
+++ b/ipa-core/src/helpers/transport/stream/input.rs
@@ -154,12 +154,12 @@ enum ExtendResult {
     Error(io::Error),
 }
 
-/// Parse a [`Stream`] of [`Bytes`] into a stream of records of some
+/// Parse a [`Stream`] of bytes into a stream of records of some
 /// fixed-length-[`Serializable`] type `T`.
 #[pin_project]
-pub struct RecordsStream<T, S>
+pub struct RecordsStream<T, S, R: AsRef<[u8]> = Bytes>
 where
-    S: BytesStream,
+    S: BytesStream<R>,
     T: Serializable,
 {
     // Our implementation of `poll_next` turns a `None` from the inner stream into `Some(Err(_))` if
@@ -169,12 +169,12 @@ where
     #[pin]
     stream: Fuse<S>,
     buffer: BufDeque,
-    phantom_data: PhantomData<T>,
+    phantom_data: PhantomData<(T, R)>,
 }
 
-impl<T, S> RecordsStream<T, S>
+impl<T, S, R: AsRef<[u8]>> RecordsStream<T, S, R>
 where
-    S: BytesStream,
+    S: BytesStream<R>,
     T: Serializable,
 {
     #[must_use]

--- a/ipa-core/src/helpers/transport/stream/mod.rs
+++ b/ipa-core/src/helpers/transport/stream/mod.rs
@@ -27,7 +27,7 @@ pub trait BytesStream: Stream<Item = Result<Bytes, BoxError>> + Send {
     {
         use futures::StreamExt;
 
-        Box::pin(self.map(|item| item.unwrap().as_ref().to_vec()).concat())
+        Box::pin(self.map(|item| item.unwrap().to_vec()).concat())
     }
 }
 

--- a/ipa-core/src/helpers/transport/stream/mod.rs
+++ b/ipa-core/src/helpers/transport/stream/mod.rs
@@ -16,7 +16,7 @@ pub use input::{LengthDelimitedStream, RecordsStream};
 
 use crate::error::BoxError;
 
-pub trait BytesStream: Stream<Item = Result<Bytes, BoxError>> + Send {
+pub trait BytesStream<R: AsRef<[u8]> = Bytes>: Stream<Item = Result<R, BoxError>> + Send {
     /// Collects the entire stream into a vec; only intended for use in tests
     /// # Panics
     /// if the stream has any failure
@@ -27,11 +27,11 @@ pub trait BytesStream: Stream<Item = Result<Bytes, BoxError>> + Send {
     {
         use futures::StreamExt;
 
-        Box::pin(self.map(|item| item.unwrap().to_vec()).concat())
+        Box::pin(self.map(|item| item.unwrap().as_ref().to_vec()).concat())
     }
 }
 
-impl<S: Stream<Item = Result<Bytes, BoxError>> + Send> BytesStream for S {}
+impl<R: AsRef<[u8]>, S: Stream<Item = Result<R, BoxError>> + Send> BytesStream<R> for S {}
 
 pub type BoxBytesStream = Pin<Box<dyn BytesStream>>;
 

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -624,8 +624,9 @@ pub(crate) mod tests {
 
         MpcHelperClient::resp_ok(resp).await.unwrap();
 
-        let mut stream =
-            Arc::clone(&transport).receive(HelperIdentity::ONE, (QueryId, expected_step.clone()));
+        let mut stream = Arc::clone(&transport)
+            .receive(HelperIdentity::ONE, (QueryId, expected_step.clone()))
+            .into_bytes_stream();
 
         assert_eq!(
             poll_immediate(&mut stream).next().await,

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -70,7 +70,9 @@ mod tests {
         .await
         .unwrap();
 
-        let mut stream = Arc::clone(&transport).receive(HelperIdentity::TWO, (QueryId, step));
+        let mut stream = Arc::clone(&transport)
+            .receive(HelperIdentity::TWO, (QueryId, step))
+            .into_bytes_stream();
 
         assert_eq!(
             poll_immediate(&mut stream).next().await,


### PR DESCRIPTION
This change is to unify stream handling between in-memory and real-world implementations. Before, in memory streams yielded `Vec<u8>` and HTTP streams operated on `Result<Bytes, _>`.

This discrepancy required us to build a compatibility layer, and it makes sense now to unify both implementations.

The main motivator for this change is to be able to use `RecordsStream` inside shard receivers - `UnorderedReceiver` use case fits MPC model well, but is clunky to use inside shard channels - we always receive items in a pure streaming fashion instead.