### PR TITLE
Using Rustls 0.23

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -116,6 +116,8 @@ hyper = { version = "0.14.28", optional = true, features = [
     "stream",
     "runtime",
 ] }
+# The following is a temporary version until we can stabilize the build on a higher version
+# of axum, rustls and the http stack.
 hyper-rustls = { git = "https://github.com/cberkhoff/hyper-rustls/", branch = "rustls-0.23", version = "0.25.1", optional = true, features = ["http2"] }
 iai = { version = "0.1.1", optional = true }
 metrics = "0.21.0"

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -81,7 +81,7 @@ async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
 axum = { version = "0.5.17", optional = true, features = ["http2"] }
 # The following is a temporary version until we can stabilize the build on a higher version
 # of axum, rustls and the http stack.
-axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.22", version = "0.5.2", optional = true, features = [
+axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.23", version = "0.5.3", optional = true, features = [
     "tls-rustls",
 ] }
 base64 = { version = "0.21.2", optional = true }
@@ -116,7 +116,7 @@ hyper = { version = "0.14.28", optional = true, features = [
     "stream",
     "runtime",
 ] }
-hyper-rustls = { version = "0.25.0", optional = true, features = ["http2"] }
+hyper-rustls = { git = "https://github.com/cberkhoff/hyper-rustls/", branch = "rustls-0.23", version = "0.25.1", optional = true, features = ["http2"] }
 iai = { version = "0.1.1", optional = true }
 metrics = "0.21.0"
 metrics-tracing-context = "0.14.0"
@@ -126,11 +126,8 @@ pin-project = "1.0"
 rand = "0.8"
 rand_core = "0.6"
 rcgen = { version = "0.11.3", optional = true }
-rustls = { version = "0.22.3", optional = true }
+rustls = { version = "0.23", optional = true }
 rustls-pemfile = { version = "2.1.2", optional = true }
-# TODO: https://rustsec.org/advisories/RUSTSEC-2023-0053. tokio-rustls and hyper-rustls need to be upgraded first, before
-# we can remove pinning
-rustls-webpki = "0.102.1"
 rustls-pki-types = "1.4.1"
 # TODO consider using zerocopy or serde_bytes or in-house serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -140,7 +137,7 @@ shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
 tokio = { version = "1.35", features = ["fs", "rt", "rt-multi-thread", "macros"] }
-tokio-rustls = { version = "0.25", optional = true }
+tokio-rustls = { version = "0.26", optional = true }
 tokio-stream = "0.1.14"
 toml = { version = "0.8", optional = true }
 tower = { version = "0.4.13", optional = true }
@@ -162,7 +159,7 @@ command-fds = "0.2.2"
 hex = "0.4"
 permutation = "0.4.1"
 proptest = "1.4"
-rustls = { version = "0.22.3" }
+rustls = { version = "0.23" }
 tempfile = "3"
 
 [lib]

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         HelperIdentity,
     },
-    net::{http_serde, server::HTTP_CLIENT_ID_HEADER, Error},
+    net::{http_serde, server::HTTP_CLIENT_ID_HEADER, setup_crypto_provider, Error},
     protocol::{step::Gate, QueryId},
 };
 
@@ -180,6 +180,7 @@ impl MpcHelperClient {
         peer_config: PeerConfig,
         identity: ClientIdentity,
     ) -> Self {
+        setup_crypto_provider();
         let (connector, auth_header) = if peer_config.url.scheme() == Some(&Scheme::HTTP) {
             // This connector works for both http and https. A regular HttpConnector would suffice,
             // but would make the type of `self.client` variable.

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -27,7 +27,7 @@ use crate::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         HelperIdentity,
     },
-    net::{get_crypto_provider, http_serde, server::HTTP_CLIENT_ID_HEADER, Error},
+    net::{http_serde, server::HTTP_CLIENT_ID_HEADER, Error, CRYPTO_PROVIDER},
     protocol::{step::Gate, QueryId},
 };
 
@@ -193,7 +193,7 @@ impl MpcHelperClient {
             };
             (
                 HttpsConnectorBuilder::new()
-                    .with_provider_and_native_roots(get_crypto_provider().as_ref().clone())
+                    .with_provider_and_native_roots(CRYPTO_PROVIDER.as_ref().clone())
                     .expect("Error creating client with Rustls, native roots should be available.")
                     .https_or_http()
                     .enable_http2()
@@ -201,10 +201,9 @@ impl MpcHelperClient {
                 auth_header,
             )
         } else {
-            let builder =
-                rustls::ClientConfig::builder_with_provider(Arc::clone(get_crypto_provider()))
-                    .with_safe_default_protocol_versions()
-                    .expect("Default crypto provider should be valid");
+            let builder = rustls::ClientConfig::builder_with_provider(Arc::clone(&CRYPTO_PROVIDER))
+                .with_safe_default_protocol_versions()
+                .expect("Default crypto provider should be valid");
             let client_config = if let Some(certificate) = peer_config.certificate {
                 let cert_store = {
                     let mut store = RootCertStore::empty();

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, io::BufRead};
+use std::{io, io::BufRead, sync::Once};
 
 use rustls_pki_types::CertificateDer;
 
@@ -16,6 +16,17 @@ pub use client::{ClientIdentity, MpcHelperClient};
 pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpShardTransport, HttpTransport};
+
+static CRYPTO_INIT: Once = Once::new();
+
+/// Rustls requires to explicitly set the Crypto Provider before `ClientConfig::builder()`,
+/// `ServerConfig::builder()`, `WebPkiServerVerifier::builder()` and
+/// `WebPkiClientVerifier::builder()`.
+pub fn setup_crypto_provider() {
+    CRYPTO_INIT.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
 
 /// Reads certificates and a private key from the corresponding readers
 ///

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Once},
 };
 
