### PR TITLE
Reveal wrapper

### DIFF
--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -12,7 +12,9 @@ use crate::{
         prss::{FromPrss, FromRandom, PrssIndex, SharedRandomness},
     },
     secret_sharing::{
-        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+        replicated::{
+            malicious::ExtendableField, semi_honest::AdditiveShare, ReplicatedSecretSharing,
+        },
         Block, FieldVectorizable, SharedValue, StdArray, Vectorizable,
     },
 };
@@ -217,6 +219,14 @@ impl Field for Fp25519 {
     const NAME: &'static str = "Fp25519";
 
     const ONE: Fp25519 = Fp25519::ONE;
+}
+
+impl ExtendableField for Fp25519 {
+    type ExtendedField = Self;
+
+    fn to_extended(&self) -> Self::ExtendedField {
+        *self
+    }
 }
 
 impl FromRandom for Fp25519 {

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -9,21 +9,22 @@ pub mod step;
 
 use std::ops::Not;
 
-pub use check_zero::check_zero;
+pub use check_zero::semi_honest_check_zero;
 pub use if_else::select;
 pub use mul::{BooleanArrayMul, SecureMul};
 pub use reshare::Reshare;
-pub use reveal::{partial_reveal, reveal, Reveal};
+pub use reveal::{
+    partial_reveal, reveal, semi_honest_reveal, Reveal, ThisCodeIsAuthorizedToObserveRevealedValues,
+};
 pub use share_known_value::ShareKnownValue;
 
 use crate::{
     const_assert_eq,
-    ff::{boolean::Boolean, PrimeField},
+    ff::{boolean::Boolean, ec_prime_field::Fp25519, PrimeField},
     protocol::{
-        context::{
-            Context, SemiHonestContext, UpgradedMaliciousContext, UpgradedSemiHonestContext,
-        },
+        context::{Context, UpgradedMaliciousContext, UpgradedSemiHonestContext},
         ipa_prf::{AGG_CHUNK, PRF_CHUNK},
+        prss::FromPrss,
     },
     secret_sharing::{
         replicated::{
@@ -35,15 +36,60 @@ use crate::{
     sharding::ShardBinding,
 };
 
-pub trait BasicProtocols<C: Context, V: SharedValue + Vectorizable<N>, const N: usize = 1>:
+/// Basic suite of MPC protocols.
+///
+/// This is currently applicable only in unvectorized contexts, because `Reshare` and
+/// `ShareKnownValue` are not vectorized. For this reason there is no `N` const parameter. The
+/// alternate `VectorProtocols` can be used in vectorized contexts. With parity of supported
+/// protocols, this could be merged with `VectorProtocols`.
+pub trait BasicProtocols<C: Context, V: SharedValue + Vectorizable<1>>:
     SecretSharing<V>
     + Reshare<C>
-    + Reveal<C, N, Output = <V as Vectorizable<N>>::Array>
+    + Reveal<C, 1, Output = <V as Vectorizable<1>>::Array>
     + SecureMul<C>
     + ShareKnownValue<C, V>
 {
 }
 
+impl<'a, B: ShardBinding, F: ExtendableField> BasicProtocols<UpgradedSemiHonestContext<'a, B, F>, F>
+    for AdditiveShare<F>
+{
+}
+
+impl<'a, F: ExtendableField> BasicProtocols<UpgradedMaliciousContext<'a, F>, F>
+    for MaliciousReplicated<F>
+{
+}
+
+/// Basic suite of MPC protocols for vectorized data.
+///
+/// Like `BasicProtocols`, but without `Reshare` and `ShareKnownValue`, which are not vectorized.
+/// (`ShareKnownValue` has the difficulty of resolving `V` vs. `[V; 1]` issues for the known value
+/// type. `Reshare` hasn't been attempted.)
+///
+/// `VectorProtocols` also adds `FromPrss`, which would probably be reasonable to have in
+/// `BasicProtocols` and `BooleanProtocols` as well.
+pub trait VectorProtocols<C: Context, V: SharedValue + Vectorizable<N>, const N: usize = 1>:
+    SecretSharing<V> + Reveal<C, N, Output = <V as Vectorizable<N>>::Array> + SecureMul<C> + FromPrss
+{
+}
+
+// For PRF test
+impl<'a, B: ShardBinding> VectorProtocols<UpgradedSemiHonestContext<'a, B, Fp25519>, Fp25519>
+    for AdditiveShare<Fp25519>
+{
+}
+
+impl<'a, B: ShardBinding>
+    VectorProtocols<UpgradedSemiHonestContext<'a, B, Fp25519>, Fp25519, PRF_CHUNK>
+    for AdditiveShare<Fp25519, PRF_CHUNK>
+{
+}
+
+/// Basic suite of MPC protocols for (possibly vectorized) boolean shares.
+///
+/// Adds the requirement that the type implements `Not`. Like `VectorProtocols`, excludes `Reshare`
+/// and `ShareKnownValue`.
 pub trait BooleanProtocols<C: Context, const N: usize = 1>:
     SecretSharing<Boolean>
     + Reveal<C, N, Output = <Boolean as Vectorizable<N>>::Array>
@@ -54,44 +100,24 @@ where
 {
 }
 
-// TODO: It might be better to remove this (protocols should use upgraded contexts)
-impl<'a, B: ShardBinding, F: PrimeField> BasicProtocols<SemiHonestContext<'a, B>, F>
-    for AdditiveShare<F>
-{
-}
-
-impl<'a, B: ShardBinding, F: PrimeField> BasicProtocols<UpgradedSemiHonestContext<'a, B, F>, F>
-    for AdditiveShare<F>
-{
-}
-
-// TODO: It might be better to remove this (protocols should use upgraded contexts)
-impl<'a, B: ShardBinding> BooleanProtocols<SemiHonestContext<'a, B>, 1> for AdditiveShare<Boolean> {}
-
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 1>
+impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>>
     for AdditiveShare<Boolean>
 {
 }
 
 // Used for aggregation tests
-// TODO: It might be better to remove this (protocols should use upgraded contexts)
-impl<'a, B: ShardBinding> BooleanProtocols<SemiHonestContext<'a, B>, 8>
-    for AdditiveShare<Boolean, 8>
-{
-}
-
 impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 8>
     for AdditiveShare<Boolean, 8>
 {
 }
 
-impl<C: Context> BooleanProtocols<C, PRF_CHUNK> for AdditiveShare<Boolean, PRF_CHUNK> where
-    AdditiveShare<Boolean, PRF_CHUNK>: SecureMul<C>
+impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, PRF_CHUNK>
+    for AdditiveShare<Boolean, PRF_CHUNK>
 {
 }
 
-impl<C: Context> BooleanProtocols<C, AGG_CHUNK> for AdditiveShare<Boolean, AGG_CHUNK> where
-    AdditiveShare<Boolean, AGG_CHUNK>: SecureMul<C>
+impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, AGG_CHUNK>
+    for AdditiveShare<Boolean, AGG_CHUNK>
 {
 }
 
@@ -110,19 +136,14 @@ const_assert_eq!(
     "Implementation for N = 16 required for num_breakdowns"
 );
 
-impl<C: Context> BooleanProtocols<C, 32> for AdditiveShare<Boolean, 32> where
-    AdditiveShare<Boolean, 32>: SecureMul<C>
+impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 32>
+    for AdditiveShare<Boolean, 32>
 {
 }
 
 const_assert_eq!(
     AGG_CHUNK,
     256,
-    "Implementation for N = 256 required for breakdown keys"
+    "Implementation for N = 256 required for num_breakdowns"
 );
 // End implementations for 2^|bk|
-
-impl<'a, F: ExtendableField> BasicProtocols<UpgradedMaliciousContext<'a, F>, F>
-    for MaliciousReplicated<F>
-{
-}

--- a/ipa-core/src/protocol/basics/mul/semi_honest.rs
+++ b/ipa-core/src/protocol/basics/mul/semi_honest.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField},
+    ff::Field,
     helpers::Direction,
     protocol::{
         context::{
@@ -14,7 +14,8 @@ use crate::{
         RecordId,
     },
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare as Replicated, FieldSimd, Vectorizable,
+        replicated::{malicious::ExtendableField, semi_honest::AdditiveShare as Replicated},
+        FieldSimd, Vectorizable,
     },
     sharding,
 };
@@ -123,7 +124,7 @@ impl<'a, B, F, const N: usize> super::SecureMul<UpgradedSemiHonestContext<'a, B,
     for Replicated<F, N>
 where
     B: sharding::ShardBinding,
-    F: PrimeField + FieldSimd<N>,
+    F: ExtendableField + FieldSimd<N>,
 {
     async fn multiply<'fut>(
         &self,

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -7,7 +7,7 @@ use crate::{
     error::Error,
     helpers::{Direction, MaybeFuture, Role},
     protocol::{
-        context::{Context, UpgradedMaliciousContext},
+        context::{Context, UpgradedMaliciousContext, UpgradedSemiHonestContext},
         RecordId,
     },
     secret_sharing::{
@@ -17,10 +17,117 @@ use crate::{
         },
         SharedValue, Vectorizable,
     },
+    sharding::ShardBinding,
 };
 
+#[must_use = "You should not be revealing values without calling `MaliciousValidator::validate()`"]
+pub struct UnauthorizedRevealWrapper<T>(T);
+impl<T> UnauthorizedRevealWrapper<T> {
+    pub(crate) fn new(v: T) -> Self {
+        Self(v)
+    }
+}
+
+pub trait ThisCodeIsAuthorizedToObserveRevealedValues<T> {
+    fn access_without_verification(self) -> T;
+}
+
+impl<T> ThisCodeIsAuthorizedToObserveRevealedValues<T> for UnauthorizedRevealWrapper<T> {
+    fn access_without_verification(self) -> T {
+        self.0
+    }
+}
+
+/// Raw semi-honest reveal protocol.
+///
+/// This should only be used in rare cases. Prefer to use the `Reveal` trait or the `reveal` function.
+///
+/// # Errors
+/// If there is a problem communicating with other helpers.
+pub async fn semi_honest_reveal<'fut, C, V, const N: usize>(
+    value: &'fut Replicated<V, N>,
+    ctx: C,
+    record_id: RecordId,
+    excluded: Option<Role>,
+) -> Result<Option<<V as Vectorizable<N>>::Array>, Error>
+where
+    C: Context + 'fut,
+    V: SharedValue + Vectorizable<N>,
+{
+    let left = value.left_arr();
+    let right = value.right_arr();
+
+    // Send shares, unless the target helper is excluded
+    if Some(ctx.role().peer(Direction::Right)) != excluded {
+        ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right))
+            .send(record_id, left)
+            .await?;
+    }
+
+    if Some(ctx.role()) == excluded {
+        Ok(None)
+    } else {
+        // Sleep until `helper's left` sends their share
+        let share: <V as Vectorizable<N>>::Array = ctx
+            .recv_channel(ctx.role().peer(Direction::Left))
+            .receive(record_id)
+            .await?;
+
+        Ok(Some(share + left + right))
+    }
+}
+
+async fn malicious_reveal<'fut, C, F>(
+    value: &'fut MaliciousReplicated<F>,
+    ctx: C,
+    record_id: RecordId,
+    excluded: Option<Role>,
+) -> Result<Option<<F as Vectorizable<1>>::Array>, Error>
+where
+    C: Context + 'fut,
+    F: ExtendableField,
+{
+    use futures::future::try_join;
+
+    use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
+
+    let (left, right) = value.x().access_without_downgrade().as_tuple();
+    let left_sender = ctx.send_channel(ctx.role().peer(Direction::Left));
+    let left_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Left));
+    let right_sender = ctx.send_channel(ctx.role().peer(Direction::Right));
+    let right_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Right));
+
+    // Send shares to the left and right helpers, unless excluded.
+    let send_left_fut =
+        MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Left)) != excluded, || {
+            left_sender.send(record_id, right)
+        });
+
+    let send_right_fut =
+        MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Right)) != excluded, || {
+            right_sender.send(record_id, left)
+        });
+    try_join(send_left_fut, send_right_fut).await?;
+
+    if Some(ctx.role()) == excluded {
+        Ok(None)
+    } else {
+        let (share_from_left, share_from_right) = try_join(
+            left_receiver.receive(record_id),
+            right_receiver.receive(record_id),
+        )
+        .await?;
+
+        if share_from_left == share_from_right {
+            Ok(Some((left + right + share_from_left).into_array()))
+        } else {
+            Err(Error::MaliciousRevealFailed)
+        }
+    }
+}
+
 /// Trait for reveal protocol to open a shared secret to all helpers inside the MPC ring.
