### PR TITLE
Compute zero shares for all proofs at once

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -11,9 +11,12 @@ use crate::{
 };
 
 /// This function computes the shares that sum to zero from the zero-knowledge proofs.
+///
+/// `out_share` is a share of `x` where the proof proves the statement `sum_i u_i * v_i = x`
 pub fn compute_g_differences<F, const P: usize, const λ: usize>(
-    zkp: &Vec<[F; P]>,
+    zkps: &Vec<[F; P]>,
     challenges: &[F],
+    out_share: F,
 ) -> Vec<F>
 where
     F: PrimeField,
@@ -22,28 +25,28 @@ where
     let lagrange_denominator: CanonicalLagrangeDenominator<F, P> =
         CanonicalLagrangeDenominator::<F, P>::new();
 
-    // compute g_r with "empty" first spot
-    let g_r = iter::once(F::ZERO)
+    // compute expected_sum with "out_share" at the first spot
+    let expected_sums = iter::once(out_share)
         .chain(
             challenges
                 .iter()
-                .zip(zkp)
+                .zip(zkps)
                 .map(|(challenge, zkp)| interpolate_at_r(zkp, *challenge, &lagrange_denominator)),
         )
         .collect::<Vec<_>>();
 
     // compute g_sum)
-    let g_sum = zkp
+    let g_sums = zkps
         .iter()
         .map(compute_sum_share::<F, λ, P>)
         // append spot for final sum
         .chain(iter::once(F::ZERO))
         .collect::<Vec<_>>();
 
-    g_sum
+    g_sums
         .iter()
-        .zip(g_r)
-        .map(|(g_sum, g_r)| *g_sum - g_r)
+        .zip(expected_sums)
+        .map(|(g_sum, expected_sum)| *g_sum - expected_sum)
         .collect()
 }
 
@@ -157,82 +160,116 @@ mod test {
             .collect::<Vec<_>>()
     }
 
