### PR TITLE
Decouple vectorization for share conversion and PRF evaluation

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -90,25 +90,28 @@ impl<C: Context> BooleanProtocols<C, PRF_CHUNK> for AdditiveShare<Boolean, PRF_C
 {
 }
 
-// Used by semi_honest_compare_gt_vec test.
 impl<C: Context> BooleanProtocols<C, AGG_CHUNK> for AdditiveShare<Boolean, AGG_CHUNK> where
     AdditiveShare<Boolean, AGG_CHUNK>: SecureMul<C>
 {
 }
 
+// Used by semi_honest_compare_gt_vec test.
 const_assert_eq!(
     AGG_CHUNK,
     256,
     "Implementation for N = 256 required for semi_honest_compare_gt_vec test"
 );
 
-// Implementations for 2^|bk|
+// Implementations for num_breakdowns (2^|bk|)
+// These are used for aggregate_values and dp noise gen.
+const_assert_eq!(
+    PRF_CHUNK,
+    16,
+    "Implementation for N = 16 required for num_breakdowns"
+);
+
 impl<C: Context> BooleanProtocols<C, 32> for AdditiveShare<Boolean, 32> where
     AdditiveShare<Boolean, 32>: SecureMul<C>
-{
-}
-impl<C: Context> BooleanProtocols<C, 16> for AdditiveShare<Boolean, 16> where
-    AdditiveShare<Boolean, 16>: SecureMul<C>
 {
 }
 

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -1,6 +1,11 @@
-use std::{array, convert::Infallible, iter, num::NonZeroU32, ops::Add};
+use std::{
+    convert::Infallible,
+    iter::{self, zip},
+    num::NonZeroU32,
+    ops::Add,
+};
 
-use futures_util::TryStreamExt;
+use futures::{stream, StreamExt, TryStreamExt};
 use generic_array::{ArrayLength, GenericArray};
 use typenum::{Unsigned, U18};
 
@@ -13,7 +18,7 @@ use crate::{
         ec_prime_field::Fp25519,
         CustomArray, Serializable, U128Conversions,
     },
