### PR TITLE
Go down from 9 to 8 bits in bool_and operation

### DIFF
--- a/ipa-core/src/protocol/boolean/and.rs
+++ b/ipa-core/src/protocol/boolean/and.rs
@@ -9,21 +9,21 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
 };
 
-const MAX_BITS: usize = 9;
+const MAX_BITS: usize = 8;
 
 #[derive(Step)]
 pub(crate) enum BoolAndStep {
-    #[dynamic(9)] // keep in sync with MAX_BITS
+    #[dynamic(8)] // keep in sync with MAX_BITS
     Bit(usize),
 }
 
-/// Matrix bitwise AND for use with vectors of bit-decomposed values. Supports up to 9 bits of input
-/// that is enough to support both WALR and PRF IPA use cases. IPA currently supports up to
-/// 512 breakdowns (see [`MAX_BREAKDOWN`] limitation) and WALR does not need more than that.
+/// Matrix bitwise AND for use with vectors of bit-decomposed values. Supports up to 8 bits of input
+/// that is enough to support both WALR and PRF IPA use cases.
+///
+/// In IPA this function is used to process trigger values and 8 bit is enough to represent them.
+/// WALR uses it on feature-vector where 8 bits are used to represent decimals.
 /// Limiting the number of bits helps with our static compact gate compilation, so we want this
 /// number to be as small as possible.
-///
-/// [`MAX_BREAKDOWN`]: crate::protocol::ipa_prf::aggregation::bucket::move_single_value_to_bucket
 ///
 /// ## Errors
 /// Propagates errors from the multiplication protocol.
@@ -32,7 +32,7 @@ pub(crate) enum BoolAndStep {
 //
 // Supplying an iterator saves constructing a complete copy of the argument
 // in memory when it is a uniform constant.
-pub async fn bool_and_9_bit<'a, C, BI, const N: usize>(
+pub async fn bool_and_8_bit<'a, C, BI, const N: usize>(
     ctx: C,
     record_id: RecordId,
     a: &BitDecomposed<AdditiveShare<Boolean, N>>,

--- a/ipa-core/src/protocol/ipa_prf/aggregation/bucket.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/bucket.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     ff::boolean::Boolean,
     helpers::repeat_n,
-    protocol::{basics::SecureMul, boolean::and::bool_and_9_bit, context::Context, RecordId},
+    protocol::{basics::SecureMul, boolean::and::bool_and_8_bit, context::Context, RecordId},
     secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
 };
 
@@ -129,7 +129,7 @@ where
                     let index_contribution = &row_contribution[tree_index];
 
                     (robust || tree_index + span < breakdown_count).then(|| {
-                        bool_and_9_bit(
+                        bool_and_8_bit(
                             bucket_c,
                             record_id,
                             index_contribution,

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -13,7 +13,7 @@ use crate::{
     helpers::{repeat_n, stream::TryFlattenItersExt},
     protocol::{
         basics::{SecureMul, ShareKnownValue},
-        boolean::{and::bool_and_9_bit, or::or},
+        boolean::{and::bool_and_8_bit, or::or},
         context::{Context, UpgradedSemiHonestContext},
         ipa_prf::aggregation::aggregate_values,
         BooleanProtocols, RecordId,
@@ -109,7 +109,7 @@ impl InputsRequiredFromPrevRow {
         bit_decomposed_output
             .transpose_from(&input_row.feature_vector)
             .unwrap_infallible();
-        let capped_attributed_feature_vector = bool_and_9_bit(
+        let capped_attributed_feature_vector = bool_and_8_bit(
             ctx,
             record_id,
             &bit_decomposed_output,


### PR DESCRIPTION

Synced up with @benjaminsavage and fixed the documentation for this function - we use it on trigger values, not on breakdown keys.