### PR TITLE
Simplify some things related to boolean arrays

### DIFF
--- a/ipa-core/src/ff/boolean_array.rs
+++ b/ipa-core/src/ff/boolean_array.rs
@@ -9,7 +9,7 @@ use typenum::{U14, U2, U32, U8};
 
 use crate::{
     error::LengthError,
-    ff::{boolean::Boolean, ArrayAccess, Field, Serializable, U128Conversions},
+    ff::{boolean::Boolean, ArrayAccess, Expand, Field, Serializable, U128Conversions},
     protocol::prss::{FromRandom, FromRandomU128},
     secret_sharing::{Block, SharedValue, StdArray, Vectorizable},
 };
@@ -29,6 +29,19 @@ macro_rules! store_impl {
             type Size = $arraylength;
         }
     };
+}
+
+pub trait BooleanArray:
+    SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean> + FromIterator<Boolean>
+{
+}
+
+impl<A> BooleanArray for A where
+    A: SharedValue
+        + ArrayAccess<Output = Boolean>
+        + Expand<Input = Boolean>
+        + FromIterator<Boolean>
+{
 }
 
 /// Iterator returned by `.iter()` on Boolean arrays
@@ -256,7 +269,7 @@ macro_rules! boolean_array_impl {
                 ff::{boolean::Boolean, ArrayAccess, Expand, Serializable},
                 impl_shared_value_common,
                 secret_sharing::{
-                    replicated::semi_honest::{ASIterator, AdditiveShare},
+                    replicated::semi_honest::{BAASIterator, AdditiveShare},
                     FieldArray, SharedValue, SharedValueArray,
                 },
             };
@@ -532,7 +545,7 @@ macro_rules! boolean_array_impl {
             #[allow(clippy::into_iter_without_iter)]
             impl<'a> IntoIterator for &'a AdditiveShare<$name> {
                 type Item = AdditiveShare<Boolean>;
-                type IntoIter = ASIterator<'a, $name, Boolean>;
+                type IntoIter = BAASIterator<'a, $name>;
 
                 fn into_iter(self) -> Self::IntoIter {
                     self.iter()

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -11,7 +11,6 @@ mod galois_field;
 mod prime_field;
 
 use std::{
-    borrow::Borrow,
     convert::Infallible,
     ops::{Add, AddAssign, Sub, SubAssign},
 };
@@ -110,43 +109,8 @@ pub trait ArrayAccess {
     }
 }
 
-pub trait ArrayAccessRef {
-    type Element;
-    type Ref<'a>: Borrow<Self::Element> + Clone
-    where
-        Self: 'a;
-    type Iter<'a>: Iterator<Item = Self::Ref<'a>> + ExactSizeIterator + Send
-    where
-        Self: 'a;
-
-    fn get(&self, index: usize) -> Option<Self::Ref<'_>>;
-
-    fn set(&mut self, index: usize, e: Self::Ref<'_>);
-
-    fn iter(&self) -> Self::Iter<'_>;
-}
-
 pub trait Expand {
     type Input;
 
     fn expand(v: &Self::Input) -> Self;
-}
-
-/// Custom Array trait
-/// supports access to elements via `ArrayAccess` and functions `get(Index: usize)` and `set(Index: usize, v: Element)`
-/// supports `Expand` for `Element`, converts Element into array, all array elements will be set to the value of `Element`
-/// supports `FromIterator` to collect an iterator of elements back into the original type
-pub trait CustomArray
-where
-    Self: ArrayAccess<Output = Self::Element> + Expand<Input = Self::Element>,
-{
-    type Element;
-}
-
-/// impl Custom Array for all compatible structs
-impl<S> CustomArray for S
-where
-    S: ArrayAccess + Expand<Input = <S as ArrayAccess>::Output>,
-{
-    type Element = <S as ArrayAccess>::Output;
 }

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -9,7 +9,7 @@ use tracing::Instrument;
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
-    ff::{boolean::Boolean, CustomArray, U128Conversions},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, U128Conversions},
     helpers::{
         stream::{process_stream_by_chunks, ChunkBuffer, FixedLength, TryFlattenItersExt},
         TotalRecords,
@@ -132,8 +132,8 @@ pub async fn aggregate_contributions<'ctx, St, BK, TV, HV, const B: usize, const
 where
     St: Stream<Item = Result<SecretSharedAttributionOutputs<BK, TV>, Error>> + Send,
     BK: BreakdownKey<B>,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: BooleanArray + U128Conversions,
+    HV: BooleanArray + U128Conversions,
     Boolean: FieldSimd<N> + FieldSimd<B>,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
@@ -235,7 +235,7 @@ pub async fn aggregate_values<'ctx, 'fut, OV, const B: usize>(
 ) -> Result<BitDecomposed<Replicated<Boolean, B>>, Error>
 where
     'ctx: 'fut,
-    OV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    OV: BooleanArray + U128Conversions,
     Boolean: FieldSimd<B>,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -4,7 +4,7 @@ use ipa_step::StepNarrow;
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, ArrayAccessRef},
+    ff::boolean::Boolean,
     helpers::repeat_n,
     protocol::{
         basics::{BooleanProtocols, SecureMul},

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -10,16 +10,14 @@ use ipa_step::StepNarrow;
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, ArrayAccessRef, CustomArray, Field},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, Field},
     protocol::{
         basics::{select, BooleanArrayMul, BooleanProtocols, SecureMul, ShareKnownValue},
         boolean::NBitStep,
         context::{Context, SemiHonestContext},
         Gate, RecordId,
     },
-    secret_sharing::{
-        replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd, SharedValue,
-    },
+    secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
 };
 
 /// Comparison operation