-pub trait Reveal<C: Context, const N: usize>: Sized {
+pub trait Reveal<C: Context, const N: usize = 1>: Sized {
     type Output;
     /// Reveal a shared secret to all helpers in the MPC ring.
     ///
@@ -31,7 +138,7 @@ pub trait Reveal<C: Context, const N: usize>: Sized {
         &'fut self,
         ctx: C,
         record_id: RecordId,
-    ) -> impl Future<Output = Result<Self::Output, Error>> + Send + 'fut
+    ) -> impl Future<Output = Result<UnauthorizedRevealWrapper<Self::Output>, Error>> + Send + 'fut
     where
         C: 'fut,
     {
@@ -46,7 +153,7 @@ pub trait Reveal<C: Context, const N: usize>: Sized {
         ctx: C,
         record_id: RecordId,
         excluded: Role,
-    ) -> impl Future<Output = Result<Option<Self::Output>, Error>> + Send + 'fut
+    ) -> impl Future<Output = Result<Option<UnauthorizedRevealWrapper<Self::Output>>, Error>> + Send + 'fut
     where
         C: 'fut,
     {
@@ -63,7 +170,7 @@ pub trait Reveal<C: Context, const N: usize>: Sized {
         ctx: C,
         record_id: RecordId,
         excluded: Option<Role>,
-    ) -> impl Future<Output = Result<Option<Self::Output>, Error>> + Send + 'fut
+    ) -> impl Future<Output = Result<Option<UnauthorizedRevealWrapper<Self::Output>>, Error>> + Send + 'fut
     where
         C: 'fut;
 }