-    helpers::stream::{process_slice_by_chunks, ChunkData, TryFlattenItersExt},
+    helpers::stream::{process_slice_by_chunks, Chunk, ChunkData, TryFlattenItersExt},
     protocol::{
         basics::{BooleanArrayMul, BooleanProtocols, SecureMul},
         context::{
@@ -75,8 +80,11 @@ pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>:
 impl BreakdownKey<32> for BA5 {}
 impl BreakdownKey<256> for BA8 {}
 
+/// Vectorization dimension for share conversion
+pub const CONV_CHUNK: usize = 256;
+
 /// Vectorization dimension for PRF
-pub const PRF_CHUNK: usize = 64;
+pub const PRF_CHUNK: usize = 16;
 
 /// Vectorization dimension for aggregation.
 pub const AGG_CHUNK: usize = 256;
@@ -267,59 +275,33 @@ where
     BK: SharedValue + CustomArray<Element = Boolean>,
     TV: SharedValue + CustomArray<Element = Boolean>,
     TS: SharedValue + CustomArray<Element = Boolean>,
-    Replicated<Boolean, PRF_CHUNK>: BooleanProtocols<C, PRF_CHUNK>,
+    Replicated<Boolean, CONV_CHUNK>: BooleanProtocols<C, CONV_CHUNK>,
     Replicated<Fp25519, PRF_CHUNK>: SecureMul<C> + FromPrss,
 {
-    let ctx = ctx.set_total_records((input_rows.len() + PRF_CHUNK - 1) / PRF_CHUNK);
-    let convert_ctx = ctx.narrow(&Step::ConvertFp25519);
-    let eval_ctx = ctx.narrow(&Step::EvalPrf);
+    let convert_ctx = ctx
+        .narrow(&Step::ConvertFp25519)
+        .set_total_records((input_rows.len() + CONV_CHUNK - 1) / CONV_CHUNK);
+    let eval_ctx = ctx
+        .narrow(&Step::EvalPrf)
+        .set_total_records((input_rows.len() + PRF_CHUNK - 1) / PRF_CHUNK);
 
     let prf_key = gen_prf_key(&eval_ctx);
 
-    seq_join(
+    let curve_pts = seq_join(
         ctx.active_work(),
         process_slice_by_chunks(
             input_rows,
-            move |idx, records: ChunkData<_, PRF_CHUNK>| {
+            move |idx, records: ChunkData<_, CONV_CHUNK>| {
+                let record_id = RecordId::from(idx);
                 let convert_ctx = convert_ctx.clone();
-                let eval_ctx = eval_ctx.clone();
-                let prf_key = prf_key.clone();
-
-                async move {
-                    let record_id = RecordId::from(idx);
-                    let input_match_keys: &dyn Fn(usize) -> Replicated<MatchKey> =
-                        &|i| records[i].match_key.clone();
-                    let mut match_keys = BitDecomposed::new(iter::empty());
-                    match_keys
-                        .transpose_from(input_match_keys)
-                        .unwrap_infallible();
-                    let curve_pts =
-                        convert_to_fp25519::<_, PRF_CHUNK>(convert_ctx, record_id, match_keys)
-                            .await?;
-
-                    let prf_of_match_keys =
-                        eval_dy_prf::<_, PRF_CHUNK>(eval_ctx, record_id, &prf_key, curve_pts)
-                            .await?;
-
-                    Ok(array::from_fn(|i| {
-                        let OPRFIPAInputRow {
-                            match_key: _,
-                            is_trigger,
-                            breakdown_key,
-                            trigger_value,
-                            timestamp,
-                        } = &records[i];
-
-                        PrfShardedIpaInputRow {
-                            prf_of_match_key: prf_of_match_keys[i],
-                            is_trigger_bit: is_trigger.clone(),
-                            breakdown_key: breakdown_key.clone(),
-                            trigger_value: trigger_value.clone(),
-                            timestamp: timestamp.clone(),
-                            sort_key: Replicated::ZERO,
-                        }
-                    }))
-                }
+                let input_match_keys: &dyn Fn(usize) -> Replicated<MatchKey> =
+                    &|i| records[i].match_key.clone();
+                let mut match_keys: BitDecomposed<Replicated<Boolean, 256>> =
+                    BitDecomposed::new(iter::empty());
+                match_keys
+                    .transpose_from(input_match_keys)
+                    .unwrap_infallible();
+                convert_to_fp25519::<_, CONV_CHUNK, PRF_CHUNK>(convert_ctx, record_id, match_keys)
             },
             || OPRFIPAInputRow {
                 match_key: Replicated::<MatchKey>::ZERO,
@@ -330,9 +312,44 @@ where
             },
         ),
     )
+    .map_ok(Chunk::unpack::<PRF_CHUNK>)
     .try_flatten_iters()
-    .try_collect()
-    .await
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    let prf_of_match_keys = seq_join(
+        ctx.active_work(),
+        stream::iter(curve_pts).enumerate().map(|(i, curve_pts)| {
+            let record_id = RecordId::from(i);
+            let eval_ctx = eval_ctx.clone();
+            let prf_key = &prf_key;
+            curve_pts
+                .then(move |pts| eval_dy_prf::<_, PRF_CHUNK>(eval_ctx, record_id, prf_key, pts))
+        }),
+    )
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    Ok(zip(input_rows, prf_of_match_keys.into_iter().flatten())
+        .map(|(input, prf_of_match_key)| {
+            let OPRFIPAInputRow {
+                match_key: _,
+                is_trigger,
+                breakdown_key,
+                trigger_value,
+                timestamp,
+            } = &input;
+
+            PrfShardedIpaInputRow {
+                prf_of_match_key,
+                is_trigger_bit: is_trigger.clone(),
+                breakdown_key: breakdown_key.clone(),
+                trigger_value: trigger_value.clone(),
+                timestamp: timestamp.clone(),
+                sort_key: Replicated::ZERO,
+            }
+        })
+        .collect())
 }
 
 #[cfg(all(test, any(unit_test, feature = "shuttle")))]

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -10,9 +10,7 @@ use crate::{
         prss::{FromPrss, SharedRandomness},
         RecordId,
     },
-    secret_sharing::{
-        replicated::semi_honest::AdditiveShare, FieldSimd, Sendable, StdArray, Vectorizable,
-    },
+    secret_sharing::{replicated::semi_honest::AdditiveShare, Sendable, StdArray, Vectorizable},
 };
 
 /// generates match key pseudonyms from match keys (in Fp25519 format) and PRF key
@@ -82,8 +80,6 @@ where
     C: Context,
     Fp25519: Vectorizable<N>,
     RP25519: Vectorizable<N, Array = StdArray<RP25519, N>>,
-    Boolean: FieldSimd<N>,
-    AdditiveShare<Boolean, N>: SecureMul<C>,
     AdditiveShare<Fp25519, N>: SecureMul<C> + FromPrss,
     StdArray<RP25519, N>: Sendable,
 {

--- a/ipa-core/src/secret_sharing/vector/array.rs
+++ b/ipa-core/src/secret_sharing/vector/array.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use generic_array::{ArrayLength, GenericArray};
-use typenum::{U128, U16, U256, U32, U64};
+use typenum::{U16, U256, U32, U64};
 
 use crate::{
     const_assert_eq,
@@ -329,10 +329,10 @@ macro_rules! impl_from_random {
 
 const_assert_eq!(
     PRF_CHUNK,
-    64,
+    16,
     "Appropriate FromRandom implementation required"
 );
-impl_from_random!(Fp25519, 64, U128, 2);
+impl_from_random!(Fp25519, 16, U32, 2);
 
 impl_from_random!(Fp32BitPrime, 32, U32, 1);
 


### PR DESCRIPTION
Share conversion uses boolean shares, while PRF evaluation uses Fp25519 and RP25519 shares. The latter are much larger than the former, so adjust the implementation to support differing vectorization factors. This introduces a vector-to-vector conversion problem like the one in aggregation, although vectorization is still across records on both sides so the solution here at least doesn't involve a transpose.

The separation of share conversion and PRF evaluation into two seq_joins may also be useful when adding malicious securitiy.

This also cleans up a few things that were left over from when there were multiple versions of the share conversion test for vectorization factors of 1, 16, 64, and 256.