### PR TITLE
Step one of removing UpgradedSemiHonestContext

### DIFF
--- a/ipa-core/src/protocol/dp/mod.rs
+++ b/ipa-core/src/protocol/dp/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     ff::{boolean::Boolean, boolean_array::BooleanArray, U128Conversions},
     protocol::{
         boolean::step::SixteenBitStep,
-        context::{Context, UpgradedSemiHonestContext},
+        context::Context,
         dp::step::DPStep,
         ipa_prf::{aggregation::aggregate_values, boolean_ops::addition_sequential::integer_add},
         prss::{FromPrss, SharedRandomness},
@@ -19,23 +19,22 @@ use crate::{
         replicated::semi_honest::{AdditiveShare as Replicated, AdditiveShare},
         BitDecomposed, FieldSimd, TransposeFrom, Vectorizable,
     },
-    sharding::NotSharded,
 };
 /// # Panics
 /// Will panic if there are not enough bits in the outputs size for the noise gen sum. We can't have the noise sum saturate
 /// as that would be insecure noise.
 /// # Errors
 /// may have errors generated in `aggregate_values` also some asserts here
-pub async fn gen_binomial_noise<'ctx, const B: usize, OV>(
-    ctx: UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>,
+pub async fn gen_binomial_noise<C, const B: usize, OV>(
+    ctx: C,
     num_bernoulli: u32,
 ) -> Result<BitDecomposed<Replicated<Boolean, B>>, Error>
 where
+    C: Context,
     Boolean: Vectorizable<B> + FieldSimd<B>,
     BitDecomposed<Replicated<Boolean, B>>: FromPrss<usize>,
     OV: BooleanArray + U128Conversions,
-    Replicated<Boolean, B>:
-        BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
+    Replicated<Boolean, B>: BooleanProtocols<C, B>,
 {
     // Step 1:  Generate Bernoulli's with PRSS
     // sample a stream of `total_bits = num_bernoulli * B` bit from PRSS where B is number of histogram bins
@@ -58,7 +57,7 @@ where
     let aggregation_input = Box::pin(stream::iter(vector_input_to_agg.into_iter()).map(Ok));
     // Step 3: Call `aggregate_values` to sum up Bernoulli noise.
     let noise_vector: Result<BitDecomposed<AdditiveShare<Boolean, { B }>>, Error> =
-        aggregate_values::<OV, B>(ctx, aggregation_input, num_bernoulli as usize).await;
+        aggregate_values::<_, OV, B>(ctx, aggregation_input, num_bernoulli as usize).await;
     noise_vector
 }
 /// `apply_dp_noise` takes the noise distribution parameters (`num_bernoulli` and in the future `quantization_scale`)
@@ -68,22 +67,22 @@ where
 /// asserts that `num_histogram_bins` matches what we are using for vectorization, B.
 /// # Errors
 /// Result error case could come from transpose
-pub async fn apply_dp_noise<'ctx, const B: usize, OV>(
-    ctx: UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>,
+pub async fn apply_dp_noise<C, const B: usize, OV>(
+    ctx: C,
     histogram_bin_values: BitDecomposed<Replicated<Boolean, B>>,
     num_bernoulli: u32,
 ) -> Result<Vec<Replicated<OV>>, Error>
 where
+    C: Context,
     Boolean: Vectorizable<B> + FieldSimd<B>,
     BitDecomposed<Replicated<Boolean, B>>: FromPrss<usize>,
     OV: BooleanArray + U128Conversions,
