### PR TITLE
Update to Axum  0.6

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -37,7 +37,6 @@ web-app = [
     "toml",
     "tower",
     "tower-http",
-    "mime",
 ]
 test-fixture = ["weak-field"]
 # Include observability instruments that detect lack of progress inside MPC. If there is a bug that leads to helper
@@ -85,7 +84,6 @@ axum = { version = "0.6", optional = true, features = ["http2", "macros"] }
 axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.23", version = "0.5.3", optional = true, features = [
     "tls-rustls",
 ] }
-mime = { version = "0.3", optional = true}
 base64 = { version = "0.21.2", optional = true }
 bitvec = "1.0"
 bytes = "1.4"

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -37,6 +37,7 @@ web-app = [
     "toml",
     "tower",
     "tower-http",
+    "mime",
 ]
 test-fixture = ["weak-field"]
 # Include observability instruments that detect lack of progress inside MPC. If there is a bug that leads to helper
@@ -78,12 +79,13 @@ ipa-macros = { version = "*", path = "../ipa-macros" }
 aes = "0.8.3"
 async-trait = "0.1.79"
 async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
-axum = { version = "0.5.17", optional = true, features = ["http2"] }
+axum = { version = "0.6", optional = true, features = ["http2", "macros"] }
 # The following is a temporary version until we can stabilize the build on a higher version
 # of axum, rustls and the http stack.
 axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.23", version = "0.5.3", optional = true, features = [
     "tls-rustls",
 ] }
+mime = { version = "0.3", optional = true}
 base64 = { version = "0.21.2", optional = true }
 bitvec = "1.0"
 bytes = "1.4"

--- a/ipa-core/src/helpers/transport/stream/box_body.rs
+++ b/ipa-core/src/helpers/transport/stream/box_body.rs
@@ -3,6 +3,8 @@ use std::{
     task::{Context, Poll},
 };
 
+#[cfg(all(feature = "in-memory-infra", feature = "web-app"))]
+use axum::RequestExt;
 use bytes::Bytes;
 use futures::{stream::StreamExt, Stream};
 
