### PR TITLE
Small aggregation changes and test speedup

### DIFF
--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -14,19 +14,26 @@ use typenum::Unsigned;
 
 use crate::{
     cli::IpaQueryResult,
-    ff::{Serializable, U128Conversions},
+    ff::{
+        boolean_array::{BA20, BA3, BA8},
+        Serializable, U128Conversions,
+    },
     helpers::{
         query::{IpaQueryConfig, QueryInput, QuerySize},
         BodyStream,
     },
     hpke::PublicKeyRegistry,
     net::MpcHelperClient,
-    protocol::{ipa_prf::OPRFIPAInputRow, BreakdownKey, QueryId, Timestamp, TriggerValue},
+    protocol::{ipa_prf::OPRFIPAInputRow, QueryId},
     query::QueryStatus,
     report::{KeyIdentifier, OprfReport},
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares, SharedValue},
     test_fixture::{ipa::TestRawDataRecord, Reconstruct},
 };
+
+type BreakdownKey = BA8;
+type Timestamp = BA20;
+type TriggerValue = BA3;
 
 /// Executes the IPA v3 protocol.
 ///

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -4,13 +4,13 @@ use std::{
     pin::Pin,
 };
 
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
     ff::{boolean::Boolean, CustomArray, U128Conversions},
     helpers::{
-        stream::{process_stream_by_chunks, Chunk, ChunkBuffer, FixedLength, TryFlattenItersExt},
+        stream::{process_stream_by_chunks, ChunkBuffer, FixedLength, TryFlattenItersExt},
         TotalRecords,
     },
     protocol::{
@@ -21,6 +21,7 @@ use crate::{
             aggregation::step::{AggregateValuesStep, AggregationStep as Step},
             boolean_ops::addition_sequential::{integer_add, integer_sat_add},
             prf_sharding::AttributionOutputs,
+            BreakdownKey,
         },
         RecordId,
     },
