### PR TITLE
Carve out the attribution circuit from aggregation routine

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
+use tracing::Instrument;
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
@@ -20,7 +21,7 @@ use crate::{
         ipa_prf::{
             aggregation::step::{AggregateValuesStep, AggregationStep as Step},
             boolean_ops::addition_sequential::{integer_add, integer_sat_add},
-            prf_sharding::AttributionOutputs,
+            prf_sharding::{AttributionOutputs, SecretSharedAttributionOutputs},
             BreakdownKey,
         },
         RecordId,
@@ -122,13 +123,14 @@ where
 //
 // The output is `&[BitDecomposed<AdditiveShare<Boolean, {buckets}>>]`, indexed by
 // contribution rows, bits of trigger value, and buckets.
+#[tracing::instrument(name = "aggregate", skip_all, fields(streams = contributions_stream_len))]
 pub async fn aggregate_contributions<'ctx, St, BK, TV, HV, const B: usize, const N: usize>(
     ctx: UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>,
     contributions_stream: St,
     contributions_stream_len: usize,
 ) -> Result<Vec<Replicated<HV>>, Error>
 where
-    St: Stream<Item = Result<AttributionOutputs<Replicated<BK>, Replicated<TV>>, Error>> + Send,
+    St: Stream<Item = Result<SecretSharedAttributionOutputs<BK, TV>, Error>> + Send,
     BK: BreakdownKey<B>,
     TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
     HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
@@ -170,6 +172,7 @@ where
                     B,
                     false,
                 )
+                .instrument(tracing::debug_span!("move_to_bucket", chunk = idx))
                 .await
             }
         },
@@ -285,7 +288,7 @@ where
                                 } else {
                                     assert!(
                                         OV::BITS <= SixteenBitStep::BITS,
-                                        "SixteenBitStep not large enough to accomodate this sum"
+                                        "SixteenBitStep not large enough to accommodate this sum"
                                     );
                                     integer_sat_add::<_, SixteenBitStep, B>(
                                         ctx.narrow(&AggregateValuesStep::SaturatingAdd),
@@ -298,6 +301,12 @@ where
                             }
                         }
                     }
+                    .instrument(tracing::trace_span!(
+                        "reduce",
+                        depth = depth,
+                        rows = num_rows,
+                        record = i
+                    ))
                 }),
         );
         num_rows = next_num_rows;


### PR DESCRIPTION
It should help to better understand the bottlenecks, so more tracing was added to each routine to see the latency breakdown

I also had to fix some clippy issues after refactoring, so new type alias is there for this exact reason

## Testing

```bash
2024-06-04T00:51:33.032403Z  INFO ipa_core::cli::verbosity: Logging setup at level info
2024-06-04T00:51:33.424129Z  INFO ipa_core::net::server: server listening on http://0.0.0.0:3002
2024-06-04T00:53:05.842863Z  INFO stall_detector{role=H3}: ipa_core::helpers::gateway::stall_detection::gateway: new
2024-06-04T00:53:05.846146Z  INFO oprf_ipa_query{sz=50000}: ipa_core::query::runner::oprf_ipa: new
2024-06-04T00:53:05.846201Z  INFO oprf_ipa_query{sz=50000}: ipa_core::query::runner::oprf_ipa: New query: IpaQueryConfig { per_user_credit_cap: 8, max_breakdown_key: 20, attribution_window_seconds: None, num_multi_bits: 3, plaintext_match_keys: true }
2024-06-04T00:53:05.848522Z  INFO oprf_ipa_query{sz=50000}:shuffle_inputs: ipa_core::protocol::ipa_prf::shuffle: new
2024-06-04T00:53:06.577035Z  INFO oprf_ipa_query{sz=50000}:shuffle_inputs: ipa_core::protocol::ipa_prf::shuffle: close time.busy=434ms time.idle=294ms
2024-06-04T00:53:06.577098Z  INFO oprf_ipa_query{sz=50000}:compute_prf_for_inputs: ipa_core::protocol::ipa_prf: new
2024-06-04T00:53:16.703835Z  INFO oprf_ipa_query{sz=50000}:compute_prf_for_inputs: ipa_core::protocol::ipa_prf: close time.busy=4.38s time.idle=5.75s
2024-06-04T00:53:16.706598Z  INFO oprf_ipa_query{sz=50000}:histograms_ranges_sortkeys: ipa_core::protocol::ipa_prf::prf_sharding: new
2024-06-04T00:53:16.717030Z  INFO oprf_ipa_query{sz=50000}:histograms_ranges_sortkeys: ipa_core::protocol::ipa_prf::prf_sharding: close time.busy=10.4ms time.idle=22.7µs
2024-06-04T00:53:16.854015Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate: ipa_core::protocol::ipa_prf::prf_sharding: new
2024-06-04T00:53:16.855536Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate:attribute_cap{unique_match_keys=8161}: ipa_core::protocol::ipa_prf::prf_sharding: new
2024-06-04T00:53:20.499627Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate:attribute_cap{unique_match_keys=8161}: ipa_core::protocol::ipa_prf::prf_sharding: close time.busy=1.41s time.idle=2.24s
2024-06-04T00:53:20.499669Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate:aggregate{streams=40926}: ipa_core::protocol::ipa_prf::aggregation: new
2024-06-04T00:53:30.700421Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate:aggregate{streams=40926}: ipa_core::protocol::ipa_prf::aggregation: close time.busy=1.98s time.idle=8.22s
2024-06-04T00:53:30.700461Z  INFO oprf_ipa_query{sz=50000}:attribute_cap_aggregate: ipa_core::protocol::ipa_prf::prf_sharding: close time.busy=1.30s time.idle=12.5s
2024-06-04T00:53:30.700469Z  INFO oprf_ipa_query{sz=50000}: ipa_core::query::runner::oprf_ipa: close time.busy=1.85s time.idle=23.0s
2024-06-04T00:53:35.845004Z  INFO stall_detector{role=H3}: ipa_core::helpers::gateway::stall_detection::gateway: close time.busy=18.8µs time.idle=30.0s
```

