### PR TITLE
Disable connection-level flow control for HTTP2 streams

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -221,7 +221,7 @@ impl Gateway {
 
 impl Default for GatewayConfig {
     fn default() -> Self {
-        Self::new(32)
+        Self::new(1024)
     }
 }
 

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -25,6 +25,13 @@ pub use transport::{HttpShardTransport, HttpTransport};
 pub const APPLICATION_JSON: &str = "application/json";
 pub const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
 
+/// This has the same meaning as const defined in h2 crate, but we don't import it directly.
+/// According to the [`spec`] it cannot exceed 2^31 - 1.
+///
+/// Setting up initial window size to this value effectively turns off the flow control mechanism.
+/// [`spec`]: <https://datatracker.ietf.org/doc/html/rfc9113#name-the-flow-control-window>
+pub(crate) const MAX_HTTP2_WINDOW_SIZE: u32 = (1 << 31) - 1;
+
 /// Provides access to IPAs Crypto Provider (AWS Libcrypto).
 static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
     Lazy::new(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));

--- a/ipa-core/src/net/server/config.rs
+++ b/ipa-core/src/net/server/config.rs
@@ -1,0 +1,33 @@
+use axum_server::HttpConfig;
+
+use crate::net::MAX_HTTP2_WINDOW_SIZE;
+
+pub(super) struct HttpServerConfig(HttpConfig);
+
+impl Default for HttpServerConfig {
+    fn default() -> Self {
+        Self(
+            HttpConfig::default()
+                // This turns off the flow control at the connection level. We ran into issues
+                // (see #1085) while having it in place. IPA protocol tend to open many concurrent
+                // streams and push data simultaneously through them without having any explicit
+                // ordering defined. The execution order however relies on steps that appear early
+                // in the execution phase to be scheduled before the later ones. Any mechanism that
+                // prevents progress in these scenarios may lead to a deadlock. Connection level
+                // flow control is one of these mechanisms, therefore it must be disabled.
+                //
+                // Because HTTP2 streams are bidirectional, it is important that it is turned off
+                // on the receiver (server) side, because we don't push a lot of data
+                // from server to client. It should be possible to disable it on the client,
+                // if needed
+                .http2_initial_connection_window_size(MAX_HTTP2_WINDOW_SIZE)
+                .build(),
+        )
+    }
+}
+
+impl From<HttpServerConfig> for HttpConfig {
+    fn from(value: HttpServerConfig) -> Self {
+        value.0
+    }
+}

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -1,3 +1,4 @@
+mod config;
 mod handlers;
 
 use std::{
@@ -21,7 +22,7 @@ use axum_server::{
     accept::Accept,
     service::{MakeServiceRef, SendService},
     tls_rustls::{RustlsAcceptor, RustlsConfig},
-    Handle, HttpConfig, Server,
+    Handle, Server,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use futures::{
@@ -43,7 +44,10 @@ use crate::{
     config::{NetworkConfig, OwnedCertificate, OwnedPrivateKey, ServerConfig, TlsConfig},
     error::BoxError,
     helpers::HelperIdentity,
-    net::{parse_certificate_and_private_key_bytes, Error, HttpTransport, CRYPTO_PROVIDER},
+    net::{
+        parse_certificate_and_private_key_bytes, server::config::HttpServerConfig, Error,
+        HttpTransport, CRYPTO_PROVIDER,
+    },
     sync::Arc,
     task::JoinHandle,
     telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
@@ -230,8 +234,7 @@ where
     tokio::spawn({
         async move {
             server
-                // TODO: configuration
-                .http_config(HttpConfig::default())
+                .http_config(HttpServerConfig::default().into())
                 .handle(handle)
                 .serve(svc)
                 .await


### PR DESCRIPTION
It was diagnosed as root cause for #1085. Here are the reasons why we think it is safe to turn it off:

* We have flow control built in at the application layer. `OrderingSender` provides backpressure per stream/step and MPC protocol logic breaks the whole execution into chunks where we open large but limited number of streams.
* We have flow control at TCP layer
* Connection level flow control for HTTP2 connections works well for web-servers that don't control clients that can connect to it. In our case, we have a very limited set of clients for each MPC-to-MPC connection.

I had a chat with @aleiserson, and we think ultimately it will be beneficial if we only used one mechanism to provide and given the nature of IPA, it would be better to have full control there. This means that application-level mechanism will be our preferred way to establish congestion control and turning off transport-layer flow control fits into our long-term view for IPA.

This change also reverts the active window back to 1024. I am concerned that the attribution phase may run slower with 32 and if PRF can work with 1024, even at the expense of dropping very large buffers down to the network, we can live with it for now.

Next step I want to implement variable-sized send buffers to maintain the guarantee from our infrastructure to flush fixed-size chunks down to the network layer

## Testing
Local run for 50k left overnight.
draft [run](https://draft-mpc.vercel.app/query/view/sewed-debit-6490) succeeded