@@ -79,42 +186,36 @@ pub trait Reveal<C: Context, const N: usize>: Sized {
 /// ![Reveal steps][reveal]
 /// Each helper sends their left share to the right helper. The helper then reconstructs their secret by adding the three shares
 /// i.e. their own shares and received share.
+//
+// This impl uses distinct `V` and `CtxF` type parameters to support the PRF evaluation protocol,
+// which uses `Fp25519` for the malicious context, but needs to reveal `RP25519` values. The reveal
+// impl here is not a malicious-secure protocol, but even for the MAC-based malicious protocol, as
+// long as we checked the shares being revealed for consistency, it wouldn't matter that they are in
+// the same field as is used for the malicious context, so these decoupled type parameters would be
+// okay. Contrast with multiplication, which can only be supported in the malicious context's
+// field.
 #[embed_doc_image("reveal", "images/reveal.png")]
-impl<C: Context, V: SharedValue + Vectorizable<N>, const N: usize> Reveal<C, N>
+impl<'a, B, V, CtxF, const N: usize> Reveal<UpgradedSemiHonestContext<'a, B, CtxF>, N>
     for Replicated<V, N>
+where
+    B: ShardBinding,
+    V: SharedValue + Vectorizable<N>,
+    CtxF: ExtendableField,
 {
     type Output = <V as Vectorizable<N>>::Array;
 
     async fn generic_reveal<'fut>(
         &'fut self,
-        ctx: C,
+        ctx: UpgradedSemiHonestContext<'a, B, CtxF>,
         record_id: RecordId,
         excluded: Option<Role>,
-    ) -> Result<Option<<V as Vectorizable<N>>::Array>, Error>
+    ) -> Result<Option<UnauthorizedRevealWrapper<<V as Vectorizable<N>>::Array>>, Error>
     where
