### PR TITLE
Bring back serde(transparent) on RoleAssignment struct

### DIFF
--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -248,6 +248,7 @@ const_assert!(Role::eq(Role::H3.peer(Direction::Right), Role::H1));
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(transparent)]
 pub struct RoleAssignment {
     helper_roles: [HelperIdentity; 3],
 }

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -112,6 +112,7 @@ mod tests {
     }
 
     #[derive(Serialize)]
+    #[serde(transparent)]
     struct OverrideReqRoles {
         helper_roles: Vec<i8>,
     }


### PR DESCRIPTION
We used to have this attribute, but it was lost in refactoring sometime in April

This change brings it back and fixes unit tests.