+    fn chunks_from_vector<F: PrimeField, const N: usize>(a: Vec<&[u128]>) -> Vec<[F; N]> {
+        make_chunks(
+            &a.into_iter()
+                .flat_map(|x| x.iter())
+                .map(Clone::clone)
+                .collect::<Vec<u128>>(),
+        )
+    }
+
+    // test proof for Fp31
+    // u, v values
+    const U_1: [u128; 32] = [
+        0, 30, 0, 16, 0, 1, 0, 15, 0, 0, 0, 16, 0, 30, 0, 16, 29, 1, 1, 15, 0, 0, 1, 15, 2, 30, 30,
+        16, 0, 0, 30, 16,
+    ];
+    const V_1: [u128; 32] = [
+        0, 0, 0, 30, 0, 0, 0, 1, 30, 30, 30, 30, 0, 0, 30, 30, 0, 30, 0, 30, 0, 0, 0, 1, 0, 0, 1,
+        1, 0, 0, 1, 1,
+    ];
+
+    const U_2: [u128; 8] = [0, 0, 26, 0, 7, 18, 24, 13];
+    const V_2: [u128; 8] = [10, 21, 30, 28, 15, 21, 3, 3];
+
+    const V_3: [u128; 4] = [5, 24, 0, 0];
+    const U_3: [u128; 4] = [3, 3, 0, 0];
+
+    // out shares
+    const OUT_LEFT: u128 = 27;
+    const OUT_RIGHT: u128 = 0;
+
+    // weights
+    const P_RANDOM_WEIGHT: u128 = 12;
+    const Q_RANDOM_WEIGHT: u128 = 1;
+
+    // proofs
+    const ZKP_1_LEFT: [u128; 7] = [0, 0, 13, 17, 11, 25, 7];
+    const ZKP_1_RIGHT: [u128; 7] = [0, 30, 16, 13, 25, 3, 6];
+
+    const ZKP_2_LEFT: [u128; 7] = [11, 25, 17, 9, 22, 23, 3];
+    const ZKP_2_RIGHT: [u128; 7] = [1, 12, 29, 30, 7, 7, 3];
+
+    const ZKP_3_LEFT: [u128; 5] = [21, 1, 6, 25, 1];
+    const ZKP_3_RIGHT: [u128; 5] = [22, 14, 4, 20, 16];
+
+    // challenges
+    const CHALLENGES: [u128; 3] = [22, 17, 30];
+
+    // expected values
+    const EXPECTED_G_R_1_LEFT: u128 = 0;
+    const EXPECTED_G_R_1_RIGHT: u128 = 10;
+    const EXPECTED_B_1_LEFT: u128 = 3;
+    const EXPECTED_B_1_RIGHT: u128 = 28;
+    const EXPECTED_G_R_2_LEFT: u128 = 13;
+    const EXPECTED_G_R_2_RIGHT: u128 = 12;
+    const EXPECTED_B_2_LEFT: u128 = 0;
+    const EXPECTED_B_2_RIGHT: u128 = 0;
+
+    const EXPECTED_G_R_FINAL_LEFT: u128 = 0;
+    const EXPECTED_G_R_FINAL_RIGHT: u128 = 19;
+    const EXPECTED_P_FINAL: u128 = 27;
+    const EXPECTED_Q_FINAL: u128 = 10;
+
     #[test]
     fn sample_proof_u() {
-        const OUT_1: u128 = 27;
-        const ZKP_1: [u128; 7] = [0, 0, 13, 17, 11, 25, 7];
-        const R_1: u128 = 22;
-
-        const EXPECTED_G_R_1: u128 = 0;
-        const EXPECTED_B_1: u128 = 3;
-
-        const ZKP_2: [u128; 7] = [11, 25, 17, 9, 22, 23, 3];
-        const R_2: u128 = 17;
-
-        const EXPECTED_G_R_2: u128 = 13;
-        const EXPECTED_B_2: u128 = 0;
-
-        const ZKP_3: [u128; 5] = [21, 1, 6, 25, 1];
-
-        const R_3: u128 = 30;
-
-        const EXPECTED_G_R_FINAL: u128 = 0;
-
         let lagrange_denominator: CanonicalLagrangeDenominator<Fp31, 7> =
             CanonicalLagrangeDenominator::<Fp31, 7>::new();
 
         // first iteration
-        let zkp_1 = ZKP_1.map(Fp31::truncate_from);
+        let zkp_1 = ZKP_1_LEFT.map(Fp31::truncate_from);
 
-        let g_r_share_1 =
-            interpolate_at_r(&zkp_1, Fp31::try_from(R_1).unwrap(), &lagrange_denominator);
+        let g_r_share_1 = interpolate_at_r(
+            &zkp_1,
+            Fp31::try_from(CHALLENGES[0]).unwrap(),
+            &lagrange_denominator,
+        );
         let sum_share_1 = compute_sum_share::<Fp31, 4, 7>(&zkp_1);
-        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_1).unwrap();
+        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_LEFT).unwrap();
 
-        assert_eq!(g_r_share_1.as_u128(), EXPECTED_G_R_1);
-        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1);
+        assert_eq!(g_r_share_1.as_u128(), EXPECTED_G_R_1_LEFT);
+        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1_LEFT);
 
         // second iteration
-        let zkp_2 = ZKP_2.map(Fp31::truncate_from);
+        let zkp_2 = ZKP_2_LEFT.map(Fp31::truncate_from);
 
-        let g_r_share_2 =
-            interpolate_at_r(&zkp_2, Fp31::try_from(R_2).unwrap(), &lagrange_denominator);
+        let g_r_share_2 = interpolate_at_r(
+            &zkp_2,
+            Fp31::try_from(CHALLENGES[1]).unwrap(),
+            &lagrange_denominator,
+        );
         let sum_share_2 = compute_sum_share::<Fp31, 4, 7>(&zkp_2);
         let zero_share_2 = sum_share_2 - g_r_share_1;
 
-        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2);
-        assert_eq!(zero_share_2.as_u128(), EXPECTED_B_2);
+        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2_LEFT);
+        assert_eq!(zero_share_2.as_u128(), EXPECTED_B_2_LEFT);
 
         // final iteration