-        C: 'fut,
+        UpgradedSemiHonestContext<'a, B, CtxF>: 'fut,
     {
-        let left = self.left_arr();
-        let right = self.right_arr();
-
-        // Send shares, unless the target helper is excluded
-        if Some(ctx.role().peer(Direction::Right)) != excluded {
-            ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right))
-                .send(record_id, left)
-                .await?;
-        }
-
-        if Some(ctx.role()) == excluded {
-            Ok(None)
-        } else {
-            // Sleep until `helper's left` sends their share
-            let share: <V as Vectorizable<N>>::Array = ctx
-                .recv_channel(ctx.role().peer(Direction::Left))
-                .receive(record_id)
-                .await?;
-
-            Ok(Some(share + left + right))
-        }
+        semi_honest_reveal(self, ctx, record_id, excluded)
+            .await
+            .map(|opt| opt.map(UnauthorizedRevealWrapper))
     }
 }
 
@@ -122,7 +223,7 @@ impl<C: Context, V: SharedValue + Vectorizable<N>, const N: usize> Reveal<C, N>
 /// It works similarly to semi-honest reveal, the key difference is that each helper sends its share
 /// to both helpers (right and left) and upon receiving 2 shares from peers it validates that they
 /// indeed match.
-impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>, 1> for MaliciousReplicated<F> {
+impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>> for MaliciousReplicated<F> {
     type Output = <F as Vectorizable<1>>::Array;
 
     async fn generic_reveal<'fut>(
@@ -130,61 +231,27 @@ impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>, 1> for Mali
         ctx: UpgradedMaliciousContext<'a, F>,
         record_id: RecordId,
         excluded: Option<Role>,
-    ) -> Result<Option<<F as Vectorizable<1>>::Array>, Error>
+    ) -> Result<Option<UnauthorizedRevealWrapper<<F as Vectorizable<1>>::Array>>, Error>
     where
         UpgradedMaliciousContext<'a, F>: 'fut,
     {
-        use futures::future::try_join;
-
-        use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
-
-        let (left, right) = self.x().access_without_downgrade().as_tuple();
-        let left_sender = ctx.send_channel(ctx.role().peer(Direction::Left));
-        let left_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Left));
-        let right_sender = ctx.send_channel(ctx.role().peer(Direction::Right));
-        let right_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Right));
-
-        // Send shares to the left and right helpers, unless excluded.
-        let send_left_fut =
-            MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Left)) != excluded, || {
-                left_sender.send(record_id, right)
-            });
-
-        let send_right_fut =
-            MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Right)) != excluded, || {
-                right_sender.send(record_id, left)
-            });
-        try_join(send_left_fut, send_right_fut).await?;
-
-        if Some(ctx.role()) == excluded {
-            Ok(None)
-        } else {
-            let (share_from_left, share_from_right) = try_join(
-                left_receiver.receive(record_id),
-                right_receiver.receive(record_id),
-            )
-            .await?;
-
-            if share_from_left == share_from_right {
-                Ok(Some((left + right + share_from_left).into_array()))
-            } else {
-                Err(Error::MaliciousRevealFailed)
-            }
-        }
+        malicious_reveal(self, ctx, record_id, excluded)
+            .await
+            .map(|opt| opt.map(UnauthorizedRevealWrapper::new))
     }
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/100013. Calling these wrapper functions
 // instead of the trait methods seems to hide the `impl Future` GAT.
 
