### PR TITLE
Update async-trait

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -76,7 +76,7 @@ ipa-prf = []
 ipa-macros = { version = "*", path = "../ipa-macros" }
 
 aes = "0.8.3"
-async-trait = "0.1.68"
+async-trait = "0.1.79"
 async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
 axum-server = { version = "0.5.1", optional = true, features = [

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -403,7 +403,6 @@ impl<const SHARDS: usize> Runner<WithShards<SHARDS>> for TestWorld<WithShards<SH
             .await
     }
 
-    #[allow(clippy::diverging_sub_expression)]
     async fn malicious<'a, I, A, O, H, R>(&'a self, _input: I, _helper_fn: H) -> [O; 3]
     where
         I: IntoShares<A> + Send + 'static,
@@ -415,7 +414,6 @@ impl<const SHARDS: usize> Runner<WithShards<SHARDS>> for TestWorld<WithShards<SH
         unimplemented!()
     }
 
-    #[allow(clippy::diverging_sub_expression)]
     async fn upgraded_malicious<'a, F, I, A, M, O, H, R, P>(
         &'a self,
         _input: I,


### PR DESCRIPTION
I had previously determined this could be fixed with a cargo update, but I'm not sure why I didn't just update Cargo.toml at the time. Possibly I thought that the fix was in the `syn` crate or one of the proc macro crates, that are not named directly in Cargo.toml?