### PR TITLE
Biased field conversion for Fiat-Shamir

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/hashing.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/hashing.rs
@@ -50,37 +50,51 @@ where
     Hash(sha.finalize())
 }
 
-/// This function takes two hash a vector of field elements into a single field element
+/// This function takes two hashes, combines them together and returns a single field element.
+///
+/// Its use is tailored to malicious security requirements where the random challenge point `r`
+/// must be uniformly drawn from the field `F`, with the constraint that it does NOT appear
+/// in the set {0, 1, ..., λ-1}.
+/// In the paper [`ZKP_PROOF`] this is shown on step (2.f) of protocol C.2.1
+/// on page 21 where it says: "The parties call `F_{coin}` to receive a random `r ∈ F_{p} \ [λ]`"
+/// When using Fiat-Shamir to generate the random challenge point, we simply constrain
+/// the conversion from SHA-derived-entropy to field element to only generate valid values,
+/// rather than use rejection sampling. The range [0, λ) is provided through `exclude_to` parameter.
+///
+/// [`ZKP_PROOF`]: https://eprint.iacr.org/2023/909.pdf
 /// # Panics
-/// does not panic
+/// If field size is too large compared to 128 bits of entropy required to generate `r` or
+/// if exclude range is greater than half size of the field `F`.
 pub fn hash_to_field<F>(left: &Hash, right: &Hash, exclude_to: u128) -> F
 where
     F: PrimeField + FromRandomU128,
 {
-    assert!(F::BITS <= 64, "Field size is not sufficiently small");
+    let prime = F::PRIME.into();
     assert!(
-        2 * exclude_to < F::PRIME.into(),
-        "Ben and Martin decided it to be like that"
+        F::BITS <= 64,
+        "Field size {f_sz} is too large, compared to the 128 bits of entropy, \
+        which will result in excessive bias when converting to a field element",
+        f_sz = F::BITS
+    );
+    assert!(
+        2 * exclude_to < prime,
+        "Exclude range {exclude_range:?} is too large relative to the size of the field {prime:?}",
+        exclude_range = 0..exclude_to,
     );
 
-    // set up hash
-    let mut sha = Sha256::new();
-
     // set state
+    let combine = compute_hash([left, right]);
     let mut buf = GenericArray::default();
-    left.serialize(&mut buf);
-    sha.update(buf);
-    right.serialize(&mut buf);
-    sha.update(buf);
+    combine.serialize(&mut buf);
 
     // compute hash as a field element
     // ideally we would generate `hash` as a `[u8;F::Size]` and `deserialize` it to generate `r`
     // however, deserialize might fail for some fields so we use `truncate_from` instead
     // this results in at most 128 bits of security/collision probability rather than 256 bits as offered by `Sha256`
     // for field elements of size less than 129 bits, this does not make a difference
-    let val = u128::from_le_bytes(sha.finalize()[0..16].try_into().unwrap());
+    let val = u128::from_le_bytes(buf[..16].try_into().unwrap());
 
-    F::truncate_from(val % (F::PRIME.into() - exclude_to) + exclude_to)
+    F::truncate_from(val % (prime - exclude_to) + exclude_to)
 }
 
 #[cfg(all(test, unit_test))]

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -182,7 +182,11 @@ where
             "When the output is this small, you should validate the proof with a more straightforward reveal"
         );
 
-        let r: F = hash_to_field(&compute_hash(proof_left), &compute_hash(proof_right));
+        let r: F = hash_to_field(
+            &compute_hash(proof_left),
+            &compute_hash(proof_right),
+            λ::U128,
+        );
         let mut p = GenericArray::<F, λ>::generate(|_| F::ZERO);
         let mut q = GenericArray::<F, λ>::generate(|_| F::ZERO);
         let denominator = CanonicalLagrangeDenominator::<F, λ>::new();
@@ -248,12 +252,12 @@ mod test {
             1, 1, 0, 0, 1, 1,
         ];
         const PROOF_1: [u128; 7] = [0, 30, 29, 30, 5, 28, 13];
-        const PROOF_LEFT_1: [u128; 7] = [1, 4, 10, 15, 12, 15, 29];
+        const PROOF_LEFT_1: [u128; 7] = [0, 11, 24, 8, 0, 4, 3];
         const U_2: [u128; 8] = [0, 0, 26, 0, 7, 18, 24, 13];
         const V_2: [u128; 8] = [10, 21, 30, 28, 15, 21, 3, 3];
 
         const PROOF_2: [u128; 7] = [12, 6, 15, 8, 29, 30, 6];
-        const PROOF_LEFT_2: [u128; 7] = [30, 28, 10, 25, 12, 23, 29];
+        const PROOF_LEFT_2: [u128; 7] = [5, 26, 14, 9, 0, 25, 2];
         const U_3: [u128; 2] = [3, 3];
         const V_3: [u128; 2] = [5, 24];
 


### PR DESCRIPTION
The previous implementation was not 100% correct because with some probability it could generate an `r` value that must not be used by the prover. This change fixes that by introducing small bias when converting from 32 byte hash to a field value.