@@ -128,7 +129,7 @@ pub async fn aggregate_contributions<'ctx, St, BK, TV, HV, const B: usize, const
 ) -> Result<Vec<Replicated<HV>>, Error>
 where
     St: Stream<Item = Result<AttributionOutputs<Replicated<BK>, Replicated<TV>>, Error>> + Send,
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    BK: BreakdownKey<B>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     Boolean: FieldSimd<N> + FieldSimd<B>,
@@ -145,7 +146,6 @@ where
     Vec<Replicated<HV>>:
         for<'a> TransposeFrom<&'a BitDecomposed<Replicated<Boolean, B>>, Error = LengthError>,
 {
-    let num_chunks = (contributions_stream_len + N - 1) / N;
     // Indeterminate TotalRecords is currently required because aggregation does not poll futures in
     // parallel (thus cannot reach a batch of records).
     let bucket_ctx = ctx
@@ -181,21 +181,25 @@ where
 
     let aggregation_input = Box::pin(
         row_contribution_chunk_stream
-            // The final chunk from the previous stage is padded with zero-credit records. Rather
-            // than transpose out of vectorized form, flatten the chunked stream, discard the
-            // trailing records, and transpose again for final aggregation, we instead call into_raw
-            // to get the padded record chunk and transpose directly to the form we need for the
-            // final stage. Including the zero-credit padding records does not affect the final
-            // output.
-            .then(|fut| async move { fut.await.map(Chunk::into_raw) })
-            .map_ok(|chunk| {
-                // This is the aggregation intermediate transpose, see the function comment.
-                Vec::transposed_from(chunk.as_slice()).unwrap_infallible()
+            // Rather than transpose out of record-vectorized form and then transpose again back
+            // into bucket-vectorized form, we use a special transpose (the "aggregation
+            // intermediate transpose") that combines the two steps.
+            //
+            // Since the bucket-vectorized representation is separable by records, we do the
+            // transpose within the `Chunk` wrapper using `Chunk::map`, and then invoke
+            // `Chunk::into_iter` via `try_flatten_iters` to produce an unchunked stream of
+            // records, vectorized by buckets.
+            .then(|fut| {
+                fut.map(|res| {
+                    res.map(|chunk| {
+                        chunk.map(|data| Vec::transposed_from(data.as_slice()).unwrap_infallible())
+                    })
+                })
             })
-            .try_flatten_iters::<BitDecomposed<_>, Vec<_>>(),
+            .try_flatten_iters(),
     );
 
-    aggregate_values::<_, B>(ctx, aggregation_input, num_chunks * N).await
+    aggregate_values::<_, B>(ctx, aggregation_input, contributions_stream_len).await
 }
 
 /// A vector of histogram contributions for each output bucket.

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -8,8 +8,10 @@ use self::{quicksort::quicksort_ranges_by_key_insecure, shuffle::shuffle_inputs}
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
     ff::{
-        boolean::Boolean, boolean_array::BA64, ec_prime_field::Fp25519, CustomArray, Serializable,
-        U128Conversions,
+        boolean::Boolean,
+        boolean_array::{BA5, BA64, BA8},
+        ec_prime_field::Fp25519,
+        CustomArray, Serializable, U128Conversions,
     },
     helpers::stream::{process_slice_by_chunks, ChunkData, TryFlattenItersExt},
     protocol::{
@@ -51,6 +53,26 @@ pub(crate) mod step;
 pub type MatchKey = BA64;
 /// Match key size
 pub const MK_BITS: usize = BA64::BITS as usize;
+
+// In theory, we could support (runtime-configured breakdown count) ≤ (compile-time breakdown count)
+// ≤ 2^|bk|, with all three values distinct, but at present, there is no runtime configuration and
+// the latter two must be equal. The implementation of `move_single_value_to_bucket` does support a
+// runtime-specified count via the `breakdown_count` parameter, and implements a runtime check of
+// its value.
+//
+// It would usually be more appropriate to make `MAX_BREAKDOWNS` an associated constant rather than
+// a const parameter. However, we want to use it to enforce a correct pairing of the `BK` type
+// parameter and the `B` const parameter, and specifying a constraint like
+// `BreakdownKey<MAX_BREAKDOWNS = B>` on an associated constant is not currently supported. (Nor is
+// supplying an associated constant `<BK as BreakdownKey>::MAX_BREAKDOWNS` as the value of a const
+// parameter.) Structured the way we have it, it probably doesn't make sense to use the
+// `BreakdownKey` trait in places where the `B` const parameter is not already available.
+pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>:
+    SharedValue + U128Conversions + CustomArray<Element = Boolean>
+{
+}
+impl BreakdownKey<32> for BA5 {}
+impl BreakdownKey<256> for BA8 {}
 
 /// Vectorization dimension for PRF
 pub const PRF_CHUNK: usize = 64;
@@ -188,7 +210,7 @@ pub async fn oprf_ipa<'ctx, BK, TV, HV, TS, const SS_BITS: usize, const B: usize
     attribution_window_seconds: Option<NonZeroU32>,
 ) -> Result<Vec<Replicated<HV>>, Error>
 where
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    BK: BreakdownKey<B>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
@@ -316,7 +338,7 @@ where
 pub mod tests {
     use crate::{
         ff::{
-            boolean_array::{BA16, BA20, BA3, BA8},
+            boolean_array::{BA20, BA3, BA5, BA8},
             U128Conversions,
         },
         protocol::ipa_prf::oprf_ipa,
@@ -357,7 +379,7 @@ pub mod tests {
 
             let mut result: Vec<_> = world
                 .semi_honest(records.into_iter(), |ctx, input_rows| async move {
-                    oprf_ipa::<BA8, BA3, BA16, BA20, 5, 256>(ctx, input_rows, None)
+                    oprf_ipa::<BA5, BA3, BA8, BA20, 5, 32>(ctx, input_rows, None)
                         .await
                         .unwrap()
                 })
@@ -382,6 +404,8 @@ pub mod tests {
     #[test]
     fn duplicate_timestamps() {
         use rand::{seq::SliceRandom, thread_rng};
+
+        use crate::ff::boolean_array::BA16;
 
         const EXPECTED: &[u128] = &[0, 2, 10, 0, 0, 0, 0, 0];
 

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -41,7 +41,7 @@ use crate::{
                 AttributionWindowStep as WindowStep,
                 AttributionZeroOutTriggerStep as ZeroOutTriggerStep, UserNthRowStep,
             },
-            AGG_CHUNK,
+            BreakdownKey, AGG_CHUNK,
         },
         RecordId,
     },
@@ -400,7 +400,7 @@ pub async fn attribute_cap_aggregate<'ctx, BK, TV, HV, TS, const SS_BITS: usize,
     histogram: &[usize],
 ) -> Result<Vec<Replicated<HV>>, Error>
 where
-    BK: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    BK: BreakdownKey<B>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,

--- a/ipa-core/src/protocol/mod.rs
+++ b/ipa-core/src/protocol/mod.rs
@@ -15,15 +15,7 @@ use std::{
 pub use basics::{BasicProtocols, BooleanProtocols};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    error::Error,
-    ff::{Gf20Bit, Gf3Bit, Gf40Bit, Gf8Bit},
-};
-
-pub type MatchKey = Gf40Bit;
-pub type BreakdownKey = Gf8Bit;
-pub type TriggerValue = Gf3Bit;
-pub type Timestamp = Gf20Bit;
+use crate::error::Error;
 
 // These two cfg flags are defined to be mutually exclusive.
 #[cfg(compact_gate)]


### PR DESCRIPTION
* Remove some unnecessary `IntoIterator` bounds on `Chunk` methods.
* Add a `Chunk::map` helper to transform chunk data without extracting it from the wrapper. Use this instead of the somewhat confusing `into_raw` method. A side effect of this change is we no longer aggregate extra zero rows in the last block, which improves performance on small inputs.
* To further speed up `protocol::ipa_prf::tests::semi_honest`, switch it to 5-bit breakdown keys and 8-bit histogram values.
* Add a check that the `BK` and `B` parameters are consistent.
* Move type aliases from `protocol` to `cli/playbook/ipa`. Fixes #1079.