-        let zkp_3 = ZKP_3.map(Fp31::truncate_from);
+        let zkp_3 = ZKP_3_LEFT.map(Fp31::truncate_from);
 
         let final_lagrange_denominator = CanonicalLagrangeDenominator::<Fp31, 5>::new();
         let g_r_share_3 = interpolate_at_r(
             &zkp_3,
-            Fp31::try_from(R_3).unwrap(),
+            Fp31::try_from(CHALLENGES[2]).unwrap(),
             &final_lagrange_denominator,
         );
 
-        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL);
+        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL_LEFT);
     }
 
     #[tokio::test]
     async fn sample_u_recursion() {
-        const U_1: [u128; 32] = [
-            0, 30, 0, 16, 0, 1, 0, 15, 0, 0, 0, 16, 0, 30, 0, 16, 29, 1, 1, 15, 0, 0, 1, 15, 2, 30,
-            30, 16, 0, 0, 30, 16,
-        ];
-
-        const U_2: [u128; 8] = [0, 0, 26, 0, 7, 18, 24, 13];
-
-        const U_3: [u128; 4] = [3, 3, 0, 0];
-
-        const CHALLENGES: [u128; 3] = [22, 17, 30];
-
-        const P_RANDOM_WEIGHT: u128 = 12;
-
-        const EXPECTED_P_FINAL: u128 = 27;
-
         // compute Lagrange tables
         let denominator_p_or_q = CanonicalLagrangeDenominator::<Fp31, 4>::new();
         let tables: [LagrangeTable<Fp31, 4, 1>; 3] = CHALLENGES
@@ -283,76 +320,51 @@ mod test {
 
     #[test]
     fn sample_proof_v() {
-        const OUT_1: u128 = 0;
-        const ZKP_1: [u128; 7] = [0, 30, 16, 13, 25, 3, 6];
-        const R_1: u128 = 22;
-
-        const EXPECTED_G_R_1: u128 = 10;
-        const EXPECTED_B_1: u128 = 28;
-
-        const ZKP_2: [u128; 7] = [1, 12, 29, 30, 7, 7, 3];
-        const R_2: u128 = 17;
-
-        const EXPECTED_G_R_2: u128 = 12;
-        const EXPECTED_B_2: u128 = 0;
-
-        const ZKP_3: [u128; 5] = [22, 14, 4, 20, 16];
-        const R_3: u128 = 30;
-
-        const EXPECTED_G_R_FINAL: u128 = 19;
-
         let lagrange_denominator: CanonicalLagrangeDenominator<Fp31, 7> =
             CanonicalLagrangeDenominator::<Fp31, 7>::new();
 
         // first iteration
-        let zkp_1 = ZKP_1.map(Fp31::truncate_from);
+        let zkp_1 = ZKP_1_RIGHT.map(Fp31::truncate_from);
 
-        let g_r_share_1 =
-            interpolate_at_r(&zkp_1, Fp31::try_from(R_1).unwrap(), &lagrange_denominator);
+        let g_r_share_1 = interpolate_at_r(
+            &zkp_1,
+            Fp31::try_from(CHALLENGES[0]).unwrap(),
+            &lagrange_denominator,
+        );
         let sum_share_1 = compute_sum_share::<Fp31, 4, 7>(&zkp_1);
-        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_1).unwrap();
+        let zero_share_1 = sum_share_1 - Fp31::try_from(OUT_RIGHT).unwrap();
 
-        assert_eq!(g_r_share_1, EXPECTED_G_R_1);
-        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1);
+        assert_eq!(g_r_share_1, EXPECTED_G_R_1_RIGHT);
+        assert_eq!(zero_share_1.as_u128(), EXPECTED_B_1_RIGHT);
 
         // second iteration
-        let zkp_2 = ZKP_2.map(Fp31::truncate_from);
+        let zkp_2 = ZKP_2_RIGHT.map(Fp31::truncate_from);
 
-        let g_r_share_2 =
-            interpolate_at_r(&zkp_2, Fp31::try_from(R_2).unwrap(), &lagrange_denominator);
+        let g_r_share_2 = interpolate_at_r(
+            &zkp_2,
+            Fp31::try_from(CHALLENGES[1]).unwrap(),
+            &lagrange_denominator,
+        );
         let sum_share_2 = compute_sum_share::<Fp31, 4, 7>(&zkp_2);
         let zero_share_2 = sum_share_2 - g_r_share_1;
 
-        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2);
-        assert_eq!(zero_share_2, EXPECTED_B_2);
+        assert_eq!(g_r_share_2.as_u128(), EXPECTED_G_R_2_RIGHT);
+        assert_eq!(zero_share_2, EXPECTED_B_2_RIGHT);
 
         // final iteration
