### PR TITLE
Add more tracing to the infrastructure

### DIFF
--- a/ipa-core/src/helpers/buffers/ordering_sender.rs
+++ b/ipa-core/src/helpers/buffers/ordering_sender.rs
@@ -408,7 +408,14 @@ impl OrderingSender {
         let mut b = self.state.lock().unwrap();
 
         if let Poll::Ready(v) = b.take(cx) {
-            self.waiting.wake(self.next.load(Acquire));
+            let next = self.next.load(Acquire);
+            tracing::trace!(
+                closed = b.closed,
+                next = next,
+                len = v.len(),
+                "take_next ready"
+            );
+            self.waiting.wake(next);
             Poll::Ready(Some(v))
         } else if b.closed {
             Poll::Ready(None)

--- a/ipa-core/src/helpers/buffers/unordered_receiver.rs
+++ b/ipa-core/src/helpers/buffers/unordered_receiver.rs
@@ -247,7 +247,9 @@ where
                     return Poll::Pending;
                 }
                 Poll::Ready(Some(b)) => {
-                    if let Some(m) = self.spare.extend(b.as_ref()) {
+                    let b = b.as_ref();
+                    tracing::trace!(len = b.len(), "next chunk");
+                    if let Some(m) = self.spare.extend(b) {
                         self.wake_next();
                         return Poll::Ready(
                             m.map_err(|e| DeserializeError::new::<M>(self.next, e).into()),

--- a/ipa-core/src/helpers/gateway/send.rs
+++ b/ipa-core/src/helpers/gateway/send.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Borrow,
+    fmt::Debug,
     marker::PhantomData,
     num::NonZeroUsize,
     pin::Pin,
@@ -240,9 +241,10 @@ impl<I: TransportIdentity> GatewaySenders<I> {
     }
 }
 
-impl<I> Stream for GatewaySendStream<I> {
+impl<I: Debug> Stream for GatewaySendStream<I> {
     type Item = Vec<u8>;
 
+    #[tracing::instrument(level = "trace", name = "send_stream", skip_all, fields(to = ?self.inner.channel_id.peer, gate = ?self.inner.channel_id.gate))]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::get_mut(self).inner.ordering_tx.take_next(cx)
     }

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 #[allow(clippy::unused_async)] // axum doesn't like synchronous handler
+#[tracing::instrument(level = "trace", "step", skip_all, fields(from = ?**from, gate = ?gate))]
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
     from: Extension<ClientIdentity>,


### PR DESCRIPTION
I've been using these for quite a while, but forgot to commit them to the main branch. This logs the following operations:

* When Hyper comes in to take the next chunk from ordering sender
* When unordered receiver gets more data from the underlying HTTP stream
* When helper receives a new step request