-pub fn reveal<'fut, C, S>(
+pub fn reveal<'fut, C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     v: &'fut S,
-) -> impl Future<Output = Result<S::Output, Error>> + Send + 'fut
+) -> impl Future<Output = Result<UnauthorizedRevealWrapper<S::Output>, Error>> + Send + 'fut
 where
     C: Context + 'fut,
-    S: Reveal<C, 1>,
+    S: Reveal<C, N>,
 {
     S::reveal(v, ctx, record_id)
 }
@@ -194,7 +261,7 @@ pub fn partial_reveal<'fut, C, S, const N: usize>(
     record_id: RecordId,
     excluded: Role,
     v: &'fut S,
-) -> impl Future<Output = Result<Option<S::Output>, Error>> + Send + 'fut
+) -> impl Future<Output = Result<Option<UnauthorizedRevealWrapper<S::Output>>, Error>> + Send + 'fut
 where
     C: Context + 'fut,
     S: Reveal<C, N>,
@@ -208,14 +275,15 @@ mod tests {
 
     use futures::future::{join_all, try_join, try_join3};
 
+    use super::{Reveal, ThisCodeIsAuthorizedToObserveRevealedValues};
     use crate::{
         error::Error,
         ff::{Field, Fp31, Fp32BitPrime},
         helpers::{Direction, Role},
         protocol::{
-            basics::Reveal,
             context::{
-                Context, UpgradableContext, UpgradedContext, UpgradedMaliciousContext, Validator,
+                Context, UpgradableContext, UpgradedContext, UpgradedMaliciousContext,
+                UpgradedSemiHonestContext, Validator,
             },
             RecordId,
         },
@@ -230,6 +298,7 @@ mod tests {
             },
             IntoShares, SharedValue,
         },
+        sharding::NotSharded,
         test_executor::run,
         test_fixture::{join3v, Runner, TestWorld},
     };
