### PR TITLE
Stabilizing versions around rustls0.22.3 and hyper 0.14.28

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -79,6 +79,8 @@ aes = "0.8.3"
 async-trait = "0.1.79"
 async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
+# The following is a temporary version until we can stabilize the build on a higher version
+# of axum, rustls and the http stack.
 axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.22", version = "0.5.2", optional = true, features = [
     "tls-rustls",
 ] }

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -79,9 +79,7 @@ aes = "0.8.3"
 async-trait = "0.1.79"
 async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
-axum-server = { version = "0.5.1", optional = true, features = [
-    "rustls",
-    "rustls-pemfile",
+axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.22", version = "0.5.2", optional = true, features = [
     "tls-rustls",
 ] }
 base64 = { version = "0.21.2", optional = true }
@@ -110,13 +108,13 @@ hpke = { version = "0.11.0", default-features = false, features = [
     "std",
     "x25519",
 ] }
-hyper = { version = "0.14.26", optional = true, features = [
+hyper = { version = "0.14.28", optional = true, features = [
     "client",
     "h2",
     "stream",
     "runtime",
 ] }
-hyper-rustls = { version = "0.24.1", optional = true, features = ["http2"] }
+hyper-rustls = { version = "0.25.0", optional = true, features = ["http2"] }
 iai = { version = "0.1.1", optional = true }
 metrics = "0.21.0"
 metrics-tracing-context = "0.14.0"
@@ -126,11 +124,12 @@ pin-project = "1.0"
 rand = "0.8"
 rand_core = "0.6"
 rcgen = { version = "0.11.3", optional = true }
-rustls = { version = "0.21", optional = true }
-rustls-pemfile = { version = "1", optional = true }
+rustls = { version = "0.22.3", optional = true }
+rustls-pemfile = { version = "2.1.2", optional = true }
 # TODO: https://rustsec.org/advisories/RUSTSEC-2023-0053. tokio-rustls and hyper-rustls need to be upgraded first, before
 # we can remove pinning
-rustls-webpki = "^0.101.4"
+rustls-webpki = "0.102.1"
+rustls-pki-types = "1.4.1"
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
@@ -139,8 +138,7 @@ shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.35", features = ["fs", "rt", "rt-multi-thread", "macros"] }
-# TODO: axum-server holds onto 0.24 and we can't upgrade until they do. Or we move away from axum-server
-tokio-rustls = { version = "0.24", optional = true }
+tokio-rustls = { version = "0.25", optional = true }
 tokio-stream = "0.1.14"
 toml = { version = "0.8", optional = true }
 tower = { version = "0.4.13", optional = true }
@@ -162,7 +160,7 @@ command-fds = "0.2.2"
 hex = "0.4"
 permutation = "0.4.1"
 proptest = "1.4"
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls = { version = "0.22.3" }
 tempfile = "3"
 
 [lib]

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::BufReader,
     net::TcpListener,
     os::fd::{FromRawFd, RawFd},
     path::{Path, PathBuf},
@@ -97,23 +98,25 @@ enum HelperCommand {
     TestSetup(TestSetupArgs),
 }
 
-fn read_utf8_bytes(path: &Path) -> Result<Vec<u8>, BoxError> {
-    Ok(fs::read_to_string(path)
-        .map_err(|e| format!("failed to open file {}: {e:?}", path.display()))?
-        .into_bytes())
+fn read_file(path: &Path) -> Result<BufReader<fs::File>, BoxError> {
+    Ok(fs::OpenOptions::new()
+        .read(true)
+        .open(path)
+        .map(BufReader::new)
+        .map_err(|e| format!("failed to open file {}: {e:?}", path.display()))?)
 }
 
 async fn server(args: ServerArgs) -> Result<(), BoxError> {
     let my_identity = HelperIdentity::try_from(args.identity.expect("enforced by clap")).unwrap();
 
     let (identity, server_tls) = match (args.tls_cert, args.tls_key) {
-        (Some(cert), Some(key_file)) => {
-            let key = read_utf8_bytes(&key_file)?;
-            let certs = read_utf8_bytes(&cert)?;
+        (Some(cert_file), Some(key_file)) => {
+            let mut key = read_file(&key_file)?;
+            let mut certs = read_file(&cert_file)?;
             (
-                ClientIdentity::from_pks8(&certs, &key)?,
+                ClientIdentity::from_pkcs8(&mut certs, &mut key)?,
                 Some(TlsConfig::File {
-                    certificate_file: cert,
+                    certificate_file: cert_file,
                     private_key_file: key_file,
                 }),
             )
@@ -148,7 +151,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
     let network_config_path = args.network.as_deref().unwrap();
     let network_config = NetworkConfig::from_toml_str(&fs::read_to_string(network_config_path)?)?
         .override_scheme(&scheme);
-    let clients = MpcHelperClient::from_conf(&network_config, identity);
+    let clients = MpcHelperClient::from_conf(&network_config, &identity);
 
     let (transport, server) = HttpTransport::new(
         my_identity,

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -93,7 +93,7 @@ pub async fn make_clients(
 
     // Note: This closure is only called when the selected action uses clients.
 
-    let clients = MpcHelperClient::from_conf(&network, ClientIdentity::None);
+    let clients = MpcHelperClient::from_conf(&network, &ClientIdentity::None);
     while wait > 0 && !clients_ready(&clients).await {
         tracing::debug!("waiting for servers to come up");
         sleep(Duration::from_secs(1)).await;

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -194,7 +194,7 @@ impl MpcHelperClient {
             (
                 HttpsConnectorBuilder::new()
                     .with_native_roots()
-                    .unwrap()
+                    .expect("Error creating client with Rustls, native roots should be available.")
                     .https_or_http()
                     .enable_http2()
                     .wrap_connector(make_http_connector()),

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -1,5 +1,7 @@
 use std::{io, io::BufRead};
 
+use rustls_pki_types::CertificateDer;
+
 use crate::config::{OwnedCertificate, OwnedPrivateKey};
 
 mod client;
@@ -25,7 +27,7 @@ pub fn parse_certificate_and_private_key_bytes(
     private_key_read: &mut dyn BufRead,
 ) -> Result<(Vec<OwnedCertificate>, OwnedPrivateKey), io::Error> {
     let certs = rustls_pemfile::certs(cert_read)
-        .map(|r| r.map(|c| c.into_owned()))
+        .map(|r| r.map(CertificateDer::into_owned))
         .collect::<Result<Vec<_>, _>>()?;
     if certs.is_empty() {
         return Err(io::Error::other("No certificates found"));

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -1,3 +1,10 @@
+use std::{
+    io,
+    io::{BufRead, BufReader, Cursor},
+};
+
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+
 mod client;
 mod error;
 mod http_serde;
@@ -10,3 +17,71 @@ pub use client::{ClientIdentity, MpcHelperClient};
 pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpShardTransport, HttpTransport};
+
+/// Reads certificates and a private key from the corresponding bytes
+///
+/// # Errors
+/// If no private key or certificates are found and if there are any issues with
+/// their format.
+pub fn parse_certificate_and_private_key_bytes(
+    cert_bytes: &[u8],
+    private_key_bytes: &[u8],
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), io::Error> {
+    let mut certs_reader = BufReader::new(Cursor::new(cert_bytes));
+    let mut private_key_reader = BufReader::new(Cursor::new(private_key_bytes));
+    parse_certificate_and_private_key(&mut certs_reader, &mut private_key_reader)
+}
+
+/// Reads certificates and a private key from the corresponding buffered inputs
+///
+/// # Errors
+/// If no private key or certificates are found and if there are any issues with
+/// their format.
+pub fn parse_certificate_and_private_key(
+    cert_reader: &mut dyn BufRead,
+    private_key_reader: &mut dyn BufRead,
+) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), io::Error> {
+    let cert_chain: Vec<_> = rustls_pemfile::certs(cert_reader)
+        .flatten()
+        .map(CertificateDer::into_owned)
+        .collect();
+    let Some(pk) = rustls_pemfile::private_key(private_key_reader)? else {
+        return Err(io::Error::other("No private key"));
+    };
+    if cert_chain.is_empty() {
+        return Err(io::Error::other("No certificates found"));
+    }
+    Ok((cert_chain, pk))
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use std::io::ErrorKind;
+
+    use crate::net::test;
+
+    #[test]
+    fn parse_cert_pk_happy_path() {
+        super::parse_certificate_and_private_key_bytes(test::TEST_CERTS[0], test::TEST_KEYS[0])
+            .unwrap();
+    }
+
+    #[test]
+    fn parse_cert_pk_no_cert() {
+        let r = super::parse_certificate_and_private_key_bytes(b" ", test::TEST_KEYS[0]);
+        assert_eq!(r.unwrap_err().kind(), ErrorKind::Other);
+    }
+
+    #[test]
+    fn parse_cert_pk_no_pk() {
+        let r = super::parse_certificate_and_private_key_bytes(test::TEST_CERTS[0], b" ");
+        assert_eq!(r.unwrap_err().kind(), ErrorKind::Other);
+    }
+
+    #[test]
+    fn parse_cert_pk_invalid() {
+        let r =
+            super::parse_certificate_and_private_key_bytes(b"ksjdhfskjdfhsdf", test::TEST_KEYS[0]);
+        assert_eq!(r.unwrap_err().kind(), ErrorKind::Other);
+    }
+}

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -45,9 +45,9 @@ pub fn parse_certificate_and_private_key(
         .flatten()
         .map(CertificateDer::into_owned)
         .collect();
-    let Some(pk) = rustls_pemfile::private_key(private_key_reader)? else {
-        return Err(io::Error::other("No private key"));
-    };
+    let pk = rustls_pemfile::private_key(private_key_reader)?.ok_or_else(||
+      io::Error::other("No private key")
+    )?;
     if cert_chain.is_empty() {
         return Err(io::Error::other("No certificates found"));
     }

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -295,7 +295,7 @@ impl TestServerBuilder {
         else {
             panic!("TestConfig should have allocated ports");
         };
-        let clients = MpcHelperClient::from_conf(&network_config, identity.clone());
+        let clients = MpcHelperClient::from_conf(&network_config, &identity.clone_with_key());
         let handler = self.handler.as_ref().map(HandlerBox::owning_ref);
         let (transport, server) = HttpTransport::new(
             HelperIdentity::ONE,
@@ -328,8 +328,8 @@ fn get_test_certificate_and_key(id: HelperIdentity) -> (&'static [u8], &'static 
 
 #[must_use]
 pub fn get_test_identity(id: HelperIdentity) -> ClientIdentity {
-    let (certificate, private_key) = get_test_certificate_and_key(id);
-    ClientIdentity::from_pks8(certificate, private_key).unwrap()
+    let (mut certificate, mut private_key) = get_test_certificate_and_key(id);
+    ClientIdentity::from_pkcs8(&mut certificate, &mut private_key).unwrap()
 }
 
 pub const TEST_CERTS: [&[u8]; 3] = [

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
-use rustls::Certificate;
+use rustls_pki_types::CertificateDer;
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -166,7 +166,7 @@ impl TestConfigBuilder {
                 url: format!("{scheme}://localhost:{}", ports[i])
                     .parse()
                     .unwrap(),
-                certificate: cert.map(Certificate),
+                certificate: cert,
                 hpke_config: if self.disable_matchkey_encryption {
                     None
                 } else {
@@ -371,14 +371,8 @@ jn+NXYPeKEWnkCcVKjFED6MevGnOgrJylgY=
 ",
 ];
 
-pub static TEST_CERTS_DER: Lazy<[Vec<u8>; 3]> = Lazy::new(|| {
-    TEST_CERTS.map(|mut pem| {
-        rustls_pemfile::certs(&mut pem)
-            .unwrap()
-            .into_iter()
-            .next()
-            .unwrap()
-    })
+pub static TEST_CERTS_DER: Lazy<[CertificateDer; 3]> = Lazy::new(|| {
+    TEST_CERTS.map(|mut pem| rustls_pemfile::certs(&mut pem).flatten().next().unwrap())
 });
 
 pub const TEST_KEYS: [&[u8]; 3] = [

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -355,7 +355,7 @@ mod tests {
                         get_test_identity(id)
                     };
                     let (setup, handler) = AppSetup::new();
-                    let clients = MpcHelperClient::from_conf(network_config, identity);
+                    let clients = MpcHelperClient::from_conf(network_config, &identity);
                     let (transport, server) = HttpTransport::new(
                         id,
                         server_config,
@@ -376,7 +376,7 @@ mod tests {
     }
 
     async fn test_three_helpers(mut conf: TestConfig) {
-        let clients = MpcHelperClient::from_conf(&conf.network, ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(&conf.network, &ClientIdentity::None);
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,
@@ -391,7 +391,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn happy_case_twice() {
         let mut conf = TestConfigBuilder::with_open_ports().build();
-        let clients = MpcHelperClient::from_conf(&conf.network, ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(&conf.network, &ClientIdentity::None);
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,


### PR DESCRIPTION
This is part of the journey to update all of IPA's HTTP dependencies to the latest and greatest (tracked private-attribution/ipa#924). I have found that these versions (see `Cargo.toml`) together with a custom `axum-server` branch I created specifically for this change, allow us to bump until rustls0.22.3. This will be an intermediate step until all dependencies are updated.