### PR TITLE
Reduce default active work 1024 -> 32

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -221,7 +221,7 @@ impl Gateway {
 
 impl Default for GatewayConfig {
     fn default() -> Self {
-        Self::new(1024)
+        Self::new(32)
     }
 }
 


### PR DESCRIPTION
My theory is that we are deadlocking around HTTP communication because data segments of 1,024 vectorized messages are too large relative to our buffering.

Considering only steps that involve communication, the following four protocol steps occur in sequence:
* PRF evaluation: Multiply r * y
* PRF evaluation: Reveal R
* PRF evaluation: Reveal z
* Quicksort: Bit 0 subtraction for first pass

Note: there is a rate mismatch between PRF evaluation and quicksort (PRF is vectorized by 64 and quicksort is vectorized by 256). However, unlike the stall cases we saw before, all of the PRF output is collected into a vector before beginning quicksort. Also, for input sizes of 50,000 records, a segment of 1,024 vectorized records spans the entire protocol, meaning there is only one segment of step data to be transferred. The size of this segment is $$\lceil \frac{50{,}000}{64} \rceil \cdot 64 \cdot 32 = 1{,}601{,}536~\mathrm{B}$$

I have seen hangs involving the first three of those steps (spread across the three helpers), or the last three of those steps. The signature of the hang is:
* Helper N waits for step S data from helper N - 1. 
* Helper N - 1 waits for step S - 1 data from helper N - 2.
* Helper N - 2 waits for step S - 2 data from helper N

In the multiply and reveal protocols, when helper is waiting to receive step data from the left, that means it has already sent step data to the right. Thus, when helper N is waiting for step S data from helper N - 1, it has already sent step S data to helper N + 1. In the stall state, the following step data is outstanding simultaneously:
* Data for step S - 2 being sent from helper N to helper N + 1 (N - 2)
* Data for step S being sent from helper N to helper N + 1

The theory is that a deadlock can occur if the data for step S - 2 is blocked behind data for step S. 