### PR TITLE
proof recursion in prover.rs

### DIFF
--- a/ipa-core/src/protocol/basics/share_validation.rs
+++ b/ipa-core/src/protocol/basics/share_validation.rs
@@ -120,15 +120,18 @@ mod test {
 
             let r = (0..len)
                 .map(|_| rng.gen::<Fp61BitPrime>())
-                .collect::<Vec<_>>();
+                .collect::<Vec<Fp61BitPrime>>();
 
             let _ = world
                 .semi_honest(r.into_iter(), |ctx, input| async move {
-                    let r_right = input.iter().map(|x| x.right().neg()).collect::<Vec<_>>();
+                    let r_right = input
+                        .iter()
+                        .map(|x| x.right().neg())
+                        .collect::<Vec<Fp61BitPrime>>();
                     let mut r_left = input
                         .iter()
                         .map(ReplicatedSecretSharing::left)
-                        .collect::<Vec<_>>();
+                        .collect::<Vec<Fp61BitPrime>>();
 
                     validate_three_two_way_sharing_of_zero(
                         ctx.narrow("correctness"),

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -7,11 +7,11 @@ use crate::{
 };
 
 // BlockSize is fixed to 32
-pub const B: usize = 32;
+pub const BLOCK_SIZE: usize = 32;
 // UVTupleBlock is a block of interleaved U and V values
-pub type UVTupleBlock<F> = ([F; B], [F; B]);
+pub type UVTupleBlock<F> = ([F; BLOCK_SIZE], [F; BLOCK_SIZE]);
 // UVSingleBlock is either a block of U or a block of V values
-pub type UVSingleBlock<F> = [F; B];
+pub type UVSingleBlock<F> = [F; BLOCK_SIZE];
 
 /// Trait for fields compatible with DZKPs
 /// Field needs to support conversion to `SegmentEntry`, i.e. `to_segment_entry` which is required by DZKPs
@@ -55,15 +55,30 @@ pub trait DZKPBaseField: PrimeField {
     ) -> Vec<UVSingleBlock<Self>>;
 }
 
-impl FromIterator<Fp61BitPrime> for [Fp61BitPrime; B] {
+impl<const P: usize> FromIterator<Fp61BitPrime> for [Fp61BitPrime; P] {
     fn from_iter<T: IntoIterator<Item = Fp61BitPrime>>(iter: T) -> Self {
-        let mut out = [Fp61BitPrime::ZERO; B];
+        let mut out = [Fp61BitPrime::ZERO; P];
         for (i, elem) in iter.into_iter().enumerate() {
             assert!(
-                i < B,
-                "Too many elements to collect into array of length {B}",
+                i < P,
+                "Too many elements to collect into array of length {P}",
             );
             out[i] = elem;
+        }
+        out
+    }
+}
+
+impl<const P: usize> FromIterator<Fp61BitPrime> for Vec<[Fp61BitPrime; P]> {
+    fn from_iter<T: IntoIterator<Item = Fp61BitPrime>>(iter: T) -> Self {
+        let mut out = Vec::<[Fp61BitPrime; P]>::new();
+        let mut array = [Fp61BitPrime::ZERO; P];
+        for (i, elem) in iter.into_iter().enumerate() {
+            array[i % P] = elem;
+            if i % P == P - 1 {
+                out.push(array);
+                array = [Fp61BitPrime::ZERO; P];
+            }
         }
         out
     }
@@ -148,7 +163,7 @@ impl DZKPBaseField for Fp61BitPrime {
                                 Fp61BitPrime::MINUS_ONE_HALF * one_minus_two_e,
                             ]
                         })
-                        .collect::<[Fp61BitPrime; B]>(),
+                        .collect::<[Fp61BitPrime; BLOCK_SIZE]>(),
                     // h polynomial
                     b.view_bits::<Lsb0>()
                         .iter()
@@ -169,7 +184,7 @@ impl DZKPBaseField for Fp61BitPrime {
                                 one_minus_two_f,
                             ]
                         })
-                        .collect::<[Fp61BitPrime; B]>(),
+                        .collect::<[Fp61BitPrime; BLOCK_SIZE]>(),
                 )
             })
             .collect::<Vec<_>>()
