### PR TITLE
Don't emit rerun-if-changed for the build script

### DIFF
--- a/ipa-step-derive/src/track.rs
+++ b/ipa-step-derive/src/track.rs
@@ -196,7 +196,6 @@ impl ToTokens for StepModules {
         tokens.extend(quote! {
             #modules
             fn #fn_name() {
-                println!("cargo:rerun-if-changed={f}", f = ::std::file!());
                 assert!(
                     ::std::env::var(::ipa_step::COMPACT_GATE_INCLUDE_ENV).is_err(),
                     "setting `{e}` in the environment will cause build errors",


### PR DESCRIPTION
`std::file!()` is `ipa-core/build.rs`, which is then interpreted relative to the package directory as the non-existent `ipa-core/ipa-core/build.rs`. This results in rerunning the build script and rebuilding the package on every build.

The default behavior, if the build script does not emit any `rerun-if-changed` directives, is to re-run it on every build. Emitting `rerun-if-changed=build.rs` can be used to suppress this behavior in the case where there are no other applicable rerun-if-changed directives. With or without `rerun-if-changed=build.rs`, cargo is smart enough to rebuild if the build script changes.

I considered whether to emit `rerun-if-changed=build.rs` when no step definition files are configured, but optimizing for that case doesn't seem worth the extra complexity.