### PR TITLE
Revise BasicProtocols

### DIFF
--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -12,7 +12,9 @@ use crate::{
         prss::{FromPrss, FromRandom, PrssIndex, SharedRandomness},
     },
     secret_sharing::{
-        replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+        replicated::{
+            malicious::ExtendableField, semi_honest::AdditiveShare, ReplicatedSecretSharing,
+        },
         Block, FieldVectorizable, SharedValue, StdArray, Vectorizable,
     },
 };
@@ -217,6 +219,14 @@ impl Field for Fp25519 {
     const NAME: &'static str = "Fp25519";
 
     const ONE: Fp25519 = Fp25519::ONE;
+}
+
+impl ExtendableField for Fp25519 {
+    type ExtendedField = Self;
+
+    fn to_extended(&self) -> Self::ExtendedField {
+        *self
+    }
 }
 
 impl FromRandom for Fp25519 {

--- a/ipa-core/src/protocol/basics/mul/semi_honest.rs
+++ b/ipa-core/src/protocol/basics/mul/semi_honest.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     error::Error,
-    ff::{Field, PrimeField},
+    ff::Field,
     helpers::Direction,
     protocol::{
         context::{
@@ -14,7 +14,8 @@ use crate::{
         RecordId,
     },
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare as Replicated, FieldSimd, Vectorizable,
+        replicated::{malicious::ExtendableField, semi_honest::AdditiveShare as Replicated},
+        FieldSimd, Vectorizable,
     },
     sharding,
 };
@@ -123,7 +124,7 @@ impl<'a, B, F, const N: usize> super::SecureMul<UpgradedSemiHonestContext<'a, B,
     for Replicated<F, N>
 where
     B: sharding::ShardBinding,
-    F: PrimeField + FieldSimd<N>,
+    F: ExtendableField + FieldSimd<N>,
 {
     async fn multiply<'fut>(
         &self,

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -177,14 +177,14 @@ impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>, 1> for Mali
 // Workaround for https://github.com/rust-lang/rust/issues/100013. Calling these wrapper functions
 // instead of the trait methods seems to hide the `impl Future` GAT.
 
-pub fn reveal<'fut, C, S>(
+pub fn reveal<'fut, C, S, const N: usize>(
     ctx: C,
     record_id: RecordId,
     v: &'fut S,
 ) -> impl Future<Output = Result<S::Output, Error>> + Send + 'fut
 where
     C: Context + 'fut,
-    S: Reveal<C, 1>,
+    S: Reveal<C, N>,
 {
     S::reveal(v, ctx, record_id)
 }


### PR DESCRIPTION
The old BasicProtocols was no longer used anywhere. This replaces it with a version that includes only the basic protocols that have been vectorized. It also makes some progress towards not exposing semi-honest protocols on arbitrary contexts (which is unsafe).

Split from #1112.