@@ -229,7 +244,7 @@ impl DZKPBaseField for Fp61BitPrime {
                             Fp61BitPrime::MINUS_ONE_HALF * one_minus_two_e,
                         ]
                     })
-                    .collect::<[Fp61BitPrime; B]>()
+                    .collect::<[Fp61BitPrime; BLOCK_SIZE]>()
             })
             .collect::<Vec<_>>()
     }
@@ -282,7 +297,7 @@ impl DZKPBaseField for Fp61BitPrime {
                             one_minus_two_f,
                         ]
                     })
-                    .collect::<[Fp61BitPrime; B]>()
+                    .collect::<[Fp61BitPrime; BLOCK_SIZE]>()
             })
             .collect::<Vec<_>>()
     }

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -73,12 +73,17 @@ impl<const P: usize> FromIterator<Fp61BitPrime> for Vec<[Fp61BitPrime; P]> {
     fn from_iter<T: IntoIterator<Item = Fp61BitPrime>>(iter: T) -> Self {
         let mut out = Vec::<[Fp61BitPrime; P]>::new();
         let mut array = [Fp61BitPrime::ZERO; P];
-        for (i, elem) in iter.into_iter().enumerate() {
+        let mut i = 0usize;
+        for elem in iter {
             array[i % P] = elem;
-            if i % P == P - 1 {
+            if (i + 1) % P == 0 {
                 out.push(array);
                 array = [Fp61BitPrime::ZERO; P];
             }
+            i += 1;
+        }
+        if i % P != 0 {
+            out.push(array);
         }
         out
     }

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -724,7 +724,7 @@ mod tests {
 
         let original_inputs = (0..count)
             .map(|_| rng.gen::<Fp61BitPrime>())
-            .collect::<Vec<_>>();
+            .collect::<Vec<Fp61BitPrime>>();
 
         let shared_inputs: Vec<[Replicated<Fp61BitPrime>; 3]> = original_inputs
             .iter()

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -32,7 +32,6 @@ where
     fn from_iter<T: IntoIterator<Item = (F, F)>>(iter: T) -> Self {
         let mut uv_chunks = Vec::<([F; λ], [F; λ])>::new();
 
-        // iter and interpolate at x coordinate r
         let mut length = 0;
         let mut new_u_chunk = [F::ZERO; λ];
         let mut new_v_chunk = [F::ZERO; λ];
@@ -351,13 +350,13 @@ mod test {
     #[test]
     fn check_uv_length_and_is_empty() {
         run(|| async move {
-            const U_1: [u128; 32] = [
+            const U_1: [u128; 27] = [
                 0, 30, 0, 16, 0, 1, 0, 15, 0, 0, 0, 16, 0, 30, 0, 16, 29, 1, 1, 15, 0, 0, 1, 15, 2,
-                30, 30, 16, 0, 0, 30, 16,
+                30, 30,
             ];
-            const V_1: [u128; 32] = [
+            const V_1: [u128; 27] = [
                 0, 0, 0, 30, 0, 0, 0, 1, 30, 30, 30, 30, 0, 0, 30, 30, 0, 30, 0, 30, 0, 0, 0, 1, 0,
-                0, 1, 1, 0, 0, 1, 1,
+                0, 1,
             ];
 
             let denominator = CanonicalLagrangeDenominator::<Fp31, 4>::new();
@@ -379,7 +378,7 @@ mod test {
 
             assert!(!uv_values.is_empty());
 
-            assert_eq!(8, uv_values.len());
+            assert_eq!(7, uv_values.len());
         });
     }
 


### PR DESCRIPTION
This is a split from https://github.com/private-attribution/ipa/pull/1083

PR adds recursion function for the prover as well as an UVValues struct that keeps track of the length.