### PR TITLE
Specializing the BitStep for integer_add and integer_sub

### DIFF
--- a/ipa-core/src/protocol/boolean/or.rs
+++ b/ipa-core/src/protocol/boolean/or.rs
@@ -3,7 +3,7 @@ use std::iter::zip;
 use crate::{
     error::Error,
     ff::{boolean::Boolean, Field},
-    protocol::{basics::SecureMul, context::Context, step::BitOpStep, RecordId},
+    protocol::{basics::SecureMul, context::Context, step::TwoHundredFiftySixBitOpStep, RecordId},
     secret_sharing::{
         replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd,
         Linear as LinearSecretSharing,
@@ -52,7 +52,7 @@ where
 
     BitDecomposed::try_from(
         ctx.parallel_join(zip(a.iter(), b).enumerate().map(|(i, (a, b))| {
-            let ctx = ctx.narrow(&BitOpStep::Bit(i));
+            let ctx = ctx.narrow(&TwoHundredFiftySixBitOpStep::Bit(i));
             async move {
                 let ab = a.multiply(b, ctx, record_id).await?;
                 Ok::<_, Error>(-ab + a + b)

--- a/ipa-core/src/protocol/context/upgrade.rs
+++ b/ipa-core/src/protocol/context/upgrade.rs
@@ -8,7 +8,7 @@ use crate::{
     ff::Field,
     protocol::{
         context::UpgradedContext,
-        step::{BitOpStep, Gate, Step, StepNarrow},
+        step::{Gate, Step, StepNarrow, TwoHundredFiftySixBitOpStep},
         NoRecord, RecordBinding, RecordId,
     },
     secret_sharing::{
@@ -117,8 +117,10 @@ where
 {
     async fn upgrade(self, input: (T, U)) -> Result<(TM, UM), Error> {
         try_join(
-            self.narrow(&BitOpStep::from(0)).upgrade(input.0),
-            self.narrow(&BitOpStep::from(1)).upgrade(input.1),
+            self.narrow(&TwoHundredFiftySixBitOpStep::from(0))
+                .upgrade(input.0),
+            self.narrow(&TwoHundredFiftySixBitOpStep::from(1))
+                .upgrade(input.1),
         )
         .await
     }

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -21,6 +21,7 @@ use crate::{
             boolean_ops::addition_sequential::{integer_add, integer_sat_add},
             prf_sharding::AttributionOutputs,
         },
+        step::SixteenBitStep,
         RecordId,
     },
     secret_sharing::{
@@ -277,7 +278,7 @@ where
                                 let record_id = RecordId::from(i);
                                 if a.len() < usize::try_from(OV::BITS).unwrap() {
                                     // If we have enough output bits, add and keep the carry.
-                                    let (mut sum, carry) = integer_add::<_, B>(
+                                    let (mut sum, carry) = integer_add::<_, SixteenBitStep, B>(
                                         ctx.narrow(&AggregateValuesStep::OverflowingAdd),
                                         record_id,
                                         &a,
@@ -287,7 +288,7 @@ where
                                     sum.push(carry);
                                     Ok(sum)
                                 } else {
-                                    integer_sat_add::<_, B>(
+                                    integer_sat_add::<_, SixteenBitStep, B>(
                                         ctx.narrow(&AggregateValuesStep::SaturatingAdd),
                                         record_id,
                                         &a,

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -21,7 +21,7 @@ use crate::{
             boolean_ops::addition_sequential::{integer_add, integer_sat_add},
             prf_sharding::AttributionOutputs,
         },
-        step::SixteenBitStep,
+        step::{BitStep, SixteenBitStep},
         RecordId,
     },
     secret_sharing::{
@@ -277,6 +277,10 @@ where
                                 let a = chunk_pair.pop().unwrap();
                                 let record_id = RecordId::from(i);
                                 if a.len() < usize::try_from(OV::BITS).unwrap() {
+                                    assert!(
+                                        OV::BITS <= SixteenBitStep::max_bit_depth(),
+                                        "SixteenBitStep not large enough to accomodate this sum"
+                                    );
                                     // If we have enough output bits, add and keep the carry.
                                     let (mut sum, carry) = integer_add::<_, SixteenBitStep, B>(
                                         ctx.narrow(&AggregateValuesStep::OverflowingAdd),
@@ -288,6 +292,10 @@ where
                                     sum.push(carry);
                                     Ok(sum)
                                 } else {
+                                    assert!(
+                                        OV::BITS <= SixteenBitStep::max_bit_depth(),
+                                        "SixteenBitStep not large enough to accomodate this sum"
+                                    );
                                     integer_sat_add::<_, SixteenBitStep, B>(
                                         ctx.narrow(&AggregateValuesStep::SaturatingAdd),
                                         record_id,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -10,7 +10,7 @@ use crate::{
         basics::{BooleanProtocols, SecureMul},
         boolean::or::bool_or,
         context::{Context, UpgradedSemiHonestContext},
-        step::Step,
+        step::BitStep,
         RecordId,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
@@ -39,7 +39,7 @@ pub async fn integer_add<C, S, const N: usize>(
 >
 where
     C: Context,
-    S: Step + From<usize>,
+    S: BitStep,
     Boolean: FieldSimd<N>,
     AdditiveShare<Boolean, N>: BooleanProtocols<C, N>,
 {
@@ -67,7 +67,7 @@ pub async fn integer_sat_add<'a, SH, S, const N: usize>(
 ) -> Result<BitDecomposed<AdditiveShare<Boolean, N>>, Error>
 where
     SH: ShardBinding,
-    S: Step + From<usize>,
+    S: BitStep,
     Boolean: FieldSimd<N>,
     AdditiveShare<Boolean, N>: BooleanProtocols<UpgradedSemiHonestContext<'a, SH, Boolean>, N>,
 {
@@ -103,7 +103,7 @@ async fn addition_circuit<C, S, const N: usize>(
 ) -> Result<BitDecomposed<AdditiveShare<Boolean, N>>, Error>
 where
     C: Context,
-    S: Step + From<usize>,
+    S: BitStep,
     Boolean: FieldSimd<N>,
     AdditiveShare<Boolean, N>: BooleanProtocols<C, N>,
 {
@@ -170,7 +170,7 @@ mod test {
         protocol::{
             context::Context,
             ipa_prf::boolean_ops::addition_sequential::{integer_add, integer_sat_add},
-            step::SixtyFourBitStep,
+            step::DefaultBitStep,
             RecordId,
         },
         rand::thread_rng,
@@ -197,7 +197,7 @@ mod test {
 
             let (result, carry) = world
                 .semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
-                    integer_add::<_, SixtyFourBitStep, 1>(
+                    integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
                         &x_y.0.to_bits(),
@@ -238,7 +238,7 @@ mod test {
 
             let result = world
                 .upgraded_semi_honest((x_bits, y_bits), |ctx, x_y| async move {
-                    integer_sat_add::<_, SixtyFourBitStep, 1>(
+                    integer_sat_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
                         &x_y.0,
@@ -274,7 +274,7 @@ mod test {
 
             let (result, carry) = world
                 .semi_honest((x_ba64, y_ba32), |ctx, x_y| async move {
-                    integer_add::<_, SixtyFourBitStep, 1>(
+                    integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
                         &x_y.0.to_bits(),
@@ -295,7 +295,7 @@ mod test {
             let expected_carry = (x + y) >> 32 & 1;
             let (result, carry) = world
                 .semi_honest((y_ba32, x_ba64), |ctx, x_y| async move {
-                    integer_add::<_, SixtyFourBitStep, 1>(
+                    integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
                         &x_y.0.to_bits(),

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -15,7 +15,7 @@ use crate::{
     protocol::{
         basics::{BooleanProtocols, SecureMul, ShareKnownValue},
         context::Context,
-        step::BitOpStep,
+        step::Step,
         RecordId,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
@@ -36,7 +36,7 @@ use crate::{
 /// # Errors
 /// Propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn compare_geq<C>(
+pub async fn compare_geq<C, S>(
     ctx: C,
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean>>,
@@ -44,12 +44,13 @@ pub async fn compare_geq<C>(
 ) -> Result<AdditiveShare<Boolean>, Error>
 where
     C: Context,
+    S: Step + From<usize>,
     AdditiveShare<Boolean>: BooleanProtocols<C>,
 {
     // we need to initialize carry to 1 for x>=y,
     let mut carry = AdditiveShare::<Boolean>::share_known_value(&ctx, Boolean::ONE);
     // We don't care about the subtraction, we just want the carry
-    subtraction_circuit(ctx, record_id, x, y, &mut carry).await?;
+    subtraction_circuit::<_, S, 1>(ctx, record_id, x, y, &mut carry).await?;
     Ok(carry)
 }
 
@@ -58,7 +59,7 @@ where
 /// Outputs x>y for length(x) >= log2(y).
 /// # Errors
 /// propagates errors from multiply
-pub async fn compare_gt<C, const N: usize>(
+pub async fn compare_gt<C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean, N>>,
@@ -66,12 +67,13 @@ pub async fn compare_gt<C, const N: usize>(
 ) -> Result<AdditiveShare<Boolean, N>, Error>
 where
     C: Context,
+    S: Step + From<usize>,
     Boolean: FieldSimd<N>,
     AdditiveShare<Boolean, N>: BooleanProtocols<C, N>,
 {
     // we need to initialize carry to 0 for x>y
     let mut carry = AdditiveShare::<Boolean, N>::ZERO;
-    subtraction_circuit(ctx, record_id, x, y, &mut carry).await?;
+    subtraction_circuit::<_, S, N>(ctx, record_id, x, y, &mut carry).await?;
     Ok(carry)
 }
 
@@ -81,7 +83,7 @@ where
 /// length(x) bits of y.
 /// # Errors
 /// propagates errors from multiply
-pub async fn integer_sub<C>(
+pub async fn integer_sub<C, S>(
     ctx: C,
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean>>,
@@ -89,11 +91,12 @@ pub async fn integer_sub<C>(
 ) -> Result<BitDecomposed<AdditiveShare<Boolean>>, Error>
 where
     C: Context,
+    S: Step + From<usize>,
     AdditiveShare<Boolean>: BooleanProtocols<C>,
 {
     // we need to initialize carry to 1 for a subtraction
     let mut carry = AdditiveShare::<Boolean>::share_known_value(&ctx, Boolean::ONE);
-    subtraction_circuit(ctx, record_id, x, y, &mut carry).await
+    subtraction_circuit::<_, S, 1>(ctx, record_id, x, y, &mut carry).await
 }
 
 /// saturated unsigned integer subtraction
@@ -102,7 +105,7 @@ where
 /// # Errors
 /// propagates errors from multiply
 #[cfg(all(test, unit_test))]
-pub async fn integer_sat_sub<S>(
+pub async fn integer_sat_sub<S, St>(
     ctx: SemiHonestContext<'_>,
     record_id: RecordId,
     x: &AdditiveShare<S>,
@@ -110,6 +113,7 @@ pub async fn integer_sat_sub<S>(
 ) -> Result<AdditiveShare<S>, Error>
 where
     S: SharedValue + CustomArray<Element = Boolean>,
+    St: Step + From<usize>,
     for<'a> AdditiveShare<S>: BooleanArrayMul<SemiHonestContext<'a>>,
 {
     use crate::ff::ArrayAccess;
@@ -121,7 +125,7 @@ where
     }
 
     let mut carry = !AdditiveShare::<Boolean>::ZERO;
-    let result = subtraction_circuit(
+    let result = subtraction_circuit::<_, St, 1>(
         ctx.narrow(&Step::Subtract),
         record_id,
         &x.to_bits(),
@@ -150,7 +154,7 @@ where
 ///
 /// # Errors
 /// propagates errors from multiply
-async fn subtraction_circuit<C, const N: usize>(
+async fn subtraction_circuit<C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean, N>>,
@@ -159,6 +163,7 @@ async fn subtraction_circuit<C, const N: usize>(
 ) -> Result<BitDecomposed<AdditiveShare<Boolean, N>>, Error>
 where
     C: Context,
+    S: Step + From<usize>,
     Boolean: FieldSimd<N>,
     AdditiveShare<Boolean, N>: BooleanProtocols<C, N>,
 {
@@ -171,8 +176,7 @@ where
         .zip(y.chain(repeat(&AdditiveShare::<Boolean, N>::ZERO)))
         .enumerate()
     {
-        result
-            .push(bit_subtractor(ctx.narrow(&BitOpStep::from(i)), record_id, xb, yb, carry).await?);
+        result.push(bit_subtractor(ctx.narrow(&S::from(i)), record_id, xb, yb, carry).await?);
     }
     Ok(result)
 }
@@ -237,6 +241,7 @@ mod test {
             ipa_prf::boolean_ops::comparison_and_subtraction_sequential::{
                 compare_geq, compare_gt, integer_sat_sub, integer_sub,
             },
+            step::{EightBitStep, SixtyFourBitStep},
             RecordId,
         },
         rand::thread_rng,
@@ -297,7 +302,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
-                    compare_geq(
+                    compare_geq::<_, SixtyFourBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0].to_bits(),
@@ -313,7 +318,7 @@ mod test {
 
             let result2 = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    compare_geq(
+                    compare_geq::<_, SixtyFourBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0].to_bits(),
@@ -344,7 +349,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
-                    compare_gt::<_, 1>(
+                    compare_gt::<_, SixtyFourBitStep, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0].to_bits(),
@@ -361,7 +366,7 @@ mod test {
             // check that x is not greater than itself
             let result2 = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    compare_gt::<_, 1>(
+                    compare_gt::<_, SixtyFourBitStep, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0].to_bits(),
@@ -406,7 +411,13 @@ mod test {
                         ctx.active_work(),
                         stream_iter(x.into_iter().zip(repeat((ctx, y))).enumerate().map(
                             |(i, (x, (ctx, y)))| async move {
-                                compare_gt(ctx, RecordId::from(i), &x.to_bits(), &y.to_bits()).await
+                                compare_gt::<_, SixtyFourBitStep, 1>(
+                                    ctx,
+                                    RecordId::from(i),
+                                    &x.to_bits(),
+                                    &y.to_bits(),
+                                )
+                                .await
                             },
                         )),
                     )
@@ -483,7 +494,8 @@ mod test {
                         ctx.active_work(),
                         stream_iter(x.into_iter().zip(repeat((ctx, y))).enumerate().map(
                             |(i, (x, (ctx, y)))| async move {
-                                compare_gt(ctx, RecordId::from(i), &x, &y).await
+                                compare_gt::<_, SixtyFourBitStep, N>(ctx, RecordId::from(i), &x, &y)
+                                    .await
                             },
                         )),
                     )
@@ -526,7 +538,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    integer_sub(
+                    integer_sub::<_, SixtyFourBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0].to_bits(),
@@ -557,7 +569,7 @@ mod test {
 
             let result = world
                 .semi_honest(records.into_iter(), |ctx, x_y| async move {
-                    integer_sat_sub::<_>(
+                    integer_sat_sub::<_, SixtyFourBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y[0],
@@ -584,7 +596,7 @@ mod test {
 
             let result = world
                 .semi_honest((x, y), |ctx, x_y| async move {
-                    integer_sub(
+                    integer_sub::<_, EightBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y.0.to_bits(),
@@ -616,7 +628,7 @@ mod test {
 
             let result = world
                 .semi_honest(records, |ctx, x_y| async move {
-                    integer_sub(
+                    integer_sub::<_, SixtyFourBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
                         &x_y.0.to_bits(),

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -14,6 +14,7 @@ use crate::{
         context::Context,
         ipa_prf::boolean_ops::addition_sequential::integer_add,
         prss::{FromPrss, SharedRandomness},
+        step::TwoHundredFiftySixBitOpStep,
         RecordId,
     },
     secret_sharing::{
@@ -129,7 +130,7 @@ where
     // addition r+s might cause carry,
     // this is no problem since we have set bit 254 of sh_r and sh_s to 0
     let sh_rs = {
-        let (mut rs_with_higherorderbits, _) = integer_add::<_, N>(
+        let (mut rs_with_higherorderbits, _) = integer_add::<_, TwoHundredFiftySixBitOpStep, N>(
             ctx.narrow(&Step::IntegerAddBetweenMasks),
             record_id,
             &sh_r,
@@ -147,8 +148,13 @@ where
 
     // addition x+rs, where rs=r+s might cause carry
     // this is not a problem since bit 255 of rs is set to 0
-    let (sh_y, _) =
-        integer_add::<_, N>(ctx.narrow(&Step::IntegerAddMaskToX), record_id, &sh_rs, &x).await?;
+    let (sh_y, _) = integer_add::<_, TwoHundredFiftySixBitOpStep, N>(
+        ctx.narrow(&Step::IntegerAddMaskToX),
+        record_id,
+        &sh_rs,
+        &x,
+    )
+    .await?;
 
     // this leaks information, but with negligible probability
     let mut y = (ctx.role() != Role::H3).then(|| Vec::with_capacity(N));

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -35,7 +35,7 @@ use crate::{
             },
             AGG_CHUNK,
         },
-        step::{EightBitStep, ThirtyTwoBitStep},
+        step::{BitStep, EightBitStep, ThirtyTwoBitStep},
         RecordId,
     },
     secret_sharing::{
@@ -190,7 +190,7 @@ where
         .await?;
 
         assert!(
-            TV::BITS <= 8,
+            TV::BITS <= EightBitStep::max_bit_depth(),
             "EightBitStep not large enough to accomodate this sum"
         );
         let (updated_sum, overflow_bit) = integer_add::<_, EightBitStep, 1>(
@@ -202,7 +202,7 @@ where
         .await?;
 
         assert!(
-            TV::BITS <= 8,
+            TV::BITS <= EightBitStep::max_bit_depth(),
             "EightBitStep not large enough to accomodate this subtraction"
         );
         let (overflow_bit_and_prev_row_not_saturated, difference_to_cap) = try_join(
@@ -690,7 +690,7 @@ where
 {
     if let Some(attribution_window_seconds) = attribution_window_seconds {
         assert!(
-            TS::BITS <= 32,
+            TS::BITS <= ThirtyTwoBitStep::max_bit_depth(),
             "ThirtyTwoBitStep is not large enough to accomodate this subtraction"
         );
         let time_delta_bits = integer_sub::<_, ThirtyTwoBitStep>(

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -12,7 +12,7 @@ use crate::{
         basics::Reveal,
         context::{Context, SemiHonestContext},
         ipa_prf::{boolean_ops::comparison_and_subtraction_sequential::compare_gt, SORT_CHUNK},
-        step::ThirtyTwoBitStep,
+        step::{BitStep, ThirtyTwoBitStep},
         RecordId,
     },
     secret_sharing::{
@@ -173,7 +173,7 @@ where
                 .map(Ok);
 
         assert!(
-            K::BITS <= 32,
+            K::BITS <= ThirtyTwoBitStep::max_bit_depth(),
             "ThirtyTwoBitStep is not large enough to accomodate this sort"
         );
         let comp: BitVec<usize, Lsb0> = seq_join(

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -12,6 +12,7 @@ use crate::{
         basics::Reveal,
         context::{Context, SemiHonestContext},
         ipa_prf::{boolean_ops::comparison_and_subtraction_sequential::compare_gt, SORT_CHUNK},
+        step::ThirtyTwoBitStep,
         RecordId,
     },
     secret_sharing::{
@@ -171,6 +172,10 @@ where
                 })
                 .map(Ok);
 
+        assert!(
+            K::BITS <= 32,
+            "ThirtyTwoBitStep is not large enough to accomodate this sort"
+        );
         let comp: BitVec<usize, Lsb0> = seq_join(
             ctx.active_work(),
             process_stream_by_chunks::<_, _, _, _, _, _, _, SORT_CHUNK>(
@@ -182,11 +187,12 @@ where
                     let record_id = RecordId::from(idx);
                     async move {
                         // Compare the current element against pivot and reveal the result.
-                        let comparison =
-                            compare_gt::<_, SORT_CHUNK>(cmp_ctx, record_id, &k, &pivot)
-                                .await?
-                                .reveal(rvl_ctx, record_id) // reveal outcome of comparison
-                                .await?;
+                        let comparison = compare_gt::<_, ThirtyTwoBitStep, SORT_CHUNK>(
+                            cmp_ctx, record_id, &k, &pivot,
+                        )
+                        .await?
+                        .reveal(rvl_ctx, record_id) // reveal outcome of comparison
+                        .await?;
 
                         // desc = true will flip the order of the sort
                         Ok::<_, Error>(comparison + !desc)

--- a/ipa-core/src/protocol/step/mod.rs
+++ b/ipa-core/src/protocol/step/mod.rs
@@ -53,28 +53,8 @@ impl Step for str {}
 ///
 /// This is a temporary solution for narrowing contexts until the infra is
 /// updated with a new step scheme.
-#[derive(Step)]
-pub enum TwoHundredFiftySixBitOpStep {
-    #[dynamic(256)]
-    Bit(usize),
-}
-
-impl From<i32> for TwoHundredFiftySixBitOpStep {
-    fn from(v: i32) -> Self {
-        Self::Bit(usize::try_from(v).unwrap())
-    }
-}
-
-impl From<u32> for TwoHundredFiftySixBitOpStep {
-    fn from(v: u32) -> Self {
-        Self::Bit(usize::try_from(v).unwrap())
-    }
-}
-
-impl From<usize> for TwoHundredFiftySixBitOpStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
+pub trait BitStep: Step + From<usize> {
+    fn max_bit_depth() -> u32;
 }
 
 #[derive(Step)]
@@ -86,6 +66,12 @@ pub enum EightBitStep {
 impl From<usize> for EightBitStep {
     fn from(v: usize) -> Self {
         Self::Bit(v)
+    }
+}
+
+impl BitStep for EightBitStep {
+    fn max_bit_depth() -> u32 {
+        8
     }
 }
 
@@ -101,6 +87,12 @@ impl From<usize> for SixteenBitStep {
     }
 }
 
+impl BitStep for SixteenBitStep {
+    fn max_bit_depth() -> u32 {
+        16
+    }
+}
+
 #[derive(Step)]
 pub enum ThirtyTwoBitStep {
     #[dynamic(32)]
@@ -113,14 +105,47 @@ impl From<usize> for ThirtyTwoBitStep {
     }
 }
 
+impl BitStep for ThirtyTwoBitStep {
+    fn max_bit_depth() -> u32 {
+        32
+    }
+}
+
 #[derive(Step)]
-pub enum SixtyFourBitStep {
-    #[dynamic(64)]
+pub enum TwoHundredFiftySixBitOpStep {
+    #[dynamic(256)]
     Bit(usize),
 }
 
-impl From<usize> for SixtyFourBitStep {
+impl BitStep for TwoHundredFiftySixBitOpStep {
+    fn max_bit_depth() -> u32 {
+        256
+    }
+}
+
+impl From<usize> for TwoHundredFiftySixBitOpStep {
     fn from(v: usize) -> Self {
         Self::Bit(v)
+    }
+}
+
+#[cfg(test)]
+#[derive(Step)]
+pub enum DefaultBitStep {
+    #[dynamic(256)]
+    Bit(usize),
+}
+
+#[cfg(test)]
+impl From<usize> for DefaultBitStep {
+    fn from(v: usize) -> Self {
+        Self::Bit(v)
+    }
+}
+
+#[cfg(test)]
+impl BitStep for DefaultBitStep {
+    fn max_bit_depth() -> u32 {
+        256
     }
 }

--- a/ipa-core/src/protocol/step/mod.rs
+++ b/ipa-core/src/protocol/step/mod.rs
@@ -54,24 +54,72 @@ impl Step for str {}
 /// This is a temporary solution for narrowing contexts until the infra is
 /// updated with a new step scheme.
 #[derive(Step)]
-pub enum BitOpStep {
+pub enum TwoHundredFiftySixBitOpStep {
     #[dynamic(256)]
     Bit(usize),
 }
 
-impl From<i32> for BitOpStep {
+impl From<i32> for TwoHundredFiftySixBitOpStep {
     fn from(v: i32) -> Self {
         Self::Bit(usize::try_from(v).unwrap())
     }
 }
 
-impl From<u32> for BitOpStep {
+impl From<u32> for TwoHundredFiftySixBitOpStep {
     fn from(v: u32) -> Self {
         Self::Bit(usize::try_from(v).unwrap())
     }
 }
 
-impl From<usize> for BitOpStep {
+impl From<usize> for TwoHundredFiftySixBitOpStep {
+    fn from(v: usize) -> Self {
+        Self::Bit(v)
+    }
+}
+
+#[derive(Step)]
+pub enum EightBitStep {
+    #[dynamic(8)]
+    Bit(usize),
+}
+
+impl From<usize> for EightBitStep {
+    fn from(v: usize) -> Self {
+        Self::Bit(v)
+    }
+}
+
+#[derive(Step)]
+pub enum SixteenBitStep {
+    #[dynamic(16)]
+    Bit(usize),
+}
+
+impl From<usize> for SixteenBitStep {
+    fn from(v: usize) -> Self {
+        Self::Bit(v)
+    }
+}
+
+#[derive(Step)]
+pub enum ThirtyTwoBitStep {
+    #[dynamic(32)]
+    Bit(usize),
+}
+
+impl From<usize> for ThirtyTwoBitStep {
+    fn from(v: usize) -> Self {
+        Self::Bit(v)
+    }
+}
+
+#[derive(Step)]
+pub enum SixtyFourBitStep {
+    #[dynamic(64)]
+    Bit(usize),
+}
+
+impl From<usize> for SixtyFourBitStep {
     fn from(v: usize) -> Self {
         Self::Bit(v)
     }


### PR DESCRIPTION
…based on how many are actually needed.

This is my second attempt. @martinthomson says the approach in #1065 will not work in terms of reducing the total number of compact gate steps that will be generated with the new approach. Hopefully this approach works better!