### PR TITLE
Improvment to the DZKP Batch Storage

### DIFF
--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -1,6 +1,6 @@
 use crate::{
     ff::Field,
-    protocol::context::dzkp_validator::{BitArray32, SegmentEntry},
+    protocol::context::dzkp_validator::{Array256Bit, SegmentEntry},
     secret_sharing::{FieldSimd, Vectorizable},
 };
 
@@ -16,13 +16,13 @@ pub trait DZKPCompatibleField<const N: usize = 1>: FieldSimd<N> {
 pub trait DZKPBaseField: Field {
     type UnverifiedFieldValues;
     fn convert(
-        x_left: &BitArray32,
-        x_right: &BitArray32,
-        y_left: &BitArray32,
-        y_right: &BitArray32,
-        prss_left: &BitArray32,
-        prss_right: &BitArray32,
-        z_right: &BitArray32,
+        x_left: &Array256Bit,
+        x_right: &Array256Bit,
+        y_left: &Array256Bit,
+        y_right: &Array256Bit,
+        prss_left: &Array256Bit,
+        prss_right: &Array256Bit,
+        z_right: &Array256Bit,
     ) -> Self::UnverifiedFieldValues;
 }
 

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -147,8 +147,8 @@ impl<'a> UpgradableContext for Context<'a> {
     type DZKPUpgradedContext = DZKPUpgraded<'a>;
     type DZKPValidator = MaliciousDZKPValidator<'a>;
 
-    fn dzkp_validator(self, chunk_size: usize) -> Self::DZKPValidator {
-        MaliciousDZKPValidator::new(self, chunk_size)
+    fn dzkp_validator(self, multiplication_amount: usize) -> Self::DZKPValidator {
+        MaliciousDZKPValidator::new(self, multiplication_amount)
     }
 }
 

--- a/ipa-core/src/telemetry/mod.rs
+++ b/ipa-core/src/telemetry/mod.rs
@@ -17,7 +17,7 @@ pub mod metrics {
     pub const INDEXED_PRSS_GENERATED: &str = "i.prss.gen";
     pub const SEQUENTIAL_PRSS_GENERATED: &str = "s.prss.gen";
     pub const STEP_NARROWED: &str = "step.narrowed";
-    pub const DZKP_BATCH_UPDATE: &str = "batch.realloc.front";
+    pub const DZKP_BATCH_INCREMENTS: &str = "batch.realloc.front";
 
     #[cfg(feature = "web-app")]
     pub mod web {
@@ -108,7 +108,7 @@ pub mod metrics {
         );
 
         describe_counter!(
-            DZKP_BATCH_UPDATE,
+            DZKP_BATCH_INCREMENTS,
             Unit::Count,
             "Number of DZKP Batch updates, i.e. verifications"
         );

--- a/ipa-core/src/telemetry/mod.rs
+++ b/ipa-core/src/telemetry/mod.rs
@@ -17,8 +17,7 @@ pub mod metrics {
     pub const INDEXED_PRSS_GENERATED: &str = "i.prss.gen";
     pub const SEQUENTIAL_PRSS_GENERATED: &str = "s.prss.gen";
     pub const STEP_NARROWED: &str = "step.narrowed";
-    pub const DZKP_BATCH_REALLOCATION_FRONT: &str = "batch.realloc.front";
-    pub const DZKP_BATCH_REALLOCATION_BACK: &str = "batch.realloc.back";
+    pub const DZKP_BATCH_UPDATE: &str = "batch.realloc.front";
 
     #[cfg(feature = "web-app")]
     pub mod web {
@@ -109,15 +108,9 @@ pub mod metrics {
         );
 
         describe_counter!(
-            DZKP_BATCH_REALLOCATION_FRONT,
+            DZKP_BATCH_UPDATE,
             Unit::Count,
-            "Number of DZKP reallocations due to records smaller than the offset"
-        );
-
-        describe_counter!(
-            DZKP_BATCH_REALLOCATION_BACK,
-            Unit::Count,
-            "Number of DZKP reallocations due to insufficient length"
+            "Number of DZKP Batch updates, i.e. verifications"
         );
     }
 }


### PR DESCRIPTION
The PR removes the option from vec, and changes some of the more complex and expensive functionalities.

It changes the seq_join function on the validator (now validated_seq_join) and separates the chunk_size parameter in two separate parameters: chunk_size is the amount of futures processed in a single chunk (i.e. DZKP Batch) and multiplication_amount which determines how much memory is allocated within a Batch. 

chunk_size is now an input to validated_seq_join whereas multiplication_amount is specified at the time the validator is generated.

The PR does not make changes to the DZKP conversion which is a separate PR which I will also adjust as discussed: https://github.com/private-attribution/ipa/pull/1032

Upon request by Ben Savage and Alex Koshelev, the PR deletes the reallocation ability of the Batch. If the parameter multiplication_amount is set incorrectly, it will cause a panic and the program crashes (whereas previously it would recover). The benefit is a reduction in code complexity and better maintainability. 