-    Replicated<Boolean, B>:
-        BooleanProtocols<UpgradedSemiHonestContext<'ctx, NotSharded, Boolean>, B>,
+    Replicated<Boolean, B>: BooleanProtocols<C, B>,
     Vec<Replicated<OV>>:
         for<'a> TransposeFrom<&'a BitDecomposed<Replicated<Boolean, B>>, Error = LengthError>,
 {
     let noise_gen_ctx = ctx.narrow(&DPStep::NoiseGen);
-    let noise_vector = gen_binomial_noise::<B, OV>(noise_gen_ctx, num_bernoulli)
+    let noise_vector = gen_binomial_noise::<C, B, OV>(noise_gen_ctx, num_bernoulli)
         .await
         .unwrap();
     // Step 4:  Add DP noise to output values
@@ -350,7 +349,7 @@ mod test {
             vectorize_input(16, &input_values);
         let result = world
             .upgraded_semi_honest(input, |ctx, input| async move {
-                apply_dp_noise::<{ NUM_BREAKDOWNS as usize }, OutputValue>(
+                apply_dp_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                     ctx,
                     input,
                     num_bernoulli,
@@ -398,7 +397,7 @@ mod test {
         let result = world
             .upgraded_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
-                    &gen_binomial_noise::<{ NUM_BREAKDOWNS as usize }, OutputValue>(
+                    &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
                         num_bernoulli,
                     )
@@ -434,7 +433,7 @@ mod test {
         let result = world
             .upgraded_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
-                    &gen_binomial_noise::<{ NUM_BREAKDOWNS as usize }, OutputValue>(
+                    &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
                         num_bernoulli,
                     )
@@ -470,7 +469,7 @@ mod test {
         let result = world
             .upgraded_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
-                    &gen_binomial_noise::<{ NUM_BREAKDOWNS as usize }, OutputValue>(
+                    &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
                         num_bernoulli,
                     )

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -9,11 +9,10 @@ use crate::{
     protocol::{
         basics::{BooleanProtocols, SecureMul},
         boolean::{or::bool_or, NBitStep},
-        context::{Context, UpgradedSemiHonestContext},
+        context::Context,
         Gate, RecordId,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare, BitDecomposed, FieldSimd},
-    sharding::ShardBinding,
 };
 
 /// Non-saturated unsigned integer addition
@@ -53,17 +52,17 @@ where
 /// adds y to x, Output has same length as x (we dont seem to need support for different length)
 /// # Errors
 /// propagates errors from multiply
-pub async fn integer_sat_add<'a, SH, S, const N: usize>(
-    ctx: UpgradedSemiHonestContext<'a, SH, Boolean>,
+pub async fn integer_sat_add<C, S, const N: usize>(
+    ctx: C,
     record_id: RecordId,
     x: &BitDecomposed<AdditiveShare<Boolean, N>>,
     y: &BitDecomposed<AdditiveShare<Boolean, N>>,
 ) -> Result<BitDecomposed<AdditiveShare<Boolean, N>>, Error>
 where
-    SH: ShardBinding,
+    C: Context,
     S: NBitStep,
     Boolean: FieldSimd<N>,
-    AdditiveShare<Boolean, N>: BooleanProtocols<UpgradedSemiHonestContext<'a, SH, Boolean>, N>,
+    AdditiveShare<Boolean, N>: BooleanProtocols<C, N>,
     Gate: StepNarrow<S>,
 {
     use super::step::SaturatedAdditionStep as Step;

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -267,7 +267,7 @@ where
         seq_join(sh_ctx.active_work(), stream::iter(chunked_user_results)).try_flatten_iters(),
     );
     let aggregated_result: BitDecomposed<AdditiveShare<Boolean, B>> =
-        aggregate_values::<HV, B>(binary_m_ctx, flattened_stream, num_outputs).await?;
+        aggregate_values::<_, HV, B>(binary_m_ctx, flattened_stream, num_outputs).await?;
 
     let transposed_aggregated_result: Vec<Replicated<HV>> =
         Vec::transposed_from(&aggregated_result)?;

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -27,8 +27,7 @@ use crate::{
             NBitStep,
         },
         context::{
-            semi_honest::Upgraded, Context, SemiHonestContext, UpgradableContext,
-            UpgradedSemiHonestContext, Validator,
+            Context, SemiHonestContext, UpgradableContext, UpgradedSemiHonestContext, Validator,
         },
         ipa_prf::{
             aggregation::aggregate_contributions,
@@ -53,7 +52,7 @@ use crate::{
         },
         BitDecomposed, FieldSimd, SharedValue, TransposeFrom,
     },
-    seq_join::{seq_join, SeqJoin},
+    seq_join::seq_join,
     sharding::NotSharded,
 };
 
@@ -145,17 +144,19 @@ where
     ///         - `did_trigger_get_attributed` - a secret-shared bit indicating if this row corresponds to a trigger event
     ///           which was attributed. Might be able to reveal this (after a shuffle and the addition of dummies) to minimize
     ///           the amount of processing work that must be done in the Aggregation stage.
-    pub async fn compute_row_with_previous<'a>(
+    pub async fn compute_row_with_previous<C>(
         &mut self,
-        ctx: UpgradedSemiHonestContext<'a, NotSharded, Boolean>,
+        ctx: C,
         record_id: RecordId,
         input_row: &PrfShardedIpaInputRow<BK, TV, TS>,
         attribution_window_seconds: Option<NonZeroU32>,
     ) -> Result<AttributionOutputs<Replicated<BK>, Replicated<TV>>, Error>
     where
-        Replicated<BK>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-        Replicated<TS>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-        Replicated<TV>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
+        C: Context,
+        Replicated<Boolean>: BooleanProtocols<C>,
+        Replicated<BK>: BooleanArrayMul<C>,
+        Replicated<TS>: BooleanArrayMul<C>,
+        Replicated<TV>: BooleanArrayMul<C>,
     {
         let is_source_event = input_row.is_trigger_bit.clone().not();
 
@@ -444,9 +445,12 @@ where
     let mut collected = rows_chunked_by_user.collect::<Vec<_>>().await;
     collected.sort_by(|a, b| std::cmp::Ord::cmp(&b.len(), &a.len()));
 
-    let flattened_user_results =
-        attribute::<_, _, _, SS_BITS, B>(ctx_for_row_number, collected, attribution_window_seconds)
-            .await;
+    let flattened_user_results = attribute::<_, _, _, _, SS_BITS, B>(
+        ctx_for_row_number,
+        collected,
+        attribution_window_seconds,
+    )
+    .await;
 
     let attribution_validator = sh_ctx.narrow(&Step::Aggregate).validator::<Boolean>();
     let ctx = attribution_validator.context();
@@ -459,18 +463,20 @@ where
 }
 
 #[tracing::instrument(name = "attribute_cap", skip_all, fields(unique_match_keys = input.len()))]
-async fn attribute<BK, TV, TS, const SS_BITS: usize, const B: usize>(
-    contexts: Vec<Upgraded<'_, NotSharded, Boolean>>,
+async fn attribute<C, BK, TV, TS, const SS_BITS: usize, const B: usize>(
+    contexts: Vec<C>,
     input: Vec<Vec<PrfShardedIpaInputRow<BK, TV, TS>>>,
     attribution_window_seconds: Option<NonZeroU32>,
 ) -> Vec<Result<SecretSharedAttributionOutputs<BK, TV>, Error>>
 where
+    C: Context,
+    Replicated<Boolean>: BooleanProtocols<C>,
     BK: BreakdownKey<B>,
     TV: BooleanArray + U128Conversions,
     TS: BooleanArray + U128Conversions,
-    for<'a> Replicated<BK>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-    for<'a> Replicated<TS>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-    for<'a> Replicated<TV>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
+    for<'a> Replicated<BK>: BooleanArrayMul<C>,
+    for<'a> Replicated<TS>: BooleanArrayMul<C>,
+    for<'a> Replicated<TV>: BooleanArrayMul<C>,
 {
     let active_work = contexts
         .first()
@@ -483,7 +489,7 @@ where
             let num_user_rows = rows_for_user.len();
             let contexts = contexts[..num_user_rows - 1].to_owned();
 
-            evaluate_per_user_attribution_circuit::<BK, TV, TS, SS_BITS>(
+            evaluate_per_user_attribution_circuit::<_, BK, TV, TS, SS_BITS>(
                 contexts,
                 RecordId::from(record_id),
                 rows_for_user,
@@ -499,19 +505,21 @@ where
 }
 
 #[tracing::instrument(level = "debug", name = "per_user", skip_all, fields(rows = rows_for_user.len()))]
-async fn evaluate_per_user_attribution_circuit<BK, TV, TS, const SS_BITS: usize>(
-    ctx_for_row_number: Vec<UpgradedSemiHonestContext<'_, NotSharded, Boolean>>,
+async fn evaluate_per_user_attribution_circuit<C, BK, TV, TS, const SS_BITS: usize>(
+    ctx_for_row_number: Vec<C>,
     record_id: RecordId,
     rows_for_user: Vec<PrfShardedIpaInputRow<BK, TV, TS>>,
     attribution_window_seconds: Option<NonZeroU32>,
 ) -> Result<Vec<SecretSharedAttributionOutputs<BK, TV>>, Error>
 where
+    C: Context,
+    Replicated<Boolean>: BooleanProtocols<C>,
     BK: BooleanArray + U128Conversions,
     TV: BooleanArray + U128Conversions,
     TS: BooleanArray + U128Conversions,
-    for<'a> Replicated<BK>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-    for<'a> Replicated<TS>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
-    for<'a> Replicated<TV>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
+    for<'a> Replicated<BK>: BooleanArrayMul<C>,
+    for<'a> Replicated<TS>: BooleanArrayMul<C>,
+    for<'a> Replicated<TV>: BooleanArrayMul<C>,
 {
     assert!(!rows_for_user.is_empty());
     if rows_for_user.len() == 1 {
@@ -625,8 +633,8 @@ where
 /// multiply it with the bits of the `trigger_value` in order to zero out contributions from unattributed trigger events.
 ///
 #[allow(clippy::too_many_arguments)]
-async fn zero_out_trigger_value_unless_attributed<'a, TV, TS>(
-    ctx: UpgradedSemiHonestContext<'a, NotSharded, Boolean>,
+async fn zero_out_trigger_value_unless_attributed<C, TV, TS>(
+    ctx: C,
     record_id: RecordId,
     is_trigger_bit: &Replicated<Boolean>,
     ever_encountered_a_source_event: &Replicated<Boolean>,
@@ -636,9 +644,11 @@ async fn zero_out_trigger_value_unless_attributed<'a, TV, TS>(
     source_event_timestamp: &Replicated<TS>,
 ) -> Result<Replicated<TV>, Error>
 where
+    C: Context,
     TV: BooleanArray + U128Conversions,
     TS: BooleanArray + U128Conversions,
-    Replicated<TV>: BooleanArrayMul<UpgradedSemiHonestContext<'a, NotSharded, Boolean>>,
+    Replicated<Boolean>: BooleanProtocols<C>,
+    Replicated<TV>: BooleanArrayMul<C>,
 {
     let (did_trigger_get_attributed, is_trigger_within_window) = try_join(
         is_trigger_bit.multiply(

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -454,7 +454,7 @@ where
 
     let attribution_validator = sh_ctx.narrow(&Step::Aggregate).validator::<Boolean>();
     let ctx = attribution_validator.context();
-    aggregate_contributions::<_, _, _, HV, B, AGG_CHUNK>(
+    aggregate_contributions::<_, _, _, _, HV, B, AGG_CHUNK>(
         ctx,
         stream::iter(flattened_user_results),
         num_outputs,


### PR DESCRIPTION
I don't think we should be hard-coding "UpgradedSemiHonestContext" into our protocols. That's a strange dummy type that's there so that a Semi Honest Context can get "upgraded" but it won't actually do anything.

We probably want to make our protocols not really care if it's operating in a semi-honest or a malicious context. This PR is about starting to make that change.