### PR TITLE
num_bernoulli from epsilon, delta

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/dp/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/dp/mod.rs
@@ -204,6 +204,7 @@ fn find_smallest_num_bernoulli(
     ell_2_sensitivity: f64,
     ell_infty_sensitivity: f64,
 ) -> u32 {
+    let mut smallest_num_bernoulli = 0;
     for num_bernoulli in 1..10_000_000 {
         if delta_constraint(
             num_bernoulli,
@@ -224,11 +225,15 @@ fn find_smallest_num_bernoulli(
                 ell_infty_sensitivity,
             )
         {
-            return num_bernoulli;
+            smallest_num_bernoulli = num_bernoulli;
+            break;
         }
     }
-    println!("smallest num_bernoulli not found");
-    0
+    assert!(
+        smallest_num_bernoulli > 0,
+        "smallest num_bernoulli not found"
+    );
+    smallest_num_bernoulli
 }
 #[cfg(all(test, unit_test))]
 mod test {

--- a/ipa-core/src/protocol/ipa_prf/dp/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/dp/mod.rs
@@ -1,6 +1,6 @@
 // DP in MPC
-
 pub mod step;
+use std::f64;
 
 use futures_util::{stream, StreamExt};
 
@@ -24,7 +24,6 @@ use crate::{
     },
     sharding::NotSharded,
 };
-
 /// # Panics
 /// Will panic if there are not enough bits in the outputs size for the noise gen sum. We can't have the noise sum saturate
 /// as that would be insecure noise.
@@ -58,16 +57,13 @@ where
             ctx.prss().generate_with(RecordId::from(i), bits);
         vector_input_to_agg.push(element);
     }
-
     // Step 2: Convert to input from needed for aggregate_values
     let aggregation_input = Box::pin(stream::iter(vector_input_to_agg.into_iter()).map(Ok));
-
     // Step 3: Call `aggregate_values` to sum up Bernoulli noise.
     let noise_vector: Result<BitDecomposed<AdditiveShare<Boolean, { B }>>, Error> =
         aggregate_values::<OV, B>(ctx, aggregation_input, num_bernoulli as usize).await;
     noise_vector
 }
-
 /// `apply_dp_noise` takes the noise distribution parameters (`num_bernoulli` and in the future `quantization_scale`)
 /// and the vector of values to have noise added to.
 /// It calls `gen_binomial_noise` to create the noise in MPC and applies it
@@ -93,7 +89,6 @@ where
     let noise_vector = gen_binomial_noise::<B, OV>(noise_gen_ctx, num_bernoulli)
         .await
         .unwrap();
-
     // Step 4:  Add DP noise to output values
     let apply_noise_ctx = ctx.narrow(&DPStep::ApplyNoise).set_total_records(1);
     let (histogram_noised, _) = integer_add::<_, SixteenBitStep, B>(
@@ -104,22 +99,209 @@ where
     )
     .await
     .unwrap();
-
     // Step 5 Transpose output representation
     Ok(Vec::transposed_from(&histogram_noised)?)
 }