-        let zkp_3 = ZKP_3.map(Fp31::truncate_from);
+        let zkp_3 = ZKP_3_RIGHT.map(Fp31::truncate_from);
 
         let final_lagrange_denominator = CanonicalLagrangeDenominator::<Fp31, 5>::new();
         let g_r_share_3 = interpolate_at_r(
             &zkp_3,
-            Fp31::try_from(R_3).unwrap(),
+            Fp31::try_from(CHALLENGES[2]).unwrap(),
             &final_lagrange_denominator,
         );
-        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL);
+        assert_eq!(g_r_share_3, EXPECTED_G_R_FINAL_RIGHT);
     }
 
     #[tokio::test]
     async fn sample_v_recursion() {
-        const V_1: [u128; 32] = [
-            0, 0, 0, 30, 0, 0, 0, 1, 30, 30, 30, 30, 0, 0, 30, 30, 0, 30, 0, 30, 0, 0, 0, 1, 0, 0,
-            1, 1, 0, 0, 1, 1,
-        ];
-        const V_2: [u128; 8] = [10, 21, 30, 28, 15, 21, 3, 3];
-        const V_3: [u128; 4] = [5, 24, 0, 0];
-
-        const CHALLENGES: [u128; 3] = [22, 17, 30];
-
-        const Q_RANDOM_WEIGHT: u128 = 1;
-
-        const EXPECTED_Q_FINAL: u128 = 10;
-
         // compute Lagrange tables
         let denominator_p_or_q = CanonicalLagrangeDenominator::<Fp31, 4>::new();
         let tables: [LagrangeTable<Fp31, 4, 1>; 3] = CHALLENGES
@@ -404,25 +416,23 @@ mod test {
 
     #[test]
     fn differences_are_zero() {
-        const ZKP_1_and_2_LEFT: [u128; 14] = [0, 0, 13, 17, 11, 25, 7, 11, 25, 17, 9, 22, 23, 3];
-        const ZKP_1_and_2_RIGHT: [u128; 14] = [0, 30, 16, 13, 25, 3, 6, 1, 12, 29, 30, 7, 7, 3];
-        const OUT_LEFT: u128 = 27;
-        const OUT_RIGHT: u128 = 0;
-
-        let zkp_left = make_chunks::<Fp31, 7>(&ZKP_1_and_2_LEFT);
-        let zkp_right = make_chunks::<Fp31, 7>(&ZKP_1_and_2_RIGHT);
+        let zkp_left = chunks_from_vector::<Fp31, 7>(vec![&ZKP_1_LEFT, &ZKP_2_LEFT]);
+        let zkp_right = chunks_from_vector::<Fp31, 7>(vec![&ZKP_1_RIGHT, &ZKP_2_RIGHT]);
         let challenges = vec![Fp31::truncate_from(22u128), Fp31::truncate_from(17u128)];
 
-        let g_differences_left = compute_g_differences::<_, 7, 4>(&zkp_left, &challenges);
-        let g_differences_right = compute_g_differences::<_, 7, 4>(&zkp_right, &challenges);
+        let g_differences_left =
+            compute_g_differences::<_, 7, 4>(&zkp_left, &challenges, Fp31::truncate_from(OUT_LEFT));
+        let g_differences_right = compute_g_differences::<_, 7, 4>(
+            &zkp_right,
+            &challenges,
+            Fp31::truncate_from(OUT_RIGHT),
+        );
 
-        let mut g_differences = g_differences_left
+        let g_differences = g_differences_left
             .iter()
             .zip(g_differences_right)
             .map(|(left, right)| *left + right)
             .collect::<Vec<_>>();
-
-        g_differences[0] -= Fp31::truncate_from(OUT_LEFT) + Fp31::truncate_from(OUT_RIGHT);
 
         assert_eq!(Fp31::ZERO, g_differences[0]);
         assert_eq!(Fp31::ZERO, g_differences[1]);

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -1,4 +1,4 @@
-use std::pin::Pin;
+use std::{iter, pin::Pin};
 
 use futures::Stream;
 use futures_util::StreamExt;
@@ -9,6 +9,43 @@ use crate::{
         CanonicalLagrangeDenominator, LagrangeTable,
     },
 };
+
+/// This function computes the shares that sum to zero from the zero-knowledge proofs.
+pub fn compute_g_differences<F, const P: usize, const λ: usize>(
+    zkp: &Vec<[F; P]>,
+    challenges: &[F],
+) -> Vec<F>
+where
+    F: PrimeField,
+{
+    // compute denominator
+    let lagrange_denominator: CanonicalLagrangeDenominator<F, P> =
+        CanonicalLagrangeDenominator::<F, P>::new();
+
+    // compute g_r with "empty" first spot
+    let g_r = iter::once(F::ZERO)
+        .chain(
+            challenges
+                .iter()
+                .zip(zkp)
+                .map(|(challenge, zkp)| interpolate_at_r(zkp, *challenge, &lagrange_denominator)),
+        )
+        .collect::<Vec<_>>();
+
+    // compute g_sum)
+    let g_sum = zkp
+        .iter()
+        .map(compute_sum_share::<F, λ, P>)
+        // append spot for final sum
+        .chain(iter::once(F::ZERO))
+        .collect::<Vec<_>>();
+
+    g_sum
+        .iter()
+        .zip(g_r)
+        .map(|(g_sum, g_r)| *g_sum - g_r)
+        .collect()
+}
 
 ///
 /// Distributed Zero Knowledge Proofs algorithm drawn from
@@ -33,14 +70,14 @@ fn compute_sum_share<F: PrimeField, const λ: usize, const P: usize>(zkp: &[F; P
 /// This function compresses the `u_or_v` values and returns the next `u_or_v` values.
 ///
 /// The function uses streams since stream offers a chunk method.
-async fn recurse_u_or_v<'a, F: PrimeField, J, const λ: usize>(
-    u_or_v_iterator: J,
+fn recurse_u_or_v<'a, F: PrimeField, J, const λ: usize>(
+    u_or_v_stream: J,
     lagrange_table: &'a LagrangeTable<F, λ, 1>,
 ) -> impl Stream<Item = [F; λ]> + 'a
 where
     J: Stream<Item = [F; λ]> + 'a,
 {
-    u_or_v_iterator
+    u_or_v_stream
         .map(|polynomial| lagrange_table.eval(polynomial)[0])
         .chunks(λ)
         .map(|chunk| {
@@ -53,7 +90,7 @@ where
 }
 
 pub async fn recursively_compute_final_check<F: PrimeField, J, const λ: usize>(
-    u_or_v_iterator: J,
+    u_or_v_stream: J,
     challenges: Vec<F>,
     p_or_q_0: F,
 ) -> F
@@ -71,9 +108,9 @@ where
 
     // generate & evaluate recursive streams
     // to compute last array
-    let mut stream: Pin<Box<dyn Stream<Item = [F; λ]>>> = Box::pin(u_or_v_iterator);
+    let mut stream: Pin<Box<dyn Stream<Item = [F; λ]>>> = Box::pin(u_or_v_stream);
     for lagrange_table in tables.iter().take(recursions - 1) {
-        stream = Box::pin(recurse_u_or_v(stream, lagrange_table).await);
+        stream = Box::pin(recurse_u_or_v(stream, lagrange_table));
     }
     let mut last_u_or_v_array = stream.next().await.unwrap();
     // make sure stream is empty
@@ -107,7 +144,7 @@ mod test {
         protocol::ipa_prf::malicious_security::{
             lagrange::{CanonicalLagrangeDenominator, LagrangeTable},
             verifier::{
-                compute_sum_share, interpolate_at_r, recurse_u_or_v,
+                compute_g_differences, compute_sum_share, interpolate_at_r, recurse_u_or_v,
                 recursively_compute_final_check,
             },
         },
@@ -205,13 +242,11 @@ mod test {
         let u_1 = make_chunks::<_, 4>(&U_1);
 
         let u_or_v_2 = recurse_u_or_v(stream::iter(u_1), &tables[0])
-            .await
             .collect::<Vec<_>>()
             .await;
         assert_eq!(u_or_v_2, make_chunks::<Fp31, 4>(&U_2));
 
         let u_or_v_3 = recurse_u_or_v(stream::iter(u_or_v_2.into_iter()), &tables[1])
-            .await
             .collect::<Vec<_>>()
             .await;
 
@@ -225,7 +260,6 @@ mod test {
         ];
 
         let p_final = recurse_u_or_v(stream::iter(iter::once(u_or_v_3_masked)), &tables[2])
-            .await
             .collect::<Vec<_>>()
             .await;
 
@@ -328,13 +362,11 @@ mod test {
         let v_1 = make_chunks::<_, 4>(&V_1);
 
         let u_or_v_2 = recurse_u_or_v(stream::iter(v_1), &tables[0])
-            .await
             .collect::<Vec<_>>()
             .await;
         assert_eq!(u_or_v_2, make_chunks::<Fp31, 4>(&V_2));
 
         let u_or_v_3 = recurse_u_or_v(stream::iter(u_or_v_2.into_iter()), &tables[1])
-            .await
             .collect::<Vec<_>>()
             .await;
 
@@ -349,7 +381,6 @@ mod test {
 
         // final iteration
         let p_final = recurse_u_or_v(stream::iter(iter::once(u_or_v_3_masked)), &tables[2])
-            .await
             .collect::<Vec<_>>()
             .await;
 
@@ -369,5 +400,31 @@ mod test {
         .await;
 
         assert_eq!(q_final_another_way.as_u128(), EXPECTED_Q_FINAL);
+    }
+
+    #[test]
+    fn differences_are_zero() {
+        const ZKP_1_and_2_LEFT: [u128; 14] = [0, 0, 13, 17, 11, 25, 7, 11, 25, 17, 9, 22, 23, 3];
+        const ZKP_1_and_2_RIGHT: [u128; 14] = [0, 30, 16, 13, 25, 3, 6, 1, 12, 29, 30, 7, 7, 3];
+        const OUT_LEFT: u128 = 27;
+        const OUT_RIGHT: u128 = 0;
+
+        let zkp_left = make_chunks::<Fp31, 7>(&ZKP_1_and_2_LEFT);
+        let zkp_right = make_chunks::<Fp31, 7>(&ZKP_1_and_2_RIGHT);
+        let challenges = vec![Fp31::truncate_from(22u128), Fp31::truncate_from(17u128)];
+
+        let g_differences_left = compute_g_differences::<_, 7, 4>(&zkp_left, &challenges);
+        let g_differences_right = compute_g_differences::<_, 7, 4>(&zkp_right, &challenges);
+
+        let mut g_differences = g_differences_left
+            .iter()
+            .zip(g_differences_right)
+            .map(|(left, right)| *left + right)
+            .collect::<Vec<_>>();
+
+        g_differences[0] -= Fp31::truncate_from(OUT_LEFT) + Fp31::truncate_from(OUT_RIGHT);
+
+        assert_eq!(Fp31::ZERO, g_differences[0]);
+        assert_eq!(Fp31::ZERO, g_differences[1]);
     }
 }


### PR DESCRIPTION
Computes zero shares for all proofs at once.

Also removes async from recurse_u_or_v as @benjaminsavage has pointed out since it was not needed.

renamed iterators that were streams to streams