@@ -243,14 +312,18 @@ mod tests {
 
         let input = rng.gen::<TestField>();
         let results = world
-            .semi_honest(input, |ctx, share| async move {
-                TestField::from_array(
-                    &share
-                        .reveal(ctx.set_total_records(1), RecordId::from(0))
-                        .await
-                        .unwrap(),
-                )
-            })
+            .upgraded_semi_honest(
+                input,
+                |ctx: UpgradedSemiHonestContext<NotSharded, TestField>, share| async move {
+                    TestField::from_array(
+                        &share
+                            .reveal(ctx.set_total_records(1), RecordId::from(0))
+                            .await
+                            .unwrap()
+                            .access_without_verification(),
+                    )
+                },
+            )
             .await;
 
         assert_eq!(input, results[0]);
@@ -270,13 +343,18 @@ mod tests {
         for &excluded in Role::all() {
             let input = rng.gen::<TestField>();
             let results = world
-                .semi_honest(input, |ctx, share| async move {
-                    share
-                        .partial_reveal(ctx.set_total_records(1), RecordId::from(0), excluded)
-                        .await
-                        .unwrap()
-                        .map(|revealed| TestField::from_array(&revealed))
-                })
+                .upgraded_semi_honest(
+                    input,
+                    |ctx: UpgradedSemiHonestContext<NotSharded, TestField>, share| async move {
+                        share
+                            .partial_reveal(ctx.set_total_records(1), RecordId::from(0), excluded)
+                            .await
+                            .unwrap()
+                            .map(|revealed| {
+                                TestField::from_array(&revealed.access_without_verification())
+                            })
+                    },
+                )
                 .await;
 
             for &helper in Role::all() {
@@ -293,20 +371,23 @@ mod tests {
 
     #[tokio::test]
     pub async fn vectorized() -> Result<(), Error> {
-        type TestField = [Fp32BitPrime; 32];
+        type TestField = Fp32BitPrime;
+        const DIM: usize = 32;
 
         let mut rng = thread_rng();
         let world = TestWorld::default();
 
-        let input = rng.gen::<TestField>();
+        let input = rng.gen::<[TestField; DIM]>();
         let results = world
-            .semi_honest(
+            .upgraded_semi_honest(
                 input,
-                |ctx, share: AdditiveShare<Fp32BitPrime, 32>| async move {
+                |ctx: UpgradedSemiHonestContext<NotSharded, TestField>,
+                 share: AdditiveShare<TestField, DIM>| async move {
                     share
                         .reveal(ctx.set_total_records(1), RecordId::from(0))
                         .await
                         .unwrap()
+                        .access_without_verification()
                 },
             )
             .await;
@@ -339,7 +420,13 @@ mod tests {
 
         let results = join_all(zip(m_ctx.clone().into_iter(), m_shares).map(
             |(m_ctx, m_share)| async move {
-                TestField::from_array(&m_share.reveal(m_ctx, record_id).await.unwrap())
+                TestField::from_array(
+                    &m_share
+                        .reveal(m_ctx, record_id)
+                        .await
+                        .unwrap()
+                        .access_without_verification(),
+                )
             },
         ))
         .await;
@@ -382,11 +469,13 @@ mod tests {
             ))
             .await;
 
-            for &helper in Role::all() {
+            for (&helper, result) in zip(Role::all(), results) {
+                let result = result
+                    .map(ThisCodeIsAuthorizedToObserveRevealedValues::access_without_verification);
                 if helper == excluded {
-                    assert_eq!(None, results[helper]);
+                    assert_eq!(None, result);
                 } else {
-                    assert_eq!(Some(input.into_array()), results[helper]);
+                    assert_eq!(Some(input.into_array()), result);
                 }
             }
         }

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -194,7 +194,7 @@ mod test {
             let expected_carry = (x + y) >> 64 & 1;
 
             let (result, carry) = world
-                .semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
+                .upgraded_semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
@@ -271,7 +271,7 @@ mod test {
             let expected_carry = (x + y) >> 64 & 1;
 
             let (result, carry) = world
-                .semi_honest((x_ba64, y_ba32), |ctx, x_y| async move {
+                .upgraded_semi_honest((x_ba64, y_ba32), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
@@ -292,7 +292,7 @@ mod test {
             let expected = (x + y) % (1 << 32);
             let expected_carry = (x + y) >> 32 & 1;
             let (result, carry) = world
-                .semi_honest((y_ba32, x_ba64), |ctx, x_y| async move {
+                .upgraded_semi_honest((y_ba32, x_ba64), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,


### PR DESCRIPTION
Create a wrapper around revealed values similar to the existing wrapper around downgraded values. Currently just unwrap things where needed, but there is some restructuring of protocols to consolidate reveal operations.

From talking with @danielmasny, it may be better to defer the reveal until after the DZKP has been validated. Possibly we can just do the reveal within the `validate` function, and avoid the wrapper entirely.

I am also changing reveal so that it is only implemented on "upgraded" contexts. This protects against inadvertent use of semi-honest protocols, which is a much greater concern in our new malicious security protocol where the share type is still `semi_honest::AdditiveShare`. In the previous protocol where shares were `malicious::AdditiveShare`, we were protected against inadvertently using semi-honest protocols because the non-upgraded context did not implement protocols for `malicious::AdditiveShare`. Removing protocol support from the base context requires changing a bunch of tests that used to call `TestWorld::semi_honest` to call `TestWorld::upgraded_semi_honest` instead. A similar change should be made for multiplication, but that can be done in a separate PR.