### PR TITLE
remove generic support for other Fields from dzkp_validate

### DIFF
--- a/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
@@ -82,7 +82,7 @@ impl<'a, F: Field + DZKPCompatibleField<N>, const N: usize>
 mod test {
     use crate::{
         error::Error,
-        ff::{boolean::Boolean, Fp61BitPrime},
+        ff::boolean::Boolean,
         protocol::{
             basics::SecureMul,
             context::{dzkp_validator::DZKPValidator, Context, DZKPContext, UpgradableContext},
@@ -113,7 +113,7 @@ mod test {
                 assert!(matches!(mctx.is_verified(), Err(Error::ContextUnsafe(_))));
 
                 // validate all elements in the batch
-                validator.validate::<Fp61BitPrime>().await.unwrap();
+                validator.validate().await.unwrap();
 
                 // batch is empty now
                 assert!(mctx.is_verified().is_ok());

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -7,13 +7,13 @@ use futures_util::{StreamExt, TryFutureExt};
 
 use super::step::ZeroKnowledgeProofValidateStep as Step;
 #[cfg(all(test, unit_test))]
-use crate::protocol::context::dzkp_field::{UVSingleBlock, UVTupleBlock};
+use crate::protocol::context::dzkp_field::{DZKPBaseField, UVSingleBlock, UVTupleBlock};
 use crate::{
     error::{BoxError, Error},
     helpers::stream::TryFlattenItersExt,
     protocol::{
         context::{
-            dzkp_field::DZKPBaseField, dzkp_malicious::DZKPUpgraded as MaliciousDZKPUpgraded,
+            dzkp_malicious::DZKPUpgraded as MaliciousDZKPUpgraded,
             dzkp_semi_honest::DZKPUpgraded as SemiHonestDZKPUpgraded, Base, Context,
             MaliciousContext, SemiHonestContext, UpgradableContext,
         },
@@ -553,8 +553,8 @@ pub trait DZKPValidator<B: UpgradableContext> {
     /// Allows to validate the current `DZKPBatch` and empties it. The associated context is then
     /// considered safe until another multiplication is performed and thus new values are added
     /// to `DZKPBatch`.
-    /// Is generic over `DZKPBaseFields`. Please specify a sufficiently large field for the current `DZKPBatch`.
-    async fn validate<DF: DZKPBaseField>(&self) -> Result<(), Error>;
+    /// Currently only allows `Fp61BitPrime` and is not generic over `DZKPBaseFields`.
+    async fn validate(&self) -> Result<(), Error>;
 
     /// `is_verified` checks that there are no `MultiplicationInputs` that have not been verified
     /// within the associated `DZKPBatch`
@@ -568,7 +568,7 @@ pub trait DZKPValidator<B: UpgradableContext> {
     /// verified using `validator.validate()`, which uses DZKPs. Once the validation fails,
     /// the output stream will return an error.
     ///
-    fn validated_seq_join<'st, S, F, O, DF>(
+    fn validated_seq_join<'st, S, F, O>(
         &'st self,
         chunk_size: usize,
         source: S,
@@ -577,13 +577,12 @@ pub trait DZKPValidator<B: UpgradableContext> {
         S: Stream<Item = F> + Send + 'st,
         F: Future<Output = O> + Send + 'st,
         O: Send + Sync + Clone + 'static,
-        DF: DZKPBaseField,
     {
         // chunk_size is undefined in the semi-honest setting, set it to 10, ideally it would be 1
         // but there is some overhead
         seq_join::<'st, S, F, O>(self.context().active_work(), source)
             .chunks(chunk_size)
-            .then(move |chunk| self.validate::<DF>().map_ok(|()| chunk))
+            .then(move |chunk| self.validate().map_ok(|()| chunk))
             .try_flatten_iters()
     }
 }
@@ -608,7 +607,7 @@ impl<'a, B: ShardBinding> DZKPValidator<SemiHonestContext<'a, B>>
         self.context.clone()
     }
 
-    async fn validate<DF: DZKPBaseField>(&self) -> Result<(), Error> {
+    async fn validate(&self) -> Result<(), Error> {
         Ok(())
     }
 
@@ -633,7 +632,7 @@ impl<'a> DZKPValidator<MaliciousContext<'a>> for MaliciousDZKPValidator<'a> {
         self.protocol_ctx.clone()
     }
 
-    async fn validate<DF: DZKPBaseField>(&self) -> Result<(), Error> {
+    async fn validate(&self) -> Result<(), Error> {
         // LOCK BEGIN
         let mut batch = self.batch_ref.lock().unwrap();
         if batch.is_empty() {
@@ -748,7 +747,7 @@ mod tests {
                 let m_ctx = v.context().narrow(&Step::DZKPMaliciousProtocol);
 
                 let m_results = v
-                    .validated_seq_join::<_, _, _, Fp61BitPrime>(
+                    .validated_seq_join(
                         chunk_size,
                         iter(
                             zip(
@@ -785,7 +784,7 @@ mod tests {
                 let m_ctx = v.context().narrow(&Step::DZKPMaliciousProtocol);
 
                 let m_results = v
-                    .validated_seq_join::<_, _, _, Fp61BitPrime>(
+                    .validated_seq_join(
                         chunk_size,
                         iter(
                             zip(

--- a/ipa-core/src/secret_sharing/vector/impls.rs
+++ b/ipa-core/src/secret_sharing/vector/impls.rs
@@ -63,7 +63,6 @@ macro_rules! boolean_vector {
                 use super::*;
                 use crate::{
                     error::Error,
-                    ff::Fp61BitPrime,
                     protocol::{
                         basics::select,
                         context::{dzkp_validator::DZKPValidator, Context, UpgradableContext},
@@ -102,7 +101,7 @@ macro_rules! boolean_vector {
                             )
                             .await?;
 
-                            v.validate::<Fp61BitPrime>().await?;
+                            v.validate().await?;
 
                             Ok::<_, Error>(result)
                         });
@@ -142,7 +141,7 @@ macro_rules! boolean_vector {
                             )
                             .await?;
 
-                            v.validate::<Fp61BitPrime>().await?;
+                            v.validate().await?;
 
                             Ok::<_, Error>(result)
                         });


### PR DESCRIPTION
remove generic support for other Fields from dzkp_validate since we plan to only support Fp61BitPrime for now.