### PR TITLE
Eliminate compute_final_proof

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -170,7 +170,8 @@ mod test {
         ff::{Fp31, U128Conversions},
         protocol::ipa_prf::malicious_security::lagrange::{
             CanonicalLagrangeDenominator, LagrangeTable,
-        }, secret_sharing::SharedValue,
+        },
+        secret_sharing::SharedValue,
     };
 
     #[test]
@@ -304,13 +305,9 @@ mod test {
         );
         assert_eq!(pg_3, (&U_3[..], &V_3[..]));
 
-        (pg_3.u, pg_3.v);
-
         // final iteration
-        let proof_3 = ProofGenerator::<Fp31>::compute_proof::<U4, _, _>(
-            uv_3.iter(),
-            &lagrange_table,
-        );
+        let proof_3 =
+            ProofGenerator::<Fp31>::compute_proof::<U4, _, _>(uv_3.iter(), &lagrange_table);
         assert_eq!(
             proof_3.g.iter().map(Fp31::as_u128).collect::<Vec<_>>(),
             PROOF_3,


### PR DESCRIPTION
@danielmasny has pointed out that there is a lot of duplication of logic between `compute_proof` and `compute_final_proof`. We could potentially just use one. The caller just needs to be careful to "mask" the "u/v" vectors with randomly distributed points at index 0. By eliminating this method, we do not have any compile time guarantees that it will be used correctly (i.e. the inputs will be masked) but we can follow up with a solution for this later.