@@ -52,14 +54,14 @@ impl<Buf: Into<bytes::Bytes>> From<Buf> for WrappedBoxBodyStream {
 
 #[cfg(all(feature = "in-memory-infra", feature = "web-app"))]
 #[async_trait::async_trait]
-impl<B: hyper::body::HttpBody<Data = bytes::Bytes, Error = hyper::Error> + Send + 'static>
-    axum::extract::FromRequest<B> for WrappedBoxBodyStream
+impl<
+        S: Send + Sync,
+        B: hyper::body::HttpBody<Data = bytes::Bytes, Error = hyper::Error> + Send + 'static,
+    > axum::extract::FromRequest<S, B> for WrappedBoxBodyStream
 {
-    type Rejection = <axum::extract::BodyStream as axum::extract::FromRequest<B>>::Rejection;
+    type Rejection = <axum::extract::BodyStream as axum::extract::FromRequest<S, B>>::Rejection;
 
-    async fn from_request(
-        req: &mut axum::extract::RequestParts<B>,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: hyper::Request<B>, _state: &S) -> Result<Self, Self::Rejection> {
         Ok(Self::new(req.extract().await?))
     }
 }

--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -22,8 +22,6 @@ pub enum Error {
     #[error("bad path: {0}")]
     BadPathString(#[source] BoxError),
     #[error(transparent)]
-    BodyAlreadyExtracted(#[from] axum::extract::rejection::BodyAlreadyExtracted),
-    #[error(transparent)]
     MissingExtension(#[from] axum::extract::rejection::ExtensionRejection),
     #[error("query id not found: {}", .0.as_ref())]
     QueryIdNotFound(QueryId),
@@ -151,7 +149,6 @@ impl IntoResponse for Error {
             | Self::HyperHttpPassthrough(_)
             | Self::FailedHttpRequest { .. }
             | Self::InvalidUri(_)
-            | Self::BodyAlreadyExtracted(_)
             | Self::MissingExtension(_) => StatusCode::INTERNAL_SERVER_ERROR,
 
             Self::Application { code, .. } => code,

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -234,7 +234,7 @@ pub mod query {
             helpers::{query::PrepareQuery, RoleAssignment},
             net::{
                 http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
-                Error,
+                Error, APPLICATION_JSON,
             },
         };
 
@@ -267,7 +267,7 @@ pub mod query {
                 };
                 let body = hyper::Body::from(serde_json::to_string(&body)?);
                 Ok(hyper::Request::post(uri)
-                    .header(CONTENT_TYPE, "application/json")
+                    .header(CONTENT_TYPE, APPLICATION_JSON)
                     .body(body)?)
             }
         }
@@ -286,7 +286,7 @@ pub mod query {
 
         use crate::{
             helpers::query::QueryInput,
-            net::{http_serde::query::BASE_AXUM_PATH, Error},
+            net::{http_serde::query::BASE_AXUM_PATH, Error, APPLICATION_OCTET_STREAM},
         };
 
         #[derive(Debug)]
@@ -316,7 +316,7 @@ pub mod query {
                     .build()?;
                 let body = Body::wrap_stream(self.query_input.input_stream);
                 Ok(hyper::Request::post(uri)
-                    .header(CONTENT_TYPE, "application/octet-stream")
+                    .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
                     .body(body)?)
             }
         }

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -22,6 +22,9 @@ pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpShardTransport, HttpTransport};
 
+pub const APPLICATION_JSON: &str = "application/json";
+pub const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+
 /// Provides access to IPAs Crypto Provider (AWS Libcrypto).
 static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
     Lazy::new(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));

--- a/ipa-core/src/net/server/handlers/echo.rs
+++ b/ipa-core/src/net/server/handlers/echo.rs
@@ -15,9 +15,11 @@ async fn handler(
 ) -> Result<Json<http_serde::echo::Request>, Error> {
     let headers = hyper_headers
         .iter()
-        .filter_map(|(name, value)| match value.to_str() {
-            Ok(header_value) => Some((name.to_string(), header_value.to_string())),
-            Err(_) => None,
+        .filter_map(|(name, value)| {
+            value
+                .to_str()
+                .ok()
+                .map(|header_value| (name.to_string(), header_value.to_string()))
         })
         .collect();
     Ok(Json(Request {

--- a/ipa-core/src/net/server/handlers/query/create.rs
+++ b/ipa-core/src/net/server/handlers/query/create.rs
@@ -61,22 +61,19 @@ mod tests {
         let req = http_serde::query::create::Request::new(expected_query_config)
             .try_into_http_request(Scheme::HTTP, Authority::from_static("localhost"))
             .unwrap();
-        let handler = make_owned_handler(
-            // Do we need these moves? In particular the first one?
-            move |addr, _| async move {
-                let RouteId::ReceiveQuery = addr.route else {
-                    panic!("unexpected call");
-                };
+        let handler = make_owned_handler(move |addr, _| async move {
+            let RouteId::ReceiveQuery = addr.route else {
+                panic!("unexpected call");
+            };
 
-                let query_config = addr.into().unwrap();
-                assert_eq!(query_config, expected_query_config);
-                Ok(HelperResponse::from(PrepareQuery {
-                    query_id: QueryId,
-                    config: query_config,
-                    roles: RoleAssignment::try_from([Role::H1, Role::H2, Role::H3]).unwrap(),
-                }))
-            },
-        );
+            let query_config = addr.into().unwrap();
+            assert_eq!(query_config, expected_query_config);
+            Ok(HelperResponse::from(PrepareQuery {
+                query_id: QueryId,
+                config: query_config,
+                roles: RoleAssignment::try_from([Role::H1, Role::H2, Role::H3]).unwrap(),
+            }))
+        });
         let resp = assert_success_with(req, handler).await;
         let http_serde::query::create::ResponseBody { query_id } =
             serde_json::from_slice(&resp).unwrap();

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -1,21 +1,32 @@
-use axum::{routing::post, Extension, Router};
+use axum::{extract::Path, routing::post, Extension, Router};
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{routing::RouteId, Transport},
+    helpers::{query::QueryInput, routing::RouteId, Transport},
     net::{http_serde, Error, HttpTransport},
+    protocol::QueryId,
     sync::Arc,
 };
 
+#[cfg(feature = "real-world-infra")]
+type WrappedBodyStream = crate::helpers::WrappedAxumBodyStream;
+#[cfg(feature = "in-memory-infra")]
+type WrappedBodyStream = crate::helpers::WrappedBoxBodyStream;
+
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
-    req: http_serde::query::input::Request,
+    Path(query_id): Path<QueryId>,
+    input_stream: WrappedBodyStream,
 ) -> Result<(), Error> {
+    let query_input = QueryInput {
+        query_id,
+        input_stream,
+    };
     let transport = Transport::clone_ref(&*transport);
     let _ = transport
         .dispatch(
-            (RouteId::QueryInput, req.query_input.query_id),
-            req.query_input.input_stream,
+            (RouteId::QueryInput, query_input.query_id),
+            query_input.input_stream,
         )
         .await
         .map_err(|e| Error::application(StatusCode::INTERNAL_SERVER_ERROR, e))?;
@@ -31,8 +42,7 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-
-    use axum::{http::Request, Extension};
+    use axum::http::uri::{Authority, Scheme};
     use hyper::{Body, StatusCode};
     use tokio::runtime::Handle;
 
@@ -42,11 +52,7 @@ mod tests {
         },
         net::{
             http_serde,
-            server::handlers::query::{
-                input::handler,
-                test_helpers::{assert_req_fails_with, IntoFailingReq},
-            },
-            test::TestServer,
+            server::handlers::query::test_helpers::{assert_fails_with, assert_success_with},
         },
         protocol::QueryId,
     };
@@ -55,6 +61,10 @@ mod tests {
     async fn input_test() {
         let expected_query_id = QueryId;
         let expected_input = &[4u8; 4];
+        let req = http_serde::query::input::Request::new(QueryInput {
+            query_id: expected_query_id,
+            input_stream: expected_input.to_vec().into(),
+        });
         let req_handler = make_owned_handler(move |addr, data| async move {
             let RouteId::QueryInput = addr.route else {
                 panic!("unexpected call");
@@ -70,18 +80,10 @@ mod tests {
 
             Ok(HelperResponse::ok())
         });
-
-        let test_server = TestServer::builder()
-            .with_request_handler(req_handler)
-            .build()
-            .await;
-        let req = http_serde::query::input::Request::new(QueryInput {
-            query_id: expected_query_id,
-            input_stream: expected_input.to_vec().into(),
-        });
-        handler(Extension(test_server.transport), req)
-            .await
+        let req = req
+            .try_into_http_request(Scheme::HTTP, Authority::from_static("localhost"))
             .unwrap();
+        assert_success_with(req, req_handler).await;
     }
 
     struct OverrideReq {
@@ -89,16 +91,15 @@ mod tests {
         input_stream: Vec<u8>,
     }
 
-    impl IntoFailingReq for OverrideReq {
-        fn into_req(self, port: u16) -> Request<Body> {
+    impl From<OverrideReq> for hyper::Request<Body> {
+        fn from(val: OverrideReq) -> Self {
             let uri = format!(
-                "http://localhost:{}{}/{}/input",
-                port,
+                "http://localhost{}/{}/input",
                 http_serde::query::BASE_AXUM_PATH,
-                self.query_id
+                val.query_id
             );
             hyper::Request::post(uri)
-                .body(hyper::Body::from(self.input_stream))
+                .body(hyper::Body::from(val.input_stream))
                 .unwrap()
         }
     }
@@ -118,6 +119,6 @@ mod tests {
             query_id: "not_a_query_id".into(),
             ..Default::default()
         };
-        assert_req_fails_with(req, StatusCode::UNPROCESSABLE_ENTITY).await;
+        assert_fails_with(req.into(), StatusCode::BAD_REQUEST).await;
     }
 }

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -127,12 +127,7 @@ pub mod test_helpers {
     // Intended to be used for a request that will fail Starts a [`TestServer`] and gets response
     // from the server, and compare its [`StatusCode`] with what is expected.
     pub async fn assert_fails_with(req: hyper::Request<hyper::Body>, expected_status: StatusCode) {
-        // let handler = make_owned_handler(|_addr, _| async {Ok(HelperResponse::ok())});
-        //let test_server = TestServer::default().await;
-        let test_server = TestServer::builder()
-            //    .with_request_handler(handler)
-            .build()
-            .await;
+        let test_server = TestServer::builder().build().await;
         let resp = test_server.server.handle_req(req).await;
         assert_eq!(resp.status(), expected_status);
     }
@@ -148,10 +143,7 @@ pub mod test_helpers {
         let resp = test_server.server.handle_req(req).await;
         let status = resp.status();
         let body_bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
-        assert_eq!(StatusCode::OK, status,);
+        assert_eq!(StatusCode::OK, status);
         body_bytes.to_vec()
     }
-
-    // TODO: refactor shared stuff
-    // setup a handler. TestServerExt
 }

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -72,6 +72,7 @@ mod tests {
                 },
                 ClientIdentity,
             },
+            APPLICATION_JSON,
         },
         protocol::QueryId,
     };
@@ -141,7 +142,7 @@ mod tests {
             let body = OverrideReqBody { roles: val.roles };
             let body = serde_json::to_string(&body).unwrap();
             hyper::Request::post(uri)
-                .header(CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .header(CONTENT_TYPE, APPLICATION_JSON)
                 .maybe_extension(val.client_id)
                 .body(hyper::Body::from(body))
                 .unwrap()

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -1,4 +1,4 @@
-use axum::{routing::post, Extension, Router};
+use axum::{extract::Path, routing::post, Extension, Router};
 
 use crate::{
     helpers::{BodyStream, Transport},
@@ -7,6 +7,7 @@ use crate::{
         server::{ClientIdentity, Error},
         HttpTransport,
     },
+    protocol::{step::Descriptive, QueryId},
     sync::Arc,
 };
 
@@ -14,10 +15,11 @@ use crate::{
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
     from: Extension<ClientIdentity>,
-    req: http_serde::query::step::Request<BodyStream>,
+    Path((query_id, gate)): Path<(QueryId, Descriptive)>,
+    body: BodyStream,
 ) -> Result<(), Error> {
     let transport = Transport::clone_ref(&*transport);
-    transport.receive_stream(req.query_id, req.gate, **from, req.body);
+    transport.receive_stream(query_id, gate, **from, body);
     Ok(())
 }
 
@@ -31,7 +33,6 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::task::Poll;
 
-    use axum::http::Request;
     use futures::{stream::poll_immediate, StreamExt};
     use hyper::{Body, StatusCode};
 
@@ -39,9 +40,7 @@ mod tests {
     use crate::{
         helpers::{HelperIdentity, MESSAGE_PAYLOAD_SIZE_BYTES},
         net::{
-            server::handlers::query::test_helpers::{
-                assert_req_fails_with, IntoFailingReq, MaybeExtensionExt,
-            },
+            server::handlers::query::test_helpers::{assert_fails_with, MaybeExtensionExt},
             test::TestServer,
         },
         protocol::{
@@ -54,22 +53,19 @@ mod tests {
 
     #[tokio::test]
     async fn step() {
-        let TestServer { transport, .. } = TestServer::builder().build().await;
+        let payload = vec![213; DATA_LEN * MESSAGE_PAYLOAD_SIZE_BYTES];
+        let req: OverrideReq = OverrideReq {
+            payload: payload.clone(),
+            client_id: Some(ClientIdentity(HelperIdentity::TWO)),
+            ..Default::default()
+        };
+        let test_server = TestServer::builder().build().await;
 
         let step = Gate::default().narrow("test");
-        let payload = vec![213; DATA_LEN * MESSAGE_PAYLOAD_SIZE_BYTES];
-        let req =
-            http_serde::query::step::Request::new(QueryId, step.clone(), payload.clone().into());
 
-        handler(
-            Extension(Arc::clone(&transport)),
-            Extension(ClientIdentity(HelperIdentity::TWO)),
-            req,
-        )
-        .await
-        .unwrap();
+        test_server.server.handle_req(req.into()).await;
 
-        let mut stream = Arc::clone(&transport)
+        let mut stream = Arc::clone(&test_server.transport)
             .receive(HelperIdentity::TWO, (QueryId, step))
             .into_bytes_stream();
 
@@ -86,18 +82,17 @@ mod tests {
         payload: Vec<u8>,
     }
 
-    impl IntoFailingReq for OverrideReq {
-        fn into_req(self, port: u16) -> Request<Body> {
+    impl From<OverrideReq> for hyper::Request<Body> {
+        fn from(val: OverrideReq) -> Self {
             let uri = format!(
-                "http://localhost:{}{}/{}/step/{}",
-                port,
+                "http://localhost{}/{}/step/{}",
                 http_serde::query::BASE_AXUM_PATH,
-                self.query_id,
-                self.gate.as_ref()
+                val.query_id,
+                val.gate.as_ref()
             );
             hyper::Request::post(uri)
-                .maybe_extension(self.client_id)
-                .body(hyper::Body::from(self.payload))
+                .maybe_extension(val.client_id)
+                .body(hyper::Body::from(val.payload))
                 .unwrap()
         }
     }
@@ -119,7 +114,7 @@ mod tests {
             query_id: "not-a-query-id".into(),
             ..Default::default()
         };
-        assert_req_fails_with(req, StatusCode::UNPROCESSABLE_ENTITY).await;
+        assert_fails_with(req.into(), StatusCode::BAD_REQUEST).await;
     }
 
     #[tokio::test]
@@ -128,6 +123,6 @@ mod tests {
             client_id: None,
             ..Default::default()
         };
-        assert_req_fails_with(req, StatusCode::UNAUTHORIZED).await;
+        assert_fails_with(req.into(), StatusCode::UNAUTHORIZED).await;
     }
 }

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -7,7 +7,7 @@ use crate::{
         server::{ClientIdentity, Error},
         HttpTransport,
     },
-    protocol::{step::Descriptive, QueryId},
+    protocol::{step::Gate, QueryId},
     sync::Arc,
 };
 
@@ -15,7 +15,7 @@ use crate::{
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
     from: Extension<ClientIdentity>,
-    Path((query_id, gate)): Path<(QueryId, Descriptive)>,
+    Path((query_id, gate)): Path<(QueryId, Gate)>,
     body: BodyStream,
 ) -> Result<(), Error> {
     let transport = Transport::clone_ref(&*transport);

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -132,7 +132,7 @@ impl HttpTransport {
         let r = self
             .handler
             .as_ref()
-            .expect("Handler is set")
+            .expect("A Handler should be set by now")
             .handle(Addr::from_route(None, req), body);
 
         if let RouteId::CompleteQuery = route_id {

--- a/ipa-core/src/protocol/step/compact.rs
+++ b/ipa-core/src/protocol/step/compact.rs
@@ -13,8 +13,7 @@ pub struct Compact(pub u16);
 // serde::Deserialize requires From<&str> implementation
 impl From<&str> for Compact {
     fn from(id: &str) -> Self {
-        // id begins with '/'. strip it.
-        Compact::deserialize(&id[1..])
+        Compact::deserialize(id)
     }
 }
 


### PR DESCRIPTION
This is another step towards updating all of IPA's dependencies (tracked in private-attribution/ipa#924).

Note Axum 0.6 adds state to extractors, but we aren't using those for now (created private-attribution/ipa#1047 to track this). This version of Axum still uses hyper 0.14.

Also, as part of this update, Axum extractions separate Body operations from Body Parts (headers, query, etc). A nice improvement is that Body cannot be extracted twice thanks to the new API (BodyAlreadyExtracted exception is gone).

Instead of a having a custom Axum extractor per server handler, with this change we're using separate re-usable extractors for each of the HTTP parts reducing the amount of code in http_serde. Following is an example from the create handler. 

Here's how the code used to be:
```Rust
async fn handler(
    transport: Extension<Arc<HttpTransport>>,
    req: http_serde::query::create::Request, // We got rid of the "Request" custom extractor in http_serde
) -> Result<Json<http_serde::query::create::ResponseBody>, Error> {
    let transport = Transport::clone_ref(&*transport);
...
```

With this change it becomes:
```Rust
async fn handler(
    transport: Extension<Arc<HttpTransport>>,
    // req: http_serde::query::create::Request, gone
    QueryConfigQueryParams(query_config): QueryConfigQueryParams, // We use the existing QueryConfigQueryParams extractor
) -> Result<Json<http_serde::query::create::ResponseBody>, Error> {
    let transport = Transport::clone_ref(&*transport);
...
```

Also, created a few helper functions for the tests and also got rid of trait `IntoFailingReq` and just used Rust's `From` 