### PR TITLE
Implement shard communication channels for MPC circuits

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -15,7 +15,7 @@ use ipa_core::{
     config::{hpke_registry, HpkeServerConfig, NetworkConfig, ServerConfig, TlsConfig},
     error::BoxError,
     helpers::HelperIdentity,
-    net::{ClientIdentity, HttpTransport, MpcHelperClient},
+    net::{ClientIdentity, HttpShardTransport, HttpTransport, MpcHelperClient},
     AppSetup,
 };
 use tracing::{error, info};
@@ -158,7 +158,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         Some(handler),
     );
 
-    let _app = setup.connect(transport.clone());
+    let _app = setup.connect(transport.clone(), HttpShardTransport);
 
     let listener = args.server_socket_fd
         .map(|fd| {

--- a/ipa-core/src/helpers/buffers/ordering_sender.rs
+++ b/ipa-core/src/helpers/buffers/ordering_sender.rs
@@ -524,7 +524,7 @@ mod test {
     use super::OrderingSender;
     use crate::{
         ff::{Fp31, Fp32BitPrime, Gf20Bit, Gf9Bit, Serializable, U128Conversions},
-        helpers::Message,
+        helpers::MpcMessage,
         rand::thread_rng,
         sync::Arc,
         test_executor::run,
@@ -622,7 +622,7 @@ mod test {
     >;
 
     // Given a message, returns a closure that sends the message and increments an associated record index.
-    fn send_fn<M: Message>(m: M) -> BoxedSendFn {
+    fn send_fn<M: MpcMessage>(m: M) -> BoxedSendFn {
         Box::new(|s: &OrderingSender, i: &mut usize| {
             let fut = s.send(*i, m).boxed();
             *i += 1;

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -6,23 +6,26 @@ mod transport;
 
 use std::num::NonZeroUsize;
 
-pub(super) use receive::ReceivingEnd;
+pub(super) use receive::{MpcReceivingEnd, ShardReceivingEnd};
 pub(super) use send::SendingEnd;
-#[cfg(all(test, feature = "shuttle"))]
-use shuttle::future as tokio;
 #[cfg(feature = "stall-detection")]
 pub(super) use stall_detection::InstrumentedGateway;
+pub use transport::RoleResolvingTransport;
 
 use crate::{
     helpers::{
         buffers::UnorderedReceiver,
         gateway::{
-            receive::GatewayReceivers, send::GatewaySenders, transport::RoleResolvingTransport,
+            receive::{GatewayReceivers, ShardReceiveStream, UR},
+            send::GatewaySenders,
+            transport::Transports,
         },
-        transport::routing::RouteId,
-        HelperChannelId, LogErrors, Message, Role, RoleAssignment, TotalRecords, Transport,
+        HelperChannelId, LogErrors, Message, MpcMessage, RecordsStream, Role, RoleAssignment,
+        ShardChannelId, TotalRecords, Transport,
     },
     protocol::QueryId,
+    sharding::ShardIndex,
+    sync::{Arc, Mutex},
 };
 
 /// Alias for the currently configured transport.
@@ -30,17 +33,25 @@ use crate::{
 /// To avoid proliferation of type parameters, most code references this concrete type alias, rather
 /// than a type parameter `T: Transport`.
 #[cfg(feature = "in-memory-infra")]
-pub type TransportImpl = super::transport::InMemoryTransport<crate::helpers::HelperIdentity>;
+type TransportImpl<I> = super::transport::InMemoryTransport<I>;
+#[cfg(feature = "in-memory-infra")]
+pub type MpcTransportImpl = TransportImpl<crate::helpers::HelperIdentity>;
+#[cfg(feature = "in-memory-infra")]
+pub type ShardTransportImpl = TransportImpl<ShardIndex>;
 
 #[cfg(feature = "real-world-infra")]
-pub type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
+type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
+#[cfg(feature = "real-world-infra")]
+pub type MpcTransportImpl = TransportImpl;
+#[cfg(feature = "real-world-infra")]
+pub type ShardTransportImpl = crate::net::HttpShardTransport;
 
-pub type TransportError = <TransportImpl as Transport>::Error;
+pub type MpcTransportError = <MpcTransportImpl as Transport>::Error;
 
 /// Gateway into IPA Network infrastructure. It allows helpers send and receive messages.
 pub struct Gateway {
     config: GatewayConfig,
-    transport: RoleResolvingTransport,
+    transports: Transports<RoleResolvingTransport, ShardTransportImpl>,
     query_id: QueryId,
     #[cfg(feature = "stall-detection")]
     inner: crate::sync::Arc<State>,
@@ -50,8 +61,10 @@ pub struct Gateway {
 
 #[derive(Default)]
 pub struct State {
-    senders: GatewaySenders,
-    receivers: GatewayReceivers,
+    mpc_senders: GatewaySenders<Role>,
+    mpc_receivers: GatewayReceivers<Role, UR>,
+    shard_senders: GatewaySenders<ShardIndex>,
+    shard_receivers: GatewayReceivers<ShardIndex, ShardReceiveStream>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -73,15 +86,19 @@ impl Gateway {
         query_id: QueryId,
         config: GatewayConfig,
         roles: RoleAssignment,
-        transport: TransportImpl,
+        mpc_transport: MpcTransportImpl,
+        shard_transport: ShardTransportImpl,
     ) -> Self {
         #[allow(clippy::useless_conversion)] // not useless in stall-detection build
         Self {
             query_id,
             config,
-            transport: RoleResolvingTransport {
-                roles,
-                inner: transport,
+            transports: Transports {
+                mpc: RoleResolvingTransport {
+                    roles,
+                    inner: mpc_transport,
+                },
+                shard: shard_transport,
             },
             inner: State::default().into(),
         }
@@ -89,7 +106,7 @@ impl Gateway {
 
     #[must_use]
     pub fn role(&self) -> Role {
-        self.transport.identity()
+        self.transports.mpc.identity()
     }
 
     #[must_use]
@@ -97,52 +114,75 @@ impl Gateway {
         &self.config
     }
 
+    /// Returns a sender suitable for sending data between MPC helpers. The data must be approved
+    /// for sending by implementing [`MpcMessage`] trait.
+    ///
+    /// Do not remove the test below, it verifies that we don't allow raw sharings to be sent
+    /// between MPC helpers without using secure reveal.
+    ///
+    /// ```compile_fail
+    /// use ipa_core::helpers::Gateway;
+    /// use ipa_core::secret_sharing::replicated::semi_honest::AdditiveShare;
+    /// use ipa_core::ff::Fp32BitPrime;
+    ///
+    /// let gateway: Gateway = todo!();
+    /// let mpc_channel = gateway.get_mpc_sender::<AdditiveShare<Fp32BitPrime>>(todo!(), todo!());
+    /// ```
     ///
     /// ## Panics
     /// If there is a failure connecting via HTTP
     #[must_use]
-    pub fn get_sender<M: Message>(
+    pub fn get_mpc_sender<M: MpcMessage>(
         &self,
         channel_id: &HelperChannelId,
         total_records: TotalRecords,
-    ) -> send::SendingEnd<M> {
-        let (tx, maybe_stream) = self.inner.senders.get_or_create::<M>(
+    ) -> send::SendingEnd<Role, M> {
+        let transport = &self.transports.mpc;
+        let channel = self.inner.mpc_senders.get::<M, _>(
             channel_id,
+            transport,
             self.config.active_work(),
+            self.query_id,
             total_records,
         );
-        if let Some(stream) = maybe_stream {
-            tokio::spawn({
-                let channel_id = channel_id.clone();
-                let transport = self.transport.clone();
-                let query_id = self.query_id;
-                async move {
-                    // TODO(651): In the HTTP case we probably need more robust error handling here.
-                    transport
-                        .send(
-                            channel_id.peer,
-                            (RouteId::Records, query_id, channel_id.gate),
-                            stream,
-                        )
-                        .await
-                        .expect("{channel_id:?} receiving end should be accepted by transport");
-                }
-            });
-        }
 
-        send::SendingEnd::new(tx, self.role(), channel_id)
+        send::SendingEnd::new(channel, transport.identity())
+    }
+
+    /// Returns a sender for shard-to-shard traffic. This sender is more relaxed compared to one
+    /// returned by [`Self::get_mpc_sender`] as it allows anything that can be serialized into bytes
+    /// to be sent out. MPC sender needs to be more careful about it and not to allow sending sensitive
+    /// information to be accidentally revealed.
+    /// An example of such sensitive data could be secret sharings - it is perfectly fine to send them
+    /// between shards as they are known to each helper anyway. Sending them across MPC helper boundary
+    /// could lead to information reveal.
+    pub fn get_shard_sender<M: Message>(
+        &self,
+        channel_id: &ShardChannelId,
+        total_records: TotalRecords,
+    ) -> send::SendingEnd<ShardIndex, M> {
+        let transport = &self.transports.shard;
+        let channel = self.inner.shard_senders.get::<M, _>(
+            channel_id,
+            transport,
+            self.config.active_work(),
+            self.query_id,
+            total_records,
+        );
+
+        send::SendingEnd::new(channel, transport.identity())
     }
 
     #[must_use]
-    pub fn get_receiver<M: Message>(
+    pub fn get_mpc_receiver<M: MpcMessage>(
         &self,
         channel_id: &HelperChannelId,
-    ) -> receive::ReceivingEnd<M> {
-        receive::ReceivingEnd::new(
+    ) -> receive::MpcReceivingEnd<M> {
+        receive::MpcReceivingEnd::new(
             channel_id.clone(),
-            self.inner.receivers.get_or_create(channel_id, || {
+            self.inner.mpc_receivers.get_or_create(channel_id, || {
                 UnorderedReceiver::new(
-                    Box::pin(LogErrors::new(self.transport.receive(
+                    Box::pin(LogErrors::new(self.transports.mpc.receive(
                         channel_id.peer,
                         (self.query_id, channel_id.gate.clone()),
                     ))),
@@ -150,6 +190,33 @@ impl Gateway {
                 )
             }),
         )
+    }
+
+    /// Requests a stream of records to be received from the given shard. In contrast with
+    /// [`Self::get_mpc_receiver`] stream, items in this stream are available in FIFO order only.
+    pub fn get_shard_receiver<M: Message>(
+        &self,
+        channel_id: &ShardChannelId,
+    ) -> receive::ShardReceivingEnd<M> {
+        let mut called_before = true;
+        let rx = self.inner.shard_receivers.get_or_create(channel_id, || {
+            called_before = false;
+            ShardReceiveStream(Arc::new(Mutex::new(
+                self.transports
+                    .shard
+                    .receive(channel_id.peer, (self.query_id, channel_id.gate.clone())),
+            )))
+        });
+
+        assert!(
+            !called_before,
+            "Shard receiver {channel_id:?} can only be created once"
+        );
+
+        receive::ShardReceivingEnd {
+            channel_id: channel_id.clone(),
+            rx: RecordsStream::new(rx),
+        }
     }
 }
 
@@ -192,13 +259,19 @@ impl GatewayConfig {
 mod tests {
     use std::iter::{repeat, zip};
 
-    use futures_util::future::{join, try_join, try_join_all};
+    use futures::{
+        future::{join, try_join, try_join_all},
+        stream::StreamExt,
+    };
 
     use crate::{
-        ff::{Fp31, Fp32BitPrime, Gf2, U128Conversions},
-        helpers::{Direction, GatewayConfig, Message, Role, SendingEnd},
+        ff::{boolean_array::BA3, Fp31, Fp32BitPrime, Gf2, U128Conversions},
+        helpers::{Direction, GatewayConfig, MpcMessage, Role, SendingEnd},
         protocol::{context::Context, RecordId},
-        test_fixture::{Runner, TestWorld, TestWorldConfig},
+        secret_sharing::replicated::semi_honest::AdditiveShare,
+        sharding::ShardConfiguration,
+        test_executor::run,
+        test_fixture::{Reconstruct, Runner, TestWorld, TestWorldConfig, WithShards},
     };
 
     /// Verifies that [`Gateway`] send buffer capacity is adjusted to the message size.
@@ -208,7 +281,7 @@ mod tests {
     /// Gateway must be able to deal with it.
     #[tokio::test]
     async fn can_handle_heterogeneous_channels() {
-        async fn send<V: Message + U128Conversions>(channel: &SendingEnd<V>, i: usize) {
+        async fn send<V: MpcMessage + U128Conversions>(channel: &SendingEnd<Role, V>, i: usize) {
             channel
                 .send(i.into(), V::truncate_from(u128::try_from(i).unwrap()))
                 .await
@@ -378,6 +451,65 @@ mod tests {
         .unwrap();
 
         let _world = unsafe { Box::from_raw(world_ptr) };
+    }
+
+    #[test]
+    fn shards() {
+        run(|| async move {
+            let world = TestWorld::<WithShards<2>>::with_shards(TestWorldConfig::default());
+            shard_comms_test(&world).await;
+        });
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Shard receiver channel[ShardIndex(1),\"protocol/iter0\"] can only be created once"
+    )]
+    fn shards_receive_twice() {
+        run(|| async move {
+            let world = TestWorld::<WithShards<2>>::with_shards(TestWorldConfig::default());
+            world
+                .semi_honest(Vec::<()>::new().into_iter(), |ctx, _| async move {
+                    let peer = ctx.peer_shards().next().unwrap();
+                    let recv1 = ctx.shard_recv_channel::<BA3>(peer);
+                    let recv2 = ctx.shard_recv_channel::<BA3>(peer);
+                    drop(recv1);
+                    drop(recv2);
+                })
+                .await;
+        });
+    }
+
+    async fn shard_comms_test(test_world: &TestWorld<WithShards<2>>) {
+        let input = vec![BA3::truncate_from(0_u32), BA3::truncate_from(1_u32)];
+
+        let r = test_world
+            .semi_honest(input.clone().into_iter(), |ctx, input| async move {
+                let ctx = ctx.set_total_records(input.len());
+                // Swap shares between shards, works only for 2 shards.
+                let peer = ctx.peer_shards().next().unwrap();
+                for (record_id, item) in input.into_iter().enumerate() {
+                    ctx.shard_send_channel(peer)
+                        .send(record_id.into(), item)
+                        .await
+                        .unwrap();
+                }
+
+                let mut r = Vec::<AdditiveShare<BA3>>::new();
+                let mut recv_channel = ctx.shard_recv_channel(peer);
+                while let Some(v) = recv_channel.next().await {
+                    r.push(v.unwrap());
+                }
+
+                r
+            })
+            .await
+            .into_iter()
+            .flat_map(|v| v.reconstruct())
+            .collect::<Vec<_>>();
+
+        let reverse_input = input.into_iter().rev().collect::<Vec<_>>();
+        assert_eq!(reverse_input, r);
     }
 
     fn make_world() -> (&'static TestWorld, *mut TestWorld) {

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -40,9 +40,8 @@ pub type MpcTransportImpl = TransportImpl<crate::helpers::HelperIdentity>;
 pub type ShardTransportImpl = TransportImpl<ShardIndex>;
 
 #[cfg(feature = "real-world-infra")]
-type TransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
 #[cfg(feature = "real-world-infra")]
-pub type MpcTransportImpl = TransportImpl;
+pub type MpcTransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
 #[cfg(feature = "real-world-infra")]
 pub type ShardTransportImpl = crate::net::HttpShardTransport;
 

--- a/ipa-core/src/helpers/gateway/receive.rs
+++ b/ipa-core/src/helpers/gateway/receive.rs
@@ -1,36 +1,61 @@
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use dashmap::{mapref::entry::Entry, DashMap};
+use futures::Stream;
+use pin_project::pin_project;
 
 use crate::{
     error::BoxError,
     helpers::{
-        buffers::UnorderedReceiver, gateway::transport::RoleResolvingTransport, Error,
-        HelperChannelId, LogErrors, Message, Role, Transport,
+        buffers::UnorderedReceiver, gateway::transport::RoleResolvingTransport,
+        transport::SingleRecordStream, ChannelId, Error, HelperChannelId, LogErrors, Message,
+        MpcMessage, Role, ShardChannelId, ShardTransportImpl, Transport, TransportIdentity,
     },
     protocol::RecordId,
+    sync::{Arc, Mutex},
 };
 
-/// Receiving end of the gateway channel.
-pub struct ReceivingEnd<M: Message> {
+/// Receiving end of the MPC gateway channel.
+/// I tried to make it generic and work for both MPC and Shard connectors, but ran into
+/// "implementation of `S` is not general enough" issue on the client side (reveal). It may be another
+/// occurrence of [`gat`] issue
+///
+/// [`gat`]: https://github.com/rust-lang/rust/issues/100013
+pub struct MpcReceivingEnd<M> {
     channel_id: HelperChannelId,
     unordered_rx: UR,
     _phantom: PhantomData<M>,
 }
 
-/// Receiving channels, indexed by (role, step).
-#[derive(Default)]
-pub(super) struct GatewayReceivers {
-    pub(super) inner: DashMap<HelperChannelId, UR>,
+#[pin_project]
+pub struct ShardReceivingEnd<M: Message> {
+    pub(super) channel_id: ShardChannelId,
+    #[pin]
+    pub(super) rx: SingleRecordStream<M, ShardReceiveStream>,
 }
 
-pub(super) type UR = UnorderedReceiver<
+/// Receiving channels, indexed by (role, step).
+pub(super) struct GatewayReceivers<I, S> {
+    pub(super) inner: DashMap<ChannelId<I>, S>,
+}
+
+pub type UR = UnorderedReceiver<
     LogErrors<<RoleResolvingTransport as Transport>::RecordsStream, Bytes, BoxError>,
     Vec<u8>,
 >;
 
-impl<M: Message> ReceivingEnd<M> {
+/// Stream of records received from a peer shard.
+#[derive(Clone)]
+pub struct ShardReceiveStream(
+    pub(super) Arc<Mutex<<ShardTransportImpl as Transport>::RecordsStream>>,
+);
+
+impl<M: MpcMessage> MpcReceivingEnd<M> {
     pub(super) fn new(channel_id: HelperChannelId, rx: UR) -> Self {
         Self {
             channel_id,
@@ -61,8 +86,24 @@ impl<M: Message> ReceivingEnd<M> {
     }
 }
 
-impl GatewayReceivers {
-    pub fn get_or_create<F: FnOnce() -> UR>(&self, channel_id: &HelperChannelId, ctr: F) -> UR {
+impl<M: Message> Stream for ShardReceivingEnd<M> {
+    type Item = Result<M, crate::error::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().rx.poll_next(cx)
+    }
+}
+
+impl<I: TransportIdentity, S> Default for GatewayReceivers<I, S> {
+    fn default() -> Self {
+        Self {
+            inner: DashMap::default(),
+        }
+    }
+}
+
+impl<I: TransportIdentity, S: Clone> GatewayReceivers<I, S> {
+    pub fn get_or_create<F: FnOnce() -> S>(&self, channel_id: &ChannelId<I>, ctr: F) -> S {
         // TODO: raw entry API if it becomes available to avoid cloning the key
         match self.inner.entry(channel_id.clone()) {
             Entry::Occupied(entry) => entry.get().clone(),
@@ -73,5 +114,13 @@ impl GatewayReceivers {
                 stream
             }
         }
+    }
+}
+
+impl Stream for ShardReceiveStream {
+    type Item = <<ShardTransportImpl as Transport>::RecordsStream as Stream>::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(self.0.lock().unwrap()).as_mut().poll_next(cx)
     }
 }

--- a/ipa-core/src/helpers/gateway/receive.rs
+++ b/ipa-core/src/helpers/gateway/receive.rs
@@ -52,6 +52,10 @@ pub type UR = UnorderedReceiver<
 /// Stream of records received from a peer shard.
 #[derive(Clone)]
 pub struct ShardReceiveStream(
+    /// Using a mutex here may not be necessary - there is always a single caller that polls it,
+    /// and there may be an observer from stall detection that wants to know the state of it.
+    /// There could be a better way to share the state and make sure the owning reference is stored
+    /// inside the map of receivers.
     pub(super) Arc<Mutex<<ShardTransportImpl as Transport>::RecordsStream>>,
 );
 

--- a/ipa-core/src/helpers/gateway/send.rs
+++ b/ipa-core/src/helpers/gateway/send.rs
@@ -8,11 +8,16 @@ use std::{
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use futures::Stream;
+#[cfg(all(test, feature = "shuttle"))]
+use shuttle::future as tokio;
 use typenum::Unsigned;
 
 use crate::{
-    helpers::{buffers::OrderingSender, Error, HelperChannelId, Message, Role, TotalRecords},
-    protocol::RecordId,
+    helpers::{
+        buffers::OrderingSender, routing::RouteId, ChannelId, Error, Message, TotalRecords,
+        Transport, TransportIdentity,
+    },
+    protocol::{QueryId, RecordId},
     sync::Arc,
     telemetry::{
         labels::{ROLE, STEP},
@@ -21,31 +26,37 @@ use crate::{
 };
 
 /// Sending end of the gateway channel.
-pub struct SendingEnd<M: Message> {
-    sender_role: Role,
-    channel_id: HelperChannelId,
-    inner: Arc<GatewaySender>,
+pub struct SendingEnd<I: TransportIdentity, M> {
+    sender_id: I,
+    inner: Arc<GatewaySender<I>>,
     _phantom: PhantomData<M>,
 }
 
-/// Sending channels, indexed by (role, step).
-#[derive(Default)]
-pub(super) struct GatewaySenders {
-    pub(super) inner: DashMap<HelperChannelId, Arc<GatewaySender>>,
+/// Sending channels, indexed by identity and gate.
+pub(super) struct GatewaySenders<I> {
+    pub(super) inner: DashMap<ChannelId<I>, Arc<GatewaySender<I>>>,
 }
 
-pub(super) struct GatewaySender {
-    channel_id: HelperChannelId,
+pub(super) struct GatewaySender<I> {
+    channel_id: ChannelId<I>,
     ordering_tx: OrderingSender,
     total_records: TotalRecords,
 }
 
-pub(super) struct GatewaySendStream {
-    inner: Arc<GatewaySender>,
+struct GatewaySendStream<I> {
+    inner: Arc<GatewaySender<I>>,
 }
 
-impl GatewaySender {
-    fn new(channel_id: HelperChannelId, tx: OrderingSender, total_records: TotalRecords) -> Self {
+impl<I: TransportIdentity> Default for GatewaySenders<I> {
+    fn default() -> Self {
+        Self {
+            inner: DashMap::default(),
+        }
+    }
+}
+
+impl<I: TransportIdentity> GatewaySender<I> {
+    fn new(channel_id: ChannelId<I>, tx: OrderingSender, total_records: TotalRecords) -> Self {
         Self {
             channel_id,
             ordering_tx: tx,
@@ -57,7 +68,7 @@ impl GatewaySender {
         &self,
         record_id: RecordId,
         msg: B,
-    ) -> Result<(), Error<Role>> {
+    ) -> Result<(), Error<I>> {
         debug_assert!(
             self.total_records.is_specified(),
             "total_records cannot be unspecified when sending"
@@ -94,15 +105,10 @@ impl GatewaySender {
     }
 }
 
-impl<M: Message> SendingEnd<M> {
-    pub(super) fn new(
-        sender: Arc<GatewaySender>,
-        role: Role,
-        channel_id: &HelperChannelId,
-    ) -> Self {
+impl<I: TransportIdentity, M: Message> SendingEnd<I, M> {
+    pub(super) fn new(sender: Arc<GatewaySender<I>>, id: I) -> Self {
         Self {
-            sender_role: role,
-            channel_id: channel_id.clone(),
+            sender_id: id,
             inner: sender,
             _phantom: PhantomData,
         }
@@ -117,32 +123,38 @@ impl<M: Message> SendingEnd<M> {
     /// call.
     ///
     /// [`set_total_records`]: crate::protocol::context::Context::set_total_records
-    #[tracing::instrument(level = "trace", "send", skip_all, fields(i = %record_id, total = %self.inner.total_records, to = ?self.channel_id.peer, gate = ?self.channel_id.gate.as_ref()))]
-    pub async fn send<B: Borrow<M>>(&self, record_id: RecordId, msg: B) -> Result<(), Error<Role>> {
+    #[tracing::instrument(level = "trace", "send", skip_all, fields(
+        i = %record_id,
+        total = %self.inner.total_records,
+        to = ?self.inner.channel_id.peer,
+        gate = ?self.inner.channel_id.gate.as_ref()
+    ))]
+    pub async fn send<B: Borrow<M>>(&self, record_id: RecordId, msg: B) -> Result<(), Error<I>> {
         let r = self.inner.send(record_id, msg).await;
         metrics::increment_counter!(RECORDS_SENT,
-            STEP => self.channel_id.gate.as_ref().to_string(),
-            ROLE => self.sender_role.as_static_str()
+            STEP => self.inner.channel_id.gate.as_ref().to_string(),
+            ROLE => self.sender_id.as_str(),
         );
         metrics::counter!(BYTES_SENT, M::Size::U64,
-            STEP => self.channel_id.gate.as_ref().to_string(),
-            ROLE => self.sender_role.as_static_str()
+            STEP => self.inner.channel_id.gate.as_ref().to_string(),
+            ROLE => self.sender_id.as_str(),
         );
 
         r
     }
 }
 
-impl GatewaySenders {
-    /// Returns or creates a new communication channel. In case if channel is newly created,
-    /// returns the receiving end of it as well. It must be send over to the receiver in order for
-    /// messages to get through.
-    pub(crate) fn get_or_create<M: Message>(
+impl<I: TransportIdentity> GatewaySenders<I> {
+    /// Returns a communication channel for the given [`ChannelId`]. If it does not exist, it will
+    /// be created using the provided [`Transport`] implementation.
+    pub fn get<M: Message, T: Transport<Identity = I>>(
         &self,
-        channel_id: &HelperChannelId,
+        channel_id: &ChannelId<I>,
+        transport: &T,
         capacity: NonZeroUsize,
+        query_id: QueryId,
         total_records: TotalRecords, // TODO track children for indeterminate senders
-    ) -> (Arc<GatewaySender>, Option<GatewaySendStream>) {
+    ) -> Arc<GatewaySender<I>> {
         assert!(
             total_records.is_specified(),
             "unspecified total records for {channel_id:?}"
@@ -150,44 +162,64 @@ impl GatewaySenders {
 
         // TODO: raw entry API would be nice to have here but it's not exposed yet
         match self.inner.entry(channel_id.clone()) {
-            Entry::Occupied(entry) => (Arc::clone(entry.get()), None),
+            Entry::Occupied(entry) => Arc::clone(entry.get()),
             Entry::Vacant(entry) => {
-                // Spare buffer is not required when messages have uniform size and buffer is a
-                // multiple of that size.
-                const SPARE: usize = 0;
-                // a little trick - if number of records is indeterminate, set the capacity to one
-                // message.  Any send will wake the stream reader then, effectively disabling
-                // buffering.  This mode is clearly inefficient, so avoid using this mode.
-                let write_size = if total_records.is_indeterminate() {
-                    NonZeroUsize::new(M::Size::USIZE).unwrap()
-                } else {
-                    // capacity is defined in terms of number of elements, while sender wants bytes
-                    // so perform the conversion here
-                    capacity
-                        .checked_mul(
-                            NonZeroUsize::new(M::Size::USIZE)
-                                .expect("Message size should be greater than 0"),
-                        )
-                        .expect("capacity should not overflow")
-                };
-
-                let sender = Arc::new(GatewaySender::new(
-                    channel_id.clone(),
-                    OrderingSender::new(write_size, SPARE),
-                    total_records,
-                ));
+                let sender = Self::new_sender::<M>(capacity, channel_id.clone(), total_records);
                 entry.insert(Arc::clone(&sender));
 
-                (
-                    Arc::clone(&sender),
-                    Some(GatewaySendStream { inner: sender }),
-                )
+                tokio::spawn({
+                    let ChannelId { peer, gate } = channel_id.clone();
+                    let transport = transport.clone();
+                    let stream = GatewaySendStream {
+                        inner: Arc::clone(&sender),
+                    };
+                    async move {
+                        // TODO(651): In the HTTP case we probably need more robust error handling here.
+                        transport
+                            .send(peer, (RouteId::Records, query_id, gate), stream)
+                            .await
+                            .expect("{channel_id:?} receiving end should be accepted by transport");
+                    }
+                });
+
+                sender
             }
         }
     }
+
+    fn new_sender<M: Message>(
+        capacity: NonZeroUsize,
+        channel_id: ChannelId<I>,
+        total_records: TotalRecords,
+    ) -> Arc<GatewaySender<I>> {
+        // Spare buffer is not required when messages have uniform size and buffer is a
+        // multiple of that size.
+        const SPARE: usize = 0;
+        // a little trick - if number of records is indeterminate, set the capacity to one
+        // message.  Any send will wake the stream reader then, effectively disabling
+        // buffering.  This mode is clearly inefficient, so avoid using this mode.
+        let write_size = if total_records.is_indeterminate() {
+            NonZeroUsize::new(M::Size::USIZE).unwrap()
+        } else {
+            // capacity is defined in terms of number of elements, while sender wants bytes
+            // so perform the conversion here
+            capacity
+                .checked_mul(
+                    NonZeroUsize::new(M::Size::USIZE)
+                        .expect("Message size should be greater than 0"),
+                )
+                .expect("capacity should not overflow")
+        };
+
+        Arc::new(GatewaySender::new(
+            channel_id,
+            OrderingSender::new(write_size, SPARE),
+            total_records,
+        ))
+    }
 }
 
-impl Stream for GatewaySendStream {
+impl<I> Stream for GatewaySendStream<I> {
     type Item = Vec<u8>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/ipa-core/src/helpers/gateway/stall_detection.rs
+++ b/ipa-core/src/helpers/gateway/stall_detection.rs
@@ -73,11 +73,12 @@ mod gateway {
     use super::{receive, send, AtomicUsize, Debug, Formatter, ObserveState, Observed, Weak};
     use crate::{
         helpers::{
-            gateway::{Gateway, State},
-            GatewayConfig, HelperChannelId, Message, ReceivingEnd, Role, RoleAssignment,
-            SendingEnd, TotalRecords, TransportImpl,
+            gateway::{Gateway, ShardTransportImpl, State},
+            GatewayConfig, HelperChannelId, Message, MpcMessage, MpcReceivingEnd, MpcTransportImpl,
+            Role, RoleAssignment, SendingEnd, ShardChannelId, ShardReceivingEnd, TotalRecords,
         },
         protocol::QueryId,
+        sharding::ShardIndex,
         sync::Arc,
     };
 
@@ -105,13 +106,14 @@ mod gateway {
             query_id: QueryId,
             config: GatewayConfig,
             roles: RoleAssignment,
-            transport: TransportImpl,
+            mpc_transport: MpcTransportImpl,
+            shard_transport: ShardTransportImpl,
         ) -> Self {
             let version = Arc::new(AtomicUsize::default());
             let r = Self::wrap(
                 Arc::downgrade(&version),
                 InstrumentedGateway {
-                    gateway: Gateway::new(query_id, config, roles, transport),
+                    gateway: Gateway::new(query_id, config, roles, mpc_transport, shard_transport),
                     _sn: version,
                 },
             );
@@ -147,22 +149,50 @@ mod gateway {
         }
 
         #[must_use]
-        pub fn get_sender<M: Message>(
+        pub fn get_mpc_sender<M: MpcMessage>(
             &self,
             channel_id: &HelperChannelId,
             total_records: TotalRecords,
-        ) -> SendingEnd<M> {
+        ) -> SendingEnd<Role, M> {
             Observed::wrap(
                 Weak::clone(self.get_sn()),
-                self.inner().gateway.get_sender(channel_id, total_records),
+                self.inner()
+                    .gateway
+                    .get_mpc_sender(channel_id, total_records),
+            )
+        }
+
+        pub fn get_shard_sender<M: Message>(
+            &self,
+            channel_id: &ShardChannelId,
+            total_records: TotalRecords,
+        ) -> SendingEnd<ShardIndex, M> {
+            Observed::wrap(
+                Weak::clone(self.get_sn()),
+                self.inner
+                    .gateway
+                    .get_shard_sender(channel_id, total_records),
             )
         }
 
         #[must_use]
-        pub fn get_receiver<M: Message>(&self, channel_id: &HelperChannelId) -> ReceivingEnd<M> {
+        pub fn get_mpc_receiver<M: MpcMessage>(
+            &self,
+            channel_id: &HelperChannelId,
+        ) -> MpcReceivingEnd<M> {
             Observed::wrap(
                 Weak::clone(self.get_sn()),
-                self.inner().gateway.get_receiver(channel_id),
+                self.inner().gateway.get_mpc_receiver(channel_id),
+            )
+        }
+
+        pub fn get_shard_receiver<M: Message>(
+            &self,
+            channel_id: &ShardChannelId,
+        ) -> ShardReceivingEnd<M> {
+            Observed::wrap(
+                Weak::clone(self.get_sn()),
+                self.inner().gateway.get_shard_receiver(channel_id),
             )
         }
 
@@ -175,17 +205,25 @@ mod gateway {
         }
     }
 
-    pub struct GatewayWaitingTasks<S, R> {
-        senders_state: Option<S>,
-        receivers_state: Option<R>,
+    pub struct GatewayWaitingTasks<MS, MR, SS, SR> {
+        mpc_send: Option<MS>,
+        mpc_recv: Option<MR>,
+        shard_send: Option<SS>,
+        shard_recv: Option<SR>,
     }
 
-    impl<S: Debug, R: Debug> Debug for GatewayWaitingTasks<S, R> {
+    impl<MS: Debug, MR: Debug, SS: Debug, SR: Debug> Debug for GatewayWaitingTasks<MS, MR, SS, SR> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            if let Some(senders_state) = &self.senders_state {
+            if let Some(senders_state) = &self.mpc_send {
                 write!(f, "\n{{{senders_state:?}\n}}")?;
             }
-            if let Some(receivers_state) = &self.receivers_state {
+            if let Some(receivers_state) = &self.mpc_recv {
+                write!(f, "\n{{{receivers_state:?}\n}}")?;
+            }
+            if let Some(senders_state) = &self.shard_send {
+                write!(f, "\n{{{senders_state:?}\n}}")?;
+            }
+            if let Some(receivers_state) = &self.shard_recv {
                 write!(f, "\n{{{receivers_state:?}\n}}")?;
             }
 
@@ -194,15 +232,27 @@ mod gateway {
     }
 
     impl ObserveState for Weak<State> {
-        type State = GatewayWaitingTasks<send::WaitingTasks, receive::WaitingTasks>;
+        type State = GatewayWaitingTasks<
+            send::WaitingTasks<Role>,
+            receive::WaitingTasks<Role>,
+            send::WaitingTasks<ShardIndex>,
+            receive::WaitingTasks<ShardIndex>,
+        >;
 
         fn get_state(&self) -> Option<Self::State> {
             self.upgrade().and_then(|state| {
-                match (state.senders.get_state(), state.receivers.get_state()) {
-                    (None, None) => None,
-                    (senders_state, receivers_state) => Some(Self::State {
-                        senders_state,
-                        receivers_state,
+                match (
+                    state.mpc_senders.get_state(),
+                    state.mpc_receivers.get_state(),
+                    state.shard_senders.get_state(),
+                    state.shard_receivers.get_state(),
+                ) {
+                    (None, None, None, None) => None,
+                    (mpc_send, mpc_recv, shard_send, shard_recv) => Some(Self::State {
+                        mpc_send,
+                        mpc_recv,
+                        shard_send,
+                        shard_recv,
                     }),
                 }
             })
@@ -214,19 +264,27 @@ mod receive {
     use std::{
         collections::BTreeMap,
         fmt::{Debug, Formatter},
+        pin::Pin,
+        task::{Context, Poll},
     };
+
+    use futures::Stream;
 
     use super::{ObserveState, Observed};
     use crate::{
         helpers::{
             error::Error,
-            gateway::{receive::GatewayReceivers, ReceivingEnd},
-            HelperChannelId, Message, Role,
+            gateway::{
+                receive::{GatewayReceivers, ShardReceiveStream, ShardReceivingEnd, UR},
+                MpcReceivingEnd,
+            },
+            ChannelId, Message, MpcMessage, Role, TransportIdentity,
         },
         protocol::RecordId,
+        sharding::ShardIndex,
     };
 
-    impl<M: Message> Observed<ReceivingEnd<M>> {
+    impl<M: MpcMessage> Observed<MpcReceivingEnd<M>> {
         delegate::delegate! {
             to { self.advance(); self.inner() } {
                 #[inline]
@@ -235,9 +293,18 @@ mod receive {
         }
     }
 
-    pub struct WaitingTasks(BTreeMap<HelperChannelId, Vec<String>>);
+    impl<M: Message> Stream for Observed<ShardReceivingEnd<M>> {
+        type Item = <ShardReceivingEnd<M> as Stream>::Item;
 
-    impl Debug for WaitingTasks {
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.advance();
+            Pin::new(&mut self.inner).poll_next(cx)
+        }
+    }
+
+    pub struct WaitingTasks<I: TransportIdentity>(BTreeMap<ChannelId<I>, Vec<String>>);
+
+    impl<I: TransportIdentity> Debug for WaitingTasks<I> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             for (channel, records) in &self.0 {
                 write!(
@@ -251,8 +318,8 @@ mod receive {
         }
     }
 
-    impl ObserveState for GatewayReceivers {
-        type State = WaitingTasks;
+    impl ObserveState for GatewayReceivers<Role, UR> {
+        type State = WaitingTasks<Role>;
 
         fn get_state(&self) -> Option<Self::State> {
             let mut map = BTreeMap::default();
@@ -261,6 +328,23 @@ mod receive {
                 if let Some(waiting) = super::to_ranges(entry.value().waiting()).get_state() {
                     map.insert(channel.clone(), waiting);
                 }
+            }
+
+            (!map.is_empty()).then_some(WaitingTasks(map))
+        }
+    }
+
+    impl ObserveState for GatewayReceivers<ShardIndex, ShardReceiveStream> {
+        type State = WaitingTasks<ShardIndex>;
+
+        fn get_state(&self) -> Option<Self::State> {
+            let mut map = BTreeMap::default();
+            for entry in &self.inner {
+                let channel = entry.key();
+                map.insert(
+                    channel.clone(),
+                    vec!["Shard receiver state is not implemented yet".to_string()],
+                );
             }
 
             (!map.is_empty()).then_some(WaitingTasks(map))
@@ -280,23 +364,23 @@ mod send {
         helpers::{
             error::Error,
             gateway::send::{GatewaySender, GatewaySenders},
-            HelperChannelId, Message, Role, TotalRecords,
+            ChannelId, Message, TotalRecords, TransportIdentity,
         },
         protocol::RecordId,
     };
 
-    impl<M: Message> Observed<crate::helpers::gateway::send::SendingEnd<M>> {
+    impl<I: TransportIdentity, M: Message> Observed<crate::helpers::gateway::send::SendingEnd<I, M>> {
         delegate::delegate! {
             to { self.advance(); self.inner() } {
                 #[inline]
-                pub async fn send<B: Borrow<M>>(&self, record_id: RecordId, msg: B) -> Result<(), Error<Role>>;
+                pub async fn send<B: Borrow<M>>(&self, record_id: RecordId, msg: B) -> Result<(), Error<I>>;
             }
         }
     }
 
-    pub struct WaitingTasks(BTreeMap<HelperChannelId, (TotalRecords, Vec<String>)>);
+    pub struct WaitingTasks<I>(BTreeMap<ChannelId<I>, (TotalRecords, Vec<String>)>);
 
-    impl Debug for WaitingTasks {
+    impl<I: TransportIdentity> Debug for WaitingTasks<I> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             for (channel, (total, records)) in &self.0 {
                 write!(
@@ -310,8 +394,8 @@ mod send {
         }
     }
 
-    impl ObserveState for GatewaySenders {
-        type State = WaitingTasks;
+    impl<I: TransportIdentity> ObserveState for GatewaySenders<I> {
+        type State = WaitingTasks<I>;
 
         fn get_state(&self) -> Option<Self::State> {
             let mut state = BTreeMap::new();
@@ -327,7 +411,7 @@ mod send {
         }
     }
 
-    impl ObserveState for GatewaySender {
+    impl<I: TransportIdentity> ObserveState for GatewaySender<I> {
         type State = Vec<String>;
 
         fn get_state(&self) -> Option<Self::State> {

--- a/ipa-core/src/helpers/prss_protocol.rs
+++ b/ipa-core/src/helpers/prss_protocol.rs
@@ -37,10 +37,10 @@ pub async fn negotiate<R: RngCore + CryptoRng>(
     let right_channel = ChannelId::new(gateway.role().peer(Direction::Right), step.clone());
     let total_records = TotalRecords::from(1);
 
-    let left_sender = gateway.get_sender::<PublicKey>(&left_channel, total_records);
-    let right_sender = gateway.get_sender::<PublicKey>(&right_channel, total_records);
-    let left_receiver = gateway.get_receiver::<PublicKey>(&left_channel);
-    let right_receiver = gateway.get_receiver::<PublicKey>(&right_channel);
+    let left_sender = gateway.get_mpc_sender::<PublicKey>(&left_channel, total_records);
+    let right_sender = gateway.get_mpc_sender::<PublicKey>(&right_channel, total_records);
+    let left_receiver = gateway.get_mpc_receiver::<PublicKey>(&left_channel);
+    let right_receiver = gateway.get_mpc_receiver::<PublicKey>(&right_channel);
 
     // setup local prss endpoint
     let ep_setup = prss::Endpoint::prepare(rng);

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -43,16 +43,16 @@ use crate::{
 pub trait Identity:
     Copy + Clone + Debug + PartialEq + Eq + PartialOrd + Ord + Hash + Send + Sync + 'static
 {
-    fn as_str<'a>(&self) -> Cow<'a, str>;
+    fn as_str(&self) -> Cow<'static, str>;
 }
 
 impl Identity for ShardIndex {
-    fn as_str<'a>(&self) -> Cow<'a, str> {
+    fn as_str(&self) -> Cow<'static, str> {
         Cow::Owned(self.to_string())
     }
 }
 impl Identity for HelperIdentity {
-    fn as_str<'a>(&self) -> Cow<'a, str> {
+    fn as_str(&self) -> Cow<'static, str> {
         Cow::Owned(self.id.to_string())
     }
 }
@@ -60,7 +60,7 @@ impl Identity for HelperIdentity {
 /// Role is an identifier of helper peer, only valid within a given query. For every query, there
 /// exists a static mapping from role to helper identity.
 impl Identity for Role {
-    fn as_str<'a>(&self) -> Cow<'a, str> {
+    fn as_str(&self) -> Cow<'static, str> {
         Cow::Borrowed(Role::as_static_str(self))
     }
 }

--- a/ipa-core/src/helpers/transport/receive.rs
+++ b/ipa-core/src/helpers/transport/receive.rs
@@ -89,7 +89,7 @@ impl<I: TransportIdentity, S: crate::helpers::BytesStream> ReceiveRecords<I, S> 
     /// Converts this into a stream that yields owned byte chunks.
     ///
     /// ## Panics
-    /// If inner stream yields an [`Err`] chunk.
+    /// If inner stream yields [`Err`] chunk.
     pub(crate) fn into_bytes_stream(self) -> impl Stream<Item = Vec<u8>> {
         self.inner.map(Result::unwrap).map(Into::into)
     }

--- a/ipa-core/src/helpers/transport/stream/input.rs
+++ b/ipa-core/src/helpers/transport/stream/input.rs
@@ -115,12 +115,9 @@ impl BufDeque {
         self.read_bytes(T::Size::USIZE)
             .map(|bytes| T::deserialize_infallible(GenericArray::from_slice(&bytes)))
     }
-
     /// Attempts to deserialize a single instance of `T` from the buffer.
-    /// Returns `None` if there is insufficient data available
     ///
-    /// ## Errors
-    /// Returns a deserialization error if `T` rejects the bytes from this buffer.
+    /// Returns `None` if there is insufficient data available, and an error if deserialization fails.
     fn try_read<T: Serializable>(&mut self) -> Option<Result<T, T::DeserializationError>> {
         self.read_bytes(T::Size::USIZE)
             .map(|bytes| T::deserialize(GenericArray::from_slice(&bytes)))
@@ -219,6 +216,8 @@ where
     buffer: BufDeque,
     phantom_data: PhantomData<(T, M)>,
 }
+
+pub type SingleRecordStream<T, S> = RecordsStream<T, S, Single>;
 
 impl<T, S, M> RecordsStream<T, S, M>
 where

--- a/ipa-core/src/helpers/transport/stream/mod.rs
+++ b/ipa-core/src/helpers/transport/stream/mod.rs
@@ -12,7 +12,7 @@ pub use box_body::WrappedBoxBodyStream;
 use bytes::Bytes;
 pub use collection::{StreamCollection, StreamKey};
 use futures::Stream;
-pub use input::{LengthDelimitedStream, RecordsStream};
+pub use input::{LengthDelimitedStream, RecordsStream, SingleRecordStream};
 
 use crate::error::BoxError;
 

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -9,4 +9,4 @@ mod transport;
 pub use client::{ClientIdentity, MpcHelperClient};
 pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
-pub use transport::HttpTransport;
+pub use transport::{HttpShardTransport, HttpTransport};

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -10,7 +10,10 @@ use ipa_macros::Step;
 use super::{UpgradeContext, UpgradeToMalicious};
 use crate::{
     error::Error,
-    helpers::{ChannelId, Gateway, Message, ReceivingEnd, Role, SendingEnd, TotalRecords},
+    helpers::{
+        ChannelId, Gateway, Message, MpcMessage, MpcReceivingEnd, Role, SendingEnd,
+        ShardReceivingEnd, TotalRecords,
+    },
     protocol::{
         basics::{
             mul::malicious::Step::RandomnessForValidation, SecureMul, ShareKnownValue,
@@ -32,7 +35,7 @@ use crate::{
         ReplicatedSecretSharing,
     },
     seq_join::SeqJoin,
-    sharding::NotSharded,
+    sharding::{NotSharded, ShardIndex},
     sync::Arc,
 };
 
@@ -112,12 +115,20 @@ impl<'a> super::Context for Context<'a> {
         self.inner.prss_rng()
     }
 
-    fn send_channel<M: Message>(&self, role: Role) -> SendingEnd<M> {
+    fn send_channel<M: MpcMessage>(&self, role: Role) -> SendingEnd<Role, M> {
         self.inner.send_channel(role)
     }
 
-    fn recv_channel<M: Message>(&self, role: Role) -> ReceivingEnd<M> {
+    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
+        self.inner.shard_send_channel(dest_shard)
+    }
+
+    fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner.recv_channel(role)
+    }
+
+    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
+        self.inner.shard_recv_channel(origin)
     }
 }
 
@@ -326,16 +337,29 @@ impl<'a, F: ExtendableField> super::Context for Upgraded<'a, F> {
         )
     }
 
-    fn send_channel<M: Message>(&self, role: Role) -> SendingEnd<M> {
+    fn send_channel<M: MpcMessage>(&self, role: Role) -> SendingEnd<Role, M> {
         self.inner
             .gateway
-            .get_sender(&ChannelId::new(role, self.gate.clone()), self.total_records)
+            .get_mpc_sender(&ChannelId::new(role, self.gate.clone()), self.total_records)
     }
 
-    fn recv_channel<M: Message>(&self, role: Role) -> ReceivingEnd<M> {
+    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
+        self.inner.gateway.get_shard_sender(
+            &ChannelId::new(dest_shard, self.gate.clone()),
+            self.total_records,
+        )
+    }
+
+    fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner
             .gateway
-            .get_receiver(&ChannelId::new(role, self.gate.clone()))
+            .get_mpc_receiver(&ChannelId::new(role, self.gate.clone()))
+    }
+
+    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
+        self.inner
+            .gateway
+            .get_shard_receiver(&ChannelId::new(origin, self.gate.clone()))
     }
 }
 

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -11,7 +11,10 @@ use ipa_macros::Step;
 use super::{Context as SuperContext, UpgradeContext, UpgradeToMalicious};
 use crate::{
     error::Error,
-    helpers::{Gateway, Message, ReceivingEnd, Role, SendingEnd, TotalRecords},
+    helpers::{
+        Gateway, Message, MpcMessage, MpcReceivingEnd, Role, SendingEnd, ShardReceivingEnd,
+        TotalRecords,
+    },
     protocol::{
         basics::{ShareKnownValue, ZeroPositions},
         context::{
@@ -117,12 +120,20 @@ impl<'a, B: ShardBinding> super::Context for Context<'a, B> {
         self.inner.prss_rng()
     }
 
-    fn send_channel<M: Message>(&self, role: Role) -> SendingEnd<M> {
+    fn send_channel<M: MpcMessage>(&self, role: Role) -> SendingEnd<Role, M> {
         self.inner.send_channel(role)
     }
 
-    fn recv_channel<M: Message>(&self, role: Role) -> ReceivingEnd<M> {
+    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
+        self.inner.shard_send_channel(dest_shard)
+    }
+
+    fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner.recv_channel(role)
+    }
+
+    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
+        self.inner.shard_recv_channel(origin)
     }
 }
 
@@ -201,12 +212,20 @@ impl<'a, B: ShardBinding, F: ExtendableField> super::Context for Upgraded<'a, B,
         self.inner.prss_rng()
     }
 
-    fn send_channel<M: Message>(&self, role: Role) -> SendingEnd<M> {
+    fn send_channel<M: MpcMessage>(&self, role: Role) -> SendingEnd<Role, M> {
         self.inner.send_channel(role)
     }
 
-    fn recv_channel<M: Message>(&self, role: Role) -> ReceivingEnd<M> {
+    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
+        self.inner.shard_send_channel(dest_shard)
+    }
+
+    fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner.recv_channel(role)
+    }
+
+    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
+        self.inner.shard_recv_channel(origin)
     }
 }
 

--- a/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
@@ -6,7 +6,7 @@ use rand::{distributions::Standard, prelude::Distribution, seq::SliceRandom, Rng
 
 use crate::{
     error::Error,
-    helpers::{Direction, ReceivingEnd, Role},
+    helpers::{Direction, MpcReceivingEnd, Role},
     protocol::{context::Context, RecordId},
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
@@ -335,7 +335,7 @@ where
     S: SharedValue,
 {
     let role = ctx.role().peer(direction);
-    let receive_channel: ReceivingEnd<S> = ctx
+    let receive_channel: MpcReceivingEnd<S> = ctx
         .narrow(step)
         .set_total_records(batch_size)
         .recv_channel(role);

--- a/ipa-core/src/test_fixture/mod.rs
+++ b/ipa-core/src/test_fixture/mod.rs
@@ -25,7 +25,7 @@ use rand::{distributions::Standard, prelude::Distribution, rngs::mock::StepRng};
 use rand_core::{CryptoRng, RngCore};
 pub use sharing::{get_bits, into_bits, Reconstruct, ReconstructArr};
 #[cfg(feature = "in-memory-infra")]
-pub use world::{Runner, TestExecutionStep, TestWorld, TestWorldConfig};
+pub use world::{Runner, TestExecutionStep, TestWorld, TestWorldConfig, WithShards};
 
 use crate::{
     ff::{Field, U128Conversions},


### PR DESCRIPTION
This change adds the necessary functionality to `Gateway` to be able to communicate between shards.
`get_shard_sender` and `get_shard_receiver` will allow circuits to send and request data from other shards, similarly to MPC send/recv.

There is a difference in how receives are handled for MPC and shards. The former channels use `UnorderedReceiver` that lets them receive records in any order. Shard receivers return a stream that has a FIFO order. This is a requirement that came from analysing shuffle and other protocols that require cross-shard communication. Each shard does not know in advance how many records it expects to receive from any shard.

This also adds a stub for HTTP shard transport, just to make the code compile. Actual HTTP implementation will come later.

In terms of next steps, there remains a building block for resharding shares and sharded shuffle implementation. After these two are complete, in memory implementation will be fully functional