### PR TITLE
Further simplifying the verifier code

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -8,38 +8,35 @@ use crate::{
 };
 
 #[allow(non_upper_case_globals)]
-pub struct ProofVerifier<F: PrimeField> {
-    zero_share: F,
-}
+pub struct ProofVerifier {}
 
 ///
 /// Distributed Zero Knowledge Proofs algorithm drawn from
 /// `https://eprint.iacr.org/2023/909.pdf`
 ///
 #[allow(non_upper_case_globals)]
-impl<F> ProofVerifier<F>
-where
-    F: PrimeField,
-{
-    /// This function outputs an `out_share` and a `ProofVerifier` that consists of a `zero_share`.
-    pub fn verify_proof<const λ: usize, const P: usize>(
-        out_share: F,
+impl ProofVerifier {
+    /// This function interprets the zkp as points on a polynomial, and interpolates the
+    /// value of this polynomial at the provided value of `r`
+    pub fn interpolate_at_r<F: PrimeField, const λ: usize, const P: usize>(
         zkp: &[F; P],
         r: F,
-    ) -> (F, Self) {
-        let denominator_g = CanonicalLagrangeDenominator::<F, P>::new();
-        let lagrange_table_g = LagrangeTable::<F, P, 1>::new(&denominator_g, &r);
-        let g_r_share = lagrange_table_g.eval(zkp)[0];
-        let sum_share = (0..λ).fold(F::ZERO, |acc, i| acc + zkp[i]);
+        lagrange_denominator: &CanonicalLagrangeDenominator<F, P>,
+    ) -> F {
+        let lagrange_table_g = LagrangeTable::<F, P, 1>::new(lagrange_denominator, &r);
+        lagrange_table_g.eval(zkp)[0]
+    }
 
-        // Reveal `b_share` to one another to reconstruct `b` and check if `b = 0`. If the check doesn't pass, abort.
-        let zero_share = sum_share - out_share;
-
-        (g_r_share, Self { zero_share })
+    /// This function outputs an `out_share` and a `ProofVerifier` that consists of a `zero_share`.
+    pub fn compute_sum_share<F: PrimeField, const λ: usize, const P: usize>(zkp: &[F; P]) -> F {
+        (0..λ).fold(F::ZERO, |acc, i| acc + zkp[i])
     }
 
     /// This function compresses the `u_or_v` values.
-    pub fn recurse_u_or_v<J, B, const λ: usize>(u_or_v_iterator: J, r: F) -> Vec<[F; λ]>
+    pub fn recurse_u_or_v<F: PrimeField, J, B, const λ: usize>(
+        u_or_v_iterator: J,
+        r: F,
+    ) -> Vec<[F; λ]>
     where
         J: Iterator<Item = B>,
         B: Borrow<[F; λ]>,
@@ -75,7 +72,10 @@ mod test {
     use std::iter;
 
     use super::ProofVerifier;
-    use crate::ff::{Fp31, PrimeField, U128Conversions};
+    use crate::{
+        ff::{Fp31, PrimeField, U128Conversions},
+        protocol::ipa_prf::malicious_security::lagrange::CanonicalLagrangeDenominator,
+    };
 
     fn make_chunks<F: PrimeField, const N: usize>(a: &[u128]) -> Vec<[F; N]> {
         a.chunks(N)
@@ -111,19 +111,25 @@ mod test {
         const EXPECTED_P_FINAL: u128 = 30;
         const EXPECTED_G_R_FINAL: u128 = 0;
 
+        let lagrange_denominator: CanonicalLagrangeDenominator<Fp31, 7> =
+            CanonicalLagrangeDenominator::<Fp31, 7>::new();
+
         // uv values in input format
         let u_1 = make_chunks::<_, 4>(&U_1);
 
         // first iteration
         let zkp_1 = ZKP_1.map(Fp31::truncate_from);
 
-        let (out_share_2, pv_1) = ProofVerifier::verify_proof::<4, 7>(
-            Fp31::try_from(OUT_1).unwrap(),
+        let g_r_share_1 = ProofVerifier::interpolate_at_r::<Fp31, 4, 7>(
             &zkp_1,
             Fp31::try_from(R_1).unwrap(),
+            &lagrange_denominator,
         );
-        assert_eq!(out_share_2.as_u128(), EXPECTED_G_R_1);
-        assert_eq!(pv_1.zero_share.as_u128(), EXPECTED_B_1);
+        let sum_share_1 = ProofVerifier::compute_sum_share::<Fp31, 4, 7>(&zkp_1);
+        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_1).unwrap();
+
+        assert_eq!(g_r_share_1.as_u128(), EXPECTED_G_R_1);
+        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1);
 
         let u_or_v_2 = ProofVerifier::recurse_u_or_v(u_1.iter(), Fp31::try_from(R_1).unwrap());
         assert_eq!(u_or_v_2, make_chunks::<Fp31, 4>(&U_2));
@@ -131,11 +137,16 @@ mod test {
         // second iteration
         let zkp_2 = ZKP_2.map(Fp31::truncate_from);
 
-        let (out_share_3, pv_2) =
-            ProofVerifier::verify_proof::<4, 7>(out_share_2, &zkp_2, Fp31::try_from(R_2).unwrap());
+        let g_r_share_2 = ProofVerifier::interpolate_at_r::<Fp31, 4, 7>(
+            &zkp_2,
+            Fp31::try_from(R_2).unwrap(),
+            &lagrange_denominator,
+        );
+        let sum_share_2 = ProofVerifier::compute_sum_share::<Fp31, 4, 7>(&zkp_2);
+        let zero_share_2 = sum_share_2 - g_r_share_1;
 
-        assert_eq!(out_share_3.as_u128(), EXPECTED_G_R_2);
-        assert_eq!(pv_2.zero_share.as_u128(), EXPECTED_B_2);
+        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2);
+        assert_eq!(zero_share_2.as_u128(), EXPECTED_B_2);
 
         let u_or_v_3_temp =
             ProofVerifier::recurse_u_or_v(u_or_v_2.iter(), Fp31::try_from(R_2).unwrap());
@@ -152,9 +163,14 @@ mod test {
         // final iteration
         let zkp_3 = ZKP_3.map(Fp31::truncate_from);
 
-        let (out_share_4, _) =
-            ProofVerifier::verify_proof::<3, 5>(out_share_3, &zkp_3, Fp31::try_from(R_3).unwrap());
-        assert_eq!(out_share_4.as_u128(), EXPECTED_G_R_FINAL);
+        let final_lagrange_denominator = CanonicalLagrangeDenominator::<Fp31, 5>::new();
+        let g_r_share_3 = ProofVerifier::interpolate_at_r::<Fp31, 3, 5>(
+            &zkp_3,
+            Fp31::try_from(R_3).unwrap(),
+            &final_lagrange_denominator,
+        );
+
+        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL);
 
         let p_final =
             ProofVerifier::recurse_u_or_v(iter::once(u_or_v_3), Fp31::try_from(R_3).unwrap());
@@ -190,19 +206,25 @@ mod test {
         const EXPECTED_Q_FINAL: u128 = 12;
         const EXPECTED_G_R_FINAL: u128 = 19;
 
+        let lagrange_denominator: CanonicalLagrangeDenominator<Fp31, 7> =
+            CanonicalLagrangeDenominator::<Fp31, 7>::new();
+
         // uv values in input format
         let v_1 = make_chunks::<_, 4>(&V_1);
 
         // first iteration
         let zkp_1 = ZKP_1.map(Fp31::truncate_from);
 
-        let (out_share_2, pv_1) = ProofVerifier::verify_proof::<4, 7>(
-            Fp31::try_from(OUT_1).unwrap(),
+        let g_r_share_1 = ProofVerifier::interpolate_at_r::<Fp31, 4, 7>(
             &zkp_1,
             Fp31::try_from(R_1).unwrap(),
+            &lagrange_denominator,
         );
-        assert_eq!(out_share_2.as_u128(), EXPECTED_G_R_1);
-        assert_eq!(pv_1.zero_share.as_u128(), EXPECTED_B_1);
+        let sum_share_1 = ProofVerifier::compute_sum_share::<Fp31, 4, 7>(&zkp_1);
+        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_1).unwrap();
+
+        assert_eq!(g_r_share_1, EXPECTED_G_R_1);
+        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1);
 
         let u_or_v_2 = ProofVerifier::recurse_u_or_v(v_1.iter(), Fp31::try_from(R_1).unwrap());
         assert_eq!(u_or_v_2, make_chunks::<Fp31, 4>(&V_2));
@@ -210,11 +232,16 @@ mod test {
         // second iteration
         let zkp_2 = ZKP_2.map(Fp31::truncate_from);
 
-        let (out_share_3, pv_2) =
-            ProofVerifier::verify_proof::<4, 7>(out_share_2, &zkp_2, Fp31::try_from(R_2).unwrap());
+        let g_r_share_2 = ProofVerifier::interpolate_at_r::<Fp31, 4, 7>(
+            &zkp_2,
+            Fp31::try_from(R_2).unwrap(),
+            &lagrange_denominator,
+        );
+        let sum_share_2 = ProofVerifier::compute_sum_share::<Fp31, 4, 7>(&zkp_2);
+        let zero_share_2 = sum_share_2 - g_r_share_1;
 
-        assert_eq!(out_share_3.as_u128(), EXPECTED_G_R_2);
-        assert_eq!(pv_2.zero_share.as_u128(), EXPECTED_B_2);
+        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2);
+        assert_eq!(zero_share_2, EXPECTED_B_2);
 
         let u_or_v_3_temp =
             ProofVerifier::recurse_u_or_v(u_or_v_2.iter(), Fp31::try_from(R_2).unwrap());
@@ -231,9 +258,13 @@ mod test {
         // final iteration
         let zkp_3 = ZKP_3.map(Fp31::truncate_from);
 
-        let (out_share_4, _) =
-            ProofVerifier::verify_proof::<3, 5>(out_share_3, &zkp_3, Fp31::try_from(R_3).unwrap());
-        assert_eq!(out_share_4.as_u128(), EXPECTED_G_R_FINAL);
+        let final_lagrange_denominator = CanonicalLagrangeDenominator::<Fp31, 5>::new();
+        let g_r_share_3 = ProofVerifier::interpolate_at_r::<Fp31, 3, 5>(
+            &zkp_3,
+            Fp31::try_from(R_3).unwrap(),
+            &final_lagrange_denominator,
+        );
+        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL);
 
         let p_final =
             ProofVerifier::recurse_u_or_v(iter::once(u_or_v_3), Fp31::try_from(R_3).unwrap());


### PR DESCRIPTION
We can further simplify the verifier code by just breaking down the `verify_proof` function into the two separate components.

I'm sorry the diff view is so unhelpful... I removed the ProofVerifier struct as it's no longer needed, and cargo fmt moved everything back one indentation... which is displayed so badly in the diff view.