### PR TITLE
Hand off Tokio bookkeeping tasks before starting a new IPA query

### DIFF
--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     fmt::Debug,
     future::{ready, Future},
     pin::Pin,
@@ -109,9 +110,9 @@ pub fn execute(
     }
 }
 
-pub fn do_query<F>(
+pub fn do_query<B, F>(
     config: QueryConfig,
-    gateway: Gateway,
+    gateway: B,
     input_stream: BodyStream,
     query_impl: F,
 ) -> RunningQuery
@@ -124,14 +125,16 @@ where
         ) -> Pin<Box<dyn Future<Output = QueryResult> + Send + 'a>>
         + Send
         + 'static,
+    B: Borrow<Gateway> + Send + 'static,
 {
     let (tx, rx) = oneshot::channel();
 
     let join_handle = tokio::spawn(async move {
+        let gateway = gateway.borrow();
         // TODO: make it a generic argument for this function
         let mut rng = StdRng::from_entropy();
         // Negotiate PRSS using the initial gate for the protocol (no narrowing).
-        let prss = negotiate_prss(&gateway, &prss_gate(), &mut rng)
+        let prss = negotiate_prss(gateway, &prss_gate(), &mut rng)
             .await
             .unwrap();
 
@@ -143,7 +146,7 @@ where
         // Here is an example in IPA code that led to this discovery:
         // - IPA query kicks in and first step it performs a very large reallocation, keeping the
         // task running for minutes before yielding.
-        // - At the time when query started, there was only one active thread in the runtime and
+        // - At the time when query started, there was only one active thread in the runtime, and
         // it began polling this task
         // - because other threads are parked, there is nothing that can indicate to the executor
         // that there are more tasks that are ready. Tokio Runtime is not polling any task.
@@ -164,10 +167,10 @@ where
         {
             ::tokio::task::block_in_place(|| {
                 ::tokio::runtime::Handle::current()
-                    .block_on(async { query_impl(&prss, &gateway, &config, input_stream).await })
+                    .block_on(async { query_impl(&prss, gateway, &config, input_stream).await })
             })
         } else {
-            query_impl(&prss, &gateway, &config, input_stream).await
+            query_impl(&prss, gateway, &config, input_stream).await
         };
 
         tx.send(v).unwrap();
@@ -193,10 +196,20 @@ fn prss_gate() -> Gate {
 
 #[cfg(all(test, unit_test))]
 mod tests {
+    use std::{array, future::Future, iter::zip, sync::Arc, time::Duration};
+
+    use futures::future::join_all;
+    use tokio::sync::Barrier;
+
     use crate::{
-        ff::{Fp31, U128Conversions},
-        query::ProtocolResult,
+        ff::{FieldType, Fp31, U128Conversions},
+        helpers::{
+            query::{QueryConfig, QueryType},
+            BodyStream, Gateway, Role,
+        },
+        query::{executor::do_query, state::RunningQuery, ProtocolResult},
         secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
+        test_fixture::TestWorld,
     };
 
     #[test]
@@ -210,5 +223,118 @@ mod tests {
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn does_not_block_tokio_runtime() {
+        let world = Box::leak(Box::<TestWorld>::default());
+        let world_ptr = world as *mut _;
+
+        let gateways = [
+            world.gateway(Role::H1),
+            world.gateway(Role::H2),
+            world.gateway(Role::H3),
+        ];
+
+        let runtimes: [_; 3] = array::from_fn(|_| {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(3)
+                .enable_all()
+                .build()
+                .unwrap()
+        });
+
+        let handles: Vec<_> = zip(runtimes.iter(), gateways)
+            .map(|(rt, gateway)| {
+                let _guard = rt.enter();
+
+                // we simulate the deadlock only on H1, it is enough to reproduce the issue
+                if gateway.role() == Role::H1 {
+                    let barrier = Arc::new(Barrier::new(3));
+
+                    // this task simulates busy loop. it will block its worker thread and,
+                    // if scheduled properly, must not affect the other tasks running on this
+                    // runtime
+                    let h1_query = query_task(gateway, {
+                        let barrier = Arc::clone(&barrier);
+                        || async move {
+                            barrier.wait().await;
+                            // using IO or timer is crucial to reproduce the issue with
+                            // tokio runtime (see tokio/4730)
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            #[allow(clippy::empty_loop)]
+                            loop {
+                                // uncomment the following line to prevent the deadlock with
+                                // tokio::spawn
+                                // tokio::task::yield_now().await;
+                            }
+                        }
+                    });
+
+                    // task that must run to completion even when the previous one
+                    // is blocked
+                    let h2 = rt.spawn({
+                        let b_2 = Arc::clone(&barrier);
+                        async move {
+                            b_2.wait().await;
+                            // this must sleep longer than busy task to miss the chance of being
+                            // woken up
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+
+                            42
+                        }
+                    });
+
+                    // main task unblocks both tasks and expects one of them to make progress.
+                    tokio::spawn({
+                        let barrier = Arc::clone(&barrier);
+                        async move {
+                            barrier.wait().await;
+
+                            // h1 is locked forever, but h2 should be able to run to completion
+                            assert_eq!(42, h2.await.unwrap());
+                            h1_query.join_handle.abort();
+                        }
+                    })
+                } else {
+                    // other helpers don't need to do anything
+                    tokio::spawn(async move {
+                        query_task(gateway, || futures::future::ready(()))
+                            .await
+                            .unwrap();
+                    })
+                }
+            })
+            .collect();
+
+        join_all(handles).await;
+
+        for runtime in runtimes {
+            runtime.shutdown_background();
+        }
+
+        let _ = unsafe { Box::from_raw(world_ptr) };
+    }
+
+    fn query_task<F, Fut>(gateway: &'static Gateway, f: F) -> RunningQuery
+    where
+        F: Send + 'static + FnOnce() -> Fut,
+        Fut: Future<Output = ()> + Send,
+    {
+        do_query(
+            QueryConfig {
+                size: 1.try_into().unwrap(),
+                field_type: FieldType::Fp31,
+                query_type: QueryType::TestMultiply,
+            },
+            gateway,
+            BodyStream::empty(),
+            move |_, _, _, _| {
+                Box::pin(async move {
+                    f().await;
+                    Ok(Box::<Vec<Fp31>>::default() as Box<dyn ProtocolResult>)
+                })
+            },
+        )
     }
 }

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -5,7 +5,11 @@ use std::{
     pin::Pin,
 };
 
-use ::tokio::sync::oneshot;
+use ::tokio::{
+    runtime::{Handle, RuntimeFlavor},
+    sync::oneshot,
+    task::block_in_place,
+};
 use futures::FutureExt;
 use generic_array::GenericArray;
 use ipa_step::StepNarrow;
@@ -138,35 +142,14 @@ where
             .await
             .unwrap();
 
-        // Tokio executor is a work-stealing scheduler that optimizes for low latency and
-        // resource utilization. It optimizes for low scheduling overhead and uses the same worker
-        // threads for polling tasks and to service IO and timer operations, if they are enabled.
-        // This leads to very low overhead, but also to an unfortunate possibility of tasks that are
-        // long-running to block the entire runtime, even if it is multithreaded.
-        // Here is an example in IPA code that led to this discovery:
-        // - IPA query kicks in and first step it performs a very large reallocation, keeping the
-        // task running for minutes before yielding.
-        // - At the time when query started, there was only one active thread in the runtime, and
-        // it began polling this task
-        // - because other threads are parked, there is nothing that can indicate to the executor
-        // that there are more tasks that are ready. Tokio Runtime is not polling any task.
-        // - Client asks for IPA query status and times out, because IPA application is not
-        // responding.
-        //
-        // Ultimately tokio team decided that it is not a bug in the implementation and made it
-        // clear that application needs to take care of it. There are a few ways to deal with it,
-        // one of them is to signal the executor that this task is about to block the worker thread
-        // for long time, so it has a chance to move the IO driver and pending tasks to other
-        // threads. This is what this code does.
-        //
-        // The issue in tokio repo that describes this behavior
-        // https://github.com/tokio-rs/tokio/issues/4730
+        // see private-attribution/ipa#1120
         let v = if !cfg!(feature = "shuttle")
-            && ::tokio::runtime::Handle::current().runtime_flavor()
-                == ::tokio::runtime::RuntimeFlavor::MultiThread
+            && Handle::current().runtime_flavor() == RuntimeFlavor::MultiThread
         {
-            ::tokio::task::block_in_place(|| {
-                ::tokio::runtime::Handle::current()
+            block_in_place(|| {
+                // block_on runs on the current thread, so if it is also responsible for IO
+                // it's been handed off already by block_in_place.
+                Handle::current()
                     .block_on(async { query_impl(&prss, gateway, &config, input_stream).await })
             })
         } else {


### PR DESCRIPTION
This is an attempt to mitigate #1120 by hinting Tokio executor that query task maybe blocking the worker thread for longer than expected and it should hand off everything from that worker thread.

Here is how this issue is reproducible in our environment

Tokio executor is a work-stealing scheduler that optimizes for low latency and
        resource utilization. It optimizes for low scheduling overhead and uses the same worker
        threads for polling tasks and to service IO and timer operations, if they are enabled.
        This leads to very low overhead, but also to an unfortunate possibility of tasks that are
        long-running to block the entire runtime, even if it is multithreaded.
        Here is an example in IPA code that led to this discovery:
        - IPA query kicks in and first step it performs a very large reallocation, keeping the
        task running for minutes before yielding.
        - At the time when query started, there was only one active thread in the runtime, and
        it began polling this task
        - because other threads are parked, there is nothing that can indicate to the executor
        that there are more tasks that are ready. Tokio Runtime is not polling any task.
        - Client asks for IPA query status and times out, because IPA application is not
        responding.
        
  Ultimately tokio team decided that it is not a bug in the implementation and made it
  clear that application needs to take care of it. There are a few ways to deal with it,
  one of them is to signal the executor that this task is about to block the worker thread
  for long time, so it has a chance to move the IO driver and pending tasks to other
  threads. This is what this proposed solution does.
        