### PR TITLE
Remove type parameter from `trait UpgradedContext`

### DIFF
--- a/ipa-core/src/protocol/basics/share_known_value.rs
+++ b/ipa-core/src/protocol/basics/share_known_value.rs
@@ -1,6 +1,6 @@
 use crate::{
     helpers::Role,
-    protocol::context::{Context, UpgradedContext, UpgradedMaliciousContext},
+    protocol::context::{Context, UpgradedMaliciousContext},
     secret_sharing::{
         replicated::{
             malicious::{AdditiveShare as MaliciousReplicated, ExtendableField},

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -218,18 +218,19 @@ impl<'a, F: ExtendableField> Upgraded<'a, F> {
             NotSharded,
         )
     }
-}
 
-#[async_trait]
-impl<'a, F: ExtendableField> UpgradedContext<F> for Upgraded<'a, F> {
-    type Share = MaliciousReplicated<F>;
-
-    fn share_known_value(&self, value: F) -> MaliciousReplicated<F> {
+    pub fn share_known_value(&self, value: F) -> MaliciousReplicated<F> {
         MaliciousReplicated::new(
             Replicated::share_known_value(&self.clone().base_context(), value),
             &self.inner.r_share * value.to_extended(),
         )
     }
+}
+
+#[async_trait]
+impl<'a, F: ExtendableField> UpgradedContext for Upgraded<'a, F> {
+    type Field = F;
+    type Share = MaliciousReplicated<F>;
 
     async fn upgrade_one(
         &self,

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -15,7 +15,6 @@ use crate::{
         TotalRecords,
     },
     protocol::{
-        basics::ShareKnownValue,
         context::{
             dzkp_semi_honest::DZKPUpgraded, dzkp_validator::SemiHonestDZKPValidator,
             validator::SemiHonest as Validator, Base, InstrumentedIndexedSharedRandomness,
@@ -266,12 +265,9 @@ impl<'a, B: ShardBinding, F: ExtendableField> SeqJoin for Upgraded<'a, B, F> {
 }
 
 #[async_trait]
-impl<'a, B: ShardBinding, F: ExtendableField> UpgradedContext<F> for Upgraded<'a, B, F> {
+impl<'a, B: ShardBinding, F: ExtendableField> UpgradedContext for Upgraded<'a, B, F> {
+    type Field = F;
     type Share = Replicated<F>;
-
-    fn share_known_value(&self, value: F) -> Self::Share {
-        Replicated::share_known_value(&self.inner, value)
-    }
 
     async fn upgrade_one(
         &self,

--- a/ipa-core/src/protocol/context/upgrade.rs
+++ b/ipa-core/src/protocol/context/upgrade.rs
@@ -33,12 +33,12 @@ use crate::{
 /// };
 /// // Note: Unbound upgrades only work when testing.
 /// #[cfg(test)]
-/// let _ = <UpgradeContext<C<'_, F>, F, NoRecord> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, F, RecordId> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
+/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
+/// let _ = <UpgradeContext<C<'_, F>, RecordId> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
 /// #[cfg(test)]
-/// let _ = <UpgradeContext<C<'_, F>, F, NoRecord> as UpgradeToMalicious<(Replicated<F>, Replicated<F>), _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, F, NoRecord> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, F, NoRecord> as UpgradeToMalicious<(Vec<Replicated<F>>, Vec<Replicated<F>>), _>>::upgrade;
+/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<(Replicated<F>, Replicated<F>), _>>::upgrade;
+/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
+/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<(Vec<Replicated<F>>, Vec<Replicated<F>>), _>>::upgrade;
 /// ```
 ///
 /// ```compile_fail
@@ -49,29 +49,21 @@ use crate::{
 /// };
 /// // This can't be upgraded with a record-bound context because the record ID
 /// // is used internally for vector indexing.
-/// let _ = <UpgradeContext<C<'_, F>, F, RecordId> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
-pub struct UpgradeContext<
-    'a,
-    C: UpgradedContext<F>,
-    F: ExtendableField,
-    B: RecordBinding = NoRecord,
-> {
+/// let _ = <UpgradeContext<C<'_, F>, RecordId> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
+pub struct UpgradeContext<C: UpgradedContext, B: RecordBinding = NoRecord> {
     ctx: C,
     record_binding: B,
-    _lifetime: PhantomData<&'a F>,
 }
 
-impl<'a, C, F, B> UpgradeContext<'a, C, F, B>
+impl<C, B> UpgradeContext<C, B>
 where
-    C: UpgradedContext<F>,
-    F: ExtendableField,
+    C: UpgradedContext,
     B: RecordBinding,
 {
     pub fn new(ctx: C, record_binding: B) -> Self {
         Self {
             ctx,
             record_binding,
-            _lifetime: PhantomData,
         }
     }
 
@@ -84,7 +76,7 @@ where
 }
 
 #[async_trait]
-pub trait UpgradeToMalicious<'a, T, M>
+pub trait UpgradeToMalicious<T, M>
 where
     T: Send,
 {
@@ -92,10 +84,9 @@ where
 }
 
 #[async_trait]
-impl<'a, C, F> UpgradeToMalicious<'a, (), ()> for UpgradeContext<'a, C, F, NoRecord>
+impl<C> UpgradeToMalicious<(), ()> for UpgradeContext<C, NoRecord>
 where
-    C: UpgradedContext<F>,
-    F: ExtendableField,
+    C: UpgradedContext,
 {
     async fn upgrade(self, _input: ()) -> Result<(), Error> {
         Ok(())
@@ -103,17 +94,14 @@ where
 }
 
 #[async_trait]
-impl<'a, C, F, T, TM, U, UM> UpgradeToMalicious<'a, (T, U), (TM, UM)>
-    for UpgradeContext<'a, C, F, NoRecord>
+impl<C, T, TM, U, UM> UpgradeToMalicious<(T, U), (TM, UM)> for UpgradeContext<C, NoRecord>
 where
-    C: UpgradedContext<F>,
-    F: ExtendableField,
+    C: UpgradedContext,
     T: Send + 'static,
     U: Send + 'static,
     TM: Send + Sized + 'static,
     UM: Send + Sized + 'static,
-    for<'u> UpgradeContext<'u, C, F, NoRecord>:
-        UpgradeToMalicious<'u, T, TM> + UpgradeToMalicious<'u, U, UM>,
+    UpgradeContext<C, NoRecord>: UpgradeToMalicious<T, TM> + UpgradeToMalicious<U, UM>,
 {
     async fn upgrade(self, input: (T, U)) -> Result<(TM, UM), Error> {
         try_join(
@@ -127,15 +115,14 @@ where
 }
 
 #[async_trait]
-impl<'a, C, F, I, M> UpgradeToMalicious<'a, I, Vec<M>> for UpgradeContext<'a, C, F, NoRecord>
+impl<C, I, M> UpgradeToMalicious<I, Vec<M>> for UpgradeContext<C, NoRecord>
 where
-    C: UpgradedContext<F>,
-    F: ExtendableField,
+    C: UpgradedContext,
     I: IntoIterator + Send + 'static,
     I::IntoIter: ExactSizeIterator + Send,
     I::Item: Send + 'static,
     M: Send + 'static,
-    for<'u> UpgradeContext<'u, C, F, RecordId>: UpgradeToMalicious<'u, I::Item, M>,
+    UpgradeContext<C, RecordId>: UpgradeToMalicious<I::Item, M>,
 {
     async fn upgrade(self, input: I) -> Result<Vec<M>, Error> {
         let iter = input.into_iter();
@@ -152,10 +139,9 @@ where
 }
 
 #[async_trait]
-impl<'a, C, F> UpgradeToMalicious<'a, Replicated<F>, C::Share>
-    for UpgradeContext<'a, C, F, RecordId>
+impl<C, F> UpgradeToMalicious<Replicated<F>, C::Share> for UpgradeContext<C, RecordId>
 where
-    C: UpgradedContext<F>,
+    C: UpgradedContext<Field = F>,
     F: ExtendableField,
 {
     async fn upgrade(self, input: Replicated<F>) -> Result<C::Share, Error> {
@@ -183,12 +169,12 @@ impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRowWrapper<F, 
 // Impl to upgrade a single `Replicated<F>` using a non-record-bound context. Used for tests.
 #[cfg(test)]
 #[async_trait]
-impl<'a, C, F, M> UpgradeToMalicious<'a, Replicated<F>, M> for UpgradeContext<'a, C, F, NoRecord>
+impl<C, F, M> UpgradeToMalicious<Replicated<F>, M> for UpgradeContext<C, NoRecord>
 where
-    C: UpgradedContext<F>,
+    C: UpgradedContext,
     F: ExtendableField,
     M: 'static,
-    for<'u> UpgradeContext<'u, C, F, RecordId>: UpgradeToMalicious<'u, Replicated<F>, M>,
+    UpgradeContext<C, RecordId>: UpgradeToMalicious<Replicated<F>, M>,
 {
     async fn upgrade(self, input: Replicated<F>) -> Result<M, Error> {
         let ctx = if self.ctx.total_records().is_specified() {

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -240,7 +240,7 @@ async fn compute_prf_for_inputs<C, BK, TV, TS>(
 ) -> Result<Vec<PrfShardedIpaInputRow<BK, TV, TS>>, Error>
 where
     C: UpgradableContext,
-    C::UpgradedContext<Boolean>: UpgradedContext<Boolean, Share = Replicated<Boolean>>,
+    C::UpgradedContext<Boolean>: UpgradedContext<Field = Boolean, Share = Replicated<Boolean>>,
     BK: SharedValue + CustomArray<Element = Boolean>,
     TV: SharedValue + CustomArray<Element = Boolean>,
     TS: SharedValue + CustomArray<Element = Boolean>,

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -376,8 +376,7 @@ pub trait Runner<S: ShardingScheme> {
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
-        for<'u> UpgradeContext<'u, UpgradedMaliciousContext<'a, F>, F>:
-            UpgradeToMalicious<'u, A, M>,
+        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,
@@ -469,8 +468,7 @@ impl<const SHARDS: usize, D: Distribute> Runner<WithShards<SHARDS, D>>
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
-        for<'u> UpgradeContext<'u, UpgradedMaliciousContext<'a, F>, F>:
-            UpgradeToMalicious<'u, A, M>,
+        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,
@@ -552,8 +550,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
-        for<'u> UpgradeContext<'u, UpgradedMaliciousContext<'a, F>, F>:
-            UpgradeToMalicious<'u, A, M>,
+        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,


### PR DESCRIPTION
... and make it an associated type instead.

My intuition for when the type parameter on the trait is needed is when the same trait needs to be implemented multiple times on a particular type, with some aspect of the implementation that varies based on the value of the type parameter. That is not the case for our concrete use case of this trait -- the MAC-based malicious protocol is associated with one particular field and can only work with values of that field.

If many of the places referencing the trait need to specify the value of the type, then it is more compact to specify a type parameter (`Trait<T>`) than an associated type bound (`Trait<Foo = SomeType>`). I applied this rationale for the `SharedValueArray` vectorization-related trait, but I don't think it's relevant here.

I initially made this change before modulus conversion (and a bunch of other IPAv2 protocols) was removed. The modulus conversion stuff had a bunch of places that the `UpgradedContext<Field = ...>` associated type bound was needed.

I expected this change to make other changes I was working on for reveal safety simpler. Given the current (more minimal) state of the code base, I'm not sure this change makes a huge difference. On the other hand, this change makes the MAC malicious `UpgradedContext` trait look more like the DZKP-malicious `DZKPContext` trait (which also doesn't have a type parameter), and that seems like a reasonable justification for it.