### PR TITLE
Use BooleanArrayMul and `select` for saturated add/sub

### DIFF
--- a/ipa-core/src/protocol/basics/mul/mod.rs
+++ b/ipa-core/src/protocol/basics/mul/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     error::Error,
     ff::{
         boolean::Boolean,
-        boolean_array::{BA20, BA3, BA32, BA5, BA8},
+        boolean_array::{BA20, BA3, BA32, BA5, BA64, BA8},
         Expand,
     },
     protocol::{context::Context, RecordId},
@@ -117,3 +117,4 @@ boolean_array_mul!(5, BA5);
 boolean_array_mul!(8, BA8);
 boolean_array_mul!(20, BA20);
 boolean_array_mul!(32, BA32);
+boolean_array_mul!(64, BA64);

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -16,16 +16,10 @@ use crate::{
 };
 #[cfg(all(test, unit_test))]
 use crate::{
-    ff::CustomArray,
-    secret_sharing::{FieldVectorizable, SharedValue},
+    ff::{boolean::Boolean, CustomArray},
+    protocol::basics::{select, BooleanArrayMul},
+    secret_sharing::SharedValue,
 };
-
-#[cfg(all(test, unit_test))]
-#[derive(Step)]
-pub(crate) enum Step {
-    SaturatedAddition,
-    IfElse,
-}
 
 /// Non-saturated unsigned integer addition
 /// This function adds y to x.
@@ -59,44 +53,35 @@ where
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn integer_sat_add<F, C, S, const N: usize>(
+pub async fn integer_sat_add<C, S>(
     ctx: C,
     record_id: RecordId,
     x: &AdditiveShare<S>,
     y: &AdditiveShare<S>,
 ) -> Result<AdditiveShare<S>, Error>
 where
-    F: Field + FieldSimd<N> + FieldVectorizable<N, ArrayAlias = S>,
     C: Context,
-    S: SharedValue + CustomArray<Element = F>,
-    AdditiveShare<S>: From<AdditiveShare<F, N>> + Into<AdditiveShare<F, N>>,
-    AdditiveShare<F>: BooleanProtocols<C, F>,
+    S: SharedValue + CustomArray<Element = Boolean>,
+    AdditiveShare<S>: BooleanArrayMul + std::ops::Not<Output = AdditiveShare<S>>,
 {
-    use crate::{ff::Expand, protocol::basics::if_else};
-    let mut carry = AdditiveShare::<F>::ZERO;
-    let result = addition_circuit(
-        ctx.narrow(&Step::SaturatedAddition),
-        record_id,
-        x,
-        y,
-        &mut carry,
-    )
-    .await?
-    .into();
+    #[derive(Step)]
+    enum Step {
+        Add,
+        Select,
+    }
 
-    // expand carry bit to array
-    let carry_array = AdditiveShare::<S>::expand(&carry).into();
+    let mut carry = AdditiveShare::<Boolean>::ZERO;
+    let result = addition_circuit(ctx.narrow(&Step::Add), record_id, x, y, &mut carry).await?;
 
-    // if carry_array==1 then {carry_array} else {result}:
-    if_else(
-        ctx.narrow(&Step::IfElse),
+    // if carry==1 then {all ones} else {result}
+    select(
+        ctx.narrow(&Step::Select),
         record_id,
-        &carry_array,
-        &carry_array,
+        &carry,
+        &!AdditiveShare::<S>::ZERO,
         &result,
     )
     .await
-    .map(Into::into)
 }
 
 /// addition using bit adder
@@ -258,7 +243,7 @@ mod test {
 
             let result = world
                 .semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
-                    integer_sat_add::<_, _, _, 64>(
+                    integer_sat_add::<_, _>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y.0,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -9,8 +9,6 @@ use std::{borrow::Borrow, iter::repeat};
 #[cfg(all(test, unit_test))]
 use ipa_macros::Step;
 
-#[cfg(all(test, unit_test))]
-use crate::secret_sharing::FieldVectorizable;
 use crate::{
     error::Error,
     ff::{ArrayAccessRef, ArrayBuild, ArrayBuilder, Field},
@@ -24,16 +22,10 @@ use crate::{
 };
 #[cfg(all(test, unit_test))]
 use crate::{
-    ff::{CustomArray, Expand},
+    ff::{boolean::Boolean, CustomArray},
+    protocol::basics::{select, BooleanArrayMul},
     secret_sharing::SharedValue,
 };
-
-#[cfg(all(test, unit_test))]
-#[derive(Step)]
-pub(crate) enum Step {
-    SaturatedSubtraction,
-    MultiplyWithCarry,
-}
 
 /// Comparison operation
 ///
@@ -115,40 +107,37 @@ where
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn integer_sat_sub<F, C, S, const N: usize>(
+pub async fn integer_sat_sub<C, S>(
     ctx: C,
     record_id: RecordId,
     x: &AdditiveShare<S>,
     y: &AdditiveShare<S>,
 ) -> Result<AdditiveShare<S>, Error>
 where
-    F: Field + FieldSimd<N> + FieldVectorizable<N, ArrayAlias = S>,
     C: Context,
-    S: SharedValue + CustomArray<Element = F>,
-    AdditiveShare<S>:
-        ArrayAccessRef<Element = AdditiveShare<F>> + ArrayBuild<Input = AdditiveShare<F>>,
-    AdditiveShare<F>: BooleanProtocols<C, F>,
-    AdditiveShare<S>: From<AdditiveShare<F, N>> + Into<AdditiveShare<F, N>>,
+    S: SharedValue + CustomArray<Element = Boolean>,
+    AdditiveShare<S>: BooleanArrayMul,
 {
-    let mut carry = AdditiveShare::<F>::share_known_value(&ctx, F::ONE);
-    let result = subtraction_circuit(
-        ctx.narrow(&Step::SaturatedSubtraction),
-        record_id,
-        x,
-        y,
-        &mut carry,
-    )
-    .await?
-    .into();
+    #[derive(Step)]
+    enum Step {
+        Subtract,
+        Select,
+    }
+
+    let mut carry = !AdditiveShare::<Boolean>::ZERO;
+    let result =
+        subtraction_circuit(ctx.narrow(&Step::Subtract), record_id, x, y, &mut carry).await?;
 
     // carry computes carry=(x>=y)
-    // if carry==0 {all 0 array, i.e. Array[carry]} else {result}:
-    // compute (1-carry)*Array[carry]+carry*result =carry*result
-    AdditiveShare::<S>::expand(&carry)
-        .into()
-        .multiply(&result, ctx.narrow(&Step::MultiplyWithCarry), record_id)
-        .await
-        .map(Into::into)
+    // if carry==0 then {zero} else {result}
+    select(
+        ctx.narrow(&Step::Select),
+        record_id,
+        &carry,
+        &result,
+        &AdditiveShare::<S>::ZERO,
+    )
+    .await
 }
 
 /// subtraction using bit subtractor
@@ -576,7 +565,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    integer_sat_sub::<_, _, _, 64>(
+                    integer_sat_sub::<_, _>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],


### PR DESCRIPTION
`select` did not exist yet when I initially used a vector op in these routines. They are not truly vectorized, so the revised implementation better reflects what's going on.