### PR TITLE
Improve build time for compact gate

### DIFF
--- a/ipa-step/src/gate.rs
+++ b/ipa-step/src/gate.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse2, parse_str, Ident, Path};
 
-use crate::{hashing::HashingSteps, name::GateName, CompactGateIndex, CompactStep};
+use crate::{hash::HashingSteps, name::GateName, CompactGateIndex, CompactStep};
 
 fn crate_path(p: &str) -> String {
     let Some((_, p)) = p.split_once("::") else {
@@ -102,9 +102,10 @@ fn compact_gate_impl<S: CompactStep>(gate_name: &str) -> TokenStream {
         impl ::std::str::FromStr for #ident {
             type Err = String;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                match s {
-                    "/" => Ok(Self::default()),
-                    v => GATE_LOOKUP.find(v).map(#ident).ok_or_else(|| format!(#from_panic)),
+                if s == "/" {
+                    Ok(Self::default())
+                } else {
+                    GATE_LOOKUP.find(s).map(#ident).ok_or_else(|| format!(#from_panic))
                 }
             }
         }

--- a/ipa-step/src/gate.rs
+++ b/ipa-step/src/gate.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse2, parse_str, Ident, Path};
 
-use crate::{name::GateName, CompactGateIndex, CompactStep};
+use crate::{hashing::HashingSteps, name::GateName, CompactGateIndex, CompactStep};
 
 fn crate_path(p: &str) -> String {
     let Some((_, p)) = p.split_once("::") else {
@@ -54,50 +54,57 @@ pub fn build<S: CompactStep>() {
     };
     let name_maker = GateName::new(name);
     let gate_name = name_maker.name();
-
     let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join(name_maker.filename());
     println!("writing Gate implementation {gate_name} (for {step_name}) to {out:?}");
+    let gate_impl = compact_gate_impl::<S>(&gate_name);
+
+    write(out, prettyplease::unparse(&parse2(gate_impl).unwrap())).unwrap();
+}
+
+fn compact_gate_impl<S: CompactStep>(gate_name: &str) -> TokenStream {
+    let ident: Ident = parse_str(gate_name).unwrap();
 
     let mut step_narrows = HashMap::new();
     step_narrows.insert(std::any::type_name::<S>(), vec![0]); // Add the first step.
-    let mut as_ref_arms = TokenStream::new();
-    let mut from_arms = TokenStream::new();
 
-    let ident: Ident = parse_str(&gate_name).unwrap();
+    let step_count = usize::try_from(S::STEP_COUNT).unwrap();
+    // this is an array of gate names indexed by the compact gate index.
+    let mut gate_names = Vec::with_capacity(step_count);
+    // builds a lookup table for steps to resolve them to the compact gate index.
+    let mut step_hasher = HashingSteps::new(&ident);
+
     for i in 1..=S::STEP_COUNT {
         let s = String::from("/") + &S::step_string(i - 1);
-        as_ref_arms.extend(quote! {
-            #i => #s,
-        });
-        from_arms.extend(quote! {
-            #s => Ok(#ident(#i)),
-        });
+        step_hasher.hash(&s, i);
+        gate_names.push(s);
+
         if let Some(t) = S::step_narrow_type(i - 1) {
             step_narrows.entry(t).or_insert_with(Vec::new).push(i);
         }
     }
 
     let from_panic = format!("unknown string for {gate_name}: \"{{s}}\"");
+    let gate_lookup_type = step_hasher.lookup_type();
     let mut syntax = quote! {
+
+        static STR_LOOKUP: [&str; #step_count] = [#(#gate_names),*];
+        static GATE_LOOKUP: #gate_lookup_type = #step_hasher
+
         impl ::std::convert::AsRef<str> for #ident {
-            #[allow(clippy::too_many_lines)]
             fn as_ref(&self) -> &str {
-                match self.0 {
+                match usize::try_from(self.0).unwrap() {
                     0 => "/",
-                    #as_ref_arms
-                    _ => unreachable!(),
+                    i => STR_LOOKUP[i - 1],
                 }
             }
         }
 
         impl ::std::str::FromStr for #ident {
             type Err = String;
-            #[allow(clippy::too_many_lines)]
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
                     "/" => Ok(Self::default()),
-                    #from_arms
-                    _ => Err(format!(#from_panic)),
+                    v => GATE_LOOKUP.find(v).map(#ident).ok_or_else(|| format!(#from_panic)),
                 }
             }
         }
@@ -108,7 +115,40 @@ pub fn build<S: CompactStep>() {
             }
         }
     };
-    build_narrows(&ident, &gate_name, step_narrows, &mut syntax);
+    build_narrows(&ident, gate_name, step_narrows, &mut syntax);
 
-    write(out, prettyplease::unparse(&parse2(syntax).unwrap())).unwrap();
+    syntax
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{CompactGateIndex, CompactStep, Step};
+
+    struct HashCollision;
+
+    impl Step for HashCollision {}
+
+    impl AsRef<str> for HashCollision {
+        fn as_ref(&self) -> &str {
+            std::any::type_name::<Self>()
+        }
+    }
+
+    impl CompactStep for HashCollision {
+        const STEP_COUNT: CompactGateIndex = 2;
+
+        fn base_index(&self) -> CompactGateIndex {
+            0
+        }
+
+        fn step_string(_i: CompactGateIndex) -> String {
+            "same-step".to_string()
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Hash collision for /same-step")]
+    fn panics_on_hash_collision() {
+        super::compact_gate_impl::<HashCollision>("Gate");
+    }
 }

--- a/ipa-step/src/hash.rs
+++ b/ipa-step/src/hash.rs
@@ -1,12 +1,10 @@
-use std::{
-    collections::BTreeMap,
-    hash::{DefaultHasher, Hash, Hasher},
-};
+use std::collections::BTreeMap;
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, ToTokens};
+use syn::{parse_str, Path};
 
-use crate::CompactGateIndex;
+use crate::{CompactGateIndex, StepHasher};
 
 /// Builds a map of step strings to the corresponding compact gate index. Emits an array of tuples
 /// containing the hash and the index, sorted by hash. [`FromStr`] implementation for
@@ -16,34 +14,9 @@ use crate::CompactGateIndex;
 /// The complexity of this operation at compile time is O(n) and the cost is hash(str)*n.
 /// Runtime overhead is proportional to hash(str)+log(n).
 ///
-/// ## Hash collisions
-/// This currently uses the standard library [`Hasher`] interface to generate hashes that are limited
-/// to 8 bytes in size. This means that there is a small chance of hash collisions that increases
-/// with the overall increase in number of steps.
-///
-/// If that happens, a list of potential mitigations include
-/// * salt the hash (see code below),
-/// * use a different hash algorithm
-/// * use a perfect hash function.
-///
-/// The latter may result in more work to be done at runtime, but likely shouldn't impact
-/// the latency as long as [`FromStr`] is only used to create HTTP requests.
-///
-/// This implementation panics if it detects hash collisions.
-///
-/// [`FromStr`]: std::str::FromStr
 pub(crate) struct HashingSteps {
     inner: BTreeMap<u64, CompactGateIndex>,
     type_name: Ident,
-}
-
-fn hash(s: &str) -> u64 {
-    let mut hasher = DefaultHasher::default();
-    // If you get a collision, you can avoid that by adding:
-    // > hasher.write_u8(0);
-    // Tweak the value or remove the tweak if you get another collision.
-    hasher.write_str(s);
-    hasher.finish()
 }
 
 impl HashingSteps {
@@ -59,7 +32,7 @@ impl HashingSteps {
     /// if the step already added or if there is a hash collision with any of the steps already
     /// added.
     pub fn hash(&mut self, step: &str, gate: CompactGateIndex) {
-        let h = hash(step);
+        let h = step.hash_step();
         if let Some(old_val) = self.inner.insert(h, gate) {
             panic!("Hash collision for {step}: {h} => {old_val} and {gate}. Check that there are no duplicate steps defined in the protocol.");
         }
@@ -75,6 +48,12 @@ impl ToTokens for HashingSteps {
         let lookup_type = self.lookup_type();
         let sz = self.inner.len();
         let hashes = self.inner.iter().map(|(h, i)| quote! {(#h, #i)});
+        let hasher_path: Path = parse_str(
+            &std::any::type_name::<dyn StepHasher>()
+                .strip_prefix("dyn ")
+                .expect("typename for traits returns the path with dyn prefix"),
+        )
+        .unwrap();
 
         tokens.extend(quote! {
             #lookup_type {
@@ -88,15 +67,9 @@ impl ToTokens for HashingSteps {
 
             impl #lookup_type {
                 fn find(&self, input: &str) -> Option<u32> {
-                    let h = Self::hash(input);
+                    use #hasher_path;
+                    let h = input.hash_step();
                     self.inner.binary_search_by_key(&h, |(hash, _)| *hash).ok().map(|i| self.inner[i].1)
-                }
-
-                /// This must be kept in sync with proc-macro code that generates the hash.
-                fn hash(s: &str) -> u64 {
-                    let mut hasher = ::std::hash::DefaultHasher::default();
-                    ::std::hash::Hash::hash(s, &mut hasher);
-                    ::std::hash::Hasher::finish(&hasher)
                 }
             }
         });

--- a/ipa-step/src/hash.rs
+++ b/ipa-step/src/hash.rs
@@ -49,7 +49,7 @@ impl ToTokens for HashingSteps {
         let sz = self.inner.len();
         let hashes = self.inner.iter().map(|(h, i)| quote! {(#h, #i)});
         let hasher_path: Path = parse_str(
-            &std::any::type_name::<dyn StepHasher>()
+            std::any::type_name::<dyn StepHasher>()
                 .strip_prefix("dyn ")
                 .expect("typename for traits returns the path with dyn prefix"),
         )

--- a/ipa-step/src/hashing.rs
+++ b/ipa-step/src/hashing.rs
@@ -1,0 +1,101 @@
+use std::{
+    collections::BTreeMap,
+    hash::{DefaultHasher, Hash, Hasher},
+};
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, ToTokens};
+
+use crate::CompactGateIndex;
+
+/// Builds a map of step strings to the corresponding compact gate index. Emits an array of tuples
+/// containing the hash and the index, sorted by hash. [`FromStr`] implementation for
+/// compact gate uses the same hashing algorithm for input string and uses the provided code to
+/// run binary search and find the item.
+///
+/// The complexity of this operation at compile time is O(n) and the cost is hash(str)*n.
+/// Runtime overhead is proportional to hash(str)+log(n).
+///
+/// ## Hash collisions
+/// This currently uses the standard library [`Hasher`] interface to generate hashes that are limited
+/// to 8 bytes in size. This means that there is a small chance of hash collisions that increases
+/// with the overall increase in number of steps.
+///
+/// If that happens, a list of potential mitigations include
+/// * salt the hash,
+/// * use a different hash algorithm
+/// * use a perfect hash function.
+///
+/// The latter may result in more work to be done at runtime, but likely shouldn't impact
+/// the latency as long as [`FromStr`] is only used to create HTTP requests.
+///
+/// This implementation panics if it detects hash collisions.
+///
+/// [`FromStr`]: std::str::FromStr
+pub(crate) struct HashingSteps {
+    inner: BTreeMap<u64, CompactGateIndex>,
+    type_name: Ident,
+}
+
+fn hash(s: &str) -> u64 {
+    let mut hasher = DefaultHasher::default();
+    s.hash(&mut hasher);
+    hasher.finish()
+}
+
+impl HashingSteps {
+    pub fn new(gate_type: &Ident) -> Self {
+        Self {
+            inner: BTreeMap::default(),
+            type_name: format_ident!("{}Lookup", gate_type),
+        }
+    }
+
+    /// Add a step to the map.
+    /// ## Panics
+    /// if the step already added or if there is a hash collision with any of the steps already
+    /// added.
+    pub fn hash(&mut self, step: &str, gate: CompactGateIndex) {
+        let h = hash(step);
+        if let Some(old_val) = self.inner.insert(h, gate) {
+            panic!("Hash collision for {step}: {h} => {old_val} and {gate}. Check that there are no duplicate steps defined in the protocol.");
+        }
+    }
+
+    pub fn lookup_type(&self) -> &Ident {
+        &self.type_name
+    }
+}
+
+impl ToTokens for HashingSteps {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let lookup_type = self.lookup_type();
+        let sz = self.inner.len();
+        let hashes = self.inner.iter().map(|(h, i)| quote! {(#h, #i)});
+
+        tokens.extend(quote! {
+            #lookup_type {
+                #[allow(clippy::unreadable_literal)]
+                inner: [#(#hashes),*]
+            };
+
+            struct #lookup_type {
+                inner: [(u64, u32); #sz]
+            }
+
+            impl #lookup_type {
+                fn find(&self, input: &str) -> Option<u32> {
+                    let h = Self::hash(input);
+                    self.inner.binary_search_by_key(&h, |(hash, _)| *hash).ok().map(|i| self.inner[i].1)
+                }
+
+                /// This must be kept in sync with proc-macro code that generates the hash.
+                fn hash(s: &str) -> u64 {
+                    let mut hasher = ::std::hash::DefaultHasher::default();
+                    ::std::hash::Hash::hash(s, &mut hasher);
+                    ::std::hash::Hasher::finish(&hasher)
+                }
+            }
+        });
+    }
+}

--- a/ipa-step/src/hashing.rs
+++ b/ipa-step/src/hashing.rs
@@ -22,7 +22,7 @@ use crate::CompactGateIndex;
 /// with the overall increase in number of steps.
 ///
 /// If that happens, a list of potential mitigations include
-/// * salt the hash,
+/// * salt the hash (see code below),
 /// * use a different hash algorithm
 /// * use a perfect hash function.
 ///
@@ -39,7 +39,10 @@ pub(crate) struct HashingSteps {
 
 fn hash(s: &str) -> u64 {
     let mut hasher = DefaultHasher::default();
-    s.hash(&mut hasher);
+    // If you get a collision, you can avoid that by adding:
+    // > hasher.write_u8(0);
+    // Tweak the value or remove the tweak if you get another collision.
+    hasher.write_str(s);
     hasher.finish()
 }
 

--- a/ipa-step/src/lib.rs
+++ b/ipa-step/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod descriptive;
 #[cfg(feature = "build")]
 pub mod gate;
+#[cfg(feature = "build")]
+mod hashing;
 #[cfg(feature = "name")]
 pub mod name;
 

--- a/ipa-step/src/lib.rs
+++ b/ipa-step/src/lib.rs
@@ -4,7 +4,7 @@ pub mod descriptive;
 #[cfg(feature = "build")]
 pub mod gate;
 #[cfg(feature = "build")]
-mod hashing;
+mod hash;
 #[cfg(feature = "name")]
 pub mod name;
 


### PR DESCRIPTION
I was investigating why build with compact gate takes that long and everything pointed to large match statements inside `FromStr` and `AsRef` trait implementations for `CompactGate`. The major bottleneck was `AsRef` match statement and overall the size of match statement impacts build time exponentially. Once the number of steps crosses the 70k boundary, release builds do not finish. 

The fix was to replace the match arms with something else for both `FromStr` and `AsRef`. Latter can be done with a simple array indexed by compact gate index, so it is very straightforward. That alone got the compile time down from ~4mins to 50s for 20k steps.

Fixing `FromStr` is more involved because it requires a lookup table. I've experimented with PHF and an array of tuples `(hash(str), gate index)`, sorted by hash value. Both have similar compilation times and I ended up with the array implementation to reduce the runtime cost a bit - PHF may require a few hash evaluations on a given string at runtime and array needs just one + binary search inside a sorted array which should be fast.

## Compile time impact

The following table shows the build times for `cargo bench --bench oneshot_ipa --no-default-features --features "enable-benches compact-gate"` command. For debug builds I used `cargo test --bench oneshot_ipa --no-default-features --features "enable-benches compact-gate"`

I measured the impact of the second build without the fix implemented in #1086 - that allowed me to capture the overhead of compact gate generation and compilation. 


| | debug build (fresh) | debug build (second) | release build (fresh) | release build (second) |
|-|---------------------|----------------------| --- | -- |
| before | 1m 18s  | 14.56s | 4m 02s | 3m 49s |
| after    | 1m 07s  | 10.18s | **1m 30s** | **23s** | 

As it can be seen, compiler optimizations cause the slowdown. Hinting `rustc` that there is nothing to optimize by using arrays improve optimized build times. 

## Runtime impact

I didn't anticipate any impact on `as_ref` implementation because that's just an array lookup and was more concerned about `FromStr` as it now requires a hash + binary search. Fortunately we only use it in HTTP deserialization and only when we receive a new `step` request, so the impact should be proportional to the number of gates we use and limited to one time overhead per gate creation.

We don't have reliable benchmarks to test it at scale, so I used our integration test to validate.

`cargo test --test helper_networks https_semi_honest_ipa --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"`

for release build

`cargo test --release --test helper_networks https_semi_honest_ipa --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"`

| | debug | release |
|-|---------------------|----------------------| 
| before | 6.63s  | 1.54s |
| after    | 4.65s |  1.52s | 

