### PR TITLE
Remove more GenericArray usage

### DIFF
--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -1,19 +1,17 @@
 use bitvec::{order::Lsb0, view::BitView};
-use generic_array::GenericArray;
-use typenum::U32;
 
 use crate::{
     ff::{Field, Fp61BitPrime, PrimeField},
     protocol::context::dzkp_validator::{Array256Bit, SegmentEntry},
-    secret_sharing::{FieldSimd, Vectorizable},
+    secret_sharing::{FieldSimd, SharedValue, Vectorizable},
 };
 
 // BlockSize is fixed to 32
-pub type BlockSize = U32;
+pub const B: usize = 32;
 // UVTupleBlock is a block of interleaved U and V values
-pub type UVTupleBlock<F> = (GenericArray<F, BlockSize>, GenericArray<F, BlockSize>);
+pub type UVTupleBlock<F> = ([F; B], [F; B]);
 // UVSingleBlock is either a block of U or a block of V values
-pub type UVSingleBlock<F> = GenericArray<F, BlockSize>;
+pub type UVSingleBlock<F> = [F; B];
 
 /// Trait for fields compatible with DZKPs
 /// Field needs to support conversion to `SegmentEntry`, i.e. `to_segment_entry` which is required by DZKPs
@@ -55,6 +53,16 @@ pub trait DZKPBaseField: PrimeField {
         y_left: &'a Array256Bit,
         prss_left: &'a Array256Bit,
     ) -> Vec<UVSingleBlock<Self>>;
+}
+
+impl FromIterator<Fp61BitPrime> for [Fp61BitPrime; B] {
+    fn from_iter<T: IntoIterator<Item = Fp61BitPrime>>(iter: T) -> Self {
+        let mut out = [Fp61BitPrime::ZERO; B];
+        for (i, elem) in iter.into_iter().take(B).enumerate() {
+            out[i] = elem;
+        }
+        out
+    }
 }
 
 impl DZKPBaseField for Fp61BitPrime {
@@ -136,7 +144,7 @@ impl DZKPBaseField for Fp61BitPrime {
                                 Fp61BitPrime::MINUS_ONE_HALF * one_minus_two_e,
                             ]
                         })
-                        .collect::<GenericArray<Fp61BitPrime, BlockSize>>(),
+                        .collect::<[Fp61BitPrime; B]>(),
                     // h polynomial
                     b.view_bits::<Lsb0>()
                         .iter()
@@ -157,7 +165,7 @@ impl DZKPBaseField for Fp61BitPrime {
                                 one_minus_two_f,
                             ]
                         })
-                        .collect::<GenericArray<Fp61BitPrime, BlockSize>>(),
+                        .collect::<[Fp61BitPrime; B]>(),
                 )
             })
             .collect::<Vec<_>>()
@@ -217,7 +225,7 @@ impl DZKPBaseField for Fp61BitPrime {
                             Fp61BitPrime::MINUS_ONE_HALF * one_minus_two_e,
                         ]
                     })
-                    .collect::<GenericArray<Fp61BitPrime, BlockSize>>()
+                    .collect::<[Fp61BitPrime; B]>()
             })
             .collect::<Vec<_>>()
     }
@@ -270,7 +278,7 @@ impl DZKPBaseField for Fp61BitPrime {
                             one_minus_two_f,
                         ]
                     })
-                    .collect::<GenericArray<Fp61BitPrime, BlockSize>>()
+                    .collect::<[Fp61BitPrime; B]>()
             })
             .collect::<Vec<_>>()
     }

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -58,7 +58,12 @@ pub trait DZKPBaseField: PrimeField {
 impl FromIterator<Fp61BitPrime> for [Fp61BitPrime; B] {
     fn from_iter<T: IntoIterator<Item = Fp61BitPrime>>(iter: T) -> Self {
         let mut out = [Fp61BitPrime::ZERO; B];
-        for (i, elem) in iter.into_iter().take(B).enumerate() {
+        for (i, elem) in iter.into_iter().enumerate() {
+            assert!(
+                i < B,
+                "Too many elements to collect into array of length {:?}",
+                B
+            );
             out[i] = elem;
         }
         out


### PR DESCRIPTION
Moving away from use of GenericArray in favor of just normal vanilla arrays.