### PR TITLE
apply_dp_noise function

### DIFF
--- a/ipa-core/build.rs
+++ b/ipa-core/build.rs
@@ -22,6 +22,7 @@ track_steps!(
             shuffle::step,
             aggregation::step,
             step,
+            dp::step,
         },
         step,
     },

--- a/ipa-core/src/protocol/ipa_prf/dp/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/dp/mod.rs
@@ -128,7 +128,8 @@ mod test {
         let num_bernoulli: u32 = 1000;
         let world = TestWorld::default();
         let input_values = [10, 8, 6, 41, 0, 0, 0, 0, 10, 8, 6, 41, 0, 0, 0, 0];
-        let input: BitDecomposed<[Boolean; NUM_BREAKDOWNS as usize]> = input_row(16, &input_values);
+        let input: BitDecomposed<[Boolean; NUM_BREAKDOWNS as usize]> =
+            vectorize_input(16, &input_values);
         let result = world
             .upgraded_semi_honest(input, |ctx, input| async move {
                 apply_dp_noise::<{ NUM_BREAKDOWNS as usize }, OutputValue>(
@@ -155,11 +156,16 @@ mod test {
                     > mean - 5.0 * standard_deviation
                     && f64::from(result_u32[i]) - f64::from(input_values[i])
                         < mean + 5.0 * standard_deviation
+                , "test failed because noised result is more than 5 standard deviations of the noise distribution \
+                from the original input values. This will fail with a small chance of failure"
             );
         }
     }
 
-    fn input_row<const B: usize>(bit_width: usize, values: &[u32]) -> BitDecomposed<[Boolean; B]> {
+    fn vectorize_input<const B: usize>(
+        bit_width: usize,
+        values: &[u32],
+    ) -> BitDecomposed<[Boolean; B]> {
         let values = <&[u32; B]>::try_from(values).unwrap();
         BitDecomposed::decompose(bit_width, |i| {
             values.map(|v| Boolean::from((v >> i) & 1 == 1))

--- a/ipa-core/src/protocol/ipa_prf/dp/step.rs
+++ b/ipa-core/src/protocol/ipa_prf/dp/step.rs
@@ -1,0 +1,7 @@
+use ipa_step_derive::CompactStep;
+
+#[derive(CompactStep)]
+pub(crate) enum DPStep {
+    NoiseGen,
+    ApplyNoise,
+}

--- a/ipa-core/src/protocol/step.rs
+++ b/ipa-core/src/protocol/step.rs
@@ -44,4 +44,8 @@ pub enum DeadCodeStep {
     FeatureLabelDotProduct,
     #[step(child = crate::protocol::context::step::ZeroKnowledgeProofValidateStep)]
     ZeroKnowledgeProofValidate,
+    #[step(child = crate::protocol::ipa_prf::dp::step::DPStep)]
+    NoiseGen,
+    #[step(child = crate::protocol::ipa_prf::dp::step::DPStep)]
+    ApplyNoise,
 }


### PR DESCRIPTION
Small PR for an `apply_dp_noise` function which adds noise to a vector of values.  This will be used when both applying the noise in the case of aggregation and `feature_label_dot_product` but I'll split those into separate PRs. 