@@ -107,7 +105,7 @@ pub async fn integer_sat_sub<S, St>(
     y: &AdditiveShare<S>,
 ) -> Result<AdditiveShare<S>, Error>
 where
-    S: SharedValue + CustomArray<Element = Boolean>,
+    S: BooleanArray,
     St: NBitStep,
     for<'a> AdditiveShare<S>: BooleanArrayMul<SemiHonestContext<'a>>,
     Gate: StepNarrow<St>,

--- a/ipa-core/src/protocol/ipa_prf/dp/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/dp/mod.rs
@@ -6,7 +6,7 @@ use futures_util::{stream, StreamExt};
 
 use crate::{
     error::{Error, LengthError},
-    ff::{boolean::Boolean, CustomArray, U128Conversions},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, U128Conversions},
     protocol::{
         boolean::step::SixteenBitStep,
         context::{Context, UpgradedSemiHonestContext},
@@ -20,7 +20,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::semi_honest::{AdditiveShare as Replicated, AdditiveShare},
-        BitDecomposed, FieldSimd, SharedValue, TransposeFrom, Vectorizable,
+        BitDecomposed, FieldSimd, TransposeFrom, Vectorizable,
     },
     sharding::NotSharded,
 };
@@ -37,7 +37,7 @@ pub async fn gen_binomial_noise<'ctx, const B: usize, OV>(
 where
     Boolean: Vectorizable<B> + FieldSimd<B>,
     BitDecomposed<Replicated<Boolean, B>>: FromPrss<usize>,
