### PR TITLE
Duplicate timestamp and input-sorting changes

### DIFF
--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -130,7 +130,7 @@ async fn run(args: Args) -> Result<(), Error> {
                 args.query_size,
             )
         };
-    let mut raw_data = EventGenerator::with_config(
+    let raw_data = EventGenerator::with_config(
         rng,
         EventGeneratorConfig {
             user_count,
@@ -143,9 +143,6 @@ async fn run(args: Args) -> Result<(), Error> {
     )
     .take(query_size)
     .collect::<Vec<_>>();
-    // EventGenerator produces events in random order, but IPA requires them to be sorted by
-    // timestamp.
-    raw_data.sort_by_key(|e| e.timestamp);
 
     let order = CappingOrder::CapMostRecentFirst;
 

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -155,10 +155,9 @@ fn gen_inputs(
     let rng = seed
         .map(StdRng::seed_from_u64)
         .unwrap_or_else(StdRng::from_entropy);
-    let mut event_gen = EventGenerator::with_config(rng, args)
+    let event_gen = EventGenerator::with_config(rng, args)
         .take(count as usize)
         .collect::<Vec<_>>();
-    event_gen.sort_by_key(|e| e.timestamp);
     let mut writer: Box<dyn Write> = if let Some(path) = output_file {
         Box::new(OpenOptions::new().write(true).create_new(true).open(path)?)
     } else {


### PR DESCRIPTION
IPAv3 sorts the input records, so add sorting of input records to ipa_in_the_clear, and remove it from input drivers.

IPAv3 also shuffles the input records, so if there are duplicate timestamps among a single user's records, the output may be non-deterministic. To avoid end-to-end test failures, modify the test data generator to avoid generating duplicate timestamps. Add a directed test to exercise duplicate timestamps.

Possibly a fix for #967.