### PR TITLE
Move shard send and recv channel methods to `ShardedContext` trait

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -266,7 +266,10 @@ mod tests {
     use crate::{
         ff::{boolean_array::BA3, Fp31, Fp32BitPrime, Gf2, U128Conversions},
         helpers::{Direction, GatewayConfig, MpcMessage, Role, SendingEnd},
-        protocol::{context::Context, RecordId},
+        protocol::{
+            context::{Context, ShardedContext},
+            RecordId,
+        },
         secret_sharing::replicated::semi_honest::AdditiveShare,
         sharding::ShardConfiguration,
         test_executor::run,

--- a/ipa-core/src/protocol/context/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/context/dzkp_malicious.rs
@@ -7,10 +7,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::Error,
-    helpers::{
-        ChannelId, Gateway, Message, MpcMessage, MpcReceivingEnd, Role, SendingEnd,
-        ShardReceivingEnd, TotalRecords,
-    },
+    helpers::{ChannelId, Gateway, MpcMessage, MpcReceivingEnd, Role, SendingEnd, TotalRecords},
     protocol::{
         context::{
             dzkp_validator::DZKPBatch, prss::InstrumentedIndexedSharedRandomness, Base,
@@ -20,7 +17,6 @@ use crate::{
         step::{Gate, Step, StepNarrow},
     },
     seq_join::SeqJoin,
-    sharding::ShardIndex,
     sync::Arc,
 };
 
@@ -120,23 +116,10 @@ impl<'a> super::Context for DZKPUpgraded<'a> {
             .get_mpc_sender(&ChannelId::new(role, self.gate.clone()), self.total_records)
     }
 
-    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
-        self.inner.gateway.get_shard_sender(
-            &ChannelId::new(dest_shard, self.gate.clone()),
-            self.total_records,
-        )
-    }
-
     fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner
             .gateway
             .get_mpc_receiver(&ChannelId::new(role, self.gate.clone()))
-    }
-
-    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
-        self.inner
-            .gateway
-            .get_shard_receiver(&ChannelId::new(origin, self.gate.clone()))
     }
 }
 

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -8,10 +8,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::Error,
-    helpers::{
-        ChannelId, Gateway, Message, MpcMessage, MpcReceivingEnd, Role, SendingEnd,
-        ShardReceivingEnd, TotalRecords,
-    },
+    helpers::{ChannelId, Gateway, MpcMessage, MpcReceivingEnd, Role, SendingEnd, TotalRecords},
     protocol::{
         basics::{
             mul::{malicious::Step::RandomnessForValidation, semi_honest_multiply},
@@ -35,7 +32,7 @@ use crate::{
         ReplicatedSecretSharing,
     },
     seq_join::SeqJoin,
-    sharding::{NotSharded, ShardIndex},
+    sharding::NotSharded,
     sync::Arc,
 };
 
@@ -134,16 +131,8 @@ impl<'a> super::Context for Context<'a> {
         self.inner.send_channel(role)
     }
 
-    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
-        self.inner.shard_send_channel(dest_shard)
-    }
-
     fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner.recv_channel(role)
-    }
-
-    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
-        self.inner.shard_recv_channel(origin)
     }
 }
 
@@ -342,23 +331,10 @@ impl<'a, F: ExtendableField> super::Context for Upgraded<'a, F> {
             .get_mpc_sender(&ChannelId::new(role, self.gate.clone()), self.total_records)
     }
 
-    fn shard_send_channel<M: Message>(&self, dest_shard: ShardIndex) -> SendingEnd<ShardIndex, M> {
-        self.inner.gateway.get_shard_sender(
-            &ChannelId::new(dest_shard, self.gate.clone()),
-            self.total_records,
-        )
-    }
-
     fn recv_channel<M: MpcMessage>(&self, role: Role) -> MpcReceivingEnd<M> {
         self.inner
             .gateway
             .get_mpc_receiver(&ChannelId::new(role, self.gate.clone()))
-    }
-
-    fn shard_recv_channel<M: Message>(&self, origin: ShardIndex) -> ShardReceivingEnd<M> {
-        self.inner
-            .gateway
-            .get_shard_receiver(&ChannelId::new(origin, self.gate.clone()))
     }
 }
 


### PR DESCRIPTION
There should be no reason to make them accessible via `Context` - only contexts that are created in the presence of multiple shards should provide the ability to open and close these channels.

This should improve the type safety for sharding functionality as it won't be possible to see those methods on non-sharded executions