-
+// implement calculations to instantiation Thm 1 of https://arxiv.org/pdf/1805.10559
+// which lets us determine the minimum necessary num_bernoulli for a given epsilon, delta
+// and other parameters
+// translation of notation from the paper to Rust variable names:
+//     p = success_prob
+//     s = quantization_scale
+//     Delta_1 = ell_1_sensitivity
+//     Delta_2 = ell_2_sensitivity
+//     Delta_infty = ell_infty_sensitivity
+//     N = num_bernoulli
+//     d = dimensions
+/// equation (17)
+#[allow(dead_code)]
+fn b_p(success_prob: f64) -> f64 {
+    (2.0 / 3.0) * (success_prob.powi(2) + (1.0 - success_prob).powi(2)) + 1.0 - 2.0 * success_prob
+}
+/// equation (12)
+#[allow(dead_code)]
+fn c_p(success_prob: f64) -> f64 {
+    2.0_f64.sqrt()
+        * (3.0 * success_prob.powi(3)
+            + 3.0 * (1.0 - success_prob).powi(3)
+            + 2.0 * success_prob.powi(2)
+            + 2.0 * (1.0 - success_prob).powi(2))
+}
+/// equation (16)
+#[allow(dead_code)]
+fn d_p(success_prob: f64) -> f64 {
+    (4.0 / 3.0) * (success_prob.powi(2) + (1.0 - success_prob).powi(2))
+}
+/// equation (7)
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+fn epsilon_constraint(
+    num_bernoulli: u32,
+    success_prob: f64,
+    delta: f64,
+    quantization_scale: f64,
+    dimensions: f64,
+    ell_1_sensitivity: f64,
+    ell_2_sensitivity: f64,
+    ell_infty_sensitivity: f64,
+) -> f64 {
+    let num_bernoulli_f64 = f64::from(num_bernoulli);
+    let first_term_num = ell_2_sensitivity * (2.0 * (1.25 / delta).ln()).sqrt();
+    let first_term_den =
+        quantization_scale * (num_bernoulli_f64 * success_prob * (1.0 - success_prob)).sqrt();
+    let second_term_num = ell_2_sensitivity * c_p(success_prob) * ((10.0 / delta).ln()).sqrt()
+        + ell_1_sensitivity * b_p(success_prob);
+    let second_term_den = quantization_scale
+        * num_bernoulli_f64
+        * success_prob
+        * (1.0 - success_prob)
+        * (1.0 - delta / 10.0);
+    let third_term_num = (2.0 / 3.0) * ell_infty_sensitivity * (1.25 / delta).ln()
+        + ell_infty_sensitivity
+            * d_p(success_prob)
+            * (20.0 * dimensions / delta).ln()
+            * (10.0 / delta).ln();
+    let third_term_den =
+        quantization_scale * num_bernoulli_f64 * success_prob * (1.0 - success_prob);
+    first_term_num / first_term_den
+        + second_term_num / second_term_den
+        + third_term_num / third_term_den
+}
+/// constraint from delta in Thm 1
+#[allow(dead_code)]
+fn delta_constraint(
+    num_bernoulli: u32,
+    success_prob: f64,
+    dimensions: f64,
+    quantization_scale: f64,
+    delta: f64,
+    ell_infty_sensitivity: f64,
+) -> bool {
+    let lhs = f64::from(num_bernoulli) * success_prob * (1.0 - success_prob);
+    let rhs = (23.0 * (10.0 * dimensions / delta).ln())
+        .max(2.0 * ell_infty_sensitivity / quantization_scale);
+    lhs >= rhs
+}
+/// error of mechanism in Thm 1
+#[allow(dead_code)]
+fn error(num_bernoulli: u32, success_prob: f64, dimensions: f64, quantization_scale: f64) -> f64 {
+    dimensions
+        * quantization_scale.powi(2)
+        * f64::from(num_bernoulli)
+        * success_prob
+        * (1.0 - success_prob)
+}
+/// for fixed p (and other params), find smallest `num_bernoulli` such that `epsilon < desired_epsilon`
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+fn find_smallest_num_bernoulli(
+    desired_epsilon: f64,
+    success_prob: f64,
+    delta: f64,
+    dimensions: f64,
+    quantization_scale: f64,
+    ell_1_sensitivity: f64,
+    ell_2_sensitivity: f64,
+    ell_infty_sensitivity: f64,
+) -> u32 {
+    for num_bernoulli in 1..10_000_000 {
+        if delta_constraint(
+            num_bernoulli,
+            success_prob,
+            dimensions,
+            quantization_scale,
+            delta,
+            ell_infty_sensitivity,
+        ) && desired_epsilon
+            >= epsilon_constraint(
+                num_bernoulli,
+                success_prob,
+                delta,
+                quantization_scale,
+                dimensions,
+                ell_1_sensitivity,
+                ell_2_sensitivity,
+                ell_infty_sensitivity,
+            )
+        {
+            return num_bernoulli;
+        }
+    }
+    println!("smallest num_bernoulli not found");
+    0
+}
 #[cfg(all(test, unit_test))]
 mod test {
     use crate::{
         ff::{boolean::Boolean, boolean_array::BA16, U128Conversions},
-        protocol::ipa_prf::dp::{apply_dp_noise, gen_binomial_noise},
+        protocol::ipa_prf::dp::{
+            apply_dp_noise, delta_constraint, epsilon_constraint, error,
+            find_smallest_num_bernoulli, gen_binomial_noise,
+        },
         secret_sharing::{
             replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
         },
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
-
+    #[test]
+    fn test_epsilon_simple_aggregation_case() {
+        let delta = 1e-6;
+        let dimensions = 1.0;
+        let quantization_scale = 1.0;
+        let success_prob = 0.5;
+        let ell_1_sensitivity = 1.0;
+        let ell_2_sensitivity = 1.0;
+        let ell_infty_sensitivity = 1.0;
+        let num_bernoulli = 2000;
+        assert!(delta_constraint(
+            num_bernoulli,
+            success_prob,
+            dimensions,
+            quantization_scale,
+            delta,
+            ell_infty_sensitivity
+        ));
+        let eps = epsilon_constraint(
+            num_bernoulli,
+            success_prob,
+            delta,
+            quantization_scale,
+            dimensions,
+            ell_1_sensitivity,
+            ell_2_sensitivity,
+            ell_infty_sensitivity,
+        );
+        assert!(eps > 0.6375 && eps < 0.6376, "eps = {eps}");
+    }
+    #[test]
+    fn test_num_bernoulli_simple_aggregation_case() {
+        let success_prob = 0.5;
+        let desired_epsilon = 1.0;
+        let delta = 1e-6;
+        let dimensions = 1.0;
+        let quantization_scale = 1.0;
+        let ell_1_sensitivity = 1.0;
+        let ell_2_sensitivity = 1.0;
+        let ell_infty_sensitivity = 1.0;
+        let smallest_num_bernoulli = find_smallest_num_bernoulli(
+            desired_epsilon,
+            success_prob,
+            delta,
+            dimensions,
+            quantization_scale,
+            ell_1_sensitivity,
+            ell_2_sensitivity,
+            ell_infty_sensitivity,
+        );
+        let err = error(
+            smallest_num_bernoulli,
+            success_prob,
+            dimensions,
+            quantization_scale,
+        );
+        assert_eq!(smallest_num_bernoulli, 1483_u32);
+        assert!(err <= 370.75 && err > 370.7);
+    }
     // Tests for apply_dp_noise
     #[tokio::test]
     pub async fn test_apply_dp_noise() {
@@ -155,13 +337,12 @@ mod test {
                 f64::from(result_u32[i]) - f64::from(input_values[i])
                     > mean - 5.0 * standard_deviation
                     && f64::from(result_u32[i]) - f64::from(input_values[i])
-                        < mean + 5.0 * standard_deviation
+                    < mean + 5.0 * standard_deviation
                 , "test failed because noised result is more than 5 standard deviations of the noise distribution \
                 from the original input values. This will fail with a small chance of failure"
             );
         }
     }
-
     fn vectorize_input<const B: usize>(
         bit_width: usize,
         values: &[u32],
@@ -171,7 +352,6 @@ mod test {
             values.map(|v| Boolean::from((v >> i) & 1 == 1))
         })
     }
-
     // Tests for gen_bernoulli_noise
     #[tokio::test]
     pub async fn test_16_breakdowns() {
@@ -209,7 +389,6 @@ mod test {
         }
         println!("result as u32 {result_u32:?}");
     }
-
     #[tokio::test]
     pub async fn test_32_breakdowns() {
         type OutputValue = BA16;
@@ -246,7 +425,6 @@ mod test {
         }
         println!("result as u32 {result_u32:?}");
     }
-
     #[tokio::test]
     pub async fn test_256_breakdowns() {
         type OutputValue = BA16;


### PR DESCRIPTION
Small PR to implement Thm 1 of this paper https://arxiv.org/pdf/1805.10559 which allows us to go from an epsilon, delta and other parameters to the minimum number of bernoulli samples we need to achieve that level of DP.
See this doc for more discussion. https://docs.google.com/document/d/116qQIgVoz3uV8axbmVWfif6dTjBVww5THecPqC0kERw/edit
Much of this PR is a translation into Rust of this earlier python script https://github.com/private-attribution/ipa/compare/main...bmcase:raw-ipa:binomial_variable_p