### PR TITLE
Change some methods that were generic over vectorized/not to only support vectorization

### DIFF
--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -9,7 +9,7 @@ use typenum::{U14, U2, U32, U8};
 
 use crate::{
     error::LengthError,
-    ff::{boolean::Boolean, ArrayAccess, ArrayBuilder, Field, Serializable, U128Conversions},
+    ff::{boolean::Boolean, ArrayAccess, Field, Serializable, U128Conversions},
     protocol::prss::{FromRandom, FromRandomU128},
     secret_sharing::{Block, SharedValue, StdArray, Vectorizable},
 };
@@ -253,7 +253,7 @@ macro_rules! boolean_array_impl {
         mod $modname {
             use super::*;
             use crate::{
-                ff::{boolean::Boolean, ArrayAccess, ArrayBuild, Expand, Serializable},
+                ff::{boolean::Boolean, ArrayAccess, Expand, Serializable},
                 impl_shared_value_common,
                 secret_sharing::{
                     replicated::semi_honest::{ASIterator, AdditiveShare},
@@ -472,29 +472,6 @@ macro_rules! boolean_array_impl {
                 }
             }
 
-            impl ArrayBuild for $name {
-                type Input = Boolean;
-                type Builder = BooleanArrayBuilder<$name>;
-
-                fn builder() -> Self::Builder {
-                    BooleanArrayBuilder::new()
-                }
-            }
-
-            impl ArrayBuilder for BooleanArrayBuilder<$name> {
-                type Element = Boolean;
-                type Array = $name;
-
-                fn push(&mut self, value: Self::Element) {
-                    self.array.set(self.index, value);
-                    self.index += 1;
-                }
-
-                fn build(self) -> Self::Array {
-                    assert_eq!(self.index, $bits);
-                    self.array
-                }
-            }
             impl SharedValueArray<Boolean> for $name {
                 const ZERO_ARRAY: Self = <$name as SharedValue>::ZERO;
 
@@ -808,25 +785,5 @@ impl FromRandom for BA256 {
 impl rand::distributions::Distribution<BA256> for rand::distributions::Standard {
     fn sample<R: crate::rand::Rng + ?Sized>(&self, rng: &mut R) -> BA256 {
         (rng.gen(), rng.gen()).into()
-    }
-}
-
-pub struct BooleanArrayBuilder<T>
-where
-    T: ArrayAccess<Output = Boolean>,
-{
-    array: T,
-    index: usize,
-}
-
-impl<T> BooleanArrayBuilder<T>
-where
-    T: ArrayAccess<Output = Boolean> + SharedValue,
-{
-    fn new() -> Self {
-        Self {
-            array: T::ZERO,
-            index: 0,
-        }
     }
 }

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -136,7 +136,6 @@ pub trait CustomArray
 where
     Self: ArrayAccess<Output = Self::Element>
         + Expand<Input = Self::Element>
-        + ArrayBuild<Input = Self::Element>,
 {
     type Element;
 }
@@ -146,28 +145,6 @@ impl<S> CustomArray for S
 where
     S: ArrayAccess
         + Expand<Input = <S as ArrayAccess>::Output>
-        + ArrayBuild<Input = <S as ArrayAccess>::Output>,
 {
     type Element = <S as ArrayAccess>::Output;
-}
-
-pub trait ArrayBuild {
-    type Input;
-    type Builder: ArrayBuilder<Element = Self::Input, Array = Self>;
-
-    fn builder() -> Self::Builder;
-}
-
-pub trait ArrayBuilder: Send + Sized {
-    type Element;
-    type Array;
-
-    #[must_use]
-    fn with_capacity(self, _capacity: usize) -> Self {
-        self
-    }
-
-    fn push(&mut self, value: Self::Element);
-
-    fn build(self) -> Self::Array;
 }

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -23,7 +23,7 @@ use generic_array::{ArrayLength, GenericArray};
 pub use prime_field::Fp31;
 pub use prime_field::{Fp32BitPrime, Fp61BitPrime, PrimeField};
 
-use crate::{error::UnwrapInfallible, protocol::prss::FromRandomU128};
+use crate::{error::UnwrapInfallible, protocol::prss::FromRandomU128, secret_sharing::BitDecomposed};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
@@ -102,6 +102,10 @@ pub trait ArrayAccess {
     fn set(&mut self, index: usize, e: Self::Output);
 
     fn iter(&self) -> Self::Iter<'_>;
+
+    fn to_bits(&self) -> BitDecomposed<Self::Output> {
+        BitDecomposed::new(self.iter())
+    }
 }
 
 pub trait ArrayAccessRef {

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -118,8 +118,6 @@ pub trait ArrayAccessRef {
     fn set(&mut self, index: usize, e: Self::Ref<'_>);
 
     fn iter(&self) -> Self::Iter<'_>;
-
-    fn make_ref(src: &Self::Element) -> Self::Ref<'_>;
 }
 
 pub trait Expand {

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -23,7 +23,9 @@ use generic_array::{ArrayLength, GenericArray};
 pub use prime_field::Fp31;
 pub use prime_field::{Fp32BitPrime, Fp61BitPrime, PrimeField};
 
-use crate::{error::UnwrapInfallible, protocol::prss::FromRandomU128, secret_sharing::BitDecomposed};
+use crate::{
+    error::UnwrapInfallible, protocol::prss::FromRandomU128, secret_sharing::BitDecomposed,
+};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
@@ -136,8 +138,7 @@ pub trait Expand {
 /// supports `FromIterator` to collect an iterator of elements back into the original type
 pub trait CustomArray
 where
-    Self: ArrayAccess<Output = Self::Element>
-        + Expand<Input = Self::Element>
+    Self: ArrayAccess<Output = Self::Element> + Expand<Input = Self::Element>,
 {
     type Element;
 }
@@ -145,8 +146,7 @@ where
 /// impl Custom Array for all compatible structs
 impl<S> CustomArray for S
 where
-    S: ArrayAccess
-        + Expand<Input = <S as ArrayAccess>::Output>
+    S: ArrayAccess + Expand<Input = <S as ArrayAccess>::Output>,
 {
     type Element = <S as ArrayAccess>::Output;
 }

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -267,7 +267,7 @@ where
                             if a.len() < usize::try_from(OV::BITS).unwrap() {
                                 // If we have enough output bits, add and keep the carry.
                                 let (mut sum, carry) =
-                                    integer_add::<_, _, _, _, B>(ctx, record_id, &a, &b).await?;
+                                    integer_add::<_, B>(ctx, record_id, &a, &b).await?;
                                 sum.push(carry);
                                 Ok(sum)
                             } else {

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -30,7 +30,13 @@ pub async fn integer_add<C, const N: usize>(
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean, N>>,
     y: &BitDecomposed<AdditiveShare<Boolean, N>>,
-) -> Result<(BitDecomposed<AdditiveShare<Boolean, N>>, AdditiveShare<Boolean, N>), Error>
+) -> Result<
+    (
+        BitDecomposed<AdditiveShare<Boolean, N>>,
+        AdditiveShare<Boolean, N>,
+    ),
+    Error,
+>
 where
     C: Context,
     Boolean: FieldSimd<N>,
@@ -102,14 +108,8 @@ where
     let y = y.iter();
 
     let mut result = BitDecomposed::with_capacity(x.len());
-    for (i, (xb, yb)) in x
-        .zip(y.chain(repeat(&AdditiveShare::ZERO)))
-        .enumerate()
-    {
-        result.push(
-            bit_adder(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry)
-                .await?,
-        );
+    for (i, (xb, yb)) in x.zip(y.chain(repeat(&AdditiveShare::ZERO))).enumerate() {
+        result.push(bit_adder(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry).await?);
     }
     Ok(result)
 }
@@ -161,7 +161,8 @@ mod test {
 
     use crate::{
         ff::{
-            boolean_array::{BA32, BA64}, ArrayAccess, U128Conversions
+            boolean_array::{BA32, BA64},
+            ArrayAccess, U128Conversions,
         },
         protocol::{
             context::Context,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, iter::repeat};
+use std::iter::repeat;
 
 use ipa_macros::Step;
 
@@ -101,24 +101,17 @@ where
     let x = x.iter();
     let y = y.iter();
 
-    let mut result = Vec::with_capacity(x.len());
+    let mut result = BitDecomposed::with_capacity(x.len());
     for (i, (xb, yb)) in x
         .zip(y.chain(repeat(&AdditiveShare::ZERO)))
         .enumerate()
     {
         result.push(
-            bit_adder(
-                ctx.narrow(&BitOpStep::from(i)),
-                record_id,
-                xb.borrow(),
-                yb.borrow(),
-                carry,
-            )
-            .await?,
+            bit_adder(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry)
+                .await?,
         );
     }
-
-    result.try_into()
+    Ok(result)
 }
 
 ///
@@ -168,8 +161,7 @@ mod test {
 
     use crate::{
         ff::{
-            boolean_array::{BA32, BA64},
-            U128Conversions,
+            boolean_array::{BA32, BA64}, ArrayAccess, U128Conversions
         },
         protocol::{
             context::Context,
@@ -203,8 +195,8 @@ mod test {
                     integer_add::<_, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
-                        &x_y.0,
-                        &x_y.1,
+                        &x_y.0.to_bits(),
+                        &x_y.1.to_bits(),
                     )
                     .await
                     .unwrap()
@@ -280,8 +272,8 @@ mod test {
                     integer_add::<_, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
-                        &x_y.0,
-                        &x_y.1,
+                        &x_y.0.to_bits(),
+                        &x_y.1.to_bits(),
                     )
                     .await
                     .unwrap()
@@ -301,8 +293,8 @@ mod test {
                     integer_add::<_, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
-                        &x_y.0,
-                        &x_y.1,
+                        &x_y.0.to_bits(),
+                        &x_y.1.to_bits(),
                     )
                     .await
                     .unwrap()

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -121,9 +121,15 @@ where
     }
 
     let mut carry = !AdditiveShare::<Boolean>::ZERO;
-    let result = subtraction_circuit(ctx.narrow(&Step::Subtract), record_id, &x.to_bits(), &y.to_bits(), &mut carry)
-        .await?
-        .collect_bits();
+    let result = subtraction_circuit(
+        ctx.narrow(&Step::Subtract),
+        record_id,
+        &x.to_bits(),
+        &y.to_bits(),
+        &mut carry,
+    )
+    .await?
+    .collect_bits();
 
     // carry computes carry=(x>=y)
     // if carry==0 then {zero} else {result}
@@ -165,10 +171,8 @@ where
         .zip(y.chain(repeat(&AdditiveShare::<Boolean, N>::ZERO)))
         .enumerate()
     {
-        result.push(
-            bit_subtractor(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry)
-                .await?,
-        );
+        result
+            .push(bit_subtractor(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry).await?);
     }
     Ok(result)
 }
@@ -223,11 +227,18 @@ mod test {
 
     use crate::{
         ff::{
-            boolean::Boolean, boolean_array::{BA3, BA32, BA5, BA64}, ArrayAccess, Expand, Field, U128Conversions
+            boolean::Boolean,
+            boolean_array::{BA3, BA32, BA5, BA64},
+            ArrayAccess, Expand, Field, U128Conversions,
         },
-        protocol::{self, context::Context, ipa_prf::boolean_ops::comparison_and_subtraction_sequential::{
+        protocol::{
+            self,
+            context::Context,
+            ipa_prf::boolean_ops::comparison_and_subtraction_sequential::{
                 compare_geq, compare_gt, integer_sat_sub, integer_sub,
-            }, RecordId},
+            },
+            RecordId,
+        },
         rand::thread_rng,
         secret_sharing::{
             replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -77,7 +77,7 @@ where
 
 /// non-saturated unsigned integer subtraction
 /// subtracts y from x, Output has same length as x (carries and indices of y too large for x are ignored).
-/// When y>x, it computes `(x+"XS::MaxValue"+1)-y`, considering only the least-significant
+/// When y>x, it computes `(x+2^|x|)-y`, considering only the least-significant
 /// length(x) bits of y.
 /// # Errors
 /// propagates errors from multiply

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -17,7 +17,8 @@ use crate::{
         RecordId,
     },
     secret_sharing::{
-        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing}, BitDecomposed, FieldSimd, SharedValue, SharedValueArray, TransposeFrom, Vectorizable
+        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+        BitDecomposed, FieldSimd, SharedValue, SharedValueArray, TransposeFrom, Vectorizable,
     },
 };
 
@@ -153,8 +154,7 @@ where
     // addition x+rs, where rs=r+s might cause carry
     // this is not a problem since bit 255 of rs is set to 0
     let (sh_y, _) =
-        integer_add::<_, N>(ctx.narrow(&Step::IntegerAddMaskToX), record_id, &sh_rs, &x)
-            .await?;
+        integer_add::<_, N>(ctx.narrow(&Step::IntegerAddMaskToX), record_id, &sh_rs, &x).await?;
 
     // this leaks information, but with negligible probability
     let mut y = (ctx.role() != Role::H3).then(|| Vec::with_capacity(N));
@@ -212,7 +212,10 @@ where
 fn gen_sh_r_and_sh_s<C, const BITS: usize, const N: usize>(
     ctx: &C,
     record_id: RecordId,
-) -> (BitDecomposed<AdditiveShare<Boolean, N>>, BitDecomposed<AdditiveShare<Boolean, N>>)
+) -> (
+    BitDecomposed<AdditiveShare<Boolean, N>>,
+    BitDecomposed<AdditiveShare<Boolean, N>>,
+)
 where
     C: Context,
     Boolean: FieldSimd<N>,
@@ -355,10 +358,10 @@ mod tests {
         Boolean: FieldSimd<CHUNK>,
         AdditiveShare<Boolean, CHUNK>:
             for<'a> BooleanProtocols<SemiHonestContext<'a>, Boolean, CHUNK>,
-        BitDecomposed<AdditiveShare<Boolean, CHUNK>>:
-            for<'a> TransposeFrom<&'a [AdditiveShare<BA64>; CHUNK], Error = Infallible>
+        BitDecomposed<AdditiveShare<Boolean, CHUNK>>: for<'a> TransposeFrom<&'a [AdditiveShare<BA64>; CHUNK], Error = Infallible>
             + FromPrss<usize>,
-        Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, CHUNK>>>,
+        Vec<AdditiveShare<BA256>>:
+            for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, CHUNK>>>,
         Vec<BA256>: for<'a> TransposeFrom<
             &'a [<Boolean as Vectorizable<CHUNK>>::Array; 256],
             Error = Infallible,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, convert::Infallible, ops::Neg};
+use std::{convert::Infallible, ops::Neg};
 
 use ipa_macros::Step;
 
@@ -163,7 +163,7 @@ where
             ctx.narrow(&Step::RevealY(i)),
             record_id,
             Role::H3,
-            sh_y.get(i).unwrap().borrow(),
+            sh_y.get(i).unwrap(),
         )
         .await?;
         match (&mut y, y_bit) {
@@ -239,7 +239,7 @@ where
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
                 sh_s.push(AdditiveShare::new_arr(
-                    r.get(i).unwrap().borrow().left_arr().clone(),
+                    r.get(i).unwrap().left_arr().clone(),
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
             }
@@ -248,7 +248,7 @@ where
             for i in 0..BITS {
                 sh_r.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
-                    r.get(i).unwrap().borrow().right_arr().clone(),
+                    r.get(i).unwrap().right_arr().clone(),
                 ));
                 sh_s.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
@@ -259,12 +259,12 @@ where
         Role::H3 => {
             for i in 0..BITS {
                 sh_r.push(AdditiveShare::new_arr(
-                    r.get(i).unwrap().borrow().left_arr().clone(),
+                    r.get(i).unwrap().left_arr().clone(),
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
                 sh_s.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
-                    r.get(i).unwrap().borrow().right_arr().clone(),
+                    r.get(i).unwrap().right_arr().clone(),
                 ));
             }
         }

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{Error, UnwrapInfallible},
     ff::{
         boolean::Boolean, boolean_array::BA256, ec_prime_field::Fp25519, ArrayAccess,
-        ArrayAccessRef, ArrayBuild, ArrayBuilder, CustomArray, Expand,
+        ArrayAccessRef, CustomArray, Expand,
     },
     helpers::Role,
     protocol::{
@@ -17,8 +17,7 @@ use crate::{
         RecordId,
     },
     secret_sharing::{
-        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
-        FieldSimd, SharedValue, SharedValueArray, TransposeFrom, Vectorizable,
+        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing}, BitDecomposed, FieldSimd, SharedValue, SharedValueArray, TransposeFrom, Vectorizable
     },
 };
 
@@ -102,21 +101,18 @@ pub(crate) enum Step {
 ///
 /// # Errors
 /// Propagates Errors from Integer Subtraction and Partial Reveal
-pub async fn convert_to_fp25519<C, XS, YS, const N: usize>(
+pub async fn convert_to_fp25519<C, const N: usize>(
     ctx: C,
     record_id: RecordId,
-    x: XS,
+    x: BitDecomposed<AdditiveShare<Boolean, N>>,
 ) -> Result<AdditiveShare<Fp25519, N>, Error>
 where
     C: Context,
     Fp25519: Vectorizable<N>,
     Boolean: FieldSimd<N>,
-    XS: ArrayAccessRef<Element = AdditiveShare<Boolean, N>>,
-    YS: ArrayAccessRef<Element = AdditiveShare<Boolean, N>>
-        + ArrayBuild<Input = AdditiveShare<Boolean, N>>
-        + FromPrss<usize>,
+    BitDecomposed<AdditiveShare<Boolean, N>>: FromPrss<usize>,
     AdditiveShare<Boolean, N>: BooleanProtocols<C, Boolean, N>,
-    Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a YS>,
+    Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, N>>>,
     Vec<BA256>:
         for<'a> TransposeFrom<&'a [<Boolean as Vectorizable<N>>::Array; 256], Error = Infallible>,
 {
@@ -133,12 +129,12 @@ where
     // generate sh_r = (0, 0, sh_r) and sh_s = (sh_s, 0, 0)
     // the two highest bits are set to 0 to allow carries for two additions
     let (sh_r, sh_s) =
-        gen_sh_r_and_sh_s::<_, _, BITS, N>(&ctx.narrow(&Step::GenerateSecretSharing), record_id);
+        gen_sh_r_and_sh_s::<_, BITS, N>(&ctx.narrow(&Step::GenerateSecretSharing), record_id);
 
     // addition r+s might cause carry,
     // this is no problem since we have set bit 254 of sh_r and sh_s to 0
     let sh_rs = {
-        let (mut rs_with_higherorderbits, _) = integer_add::<_, _, YS, YS, N>(
+        let (mut rs_with_higherorderbits, _) = integer_add::<_, N>(
             ctx.narrow(&Step::IntegerAddBetweenMasks),
             record_id,
             &sh_r,
@@ -148,7 +144,7 @@ where
 
         // PRSS/Multiply masks added random highest order bit,
         // remove them to not cause overflow in second addition (which is mod 256):
-        rs_with_higherorderbits.set(BITS - 1, YS::make_ref(&AdditiveShare::<Boolean, N>::ZERO));
+        rs_with_higherorderbits.set(BITS - 1, &AdditiveShare::<Boolean, N>::ZERO);
 
         // return rs
         rs_with_higherorderbits
@@ -157,7 +153,7 @@ where
     // addition x+rs, where rs=r+s might cause carry
     // this is not a problem since bit 255 of rs is set to 0
     let (sh_y, _) =
-        integer_add::<_, _, YS, XS, N>(ctx.narrow(&Step::IntegerAddMaskToX), record_id, &sh_rs, &x)
+        integer_add::<_, N>(ctx.narrow(&Step::IntegerAddMaskToX), record_id, &sh_rs, &x)
             .await?;
 
     // this leaks information, but with negligible probability
@@ -213,38 +209,36 @@ where
 }
 
 /// Generates `sh_r` and `sh_s` from PRSS randomness (`r`).
-fn gen_sh_r_and_sh_s<C, YS, const BITS: usize, const N: usize>(
+fn gen_sh_r_and_sh_s<C, const BITS: usize, const N: usize>(
     ctx: &C,
     record_id: RecordId,
-) -> (YS, YS)
+) -> (BitDecomposed<AdditiveShare<Boolean, N>>, BitDecomposed<AdditiveShare<Boolean, N>>)
 where
     C: Context,
     Boolean: FieldSimd<N>,
-    YS: ArrayAccessRef<Element = AdditiveShare<Boolean, N>>
-        + ArrayBuild<Input = AdditiveShare<Boolean, N>>
-        + FromPrss<usize>,
+    BitDecomposed<AdditiveShare<Boolean, N>>: FromPrss<usize>,
 {
     // we generate random values r = (r1,r2,r3) using PRSS
     // r: H1: (r1,r2), H2: (r2,r3), H3: (r3, r1)
-    let mut r: YS = ctx.prss().generate_with(record_id, BITS);
+    let mut r: BitDecomposed<AdditiveShare<Boolean, N>> = ctx.prss().generate_with(record_id, BITS);
 
     // set 2 highest order bits of r1, r2, r3 to 0
-    r.set(BITS - 1, YS::make_ref(&AdditiveShare::<Boolean, N>::ZERO));
-    r.set(BITS - 2, YS::make_ref(&AdditiveShare::<Boolean, N>::ZERO));
+    r.set(BITS - 1, &AdditiveShare::<Boolean, N>::ZERO);
+    r.set(BITS - 2, &AdditiveShare::<Boolean, N>::ZERO);
 
-    let mut sh_r_builder = YS::builder().with_capacity(BITS);
-    let mut sh_s_builder = YS::builder().with_capacity(BITS);
+    let mut sh_r = BitDecomposed::<AdditiveShare<Boolean, N>>::with_capacity(BITS);
+    let mut sh_s = BitDecomposed::<AdditiveShare<Boolean, N>>::with_capacity(BITS);
     // generate sh_r, sh_s
     // sh_r: H1: (0,0), H2: (0,r3), H3: (r3, 0)
     // sh_s: H1: (r1,0), H2: (0,0), H3: (0, r1)
     match ctx.role() {
         Role::H1 => {
             for i in 0..BITS {
-                sh_r_builder.push(AdditiveShare::new_arr(
+                sh_r.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
-                sh_s_builder.push(AdditiveShare::new_arr(
+                sh_s.push(AdditiveShare::new_arr(
                     r.get(i).unwrap().borrow().left_arr().clone(),
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
@@ -252,11 +246,11 @@ where
         }
         Role::H2 => {
             for i in 0..BITS {
-                sh_r_builder.push(AdditiveShare::new_arr(
+                sh_r.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                     r.get(i).unwrap().borrow().right_arr().clone(),
                 ));
-                sh_s_builder.push(AdditiveShare::new_arr(
+                sh_s.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
@@ -264,18 +258,18 @@ where
         }
         Role::H3 => {
             for i in 0..BITS {
-                sh_r_builder.push(AdditiveShare::new_arr(
+                sh_r.push(AdditiveShare::new_arr(
                     r.get(i).unwrap().borrow().left_arr().clone(),
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                 ));
-                sh_s_builder.push(AdditiveShare::new_arr(
+                sh_s.push(AdditiveShare::new_arr(
                     <Boolean as Vectorizable<N>>::Array::ZERO_ARRAY,
                     r.get(i).unwrap().borrow().right_arr().clone(),
                 ));
             }
         }
     }
-    (sh_r_builder.build(), sh_s_builder.build())
+    (sh_r, sh_s)
 }
 
 /// inserts smaller array in the larger array starting from location offset
@@ -336,7 +330,7 @@ where
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use std::iter::repeat_with;
+    use std::iter::{self, repeat_with};
 
     use curve25519_dalek::Scalar;
     use futures::stream::TryStreamExt;
@@ -348,35 +342,23 @@ mod tests {
     use crate::{
         ff::{boolean_array::BA64, Serializable},
         helpers::stream::{process_slice_by_chunks, TryFlattenItersExt},
-        protocol::{context::SemiHonestContext, ipa_prf::MK_BITS},
+        protocol::context::SemiHonestContext,
         rand::thread_rng,
         seq_join::{seq_join, SeqJoin},
         test_executor::run,
         test_fixture::{ReconstructArr, Runner, TestWorld},
-        BoolVector,
     };
 
-    fn test_semi_honest_convert_into_fp25519<XS, YS, const COUNT: usize, const CHUNK: usize>()
+    fn test_semi_honest_convert_into_fp25519<const COUNT: usize, const CHUNK: usize>()
     where
         Fp25519: Vectorizable<CHUNK>,
         Boolean: FieldSimd<CHUNK>,
-        XS: ArrayAccessRef<Element = AdditiveShare<Boolean, CHUNK>>
-            + ArrayBuild<Input = AdditiveShare<Boolean, CHUNK>>
-            + for<'a> TransposeFrom<&'a [AdditiveShare<BA64>; CHUNK], Error = Infallible>
-            + Send
-            + Sync
-            + 'static,
-        YS: ArrayAccessRef<Element = AdditiveShare<Boolean, CHUNK>>
-            + ArrayBuild<Input = AdditiveShare<Boolean, CHUNK>>
-            + FromPrss<usize>
-            + Send
-            + Sync
-            + 'static,
-        for<'a> <XS as ArrayAccessRef>::Ref<'a>: Send,
-        for<'a> <YS as ArrayAccessRef>::Ref<'a>: Send,
         AdditiveShare<Boolean, CHUNK>:
             for<'a> BooleanProtocols<SemiHonestContext<'a>, Boolean, CHUNK>,
-        Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a YS>,
+        BitDecomposed<AdditiveShare<Boolean, CHUNK>>:
+            for<'a> TransposeFrom<&'a [AdditiveShare<BA64>; CHUNK], Error = Infallible>
+            + FromPrss<usize>,
+        Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, CHUNK>>>,
         Vec<BA256>: for<'a> TransposeFrom<
             &'a [<Boolean as Vectorizable<CHUNK>>::Array; 256],
             Error = Infallible,
@@ -412,14 +394,9 @@ mod tests {
                             |idx, chunk| {
                                 let ctx = ctx.clone();
                                 async move {
-                                    let mut match_keys_builder = XS::builder();
-                                    for _ in 0..MK_BITS {
-                                        match_keys_builder
-                                            .push(AdditiveShare::<Boolean, CHUNK>::ZERO);
-                                    }
-                                    let mut match_keys = match_keys_builder.build();
+                                    let mut match_keys = BitDecomposed::new(iter::empty());
                                     match_keys.transpose_from(&chunk).unwrap_infallible();
-                                    convert_to_fp25519::<_, XS, YS, CHUNK>(
+                                    convert_to_fp25519::<_, CHUNK>(
                                         ctx.set_total_records((COUNT + CHUNK - 1) / CHUNK),
                                         RecordId::from(idx),
                                         match_keys,
@@ -460,14 +437,8 @@ mod tests {
     // a size of 4096 is reasonable.
 
     #[test]
-    fn semi_honest_convert_into_fp25519_novec() {
-        test_semi_honest_convert_into_fp25519::<BoolVector!(64, 1), BoolVector!(256, 1), 2, 1>();
-    }
-
-    #[test]
     fn semi_honest_convert_into_fp25519_vec64() {
-        test_semi_honest_convert_into_fp25519::<BoolVector!(64, 64), BoolVector!(256, 64), 65, 64>(
-        );
+        test_semi_honest_convert_into_fp25519::<65, 64>();
     }
 
     #[test]

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -94,12 +94,6 @@ pub(crate) enum Step {
 /// However, these terms are only non-zero when all `rs_{k}` terms are non-zero
 /// this happens with probability `1/(2^(256-m))` which is negligible for a sufficiently small `m`
 ///
-/// The implementation uses two type parameters to support vectorization. The type `XS` holds match
-/// keys. In the unvectorized case, `XS` is `AdditiveShare<BA64>`. In the vectorized case, `XS` is
-/// `BitDecomposed<AdditiveShare<BA{N}>>`. The type `YS` holds bitwise Fp25519 intermediates. In the
-/// unvectorized case, `YS` is `AdditiveShare<BA256>`. In the vectorized case, `YS` is
-/// `BitDecomposed<AdditiveShare<BA{n}>>`.
-///
 /// # Errors
 /// Propagates Errors from Integer Subtraction and Partial Reveal
 pub async fn convert_to_fp25519<C, const N: usize>(
@@ -121,7 +115,7 @@ where
     // not vary with vectorization. Where the type `BA256` appears literally in the source of this
     // function, it is referring to this constant. (It is also possible for `BA256` to be used to
     // hold width-256 vectorizations, but when it serves that purpose, it does not appear literally
-    // in the source of this function -- it is behind the XS and YS parameters.)
+    // in the source of this function -- it is behind the N parameter.)
     const BITS: usize = 256;
 
     // Ensure that the probability of leaking information is less than 1/(2^128).

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -188,7 +188,7 @@ where
 /// Propagates errors from config issues or while running the protocol
 /// # Panics
 /// Propagates errors from config issues or while running the protocol
-pub async fn oprf_ipa<'ctx, BK, TV, HV, TS, SS, const B: usize>(
+pub async fn oprf_ipa<'ctx, BK, TV, HV, TS, const SS_BITS: usize, const B: usize>(
     ctx: SemiHonestContext<'ctx>,
     input_rows: Vec<OPRFIPAInputRow<BK, TV, TS>>,
     attribution_window_seconds: Option<NonZeroU32>,
@@ -198,7 +198,6 @@ where
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     Boolean: FieldSimd<B>,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, Boolean, B>,
@@ -232,7 +231,7 @@ where
     )
     .await?;
 
-    attribute_cap_aggregate::<_, _, _, _, SS, B>(
+    attribute_cap_aggregate::<_, _, _, _, SS_BITS, B>(
         ctx,
         prfd_inputs,
         attribution_window_seconds,
@@ -326,7 +325,7 @@ where
 pub mod tests {
     use crate::{
         ff::{
-            boolean_array::{BA16, BA20, BA3, BA5, BA8},
+            boolean_array::{BA16, BA20, BA3, BA8},
             U128Conversions,
         },
         protocol::ipa_prf::oprf_ipa,
@@ -367,7 +366,7 @@ pub mod tests {
 
             let mut result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    oprf_ipa::<BA8, BA3, BA16, BA20, BA5, 256>(ctx, input_rows, None)
+                    oprf_ipa::<BA8, BA3, BA16, BA20, 5, 256>(ctx, input_rows, None)
                         .await
                         .unwrap()
                 })
@@ -412,7 +411,7 @@ pub mod tests {
 
             let mut result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    oprf_ipa::<BA8, BA3, BA16, BA20, BA5, 256>(ctx, input_rows, None)
+                    oprf_ipa::<BA8, BA3, BA16, BA20, 5, 256>(ctx, input_rows, None)
                         .await
                         .unwrap()
                 })

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -9,8 +9,8 @@ use self::{quicksort::quicksort_ranges_by_key_insecure, shuffle::shuffle_inputs}
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
     ff::{
-        boolean::Boolean, boolean_array::BA64, ec_prime_field::Fp25519,
-        CustomArray, Serializable, U128Conversions,
+        boolean::Boolean, boolean_array::BA64, ec_prime_field::Fp25519, CustomArray, Serializable,
+        U128Conversions,
     },
     helpers::stream::{process_slice_by_chunks, ChunkData, TryFlattenItersExt},
     protocol::{
@@ -139,8 +139,9 @@ where
         let tv_sz = <Replicated<TV> as Serializable>::Size::USIZE;
         let it_sz = <Replicated<Boolean> as Serializable>::Size::USIZE;
 
-        let match_key = Replicated::<MatchKey>::deserialize(GenericArray::from_slice(&buf[..mk_sz]))
-            .unwrap_infallible();
+        let match_key =
+            Replicated::<MatchKey>::deserialize(GenericArray::from_slice(&buf[..mk_sz]))
+                .unwrap_infallible();
         let timestamp =
             Replicated::<TS>::deserialize(GenericArray::from_slice(&buf[mk_sz..mk_sz + ts_sz]))
                 .map_err(|e| Error::ParseError(e.into()))?;
@@ -277,11 +278,9 @@ where
                     match_keys
                         .transpose_from(input_match_keys)
                         .unwrap_infallible();
-                    let curve_pts = convert_to_fp25519::<
-                        _,
-                        PRF_CHUNK,
-                    >(convert_ctx, record_id, match_keys)
-                    .await?;
+                    let curve_pts =
+                        convert_to_fp25519::<_, PRF_CHUNK>(convert_ctx, record_id, match_keys)
+                            .await?;
 
                     let prf_of_match_keys =
                         eval_dy_prf::<_, PRF_CHUNK>(eval_ctx, record_id, &prf_key, curve_pts)

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -94,8 +94,7 @@ impl<BK: SharedValue, TS: SharedValue, TV: SharedValue> GroupingKey
     }
 }
 
-struct InputsRequiredFromPrevRow<BK: SharedValue, TV: SharedValue, TS: SharedValue>
-{
+struct InputsRequiredFromPrevRow<BK: SharedValue, TV: SharedValue, TS: SharedValue> {
     ever_encountered_a_source_event: Replicated<Boolean>,
     attributed_breakdown_key_bits: Replicated<BK>,
     saturating_sum: BitDecomposed<Replicated<Boolean>>,
@@ -209,9 +208,13 @@ where
             integer_sub(
                 ctx.narrow(&Step::ComputeDifferenceToCap),
                 record_id,
-                &BitDecomposed::new(repeat_n(Replicated::ZERO, usize::try_from(TV::BITS).unwrap())),
+                &BitDecomposed::new(repeat_n(
+                    Replicated::ZERO,
+                    usize::try_from(TV::BITS).unwrap(),
+                )),
                 &updated_sum,
-            ).map(|res| res.map(BitDecomposed::collect_bits)),
+            )
+            .map(|res| res.map(BitDecomposed::collect_bits)),
         )
         .await?;
 
@@ -1105,9 +1108,14 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribute_cap_aggregate::<BA8, BA3, BA8, BA20, {SaturatingSumType::BITS as usize}, 256>(
-                        ctx, input_rows, None, &HISTOGRAM,
-                    )
+                    attribute_cap_aggregate::<
+                        BA8,
+                        BA3,
+                        BA8,
+                        BA20,
+                        { SaturatingSumType::BITS as usize },
+                        256,
+                    >(ctx, input_rows, None, &HISTOGRAM)
                     .await
                     .unwrap()
                 })

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::{
     future::{try_join, try_join3},
     stream::{self, unfold},
-    Stream, StreamExt,
+    FutureExt, Stream, StreamExt,
 };
 use ipa_macros::Step;
 
@@ -20,7 +20,7 @@ use crate::{
         boolean_array::{BA32, BA7},
         ArrayAccess, CustomArray, Expand, Field, U128Conversions,
     },
-    helpers::stream::TryFlattenItersExt,
+    helpers::{repeat_n, stream::TryFlattenItersExt},
     protocol::{
         basics::{select, BooleanArrayMul, BooleanProtocols, SecureMul, ShareKnownValue},
         boolean::or::or,
@@ -94,22 +94,21 @@ impl<BK: SharedValue, TS: SharedValue, TV: SharedValue> GroupingKey
     }
 }
 
-struct InputsRequiredFromPrevRow<BK: SharedValue, TV: SharedValue, TS: SharedValue, SS: SharedValue>
+struct InputsRequiredFromPrevRow<BK: SharedValue, TV: SharedValue, TS: SharedValue>
 {
     ever_encountered_a_source_event: Replicated<Boolean>,
     attributed_breakdown_key_bits: Replicated<BK>,
-    saturating_sum: Replicated<SS>,
+    saturating_sum: BitDecomposed<Replicated<Boolean>>,
     is_saturated: Replicated<Boolean>,
     difference_to_cap: Replicated<TV>,
     source_event_timestamp: Replicated<TS>,
 }
 
-impl<BK, TV, TS, SS> InputsRequiredFromPrevRow<BK, TV, TS, SS>
+impl<BK, TV, TS> InputsRequiredFromPrevRow<BK, TV, TS>
 where
     BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     Replicated<BK>: BooleanArrayMul,
     Replicated<TS>: BooleanArrayMul,
     Replicated<TV>: BooleanArrayMul,
@@ -192,7 +191,7 @@ where
             ctx.narrow(&Step::ComputeSaturatingSum),
             record_id,
             &self.saturating_sum,
-            &attributed_trigger_value,
+            &attributed_trigger_value.to_bits(),
         )
         .await?;
 
@@ -210,9 +209,9 @@ where
             integer_sub(
                 ctx.narrow(&Step::ComputeDifferenceToCap),
                 record_id,
-                &Replicated::<TV>::ZERO,
+                &BitDecomposed::new(repeat_n(Replicated::ZERO, usize::try_from(TV::BITS).unwrap())),
                 &updated_sum,
-            ),
+            ).map(|res| res.map(BitDecomposed::collect_bits)),
         )
         .await?;
 
@@ -417,7 +416,7 @@ where
 /// # Panics
 /// Propagates errors from multiplications
 #[tracing::instrument(name = "attribute_cap_aggregate", skip_all)]
-pub async fn attribute_cap_aggregate<'ctx, BK, TV, HV, TS, SS, const B: usize>(
+pub async fn attribute_cap_aggregate<'ctx, BK, TV, HV, TS, const SS_BITS: usize, const B: usize>(
     sh_ctx: SemiHonestContext<'ctx>,
     input_rows: Vec<PrfShardedIpaInputRow<BK, TV, TS>>,
     attribution_window_seconds: Option<NonZeroU32>,
@@ -428,7 +427,6 @@ where
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     Boolean: FieldSimd<B>,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, Boolean, B>,
@@ -472,7 +470,7 @@ where
                 let num_user_rows = rows_for_user.len();
                 let contexts = ctx_for_row_number[..num_user_rows - 1].to_owned();
 
-                evaluate_per_user_attribution_circuit::<BK, TV, TS, SS>(
+                evaluate_per_user_attribution_circuit::<BK, TV, TS, SS_BITS>(
                     contexts,
                     RecordId::from(record_id),
                     rows_for_user,
@@ -495,7 +493,7 @@ where
     .await
 }
 
-async fn evaluate_per_user_attribution_circuit<BK, TV, TS, SS>(
+async fn evaluate_per_user_attribution_circuit<BK, TV, TS, const SS_BITS: usize>(
     ctx_for_row_number: Vec<UpgradedSemiHonestContext<'_, NotSharded, Boolean>>,
     record_id: RecordId,
     rows_for_user: Vec<PrfShardedIpaInputRow<BK, TV, TS>>,
@@ -505,7 +503,6 @@ where
     BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    SS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     Replicated<BK>: BooleanArrayMul,
     Replicated<TS>: BooleanArrayMul,
     Replicated<TV>: BooleanArrayMul,
@@ -516,7 +513,7 @@ where
     }
     let first_row = &rows_for_user[0];
     let mut prev_row_inputs =
-        initialize_new_device_attribution_variables::<BK, TV, TS, SS>(first_row);
+        initialize_new_device_attribution_variables::<BK, TV, TS, SS_BITS>(first_row);
 
     let mut output = Vec::with_capacity(rows_for_user.len() - 1);
     for (row, ctx) in zip(rows_for_user.iter().skip(1), ctx_for_row_number.into_iter()) {
@@ -533,19 +530,18 @@ where
 /// Upon encountering the first row of data from a new user (as distinguished by a different OPRF of the match key)
 /// this function encapsulates the variables that must be initialized. No communication is required for this first row.
 ///
-fn initialize_new_device_attribution_variables<BK, TV, TS, SS>(
+fn initialize_new_device_attribution_variables<BK, TV, TS, const SS_BITS: usize>(
     input_row: &PrfShardedIpaInputRow<BK, TV, TS>,
-) -> InputsRequiredFromPrevRow<BK, TV, TS, SS>
+) -> InputsRequiredFromPrevRow<BK, TV, TS>
 where
     BK: SharedValue,
     TV: SharedValue,
     TS: SharedValue,
-    SS: SharedValue,
 {
     InputsRequiredFromPrevRow {
         ever_encountered_a_source_event: input_row.is_trigger_bit.clone().not(),
         attributed_breakdown_key_bits: input_row.breakdown_key.clone(),
-        saturating_sum: Replicated::<SS>::ZERO,
+        saturating_sum: BitDecomposed::new(repeat_n(Replicated::ZERO, SS_BITS)),
         is_saturated: Replicated::<Boolean>::ZERO,
         // This is incorrect in the case that the CAP is less than the maximum value of "trigger value" for a single row
         // Not a problem if you assume that's an invalid input
@@ -694,18 +690,23 @@ where
         let time_delta_bits = integer_sub(
             ctx.narrow(&Step::ComputeTimeDelta),
             record_id,
-            trigger_event_timestamp,
-            source_event_timestamp,
+            &trigger_event_timestamp.to_bits(),
+            &source_event_timestamp.to_bits(),
         )
         .await?;
 
-        let constant_bits = TS::truncate_from(attribution_window_seconds.get());
+        let attribution_window_bits = BitDecomposed::decompose(TS::BITS, |i| {
+            Replicated::share_known_value(
+                &ctx,
+                Boolean::truncate_from((attribution_window_seconds.get() >> i) & 0x1),
+            )
+        });
 
         let time_delta_gt_attribution_window = compare_gt(
             ctx.narrow(&Step::CompareTimeDeltaToAttributionWindow),
             record_id,
             &time_delta_bits,
-            &Replicated::<TS>::new(constant_bits, constant_bits),
+            &attribution_window_bits,
         )
         .await?;
         Ok(time_delta_gt_attribution_window.not())
@@ -959,7 +960,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribute_cap_aggregate::<BA5, BA3, BA16, BA20, BA5, 32>(
+                    attribute_cap_aggregate::<BA5, BA3, BA16, BA20, 5, 32>(
                         ctx, input_rows, None, &histogram,
                     )
                     .await
@@ -1013,7 +1014,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribute_cap_aggregate::<BA5, BA3, BA16, BA20, BA5, 32>(
+                    attribute_cap_aggregate::<BA5, BA3, BA16, BA20, 5, 32>(
                         ctx,
                         input_rows,
                         NonZeroU32::new(ATTRIBUTION_WINDOW_SECONDS),
@@ -1104,7 +1105,7 @@ pub mod tests {
 
             let result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    attribute_cap_aggregate::<BA8, BA3, BA8, BA20, SaturatingSumType, 256>(
+                    attribute_cap_aggregate::<BA8, BA3, BA8, BA20, {SaturatingSumType::BITS as usize}, 256>(
                         ctx, input_rows, None, &HISTOGRAM,
                     )
                     .await

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -6,7 +6,7 @@ use ipa_macros::Step;
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
-    ff::{boolean::Boolean, ArrayAccess, ArrayBuild, CustomArray, Expand},
+    ff::{boolean::Boolean, CustomArray, Expand},
     helpers::stream::{process_stream_by_chunks, ChunkBuffer, TryFlattenItersExt},
     protocol::{
         basics::Reveal,
@@ -31,8 +31,7 @@ pub(crate) enum Step {
 
 impl<K> ChunkBuffer<SORT_CHUNK> for (Vec<AdditiveShare<K>>, Vec<AdditiveShare<K>>)
 where
-    K: SharedValue + CustomArray<Element = Boolean>,
-    AdditiveShare<K>: ArrayAccess + ArrayBuild<Input = AdditiveShare<Boolean>>,
+    K: SharedValue,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
         for<'a> TransposeFrom<&'a [AdditiveShare<K>; SORT_CHUNK], Error = Infallible>,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
@@ -132,7 +131,6 @@ where
     F: Fn(&S) -> &AdditiveShare<K> + Sync + Send + Copy,
     K: SharedValue + CustomArray<Element = Boolean>,
     <Boolean as Vectorizable<SORT_CHUNK>>::Array: Expand<Input = Boolean>,
-    AdditiveShare<K>: ArrayAccess + ArrayBuild<Input = AdditiveShare<Boolean>>,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
         for<'a> TransposeFrom<&'a [AdditiveShare<K>; SORT_CHUNK], Error = Infallible>,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
@@ -185,7 +183,7 @@ where
                     async move {
                         // Compare the current element against pivot and reveal the result.
                         let comparison =
-                            compare_gt::<_, _, _, _, SORT_CHUNK>(cmp_ctx, record_id, &k, &pivot)
+                            compare_gt::<_, SORT_CHUNK>(cmp_ctx, record_id, &k, &pivot)
                                 .await?
                                 .reveal(rvl_ctx, record_id) // reveal outcome of comparison
                                 .await?;

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, LengthError},
     ff::{
         boolean::Boolean,
-        boolean_array::{BA20, BA3, BA4, BA5, BA6, BA7, BA8},
+        boolean_array::{BA20, BA3, BA8},
         CustomArray, Field, Serializable, U128Conversions,
     },
     helpers::{
@@ -111,11 +111,11 @@ where
 
         let aws = config.attribution_window_seconds;
         match config.per_user_credit_cap {
-            8 => oprf_ipa::<BA8, BA3, HV, BA20, BA3, 256>(ctx, input, aws).await,
-            16 => oprf_ipa::<BA8, BA3, HV, BA20, BA4, 256>(ctx, input, aws).await,
-            32 => oprf_ipa::<BA8, BA3, HV, BA20, BA5, 256>(ctx, input, aws).await,
-            64 => oprf_ipa::<BA8, BA3, HV, BA20, BA6, 256>(ctx, input, aws).await,
-            128 => oprf_ipa::<BA8, BA3, HV, BA20, BA7, 256>(ctx, input, aws).await,
+            8 => oprf_ipa::<BA8, BA3, HV, BA20, 3, 256>(ctx, input, aws).await,
+            16 => oprf_ipa::<BA8, BA3, HV, BA20, 4, 256>(ctx, input, aws).await,
+            32 => oprf_ipa::<BA8, BA3, HV, BA20, 5, 256>(ctx, input, aws).await,
+            64 => oprf_ipa::<BA8, BA3, HV, BA20, 6, 256>(ctx, input, aws).await,
+            128 => oprf_ipa::<BA8, BA3, HV, BA20, 7, 256>(ctx, input, aws).await,
             _ => panic!(
                 "Invalid value specified for per-user cap: {:?}. Must be one of 8, 16, 32, 64, or 128.",
                 config.per_user_credit_cap

--- a/ipa-core/src/secret_sharing/decomposed.rs
+++ b/ipa-core/src/secret_sharing/decomposed.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, ArrayAccessRef, ArrayBuild, ArrayBuilder, PrimeField},
+    ff::{boolean::Boolean, ArrayAccessRef, PrimeField},
     protocol::prss::{FromPrss, FromRandom, PrssIndex, SharedRandomness},
     secret_sharing::{
         replicated::semi_honest::AdditiveShare, Linear as LinearSecretSharing, LinearRefOps,
@@ -166,33 +166,6 @@ impl<S> TryFrom<Vec<S>> for BitDecomposed<S> {
 
 pub struct BitDecomposedBuilder<S> {
     bits: Vec<S>,
-}
-
-impl<S: Send> ArrayBuild for BitDecomposed<S> {
-    type Input = S;
-    type Builder = BitDecomposedBuilder<S>;
-
-    fn builder() -> Self::Builder {
-        BitDecomposedBuilder { bits: Vec::new() }
-    }
-}
-
-impl<S: Send> ArrayBuilder for BitDecomposedBuilder<S> {
-    type Element = S;
-    type Array = BitDecomposed<S>;
-
-    fn with_capacity(mut self, capacity: usize) -> Self {
-        self.bits.reserve(capacity);
-        self
-    }
-
-    fn push(&mut self, value: S) {
-        self.bits.push(value);
-    }
-
-    fn build(self) -> Self::Array {
-        BitDecomposed::new(self.bits)
-    }
 }
 
 impl<S> Deref for BitDecomposed<S> {

--- a/ipa-core/src/secret_sharing/decomposed.rs
+++ b/ipa-core/src/secret_sharing/decomposed.rs
@@ -62,6 +62,10 @@ impl<S> BitDecomposed<S> {
         self.bits.is_empty()
     }
 
+    pub fn collect_bits<T: FromIterator<S>>(self) -> T {
+        self.into_iter().collect()
+    }
+
     /// The inner vector of this type is a list any field type (e.g. Z2, Zp) and
     /// each element is (should be) a share of 1 or 0. This function iterates
     /// over the shares of bits and computes `Σ(2^i * b_i)`.
@@ -107,6 +111,14 @@ impl<S> BitDecomposed<S> {
     }
 }
 
+impl BitDecomposed<Boolean> {
+    pub fn as_u128(self: &BitDecomposed<Boolean>) -> u128 {
+        self.bits.iter().enumerate().fold(0, |acc, (i, b)| {
+            acc + (b.as_u128() << i)
+        })
+    }
+}
+
 impl<S: Clone> BitDecomposed<S> {
     pub fn resize(&mut self, new_len: usize, value: S) {
         assert!(new_len <= Self::MAX);
@@ -126,6 +138,15 @@ impl<S: Clone> BitDecomposed<S> {
         assert!(capacity <= Self::MAX);
         Self {
             bits: Vec::with_capacity(capacity),
+        }
+    }
+}
+
+impl<S: SharedValue> BitDecomposed<S> {
+    pub fn zero(len: usize) -> Self {
+        assert!(len <= Self::MAX);
+        Self {
+            bits: vec![S::ZERO; len],
         }
     }
 }
@@ -162,10 +183,6 @@ impl<S> TryFrom<Vec<S>> for BitDecomposed<S> {
             Err(Error::Internal)
         }
     }
-}
-
-pub struct BitDecomposedBuilder<S> {
-    bits: Vec<S>,
 }
 
 impl<S> Deref for BitDecomposed<S> {

--- a/ipa-core/src/secret_sharing/decomposed.rs
+++ b/ipa-core/src/secret_sharing/decomposed.rs
@@ -109,15 +109,24 @@ impl<S> BitDecomposed<S> {
 
 impl<S: Clone> BitDecomposed<S> {
     pub fn resize(&mut self, new_len: usize, value: S) {
+        assert!(new_len <= Self::MAX);
         self.bits.resize(new_len, value);
     }
 
     pub fn push(&mut self, value: S) {
+        assert!(self.len() < Self::MAX);
         self.bits.push(value);
     }
 
     pub fn truncate(&mut self, len: usize) {
         self.bits.truncate(len);
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        assert!(capacity <= Self::MAX);
+        Self {
+            bits: Vec::with_capacity(capacity),
+        }
     }
 }
 

--- a/ipa-core/src/secret_sharing/decomposed.rs
+++ b/ipa-core/src/secret_sharing/decomposed.rs
@@ -205,10 +205,6 @@ impl<S: Clone + Send + Sync> ArrayAccessRef for BitDecomposed<S> {
     fn iter(&self) -> Self::Iter<'_> {
         self.bits.iter()
     }
-
-    fn make_ref(src: &Self::Element) -> Self::Ref<'_> {
-        src
-    }
 }
 
 #[cfg(all(test, unit_test))]
@@ -276,33 +272,6 @@ mod tests {
                 prop_assert_eq!(v, &val.bits[i]);
                 prop_assert_eq!(iter.len(), val.len() - 1 - i);
             }
-        }
-
-        #[test]
-        fn arrayaccess_make_ref(val in any::<u8>()) {
-            prop_assert_eq!(<BitDecomposed<u8> as ArrayAccessRef>::make_ref(&val), &val);
-        }
-    }
-
-    #[test]
-    fn arraybuild() {
-        let mut b = BitDecomposed::<u8>::builder();
-        b.push(1);
-        b.push(2);
-        b.push(3);
-        assert_eq!(
-            b.build(),
-            BitDecomposed {
-                bits: vec![1, 2, 3]
-            }
-        );
-    }
-
-    proptest! {
-        #[test]
-        fn arraybuild_with_capacity(capacity in 0..MAX_TEST_SIZE) {
-            let b = BitDecomposed::<u8>::builder().with_capacity(capacity);
-            prop_assert!(b.bits.capacity() >= capacity);
         }
     }
 }

--- a/ipa-core/src/secret_sharing/decomposed.rs
+++ b/ipa-core/src/secret_sharing/decomposed.rs
@@ -113,9 +113,10 @@ impl<S> BitDecomposed<S> {
 
 impl BitDecomposed<Boolean> {
     pub fn as_u128(self: &BitDecomposed<Boolean>) -> u128 {
-        self.bits.iter().enumerate().fold(0, |acc, (i, b)| {
-            acc + (b.as_u128() << i)
-        })
+        self.bits
+            .iter()
+            .enumerate()
+            .fold(0, |acc, (i, b)| acc + (b.as_u128() << i))
     }
 }
 

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -23,7 +23,7 @@ use rand::{
 };
 pub use scheme::{Bitwise, Linear, LinearRefOps, SecretSharing};
 pub use vector::{
-    BoolVectorLookup, BoolVectorTrait, FieldArray, FieldSimd, FieldVectorizable, SharedValueArray,
+    FieldArray, FieldSimd, FieldVectorizable, SharedValueArray,
     StdArray, TransposeFrom, Vectorizable,
 };
 

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -23,8 +23,8 @@ use rand::{
 };
 pub use scheme::{Bitwise, Linear, LinearRefOps, SecretSharing};
 pub use vector::{
-    FieldArray, FieldSimd, FieldVectorizable, SharedValueArray,
-    StdArray, TransposeFrom, Vectorizable,
+    FieldArray, FieldSimd, FieldVectorizable, SharedValueArray, StdArray, TransposeFrom,
+    Vectorizable,
 };
 
 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]

--- a/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -8,7 +8,7 @@ use generic_array::{ArrayLength, GenericArray};
 use typenum::Unsigned;
 
 use crate::{
-    ff::{ArrayAccess, ArrayAccessRef, ArrayBuild, ArrayBuilder, Expand, Field, Serializable},
+    ff::{ArrayAccess, ArrayAccessRef, Expand, Field, Serializable},
     secret_sharing::{
         replicated::ReplicatedSecretSharing, FieldSimd, Linear as LinearSecretSharing,
         SecretSharing, SharedValue, SharedValueArray, Vectorizable,
@@ -492,55 +492,6 @@ impl<S: SharedValue + Vectorizable<N>, const N: usize> Iterator for UnpackIter<S
             (None, None) => None,
             (Some(left), Some(right)) => Some(AdditiveShare::new(left, right)),
             _ => unreachable!("unequal left/right length in vectorized AdditiveShare"),
-        }
-    }
-}
-
-pub struct AdditiveShareArrayBuilder<B>
-where
-    B: ArrayBuilder,
-    B::Array: SharedValue,
-    B::Element: SharedValue,
-{
-    left_builder: B,
-    right_builder: B,
-}
-
-impl<B> ArrayBuilder for AdditiveShareArrayBuilder<B>
-where
-    B: ArrayBuilder,
-    B::Array: SharedValue,
-    B::Element: SharedValue,
-{
-    type Element = AdditiveShare<B::Element>;
-    type Array = AdditiveShare<B::Array>;
-
-    fn push(&mut self, value: Self::Element) {
-        self.left_builder.push(value.left());
-        self.right_builder.push(value.right());
-    }
-
-    fn build(self) -> Self::Array {
-        let Self {
-            left_builder,
-            right_builder,
-        } = self;
-        AdditiveShare::new(left_builder.build(), right_builder.build())
-    }
-}
-
-impl<A> ArrayBuild for AdditiveShare<A>
-where
-    A: SharedValue + ArrayBuild,
-    <A as ArrayBuild>::Input: SharedValue,
-{
-    type Input = AdditiveShare<<A as ArrayBuild>::Input>;
-    type Builder = AdditiveShareArrayBuilder<<A as ArrayBuild>::Builder>;
-
-    fn builder() -> Self::Builder {
-        AdditiveShareArrayBuilder {
-            left_builder: A::builder(),
-            right_builder: A::builder(),
         }
     }
 }

--- a/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -412,10 +412,6 @@ where
     fn iter(&self) -> Self::Iter<'_> {
         ArrayAccess::iter(self)
     }
-
-    fn make_ref(src: &Self::Element) -> Self::Ref<'_> {
-        src.clone()
-    }
 }
 
 impl<S, A, T> Expand for AdditiveShare<S>

--- a/ipa-core/src/secret_sharing/vector/impls.rs
+++ b/ipa-core/src/secret_sharing/vector/impls.rs
@@ -1,17 +1,16 @@
 //! Supported vectorizations
 
 use crate::{
-    const_assert_eq,
     ff::{
         boolean::Boolean,
         boolean_array::{BA16, BA20, BA256, BA3, BA32, BA5, BA64, BA8},
         ec_prime_field::Fp25519,
         Fp32BitPrime,
     },
-    protocol::ipa_prf::{MK_BITS, PRF_CHUNK},
+    protocol::ipa_prf::PRF_CHUNK,
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd, FieldVectorizable,
-        ReplicatedSecretSharing, SharedValue, Vectorizable,
+        replicated::semi_honest::AdditiveShare, FieldSimd, FieldVectorizable,
+        ReplicatedSecretSharing, Vectorizable,
     },
 };
 
@@ -53,55 +52,3 @@ boolean_vector!(20, BA20);
 boolean_vector!(32, BA32);
 boolean_vector!(64, BA64);
 boolean_vector!(256, BA256);
-
-/// Expands to the type for storing vectorized shares of a multi-bit boolean value.
-///
-/// The "width" is the bit width of the value for each record. For example, a breakdown key might
-/// have an 8-bit width.
-///
-/// The "dimension" is the vectorization dimension, which is a number of records. For example,
-/// there might be no vectorization (dimension = 1), or computation might be vectorized over
-/// 256 records (dimension = 256).
-///
-/// When the dimension is one, `BoolVector!(width, 1)` expands to an `AdditiveShare` of the Boolean
-/// array type with the requested width.
-///
-/// When the dimension is greater than one, `BoolVector!(width, dim)` expands to
-/// `BitDecomposed<AdditiveShare<Boolean, dim>>`.
-#[macro_export]
-macro_rules! BoolVector {
-    ($width:expr, $dim:expr) => {
-        <$crate::secret_sharing::BoolVectorLookup as $crate::secret_sharing::BoolVectorTrait<
-            $width,
-            $dim,
-        >>::Share
-    };
-}
-
-pub trait BoolVectorTrait<const B: usize, const N: usize> {
-    type Share;
-}
-
-pub struct BoolVectorLookup;
-
-const_assert_eq!(
-    MK_BITS,
-    64,
-    "Appropriate BoolVectorTrait implementation required"
-);
-impl BoolVectorTrait<64, 1> for BoolVectorLookup {
-    type Share = AdditiveShare<BA64>;
-}
-
-const_assert_eq!(
-    Fp25519::BITS,
-    256,
-    "Appropriate BoolVectorTrait implementation required"
-);
-impl BoolVectorTrait<256, 1> for BoolVectorLookup {
-    type Share = AdditiveShare<BA256>;
-}
-
-impl<const B: usize> BoolVectorTrait<B, PRF_CHUNK> for BoolVectorLookup {
-    type Share = BitDecomposed<AdditiveShare<Boolean, PRF_CHUNK>>;
-}

--- a/ipa-core/src/secret_sharing/vector/mod.rs
+++ b/ipa-core/src/secret_sharing/vector/mod.rs
@@ -54,7 +54,6 @@ mod traits;
 mod transpose;
 
 pub use array::StdArray;
-pub use impls::{BoolVectorLookup, BoolVectorTrait};
 pub use traits::{FieldArray, FieldSimd, FieldVectorizable, SharedValueArray, Vectorizable};
 pub use transpose::TransposeFrom;
 #[cfg(feature = "enable-benches")]

--- a/ipa-core/src/test_fixture/ipa.rs
+++ b/ipa-core/src/test_fixture/ipa.rs
@@ -194,7 +194,7 @@ pub async fn test_oprf_ipa<F>(
 {
     use crate::{
         ff::{
-            boolean_array::{BA16, BA20, BA3, BA4, BA5, BA6, BA7, BA8},
+            boolean_array::{BA16, BA20, BA3, BA5, BA8},
             U128Conversions,
         },
         protocol::ipa_prf::oprf_ipa,
@@ -208,7 +208,7 @@ pub async fn test_oprf_ipa<F>(
         world.semi_honest(
             records.into_iter(),
             |ctx, input_rows: Vec<OPRFIPAInputRow<BA5, BA8, BA20>>| async move {
-                oprf_ipa::<BA5, BA8, BA16, BA20, BA8, 32>(ctx, input_rows, aws)
+                oprf_ipa::<BA5, BA8, BA16, BA20, 8, 32>(ctx, input_rows, aws)
                     .await
                     .unwrap()
             },
@@ -220,19 +220,19 @@ pub async fn test_oprf_ipa<F>(
             |ctx, input_rows: Vec<OPRFIPAInputRow<BA8, BA3, BA20>>| async move {
 
                 match config.per_user_credit_cap {
-                    8 => oprf_ipa::<BA8, BA3, BA16, BA20, BA3, 256>(ctx, input_rows, aws)
+                    8 => oprf_ipa::<BA8, BA3, BA16, BA20, 3, 256>(ctx, input_rows, aws)
                     .await
                     .unwrap(),
-                    16 => oprf_ipa::<BA8, BA3, BA16, BA20, BA4, 256>(ctx, input_rows, aws)
+                    16 => oprf_ipa::<BA8, BA3, BA16, BA20, 4, 256>(ctx, input_rows, aws)
                     .await
                     .unwrap(),
-                    32 => oprf_ipa::<BA8, BA3, BA16, BA20, BA5, 256>(ctx, input_rows, aws)
+                    32 => oprf_ipa::<BA8, BA3, BA16, BA20, 5, 256>(ctx, input_rows, aws)
                     .await
                     .unwrap(),
-                    64 => oprf_ipa::<BA8, BA3, BA16, BA20, BA6, 256>(ctx, input_rows, aws)
+                    64 => oprf_ipa::<BA8, BA3, BA16, BA20, 6, 256>(ctx, input_rows, aws)
                     .await
                     .unwrap(),
-                    128 => oprf_ipa::<BA8, BA3, BA16, BA20, BA7, 256>(ctx, input_rows, aws)
+                    128 => oprf_ipa::<BA8, BA3, BA16, BA20, 7, 256>(ctx, input_rows, aws)
                     .await
                     .unwrap(),
                     _ =>


### PR DESCRIPTION
More precisely, these methods still support unvectorized operation (a vectorization dimension of 1), but using them in that mode will now use 8x more memory than the previous version, because bits are not packed within bytes.

Network utilization should not be affected, because these protocols are doing bitwise arithmetic, which never had efficient network utilization in the unvectorized case.

In exchange for the performance loss under particular conditions, a bunch of code can be deleted and some of the remaining code can be simplified. However, in the (unvectorized) attribution code, things get slightly more complicated, to unpack bits into and repack bits from BitDecomposed.

I am offering this for discussion as something that simplifies some of the vectorized code.