### PR TITLE
IPA bench: log random seed and runtime at info level

### DIFF
--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -145,6 +145,8 @@ pub(crate) mod test_executor {
     }
 }
 
+pub const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+
 #[macro_export]
 macro_rules! const_assert {
     ($x:expr $(,)?) => {


### PR DESCRIPTION
This does a few things towards the end goal in the description:
* Increase the log level for the random seed from trace to info.
* Adjust the initialization order so that logging is initialized in time to log the random seed.
* Add configuration of a 2nd log target to TestWorld (specifically, we want the benchmark crate `oneshot_ipa` in addition to `ipa_core`).