### PR TITLE
Sum To Zero Check Protocol

### DIFF
--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -71,6 +71,8 @@ pub enum Error {
     ContextUnsafe(String),
     #[error("DZKP Validation failed")]
     DZKPValidationFailed,
+    #[error("Inconsistent shares")]
+    InconsistentShares,
 }
 
 impl Default for Error {

--- a/ipa-core/src/helpers/hashing.rs
+++ b/ipa-core/src/helpers/hashing.rs
@@ -8,6 +8,7 @@ use sha2::{
 
 use crate::{
     ff::{PrimeField, Serializable},
+    helpers::MpcMessage,
     protocol::prss::FromRandomU128,
 };
 
@@ -28,6 +29,12 @@ impl Serializable for Hash {
     }
 }
 
+impl MpcMessage for Hash {}
+
+/// Computes Hash of serializable values from an iterator
+///
+/// ## Panics
+/// Panics when Iterator is empty.
 pub fn compute_hash<'a, I, S>(input: I) -> Hash
 where
     I: IntoIterator<Item = &'a S>,
@@ -106,7 +113,7 @@ mod test {
     use super::{compute_hash, Hash};
     use crate::{
         ff::{Fp31, Fp32BitPrime, Serializable},
-        protocol::ipa_prf::malicious_security::hashing::hash_to_field,
+        helpers::hashing::hash_to_field,
     };
 
     #[test]

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -10,6 +10,7 @@ mod buffers;
 mod error;
 mod futures;
 mod gateway;
+pub mod hashing;
 pub(crate) mod prss_protocol;
 pub mod stream;
 mod transport;

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod mul;
 mod reshare;
 mod reveal;
 mod share_known_value;
+pub mod share_validation;
 pub mod sum_of_product;
 
 use std::ops::Not;

--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -1,0 +1,137 @@
+use futures_util::future::try_join;
+
+use crate::{
+    error::Error,
+    helpers::{Direction, MpcReceivingEnd, SendingEnd},
+    protocol::{
+        context::Context,
+        ipa_prf::malicious_security::hashing::{compute_hash, Hash},
+        RecordId,
+    },
+    secret_sharing::SharedValue,
+};
+
+/// This function checks that a vector of shares are consistent across helpers
+/// i.e. `H1` holds `(x0,x1)`, `H2` holds `(x1,x2)`, `H3` holds `(x2,x0)`
+/// the function verifies that `H1.x0 == H3.x0`, `H1.x1 == H2.x1`, `H2.x2 == H3.x2`
+///
+/// We use a hash based approach that is secure in the random oracle model
+/// further, only one of left and right helper check that it is zero
+/// this is might not be sufficient in some applications to prevent malicious behavior
+///
+/// The left helper simply hashes the vector and sends it to the right,
+/// the right helper negates his vector, hashes it and compares it to the received hash
+///
+/// # Errors
+/// propagates errors from send and receive
+pub async fn validate_replicated_shares<C, S>(
+    ctx: C,
+    input_left: &[S],
+    input_right: &[S],
+) -> Result<(), Error>
+where
+    C: Context,
+    S: SharedValue,
+{
+    // compute hash of `left.neg` and `right`
+    let hash_left = compute_hash(input_left);
+
+    // set up context
+    let ctx_new = &(ctx.set_total_records(1usize));
+    // set up channels
+    let send_channel: &SendingEnd<_, Hash> =
+        &ctx_new.send_channel(ctx.role().peer(Direction::Right));
+    let receive_channel: &MpcReceivingEnd<Hash> =
+        &ctx_new.recv_channel(ctx.role().peer(Direction::Left));
+
+    let ((), hash_right) = try_join(
+        // send hash
+        send_channel.send(RecordId::from(0usize), compute_hash(input_right)),
+        receive_channel.receive(RecordId::from(0usize)),
+    )
+    .await?;
+
+    debug_assert_eq!(hash_left, hash_right);
+
+    if hash_left == hash_right {
+        Ok(())
+    } else {
+        Err(Error::InconsistentShares)
+    }
+}
+
+/// This function is similar to validate the consistency of shares with the difference
+/// that it validates that the shares sum to zero rather than being identical
+/// i.e. `H1` holds `(x0,x1)`, `H2` holds `(x1,x2)`, `H3` holds `(x2,x0)`
+/// the function verifies that `H1.x0 == -H3.x0`, `H1.x1 == -H2.x1`, `H2.x2 == -H3.x2`
+///
+/// We use a hash based approach that is secure in the random oracle model
+/// further, only one of left and right helper check that it is zero
+/// this is sufficient for Distributed Zero Knowledge Proofs
+/// but might not be sufficient for other applications
+///
+/// The left helper simply hashes the vector and sends it to the right,
+/// the right helper negates his vector, hashes it and compares it to the received hash
+///
+/// # Errors
+/// propagates errors from `validate_replicated_shares`
+pub async fn validate_sum_to_zero<C, S>(
+    ctx: C,
+    input_left: &[S],
+    input_right: &[S],
+) -> Result<(), Error>
+where
+    C: Context,
+    S: SharedValue,
+{
+    validate_replicated_shares(
+        ctx,
+        input_left,
+        &input_right.iter().map(|x| x.neg()).collect::<Vec<_>>(),
+    )
+    .await
+}
+
+#[cfg(all(test, unit_test))]
+mod test {
+    use std::ops::Neg;
+
+    use rand::{thread_rng, Rng};
+
+    use crate::{
+        ff::Fp61BitPrime,
+        protocol::basics::share_validation::validate_sum_to_zero,
+        secret_sharing::{replicated::ReplicatedSecretSharing, SharedValue},
+        test_executor::run,
+        test_fixture::{Runner, TestWorld},
+    };
+
+    // Test sum to zero
+    // by generating a vec of zero values
+    // secret share it
+    // and run the sum to zero protocol
+    #[test]
+    fn validate_sum_to_zero_test() {
+        run(|| async move {
+            let world = TestWorld::default();
+            let mut rng = thread_rng();
+
+            let len: usize = rng.gen::<usize>() % 99usize + 1;
+
+            let mut r = vec![Fp61BitPrime::ZERO; len];
+            r.iter_mut().for_each(|x| *x = rng.gen());
+
+            let _ = world
+                .semi_honest(r.into_iter(), |ctx, input| async move {
+                    let r_right = input.iter().map(|x| x.right().neg()).collect::<Vec<_>>();
+                    let r_left = input
+                        .iter()
+                        .map(ReplicatedSecretSharing::left)
+                        .collect::<Vec<_>>();
+
+                    validate_sum_to_zero(ctx, &r_left, &r_right).await.unwrap();
+                })
+                .await;
+        });
+    }
+}

--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -15,11 +15,11 @@ use crate::{
 /// the function verifies that `H1.x0 == H3.x0`, `H1.x1 == H2.x1`, `H2.x2 == H3.x2`
 ///
 /// We use a hash based approach that is secure in the random oracle model
-/// further, only one of left and right helper check that it is zero
+/// further, only one of left and right helper check the equality of the shares
 /// this is might not be sufficient in some applications to prevent malicious behavior
 ///
 /// The left helper simply hashes the vector and sends it to the right,
-/// the right helper negates his vector, hashes it and compares it to the received hash
+/// the right helper hashes his vector and compares it to the received hash
 ///
 /// # Errors
 /// propagates errors from send and receive
@@ -43,14 +43,14 @@ where
     let send_channel = ctx_new.send_channel::<Hash>(ctx.role().peer(Direction::Right));
     let receive_channel = ctx_new.recv_channel::<Hash>(ctx.role().peer(Direction::Left));
 
-    let ((), hash_right) = try_join(
+    let ((), hash_received) = try_join(
         // send hash
         send_channel.send(RecordId::FIRST, compute_hash(input_right)),
         receive_channel.receive(RecordId::FIRST),
     )
     .await?;
 
-    if hash_left == hash_right {
+    if hash_left == hash_received {
         Ok(())
     } else {
         Err(Error::InconsistentShares)
@@ -58,9 +58,9 @@ where
 }
 
 /// This function is similar to validate the consistency of shares with the difference
-/// that it validates that the shares sum to zero rather than being identical
-/// i.e. `H1` holds `(x0,x1)`, `H2` holds `(x1,x2)`, `H3` holds `(x2,x0)`
-/// the function verifies that `H1.x0 == -H3.x0`, `H1.x1 == -H2.x1`, `H2.x2 == -H3.x2`
+/// that it validates that tuple of shares sum to zero rather than being identical
+/// i.e. `H1` holds `(H1_x0,H1_x1)`, `H2` holds `(H2_x1,H2_x2)`, `H3` holds `(H3_x2,H3_x0)`
+/// the function verifies that `H1_x0 == -H3_x0`, `H1_x1 == -H2_x1`, `H2_x2 == -H3_x2`
 ///
 /// We use a hash based approach that is secure in the random oracle model
 /// further, only one of left and right helper check that it is zero
@@ -72,7 +72,7 @@ where
 ///
 /// # Errors
 /// propagates errors from `validate_replicated_shares`
-pub async fn validate_sum_to_zero<'a, C, I, S>(
+pub async fn validate_three_two_way_sharing_of_zero<'a, C, I, S>(
     ctx: C,
     input_left: I,
     input_right: I,
@@ -98,8 +98,10 @@ mod test {
     use crate::{
         error::Error,
         ff::{Field, Fp61BitPrime},
-        protocol::{basics::share_validation::validate_sum_to_zero, context::Context},
-        secret_sharing::{replicated::ReplicatedSecretSharing, SharedValue},
+        protocol::{
+            basics::share_validation::validate_three_two_way_sharing_of_zero, context::Context,
+        },
+        secret_sharing::replicated::ReplicatedSecretSharing,
         test_executor::run,
         test_fixture::{Runner, TestWorld},
     };
@@ -111,20 +113,22 @@ mod test {
         Changed,
     }
 
-    // Test sum to zero
-    // by generating a vec of zero values
-    // secret share it
-    // and run the sum to zero protocol
+    // Test three two way shares of zero
+    // we generated replicated shares of a vector of random values
+    // each helper party negates one of its shares
+    // we then check whether validate_three_two_way_sharing_of_zero succeeds
+    // we also test for failure when the shares are misaligned or one of them has been changed
     #[test]
-    fn validate_sum_to_zero_test() {
+    fn three_two_way_shares_of_zero() {
         run(|| async move {
             let world = TestWorld::default();
             let mut rng = thread_rng();
 
             let len: usize = rng.gen_range(50..100);
 
-            let mut r = vec![Fp61BitPrime::ZERO; len];
-            r.iter_mut().for_each(|x| *x = rng.gen());
+            let r = (0..len)
+                .map(|_| rng.gen::<Fp61BitPrime>())
+                .collect::<Vec<_>>();
 
             let _ = world
                 .semi_honest(r.into_iter(), |ctx, input| async move {
@@ -134,12 +138,16 @@ mod test {
                         .map(ReplicatedSecretSharing::left)
                         .collect::<Vec<_>>();
 
-                    validate_sum_to_zero(ctx.narrow(&Step::Correctness), &r_left, &r_right)
-                        .await
-                        .unwrap();
+                    validate_three_two_way_sharing_of_zero(
+                        ctx.narrow(&Step::Correctness),
+                        &r_left,
+                        &r_right,
+                    )
+                    .await
+                    .unwrap();
 
                     // check misaligned causes error
-                    let error = validate_sum_to_zero(
+                    let error = validate_three_two_way_sharing_of_zero(
                         ctx.narrow(&Step::Misaligned),
                         &r_left[0..len - 1],
                         &r_right[1..len],
@@ -151,7 +159,7 @@ mod test {
                     // check changing causes error
                     r_left[5] += Fp61BitPrime::ONE;
 
-                    let error = validate_sum_to_zero(
+                    let error = validate_three_two_way_sharing_of_zero(
                         ctx.narrow(&Step::Changed),
                         &r_left[0..len - 1],
                         &r_right[1..len],

--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -121,7 +121,7 @@ mod test {
             let world = TestWorld::default();
             let mut rng = thread_rng();
 
-            let len: usize = rng.gen::<usize>() % 99usize + 1;
+            let len: usize = rng.gen_range(50..100);
 
             let mut r = vec![Fp61BitPrime::ZERO; len];
             r.iter_mut().for_each(|x| *x = rng.gen());

--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -2,12 +2,11 @@ use futures_util::future::try_join;
 
 use crate::{
     error::Error,
-    helpers::{Direction, MpcReceivingEnd, SendingEnd},
-    protocol::{
-        context::Context,
-        ipa_prf::malicious_security::hashing::{compute_hash, Hash},
-        RecordId,
+    helpers::{
+        hashing::{compute_hash, Hash},
+        Direction,
     },
+    protocol::{context::Context, RecordId},
     secret_sharing::SharedValue,
 };
 
@@ -24,34 +23,32 @@ use crate::{
 ///
 /// # Errors
 /// propagates errors from send and receive
-pub async fn validate_replicated_shares<C, S>(
+pub async fn validate_replicated_shares<'a, 'b, C, I, J, S>(
     ctx: C,
-    input_left: &[S],
-    input_right: &[S],
+    input_left: I,
+    input_right: J,
 ) -> Result<(), Error>
 where
     C: Context,
+    I: IntoIterator<Item = &'a S>,
+    J: IntoIterator<Item = &'b S>,
     S: SharedValue,
 {
-    // compute hash of `left.neg` and `right`
+    // compute hash of `left`
     let hash_left = compute_hash(input_left);
 
     // set up context
     let ctx_new = &(ctx.set_total_records(1usize));
     // set up channels
-    let send_channel: &SendingEnd<_, Hash> =
-        &ctx_new.send_channel(ctx.role().peer(Direction::Right));
-    let receive_channel: &MpcReceivingEnd<Hash> =
-        &ctx_new.recv_channel(ctx.role().peer(Direction::Left));
+    let send_channel = &ctx_new.send_channel::<Hash>(ctx.role().peer(Direction::Right));
+    let receive_channel = &ctx_new.recv_channel::<Hash>(ctx.role().peer(Direction::Left));
 
     let ((), hash_right) = try_join(
         // send hash
-        send_channel.send(RecordId::from(0usize), compute_hash(input_right)),
-        receive_channel.receive(RecordId::from(0usize)),
+        send_channel.send(RecordId::FIRST, compute_hash(input_right)),
+        receive_channel.receive(RecordId::FIRST),
     )
     .await?;
-
-    debug_assert_eq!(hash_left, hash_right);
 
     if hash_left == hash_right {
         Ok(())
@@ -75,36 +72,44 @@ where
 ///
 /// # Errors
 /// propagates errors from `validate_replicated_shares`
-pub async fn validate_sum_to_zero<C, S>(
+pub async fn validate_sum_to_zero<'a, C, I, S>(
     ctx: C,
-    input_left: &[S],
-    input_right: &[S],
+    input_left: I,
+    input_right: I,
 ) -> Result<(), Error>
 where
     C: Context,
+    I: IntoIterator<Item = &'a S>,
     S: SharedValue,
 {
-    validate_replicated_shares(
-        ctx,
-        input_left,
-        &input_right.iter().map(|x| x.neg()).collect::<Vec<_>>(),
-    )
-    .await
+    // compute left.neg
+    let left_neg = input_left.into_iter().map(|x| x.neg()).collect::<Vec<_>>();
+
+    validate_replicated_shares(ctx, &left_neg, input_right).await
 }
 
 #[cfg(all(test, unit_test))]
 mod test {
     use std::ops::Neg;
 
+    use ipa_macros::Step;
     use rand::{thread_rng, Rng};
 
     use crate::{
-        ff::Fp61BitPrime,
-        protocol::basics::share_validation::validate_sum_to_zero,
+        error::Error,
+        ff::{Field, Fp61BitPrime},
+        protocol::{basics::share_validation::validate_sum_to_zero, context::Context},
         secret_sharing::{replicated::ReplicatedSecretSharing, SharedValue},
         test_executor::run,
         test_fixture::{Runner, TestWorld},
     };
+
+    #[derive(Step)]
+    pub(crate) enum Step {
+        Correctness,
+        Misaligned,
+        Changed,
+    }
 
     // Test sum to zero
     // by generating a vec of zero values
@@ -124,12 +129,36 @@ mod test {
             let _ = world
                 .semi_honest(r.into_iter(), |ctx, input| async move {
                     let r_right = input.iter().map(|x| x.right().neg()).collect::<Vec<_>>();
-                    let r_left = input
+                    let mut r_left = input
                         .iter()
                         .map(ReplicatedSecretSharing::left)
                         .collect::<Vec<_>>();
 
-                    validate_sum_to_zero(ctx, &r_left, &r_right).await.unwrap();
+                    validate_sum_to_zero(ctx.narrow(&Step::Correctness), &r_left, &r_right)
+                        .await
+                        .unwrap();
+
+                    // check misaligned causes error
+                    let error = validate_sum_to_zero(
+                        ctx.narrow(&Step::Misaligned),
+                        &r_left[0..len - 1],
+                        &r_right[1..len],
+                    )
+                    .await;
+
+                    assert!(matches!(error, Err(Error::InconsistentShares)));
+
+                    // check changing causes error
+                    r_left[5] += Fp61BitPrime::ONE;
+
+                    let error = validate_sum_to_zero(
+                        ctx.narrow(&Step::Changed),
+                        &r_left[0..len - 1],
+                        &r_right[1..len],
+                    )
+                    .await;
+
+                    assert!(matches!(error, Err(Error::InconsistentShares)));
                 })
                 .await;
         });

--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -40,8 +40,8 @@ where
     // set up context
     let ctx_new = &(ctx.set_total_records(1usize));
     // set up channels
-    let send_channel = &ctx_new.send_channel::<Hash>(ctx.role().peer(Direction::Right));
-    let receive_channel = &ctx_new.recv_channel::<Hash>(ctx.role().peer(Direction::Left));
+    let send_channel = ctx_new.send_channel::<Hash>(ctx.role().peer(Direction::Right));
+    let receive_channel = ctx_new.recv_channel::<Hash>(ctx.role().peer(Direction::Left));
 
     let ((), hash_right) = try_join(
         // send hash

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/mod.rs
@@ -1,4 +1,3 @@
-mod hashing;
 pub mod lagrange;
 pub mod prover;
 pub mod verifier;

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -6,9 +6,9 @@ use std::{
 use generic_array::{sequence::GenericSequence, ArrayLength, GenericArray};
 use typenum::{Diff, Sum, U1};
 
-use super::hashing::{compute_hash, hash_to_field};
 use crate::{
     ff::PrimeField,
+    helpers::hashing::{compute_hash, hash_to_field},
     protocol::ipa_prf::malicious_security::lagrange::{
         CanonicalLagrangeDenominator, LagrangeTable,
     },


### PR DESCRIPTION
Include Sum To Zero Check Protocol since it is needed for DZKP verification.

It was originally a part of https://github.com/private-attribution/ipa/pull/930

It can also be used to check the consistency between shares, i.e. as a base protocol for https://github.com/private-attribution/ipa/pull/936

I moved Hashing to Prss, since it is similar (basic cryptographic operation). The only difference is that it is not keyed. 