+use once_cell::sync::Lazy;
 use rustls::crypto::CryptoProvider;
 use rustls_pki_types::CertificateDer;
 
@@ -24,10 +25,13 @@ pub use transport::{HttpShardTransport, HttpTransport};
 static CRYPTO_INIT: Once = Once::new();
 
 /// Provides access to IPAs Crypto Provider (AWS Libcrypto).
+static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
+    Lazy::new(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+
 ///
 /// # Panics
 /// If there are issues starting the default crypto provider
-pub fn get_crypto_provider() -> &'static Arc<CryptoProvider> {
+pub fn get_crypto_provider_old() -> &'static Arc<CryptoProvider> {
     CRYPTO_INIT.call_once(|| {
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     });

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, BufRead},
-    sync::{Arc, Once},
+    sync::Arc,
 };
 
 use once_cell::sync::Lazy;
@@ -22,21 +22,9 @@ pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpShardTransport, HttpTransport};
 
-static CRYPTO_INIT: Once = Once::new();
-
 /// Provides access to IPAs Crypto Provider (AWS Libcrypto).
 static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
     Lazy::new(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
-
-///
-/// # Panics
-/// If there are issues starting the default crypto provider
-pub fn get_crypto_provider_old() -> &'static Arc<CryptoProvider> {
-    CRYPTO_INIT.call_once(|| {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-    });
-    CryptoProvider::get_default().expect("Default Crypto provider should be initialized")
-}
 
 /// Reads certificates and a private key from the corresponding readers
 ///

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     config::{NetworkConfig, OwnedCertificate, OwnedPrivateKey, ServerConfig, TlsConfig},
     error::BoxError,
     helpers::HelperIdentity,
-    net::{parse_certificate_and_private_key_bytes, Error, HttpTransport},
+    net::{parse_certificate_and_private_key_bytes, setup_crypto_provider, Error, HttpTransport},
     sync::Arc,
     task::JoinHandle,
     telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
@@ -84,6 +84,7 @@ impl MpcHelperServer {
         config: ServerConfig,
         network_config: NetworkConfig,
     ) -> Self {
+        setup_crypto_provider();
         MpcHelperServer {
             transport,
             config,

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     config::{NetworkConfig, OwnedCertificate, OwnedPrivateKey, ServerConfig, TlsConfig},
     error::BoxError,
     helpers::HelperIdentity,
-    net::{get_crypto_provider, parse_certificate_and_private_key_bytes, Error, HttpTransport},
+    net::{parse_certificate_and_private_key_bytes, Error, HttpTransport, CRYPTO_PROVIDER},
     sync::Arc,
     task::JoinHandle,
     telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
@@ -290,11 +290,14 @@ async fn rustls_config(
         // configuration errors.
         trusted_certs.add(cert)?;
     }
-    let client_verifier = WebPkiClientVerifier::builder(trusted_certs.into())
-        .allow_unauthenticated()
-        .build()
-        .expect("Error building client verifier, should specify valid Trust Anchors");
-    let mut config = rustls::ServerConfig::builder_with_provider(Arc::clone(get_crypto_provider()))
+    let client_verifier = WebPkiClientVerifier::builder_with_provider(
+        trusted_certs.into(),
+        Arc::clone(&CRYPTO_PROVIDER),
+    )
+    .allow_unauthenticated()
+    .build()
+    .expect("Error building client verifier, should specify valid Trust Anchors");
+    let mut config = rustls::ServerConfig::builder_with_provider(Arc::clone(&CRYPTO_PROVIDER))
         .with_safe_default_protocol_versions()
         .expect("Default crypto provider should be valid")
         .with_client_cert_verifier(client_verifier)
@@ -577,7 +580,9 @@ mod e2e_tests {
         let authority = format!("localhost:{}", addr.port());
 
         // https client
-        let config = rustls::ClientConfig::builder()
+        let config = rustls::ClientConfig::builder_with_provider(Arc::clone(&CRYPTO_PROVIDER))
+            .with_safe_default_protocol_versions()
+            .expect("Tests server should have working Crypto Provider")
             .dangerous()
             .with_custom_certificate_verifier(Arc::new(NoVerify))
             .with_no_client_auth();


### PR DESCRIPTION
This is another step towards updating all of IPA's dependencies (tracked in private-attribution/ipa#924). This change bumps Rustls to the latest version. To make it work I had to fork `hyper-rustls` with some minimal changes so that all versions in the build remain compatible.