### PR TITLE
Cleaning up test code

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
@@ -62,6 +62,7 @@ where
 /// The "x coordinates" of the output points `x_N` to `x_(N+M-1)` are `N*F::ONE` to `(N+M-1)*F::ONE`
 /// when generated using `from(denominator)`
 /// unless generated using `new(denominator, x_output)` for a specific output "x coordinate" `x_output`.
+#[derive(Debug)]
 pub struct LagrangeTable<F: Field, const N: usize, const M: usize> {
     table: [[F; N]; M],
 }

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -302,7 +302,7 @@ mod test {
         const U_3: [u128; 2] = [3, 3]; // will later be padded with zeroes
         const V_3: [u128; 2] = [5, 24]; // will later be padded with zeroes
 
-        const PROOF_3: [u128; 7] = [12, 15, 10, 0, 18, 6, 5];
+        const PROOF_3: [u128; 7] = [12, 10, 0, 15, 16, 19, 5];
         const P_RANDOM_WEIGHT: u128 = 12;
         const Q_RANDOM_WEIGHT: u128 = 1;
 
@@ -361,8 +361,8 @@ mod test {
         assert_eq!(uv_3, zip_chunks(U_3, V_3));
 
         let masked_uv_3 = zip_chunks(
-            [P_RANDOM_WEIGHT, U_3[0], U_3[1]],
-            [Q_RANDOM_WEIGHT, V_3[0], V_3[1]],
+            [P_RANDOM_WEIGHT, U_3[1], 0, U_3[0]],
+            [Q_RANDOM_WEIGHT, V_3[1], 0, V_3[0]],
         );
 
         // final iteration


### PR DESCRIPTION
I left a few small naming suggestions on #1134. It's easier to just merge that PR and put up a new one with those changes given timezones =).

The tests were also bothering me. I have tried to unify what we are testing with the actual approach we intend to use. Namely:
1. To use a consistent compression factor for every step, including the final step. Not vary the compression factor for the final recursive step.
2. For the final proof, to first move element at index 0 to the end of the array, then overwrite index 0 with the mask.

Now that these are unified, we can just test it two ways, manually calling `recurse_u_or_v` many times, as well as to call `recursively_compute_final_check`. Now we can just assert these give the same answer.

How did I get the expected numbers? I updated the Google Spreadsheet where I have manually implemented this ZKP protocol: https://docs.google.com/spreadsheets/d/10tCSgiZyQbt4bMB3KqhAUOCfgfO8xIni83J2saipFCg/edit?usp=sharing

I like to see that the numbers match up. It gives me confidence that we did things correctly, since mistakes are likely to be independent in these two wildly different implementations.