### PR TITLE
Upgraded to Axum 0.7

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -113,9 +113,9 @@ hpke = { version = "0.11.0", default-features = false, features = [
     "std",
     "x25519",
 ] }
-hyper = { version = "1.3.1", optional = true, features = [ "full" ] }
+hyper = { version = "1.3.1", optional = true, features = [ "http2", "server" ] }
 hyper-rustls = { version = "0.27.1", optional = true, features = ["http2"] }
-hyper-util = { version = "0.1.3", optional = true, features = ["full"] }
+hyper-util = { version = "0.1.3", optional = true, features = ["http2"] }
 http-body-util = { version = "0.1.1", optional = true }
 http-body = { version = "1", optional = true }
 iai = { version = "0.1.1", optional = true }

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -40,6 +40,9 @@ web-app = [
     "toml",
     "tower",
     "tower-http",
+    "hyper-util",
+    "http-body",
+    "http-body-util",
 ]
 test-fixture = ["weak-field"]
 # Include observability instruments that detect lack of progress inside MPC. If there is a bug that leads to helper
@@ -78,10 +81,10 @@ ipa-step-derive = { version = "*", path = "../ipa-step-derive" }
 aes = "0.8.3"
 async-trait = "0.1.79"
 async-scoped = { version = "0.9.0", features = ["use-tokio"], optional = true }
-axum = { version = "0.6", optional = true, features = ["http2", "macros"] }
+axum = { version = "0.7.5", optional = true, features = ["http2", "macros"] }
 # The following is a temporary version until we can stabilize the build on a higher version
 # of axum, rustls and the http stack.
-axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "rustls-0.23", version = "0.5.3", optional = true, features = [
+axum-server = { git = "https://github.com/cberkhoff/axum-server/", branch = "0.6.1", version = "0.6.1", optional = true, features = [
     "tls-rustls",
 ] }
 base64 = { version = "0.21.2", optional = true }
@@ -110,15 +113,11 @@ hpke = { version = "0.11.0", default-features = false, features = [
     "std",
     "x25519",
 ] }
-hyper = { version = "0.14.28", optional = true, features = [
-    "client",
-    "h2",
-    "stream",
-    "runtime",
-] }
-# The following is a temporary version until we can stabilize the build on a higher version
-# of axum, rustls and the http stack.
-hyper-rustls = { git = "https://github.com/cberkhoff/hyper-rustls/", branch = "rustls-0.23", version = "0.25.1", optional = true, features = ["http2"] }
+hyper = { version = "1.3.1", optional = true, features = [ "full" ] }
+hyper-rustls = { version = "0.27.1", optional = true, features = ["http2"] }
+hyper-util = { version = "0.1.3", optional = true, features = ["full"] }
+http-body-util = { version = "0.1.1", optional = true }
+http-body = { version = "1", optional = true }
 iai = { version = "0.1.1", optional = true }
 metrics = "0.21.0"
 metrics-tracing-context = "0.14.0"
@@ -143,7 +142,7 @@ tokio-rustls = { version = "0.26", optional = true }
 tokio-stream = "0.1.14"
 toml = { version = "0.8", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.4.0", optional = true, features = ["trace"] }
+tower-http = { version = "0.5", optional = true, features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 typenum = { version = "1.17", features = ["i128"] }

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -141,7 +141,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         disable_https: args.disable_https,
         tls: server_tls,
         hpke_config: mk_encryption,
-        max_concurrent_stream: Some(1000),
+        max_concurrent_stream: Some(5000),
     };
 
     let scheme = if args.disable_https {

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -141,7 +141,8 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         disable_https: args.disable_https,
         tls: server_tls,
         hpke_config: mk_encryption,
-        max_concurrent_stream: Some(5000),
+        max_concurrent_stream: Some(5000), // This number is correlated to the
+                                           // maximum number of stepts that can be executed in parallel.
     };
 
     let scheme = if args.disable_https {

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -141,6 +141,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         disable_https: args.disable_https,
         tls: server_tls,
         hpke_config: mk_encryption,
+        max_concurrent_stream: Some(1000),
     };
 
     let scheme = if args.disable_https {

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -228,7 +228,10 @@ async fn ipa(
         field_type: FieldType::Fp32BitPrime,
         query_type,
     };
-    let query_id = helper_clients[0].create_query(query_config).await.unwrap();
+    let query_id = helper_clients[0]
+        .create_query(query_config)
+        .await
+        .expect("Unable to create query!");
 
     let expected = {
         let mut r = ipa_in_the_clear(

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -8,7 +8,8 @@ use std::{
     time::Duration,
 };
 
-use hyper::{client::Builder, http::uri::Scheme, Uri};
+use hyper::{http::uri::Scheme, Uri};
+use hyper_util::client::legacy::Builder;
 use rustls_pemfile::Item;
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -275,6 +276,10 @@ pub struct ServerConfig {
 
     /// Configuration needed for encrypting and decrypting match keys
     pub hpke_config: Option<HpkeServerConfig>,
+
+    // Sets the SETTINGS_MAX_CONCURRENT_STREAMS option for HTTP2 connections.
+    // [`hyper_util::server::conn::auto::Http2Builder::max_concurrent_streams`]
+    pub max_concurrent_stream: Option<u32>,
 }
 
 pub trait HyperClientConfigurator {

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -221,7 +221,7 @@ impl Gateway {
 
 impl Default for GatewayConfig {
     fn default() -> Self {
-        Self::new(32)
+        Self::new(1024)
     }
 }
 

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -221,7 +221,7 @@ impl Gateway {
 
 impl Default for GatewayConfig {
     fn default() -> Self {
-        Self::new(1024)
+        Self::new(32)
     }
 }
 

--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     WrongBodyLen { body_len: u32, element_size: usize },
     #[error(transparent)]
     InvalidJsonBody(#[from] axum::extract::rejection::JsonRejection),
+    #[error(transparent)]
+    InvalidBytesBody(#[from] axum::extract::rejection::BytesRejection),
     #[error("bad path: {0}")]
     BadPathString(#[source] BoxError),
     #[error(transparent)]
@@ -32,7 +34,7 @@ pub enum Error {
     #[error(transparent)]
     AxumPassthrough(#[from] axum::Error),
     #[error("parse error: {0}")]
-    SerdePassthrough(#[from] serde_json::Error),
+    JsonParsing(#[from] serde_json::Error),
     #[error(transparent)]
     InvalidUri(#[from] hyper::http::uri::InvalidUri),
     // `FailedHttpRequest` and `Application` are for the same errors, with slightly different
@@ -53,7 +55,7 @@ pub enum Error {
     ConnectError {
         dest: String,
         #[source]
-        inner: hyper::Error,
+        inner: hyper_util::client::legacy::Error,
     },
     #[error("{error}")]
     Application { code: StatusCode, error: BoxError },
@@ -75,7 +77,7 @@ impl Error {
         let status = resp.status();
         assert!(status.is_client_error() || status.is_server_error()); // must be failure
         let (endpoint, body) = resp.into_parts();
-        hyper::body::to_bytes(body)
+        axum::body::to_bytes(body, usize::MAX)
             .await
             .map_or_else(Into::into, |reason_bytes| Error::FailedHttpRequest {
                 dest: endpoint.to_string(),
@@ -137,11 +139,12 @@ impl IntoResponse for Error {
                 StatusCode::UNPROCESSABLE_ENTITY
             }
 
-            Self::SerdePassthrough(_)
+            Self::JsonParsing(_)
             | Self::InvalidHeader(_)
             | Self::WrongBodyLen { .. }
             | Self::AxumPassthrough(_)
             | Self::InvalidJsonBody(_)
+            | Self::InvalidBytesBody(_)
             | Self::QueryIdNotFound(_)
             | Self::ConnectError { .. } => StatusCode::BAD_REQUEST,
 
@@ -153,7 +156,6 @@ impl IntoResponse for Error {
 
             Self::Application { code, .. } => code,
         };
-
         (status_code, self.to_string()).into_response()
     }
 }

--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -77,7 +77,7 @@ impl Error {
         let status = resp.status();
         assert!(status.is_client_error() || status.is_server_error()); // must be failure
         let (endpoint, body) = resp.into_parts();
-        axum::body::to_bytes(body, usize::MAX)
+        axum::body::to_bytes(body, 36_000_000) // Roughly 36mb
             .await
             .map_or_else(Into::into, |reason_bytes| Error::FailedHttpRequest {
                 dest: endpoint.to_string(),

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -14,13 +14,15 @@
 //! This module is organized into the submodules "echo" and "query" for their
 //! respective APIs. Each module might have a Request struct used by the client
 //! to provide request parameters using [`crate::transport`] types.
+
+type OutgoingRequest = Result<hyper::Request<axum::body::Body>, crate::net::Error>;
+
 pub mod echo {
     use std::collections::HashMap;
 
+    use axum::body::Body;
     use hyper::http::uri;
     use serde::{Deserialize, Serialize};
-
-    use crate::net::Error;
 
     #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct Request {
@@ -42,7 +44,7 @@ pub mod echo {
             self,
             scheme: uri::Scheme,
             authority: uri::Authority,
-        ) -> Result<hyper::Request<hyper::Body>, Error> {
+        ) -> crate::net::http_serde::OutgoingRequest {
             let qps = self
                 .query_params
                 .iter()
@@ -59,7 +61,7 @@ pub mod echo {
                 .headers
                 .into_iter()
                 .fold(hyper::Request::get(uri), |req, (k, v)| req.header(k, v));
-            Ok(req.body(hyper::Body::empty())?)
+            Ok(req.body(Body::empty())?)
         }
     }
 
@@ -169,15 +171,13 @@ pub mod query {
 
     pub mod create {
 
+        use axum::body::Body;
         use hyper::http::uri;
         use serde::{Deserialize, Serialize};
 
         use crate::{
             helpers::{query::QueryConfig, HelperResponse},
-            net::{
-                http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
-                Error,
-            },
+            net::http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
             protocol::QueryId,
         };
 
@@ -195,7 +195,7 @@ pub mod query {
                 self,
                 scheme: uri::Scheme,
                 authority: uri::Authority,
-            ) -> Result<hyper::Request<hyper::Body>, Error> {
+            ) -> crate::net::http_serde::OutgoingRequest {
                 let uri = uri::Builder::new()
                     .scheme(scheme)
                     .authority(authority)
@@ -205,7 +205,7 @@ pub mod query {
                         QueryConfigQueryParams(self.query_config)
                     ))
                     .build()?;
-                Ok(hyper::Request::post(uri).body(hyper::Body::empty())?)
+                Ok(hyper::Request::post(uri).body(Body::empty())?)
             }
         }
 
@@ -226,7 +226,7 @@ pub mod query {
     }
 
     pub mod prepare {
-        use axum::http::uri;
+        use axum::{body::Body, http::uri};
         use hyper::header::CONTENT_TYPE;
         use serde::{Deserialize, Serialize};
 
@@ -234,7 +234,7 @@ pub mod query {
             helpers::{query::PrepareQuery, RoleAssignment},
             net::{
                 http_serde::query::{QueryConfigQueryParams, BASE_AXUM_PATH},
-                Error, APPLICATION_JSON,
+                APPLICATION_JSON,
             },
         };
 
@@ -251,7 +251,7 @@ pub mod query {
                 self,
                 scheme: uri::Scheme,
                 authority: uri::Authority,
-            ) -> Result<hyper::Request<hyper::Body>, Error> {
+            ) -> crate::net::http_serde::OutgoingRequest {
                 let uri = uri::Uri::builder()
                     .scheme(scheme)
                     .authority(authority)
@@ -265,7 +265,8 @@ pub mod query {
                 let body = RequestBody {
                     roles: self.data.roles,
                 };
-                let body = hyper::Body::from(serde_json::to_string(&body)?);
+                let body = serde_json::to_string(&body)?;
+                let body = Body::from(body);
                 Ok(hyper::Request::post(uri)
                     .header(CONTENT_TYPE, APPLICATION_JSON)
                     .body(body)?)
@@ -281,12 +282,12 @@ pub mod query {
     }
 
     pub mod input {
-        use axum::http::uri;
-        use hyper::{header::CONTENT_TYPE, Body};
+        use axum::{body::Body, http::uri};
+        use hyper::header::CONTENT_TYPE;
 
         use crate::{
             helpers::query::QueryInput,
-            net::{http_serde::query::BASE_AXUM_PATH, Error, APPLICATION_OCTET_STREAM},
+            net::{http_serde::query::BASE_AXUM_PATH, APPLICATION_OCTET_STREAM},
         };
 
         #[derive(Debug)]
@@ -299,12 +300,11 @@ pub mod query {
                 Self { query_input }
             }
 
-            #[allow(clippy::type_complexity)] // to be addressed in follow-up
             pub fn try_into_http_request(
                 self,
                 scheme: uri::Scheme,
                 authority: uri::Authority,
-            ) -> Result<hyper::Request<Body>, Error> {
+            ) -> crate::net::http_serde::OutgoingRequest {
                 let uri = uri::Uri::builder()
                     .scheme(scheme)
                     .authority(authority)
@@ -314,7 +314,7 @@ pub mod query {
                         self.query_input.query_id.as_ref(),
                     ))
                     .build()?;
-                let body = Body::wrap_stream(self.query_input.input_stream);
+                let body = Body::from_stream(self.query_input.input_stream);
                 Ok(hyper::Request::post(uri)
                     .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
                     .body(body)?)
@@ -325,7 +325,7 @@ pub mod query {
     }
 
     pub mod step {
-        use axum::http::uri;
+        use axum::{body::Body, http::uri};
 
         use crate::{
             net::{http_serde::query::BASE_AXUM_PATH, Error},
@@ -352,12 +352,12 @@ pub mod query {
         }
 
         /// Convert to hyper request. Used on client side.
-        impl Request<hyper::Body> {
+        impl Request<Body> {
             pub fn try_into_http_request(
                 self,
                 scheme: uri::Scheme,
                 authority: uri::Authority,
-            ) -> Result<hyper::Request<hyper::Body>, Error> {
+            ) -> Result<hyper::Request<Body>, Error> {
                 let uri = uri::Uri::builder()
                     .scheme(scheme)
                     .authority(authority)
@@ -420,7 +420,7 @@ pub mod query {
                 self,
                 scheme: axum::http::uri::Scheme,
                 authority: axum::http::uri::Authority,
-            ) -> Result<hyper::Request<hyper::Body>, crate::net::Error> {
+            ) -> crate::net::http_serde::OutgoingRequest {
                 let uri = axum::http::uri::Uri::builder()
                     .scheme(scheme)
                     .authority(authority)
@@ -430,7 +430,7 @@ pub mod query {
                         self.query_id.as_ref()
                     ))
                     .build()?;
-                Ok(hyper::Request::get(uri).body(hyper::Body::empty())?)
+                Ok(hyper::Request::get(uri).body(axum::body::Body::empty())?)
             }
         }
 
@@ -490,7 +490,7 @@ pub mod query {
                 self,
                 scheme: axum::http::uri::Scheme,
                 authority: axum::http::uri::Authority,
-            ) -> Result<hyper::Request<hyper::Body>, crate::net::Error> {
+            ) -> crate::net::http_serde::OutgoingRequest {
                 let uri = axum::http::uri::Uri::builder()
                     .scheme(scheme)
                     .authority(authority)
@@ -500,7 +500,7 @@ pub mod query {
                         self.query_id.as_ref()
                     ))
                     .build()?;
-                Ok(hyper::Request::get(uri).body(hyper::Body::empty())?)
+                Ok(hyper::Request::get(uri).body(axum::body::Body::empty())?)
             }
         }
 

--- a/ipa-core/src/net/server/handlers/query/create.rs
+++ b/ipa-core/src/net/server/handlers/query/create.rs
@@ -37,9 +37,10 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::num::NonZeroU32;
 
+    use axum::body::Body;
     use hyper::{
         http::uri::{Authority, Scheme},
-        Body, StatusCode,
+        StatusCode,
     };
 
     use crate::{
@@ -133,9 +134,7 @@ mod tests {
                 f = val.field_type,
                 qt = val.query_type_params
             );
-            hyper::Request::post(uri)
-                .body(hyper::Body::empty())
-                .unwrap()
+            hyper::Request::post(uri).body(Body::empty()).unwrap()
         }
     }
 

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -100,8 +100,11 @@ impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
 
 #[cfg(all(test, unit_test))]
 pub mod test_helpers {
-    use std::{any::Any, sync::Arc};
+    use std::{any::Any, io::Read, sync::Arc};
 
+    use axum::body::Body;
+    use bytes::Buf;
+    use http_body_util::BodyExt;
     use hyper::{http::request, StatusCode};
 
     use crate::{
@@ -111,11 +114,16 @@ pub mod test_helpers {
 
     /// Helper trait for optionally adding an extension to a request.
     pub trait MaybeExtensionExt {
-        fn maybe_extension<T: Any + Send + Sync + 'static>(self, extension: Option<T>) -> Self;
+        fn maybe_extension<T>(self, extension: Option<T>) -> Self
+        where
+            T: Any + Send + Sync + Clone + 'static;
     }
 
     impl MaybeExtensionExt for request::Builder {
-        fn maybe_extension<T: Any + Send + Sync + 'static>(self, extension: Option<T>) -> Self {
+        fn maybe_extension<T>(self, extension: Option<T>) -> Self
+        where
+            T: Any + Send + Sync + Clone + 'static,
+        {
             if let Some(extension) = extension {
                 self.extension(extension)
             } else {
@@ -126,14 +134,14 @@ pub mod test_helpers {
 
     // Intended to be used for a request that will fail Starts a [`TestServer`] and gets response
     // from the server, and compare its [`StatusCode`] with what is expected.
-    pub async fn assert_fails_with(req: hyper::Request<hyper::Body>, expected_status: StatusCode) {
+    pub async fn assert_fails_with(req: hyper::Request<Body>, expected_status: StatusCode) {
         let test_server = TestServer::builder().build().await;
         let resp = test_server.server.handle_req(req).await;
         assert_eq!(resp.status(), expected_status);
     }
 
     pub async fn assert_success_with(
-        req: hyper::Request<hyper::Body>,
+        req: hyper::Request<Body>,
         handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
     ) -> Vec<u8> {
         let test_server = TestServer::builder()
@@ -142,8 +150,10 @@ pub mod test_helpers {
             .await;
         let resp = test_server.server.handle_req(req).await;
         let status = resp.status();
-        let body_bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+        let buf = resp.into_body().collect().await.unwrap().aggregate();
         assert_eq!(StatusCode::OK, status);
-        body_bytes.to_vec()
+        let mut vec = Vec::new();
+        buf.reader().read_to_end(&mut vec).unwrap();
+        vec
     }
 }

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -53,7 +53,8 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use hyper::{header::CONTENT_TYPE, Body, StatusCode};
+    use axum::body::Body;
+    use hyper::{header::CONTENT_TYPE, StatusCode};
     use serde::Serialize;
 
     use crate::{
@@ -145,7 +146,7 @@ mod tests {
             hyper::Request::post(uri)
                 .header(CONTENT_TYPE, APPLICATION_JSON)
                 .maybe_extension(val.client_id)
-                .body(hyper::Body::from(body))
+                .body(Body::from(body))
                 .unwrap()
         }
     }

--- a/ipa-core/src/net/server/handlers/query/results.rs
+++ b/ipa-core/src/net/server/handlers/query/results.rs
@@ -35,8 +35,11 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 #[cfg(all(test, unit_test))]
 mod tests {
 
-    use axum::http::uri::{Authority, Scheme};
-    use hyper::{Body, StatusCode};
+    use axum::{
+        body::Body,
+        http::uri::{Authority, Scheme},
+    };
+    use hyper::StatusCode;
 
     use crate::{
         ff::Fp31,
@@ -92,7 +95,7 @@ mod tests {
                 http_serde::query::BASE_AXUM_PATH,
                 val.query_id
             );
-            hyper::Request::get(uri).body(hyper::Body::empty()).unwrap()
+            hyper::Request::get(uri).body(Body::empty()).unwrap()
         }
     }
 

--- a/ipa-core/src/net/server/handlers/query/status.rs
+++ b/ipa-core/src/net/server/handlers/query/status.rs
@@ -32,8 +32,11 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use axum::http::uri::{Authority, Scheme};
-    use hyper::{Body, StatusCode};
+    use axum::{
+        body::Body,
+        http::uri::{Authority, Scheme},
+    };
+    use hyper::StatusCode;
 
     use crate::{
         helpers::{
@@ -82,7 +85,7 @@ mod tests {
                 http_serde::query::BASE_AXUM_PATH,
                 val.query_id
             );
-            hyper::Request::get(uri).body(hyper::Body::empty()).unwrap()
+            hyper::Request::get(uri).body(Body::empty()).unwrap()
         }
     }
 

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -33,8 +33,9 @@ pub fn router(transport: Arc<HttpTransport>) -> Router {
 mod tests {
     use std::task::Poll;
 
+    use axum::body::Body;
     use futures::{stream::poll_immediate, StreamExt};
-    use hyper::{Body, StatusCode};
+    use hyper::StatusCode;
     use ipa_step::StepNarrow;
 
     use super::*;
@@ -90,7 +91,7 @@ mod tests {
             );
             hyper::Request::post(uri)
                 .maybe_extension(val.client_id)
-                .body(hyper::Body::from(val.payload))
+                .body(Body::from(val.payload))
                 .unwrap()
         }
     }

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -70,7 +70,7 @@ fn server_config_insecure_http(port: u16, matchkey_encryption: bool) -> ServerCo
         disable_https: true,
         tls: None,
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
-        max_concurrent_stream: Some(5000),
+        max_concurrent_stream: None,
     }
 }
 
@@ -89,7 +89,7 @@ pub fn server_config_https(
             private_key: String::from_utf8(private_key.to_owned()).unwrap(),
         }),
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
-        max_concurrent_stream: Some(5000),
+        max_concurrent_stream: None,
     }
 }
 

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -70,7 +70,7 @@ fn server_config_insecure_http(port: u16, matchkey_encryption: bool) -> ServerCo
         disable_https: true,
         tls: None,
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
-        max_concurrent_stream: Some(1000),
+        max_concurrent_stream: Some(5000),
     }
 }
 
@@ -89,7 +89,7 @@ pub fn server_config_https(
             private_key: String::from_utf8(private_key.to_owned()).unwrap(),
         }),
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
-        max_concurrent_stream: Some(1000),
+        max_concurrent_stream: Some(5000),
     }
 }
 

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -70,6 +70,7 @@ fn server_config_insecure_http(port: u16, matchkey_encryption: bool) -> ServerCo
         disable_https: true,
         tls: None,
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
+        max_concurrent_stream: Some(1000),
     }
 }
 
@@ -88,6 +89,7 @@ pub fn server_config_https(
             private_key: String::from_utf8(private_key.to_owned()).unwrap(),
         }),
         hpke_config: get_dummy_matchkey_encryption_info(matchkey_encryption),
+        max_concurrent_stream: Some(1000),
     }
 }
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -303,9 +303,7 @@ mod tests {
 
         let TestServer { transport, .. } = TestServer::default().await;
 
-        let body = BodyStream::from_body(
-            Box::new(ReceiverStream::new(rx)) as Box<dyn Stream<Item = _> + Send>
-        );
+        let body = BodyStream::from_receiver_stream(Box::new(ReceiverStream::new(rx)));
 
         // Register the stream with the transport (normally called by step data HTTP API handler)
         Arc::clone(&transport).receive_stream(QueryId, STEP.clone(), HelperIdentity::TWO, body);

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -61,8 +61,7 @@ impl FromIterator<Fp61BitPrime> for [Fp61BitPrime; B] {
         for (i, elem) in iter.into_iter().enumerate() {
             assert!(
                 i < B,
-                "Too many elements to collect into array of length {:?}",
-                B
+                "Too many elements to collect into array of length {B}"
             );
             out[i] = elem;
         }


### PR DESCRIPTION
Using newest version of Axum (0.7.5) and Hyper which is beyond 1.0 bringing more stability. Since Hyper doesn’t include a client, we are using the one suggested in Hyper-Utils, which is a drop-in replacement from the client that was present in Hyper 0.14.

Hyper now relies on Http-Body 1 which cascaded into a bunch of changes to HTTP bodies used throughout the code. Hyper also gives the option to pick any execution framework, but we’re sticking to Tokio.

During my testing I observed that the tests like `https_semi_honest_ipa` would get stuck. After a lot of debugging, I was able to identify `SETTINGS_MAX_CONCURRENT_STREAMS` option for HTTP2 connections as the culprit. By default, Hyper-Utils sets it to 200 which is insufficient for that test. 1000 was the “smallest” number I was able to identify that passed the tests. It might be worth investigating why the client doesn’t correctly handle the case when the server can’t take more concurrent streams. Right now, it just gets stuck in [when the transport is calling a step](https://github.com/private-attribution/ipa/blob/8c481563314c8f1c5cc9a941ca330fdfce30c2f0/ipa-core/src/net/transport.rs#L203). That await never completes.