-    OV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    OV: BooleanArray + U128Conversions,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
 {
@@ -83,7 +83,7 @@ pub async fn apply_dp_noise<'ctx, const B: usize, OV>(
 where
     Boolean: Vectorizable<B> + FieldSimd<B>,
     BitDecomposed<Replicated<Boolean, B>>: FromPrss<usize>,
-    OV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    OV: BooleanArray + U128Conversions,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
     Vec<Replicated<OV>>:

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -14,9 +14,9 @@ use crate::{
     error::{Error, LengthError, UnwrapInfallible},
     ff::{
         boolean::Boolean,
-        boolean_array::{BA5, BA64, BA8},
+        boolean_array::{BooleanArray, BA5, BA64, BA8},
         ec_prime_field::Fp25519,
-        CustomArray, Serializable, U128Conversions,
+        Serializable, U128Conversions,
     },
     helpers::stream::{process_slice_by_chunks, Chunk, ChunkData, TryFlattenItersExt},
     protocol::{
@@ -73,10 +73,7 @@ pub const MK_BITS: usize = BA64::BITS as usize;
 // supplying an associated constant `<BK as BreakdownKey>::MAX_BREAKDOWNS` as the value of a const
 // parameter.) Structured the way we have it, it probably doesn't make sense to use the
 // `BreakdownKey` trait in places where the `B` const parameter is not already available.
-pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>:
-    SharedValue + U128Conversions + CustomArray<Element = Boolean>
-{
-}
+pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>: BooleanArray + U128Conversions {}
 impl BreakdownKey<32> for BA5 {}
 impl BreakdownKey<256> for BA8 {}
 
@@ -220,9 +217,9 @@ pub async fn oprf_ipa<'ctx, BK, TV, HV, TS, const SS_BITS: usize, const B: usize
 ) -> Result<Vec<Replicated<HV>>, Error>
 where
     BK: BreakdownKey<B>,
-    TV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
-    TS: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    TV: BooleanArray + U128Conversions,
+    HV: BooleanArray + U128Conversions,
+    TS: BooleanArray + U128Conversions,
     Boolean: FieldSimd<B>,
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
@@ -272,9 +269,9 @@ async fn compute_prf_for_inputs<C, BK, TV, TS>(
 where
     C: UpgradableContext,
     C::UpgradedContext<Boolean>: UpgradedContext<Field = Boolean, Share = Replicated<Boolean>>,
-    BK: SharedValue + CustomArray<Element = Boolean>,
-    TV: SharedValue + CustomArray<Element = Boolean>,
-    TS: SharedValue + CustomArray<Element = Boolean>,
+    BK: BooleanArray,
+    TV: BooleanArray,
+    TS: BooleanArray,
     Replicated<Boolean, CONV_CHUNK>: BooleanProtocols<C, CONV_CHUNK>,
     Replicated<Fp25519, PRF_CHUNK>: SecureMul<C> + FromPrss,
 {

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -8,7 +8,7 @@ use futures_util::{future::try_join, stream::unfold, Stream, StreamExt};
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
-    ff::{boolean::Boolean, CustomArray, Expand, Field, U128Conversions},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, Expand, Field, U128Conversions},
     helpers::{repeat_n, stream::TryFlattenItersExt},
     protocol::{
         basics::{SecureMul, ShareKnownValue},
@@ -220,7 +220,7 @@ where
     Replicated<Boolean, B>:
         BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
     TV: SharedValue,
-    HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    HV: BooleanArray + U128Conversions,
     BitDecomposed<Replicated<Boolean, B>>:
         for<'a> TransposeFrom<&'a [Replicated<TV>; B], Error = Infallible>,
     Vec<Replicated<HV>>:

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -5,7 +5,7 @@ use futures::stream::{self, repeat, StreamExt, TryStreamExt};
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
-    ff::{boolean::Boolean, CustomArray, Expand},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, Expand},
     helpers::stream::{process_stream_by_chunks, ChunkBuffer, TryFlattenItersExt},
     protocol::{
         basics::Reveal,
@@ -125,7 +125,7 @@ pub async fn quicksort_ranges_by_key_insecure<K, F, S>(
 where
     S: Send + Sync,
     F: Fn(&S) -> &AdditiveShare<K> + Sync + Send + Copy,
-    K: SharedValue + CustomArray<Element = Boolean>,
+    K: BooleanArray,
     <Boolean as Vectorizable<SORT_CHUNK>>::Array: Expand<Input = Boolean>,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
         for<'a> TransposeFrom<&'a [AdditiveShare<K>; SORT_CHUNK], Error = Infallible>,

--- a/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     error::Error,
     ff::{
         boolean::Boolean,
-        boolean_array::{BA112, BA64},
-        ArrayAccess, CustomArray, Expand,
+        boolean_array::{BooleanArray, BA112, BA64},
+        ArrayAccess,
     },
     protocol::{context::Context, ipa_prf::OPRFIPAInputRow},
     secret_sharing::{
@@ -26,9 +26,9 @@ pub async fn shuffle_inputs<C, BK, TV, TS>(
 ) -> Result<Vec<OPRFIPAInputRow<BK, TV, TS>>, Error>
 where
     C: Context,
-    BK: SharedValue + CustomArray<Element = Boolean>,
-    TV: SharedValue + CustomArray<Element = Boolean>,
-    TS: SharedValue + CustomArray<Element = Boolean>,
+    BK: BooleanArray,
+    TV: BooleanArray,
+    TS: BooleanArray,
 {
     let shuffle_input: Vec<AdditiveShare<BA112>> = input
         .into_iter()
@@ -48,10 +48,10 @@ pub fn oprfreport_to_shuffle_input<YS, BK, TV, TS>(
     input: &OPRFIPAInputRow<BK, TV, TS>,
 ) -> AdditiveShare<YS>
 where
-    YS: CustomArray<Element = <BA112 as CustomArray>::Element> + SharedValue,
-    BK: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
-    TV: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
-    TS: SharedValue + ArrayAccess<Output = Boolean> + Expand<Input = Boolean>,
+    YS: BooleanArray,
+    BK: BooleanArray,
+    TV: BooleanArray,
+    TS: BooleanArray,
 {
     let mut y = AdditiveShare::new(YS::ZERO, YS::ZERO);
     expand_shared_array_in_place(&mut y, &input.match_key, 0);
@@ -78,10 +78,10 @@ pub fn shuffled_to_oprfreport<YS, BK, TV, TS>(
     input: &AdditiveShare<YS>,
 ) -> OPRFIPAInputRow<BK, TV, TS>
 where
-    YS: SharedValue + CustomArray<Element = Boolean>,
-    BK: SharedValue + CustomArray<Element = Boolean>,
-    TV: SharedValue + CustomArray<Element = Boolean>,
-    TS: SharedValue + CustomArray<Element = Boolean>,
+    YS: BooleanArray,
+    BK: BooleanArray,
+    TV: BooleanArray,
+    TS: BooleanArray,
 {
     let match_key = extract_from_shared_array::<YS, BA64>(input, 0);
 

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -7,8 +7,8 @@ use crate::{
     error::{Error, LengthError},
     ff::{
         boolean::Boolean,
-        boolean_array::{BA20, BA3, BA8},
-        CustomArray, Field, Serializable, U128Conversions,
+        boolean_array::{BooleanArray, BA20, BA3, BA8},
+        Field, Serializable, U128Conversions,
     },
     helpers::{
         query::{IpaQueryConfig, QuerySize},
@@ -48,7 +48,7 @@ impl<'a, HV> OprfIpaQuery<'a, HV> {
 #[allow(clippy::too_many_lines)]
 impl<'ctx, HV> OprfIpaQuery<'ctx, HV>
 where
-    HV: SharedValue + U128Conversions + CustomArray<Element = Boolean>,
+    HV: BooleanArray + U128Conversions,
     Replicated<Boolean>: Serializable + ShareKnownValue<SemiHonestContext<'ctx>, Boolean>,
     Vec<Replicated<HV>>:
         for<'a> TransposeFrom<&'a BitDecomposed<Replicated<Boolean, 256>>, Error = LengthError>,

--- a/ipa-core/src/secret_sharing/replicated/semi_honest/mod.rs
+++ b/ipa-core/src/secret_sharing/replicated/semi_honest/mod.rs
@@ -1,3 +1,3 @@
 mod additive_share;
 
-pub use additive_share::{ASIterator, AdditiveShare};
+pub use additive_share::{AdditiveShare, BAASIterator};

--- a/ipa-core/src/secret_sharing/vector/transpose.rs
+++ b/ipa-core/src/secret_sharing/vector/transpose.rs
@@ -893,8 +893,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ff::ArrayAccess,
-        secret_sharing::{StdArray, Vectorizable},
+        ff::{boolean_array::BooleanArray, ArrayAccess},
+        secret_sharing::Vectorizable,
     };
 
     fn random_array<T, const N: usize>() -> [T; N]
@@ -1022,12 +1022,9 @@ mod tests {
         test_transpose_array::<u16, 16, 32>(super::transpose_16x16);
     }
 
-    fn ba_shares_test_matrix<BA, const M: usize, const N: usize>(
+    fn ba_shares_test_matrix<BA: BooleanArray, const M: usize, const N: usize>(
         step: usize,
-    ) -> [AdditiveShare<BA>; M]
-    where
-        BA: SharedValue + FromIterator<Boolean> + Vectorizable<1, Array = StdArray<BA, 1>>,
-    {
+    ) -> [AdditiveShare<BA>; M] {
         array::from_fn(|i| {
             let mut left = vec![Boolean::FALSE; N];
             let mut right = vec![Boolean::FALSE; N];
@@ -1072,8 +1069,8 @@ mod tests {
         const DM: usize, // Destination rows (== source cols)
     >()
     where
-        SR: PartialEq<SR> + SharedValue + ArrayAccess<Output = Boolean>,
-        DR: PartialEq<DR> + SharedValue + ArrayAccess<Output = Boolean>,
+        SR: PartialEq<SR> + BooleanArray,
+        DR: PartialEq<DR> + BooleanArray,
         [DR; DM]: for<'a> TransposeFrom<&'a [SR; SM], Error = Infallible>,
         Standard: Distribution<SR>,
     {
@@ -1118,11 +1115,8 @@ mod tests {
     >()
     where
         Boolean: Vectorizable<SM>,
-        <Boolean as Vectorizable<SM>>::Array: ArrayAccess<Output = Boolean>,
-        SR: SharedValue
-            + ArrayAccess<Output = Boolean>
-            + FromIterator<Boolean>
-            + Vectorizable<1, Array = StdArray<SR, 1>>,
+        <Boolean as Vectorizable<SM>>::Array: BooleanArray,
+        SR: BooleanArray,
         [AdditiveShare<Boolean, SM>; DM]:
             for<'a> TransposeFrom<&'a [AdditiveShare<SR>; SM], Error = Infallible>,
         Standard: Distribution<SR>,
@@ -1160,11 +1154,8 @@ mod tests {
     >()
     where
         Boolean: Vectorizable<SM>,
-        <Boolean as Vectorizable<SM>>::Array: ArrayAccess<Output = Boolean>,
-        SR: SharedValue
-            + ArrayAccess<Output = Boolean>
-            + FromIterator<Boolean>
-            + Vectorizable<1, Array = StdArray<SR, 1>>,
+        <Boolean as Vectorizable<SM>>::Array: BooleanArray,
+        SR: BooleanArray,
         BitDecomposed<AdditiveShare<Boolean, SM>>:
             for<'a> TransposeFrom<&'a Vec<AdditiveShare<SR>>, Error = LengthError>,
         Standard: Distribution<SR>,
@@ -1203,11 +1194,8 @@ mod tests {
     >()
     where
         Boolean: Vectorizable<SM>,
-        <Boolean as Vectorizable<SM>>::Array: ArrayAccess<Output = Boolean>,
-        SR: SharedValue
-            + ArrayAccess<Output = Boolean>
-            + FromIterator<Boolean>
-            + Vectorizable<1, Array = StdArray<SR, 1>>,
+        <Boolean as Vectorizable<SM>>::Array: BooleanArray,
+        SR: BooleanArray,
         [AdditiveShare<Boolean, SM>; DM]:
             for<'a> TransposeFrom<&'a dyn Fn(usize) -> AdditiveShare<SR>, Error = Infallible>,
         Standard: Distribution<SR>,
@@ -1247,11 +1235,8 @@ mod tests {
     >()
     where
         Boolean: Vectorizable<DM>,
-        <Boolean as Vectorizable<DM>>::Array: ArrayAccess<Output = Boolean>,
-        DR: SharedValue
-            + ArrayAccess<Output = Boolean>
-            + FromIterator<Boolean>
-            + Vectorizable<1, Array = StdArray<DR, 1>>,
+        <Boolean as Vectorizable<DM>>::Array: BooleanArray,
+        DR: BooleanArray,
         [AdditiveShare<DR>; DM]:
             for<'a> TransposeFrom<&'a [AdditiveShare<Boolean, DM>; SM], Error = Infallible>,
     {
@@ -1286,8 +1271,8 @@ mod tests {
     >()
     where
         Boolean: Vectorizable<SM> + Vectorizable<DM>,
-        <Boolean as Vectorizable<SM>>::Array: ArrayAccess<Output = Boolean>,
-        <Boolean as Vectorizable<DM>>::Array: ArrayAccess<Output = Boolean>,
+        <Boolean as Vectorizable<SM>>::Array: BooleanArray,
+        <Boolean as Vectorizable<DM>>::Array: BooleanArray,
         Vec<BitDecomposed<AdditiveShare<Boolean, SM>>>: for<'a> TransposeFrom<
             &'a [BitDecomposed<AdditiveShare<Boolean, DM>>],
             Error = Infallible,

--- a/ipa-core/src/test_fixture/input/sharing.rs
+++ b/ipa-core/src/test_fixture/input/sharing.rs
@@ -1,13 +1,17 @@
 use std::iter::{repeat, zip};
 
 use crate::{
-    ff::{boolean::Boolean, boolean_array::BA64, U128Conversions},
+    ff::{
+        boolean::Boolean,
+        boolean_array::{BooleanArray, BA64},
+        U128Conversions,
+    },
     protocol::ipa_prf::OPRFIPAInputRow,
     rand::Rng,
     report::{EventType, OprfReport},
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},
-        IntoShares, SharedValue,
+        IntoShares,
     },
     test_fixture::{ipa::TestRawDataRecord, Reconstruct},
 };
@@ -22,9 +26,9 @@ const DOMAINS: &[&str] = &[
 // TODO: this mostly duplicates the impl for GenericReportTestInput, can we avoid that?
 impl<BK, TV, TS> IntoShares<OprfReport<BK, TV, TS>> for TestRawDataRecord
 where
-    BK: SharedValue + U128Conversions + IntoShares<Replicated<BK>>,
-    TV: SharedValue + U128Conversions + IntoShares<Replicated<TV>>,
-    TS: SharedValue + U128Conversions + IntoShares<Replicated<TS>>,
+    BK: BooleanArray + U128Conversions + IntoShares<Replicated<BK>>,
+    TV: BooleanArray + U128Conversions + IntoShares<Replicated<TV>>,
+    TS: BooleanArray + U128Conversions + IntoShares<Replicated<TS>>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [OprfReport<BK, TV, TS>; 3] {
         let match_key = BA64::try_from(u128::from(self.user_id))
@@ -67,9 +71,9 @@ where
 
 impl<BK, TV, TS> IntoShares<OPRFIPAInputRow<BK, TV, TS>> for TestRawDataRecord
 where
-    BK: SharedValue + U128Conversions + IntoShares<Replicated<BK>>,
-    TV: SharedValue + U128Conversions + IntoShares<Replicated<TV>>,
-    TS: SharedValue + U128Conversions + IntoShares<Replicated<TS>>,
+    BK: BooleanArray + U128Conversions + IntoShares<Replicated<BK>>,
+    TV: BooleanArray + U128Conversions + IntoShares<Replicated<TV>>,
+    TS: BooleanArray + U128Conversions + IntoShares<Replicated<TS>>,
 {
     fn share_with<R: Rng>(self, rng: &mut R) -> [OPRFIPAInputRow<BK, TV, TS>; 3] {
         let is_trigger = Replicated::new(
@@ -112,9 +116,9 @@ where
 
 impl<BK, TV, TS> Reconstruct<TestRawDataRecord> for [&OPRFIPAInputRow<BK, TV, TS>; 3]
 where
-    BK: SharedValue + U128Conversions,
-    TV: SharedValue + U128Conversions,
-    TS: SharedValue + U128Conversions,
+    BK: BooleanArray + U128Conversions + IntoShares<Replicated<BK>>,
+    TV: BooleanArray + U128Conversions + IntoShares<Replicated<TV>>,
+    TS: BooleanArray + U128Conversions + IntoShares<Replicated<TS>>,
 {
     fn reconstruct(&self) -> TestRawDataRecord {
         let [s0, s1, s2] = self;


### PR DESCRIPTION
* Add a BooleanArray trait as shorthand for `SharedValue + CustomArray<Element = Boolean>` (and a few other traits that are always implemented for boolean arrays).
* Delete ArrayAccessRef (not needed after #1049 and perhaps `impl DerefMut for BitDecomposed`).
* Remove ArrayAccess for Galois fields (perhaps not needed after fix for #1079).
* Remove some generics from some AdditiveShare-related things that are only used with Boolean arrays.