### PR TITLE
Create test addition circuit

### DIFF
--- a/ipa-core/src/bin/test_mpc.rs
+++ b/ipa-core/src/bin/test_mpc.rs
@@ -5,11 +5,14 @@ use generic_array::ArrayLength;
 use hyper::http::uri::Scheme;
 use ipa_core::{
     cli::{
-        playbook::{make_clients, secure_mul, validate, InputSource},
+        playbook::{make_clients, secure_add, secure_mul, validate, InputSource},
         Verbosity,
     },
     ff::{Field, FieldType, Fp31, Fp32BitPrime, Serializable, U128Conversions},
-    helpers::query::{QueryConfig, QueryType::TestMultiply},
+    helpers::query::{
+        QueryConfig,
+        QueryType::{TestAdd, TestMultiply},
+    },
     net::MpcHelperClient,
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
 };
@@ -53,12 +56,21 @@ pub struct CommandInput {
 
     #[arg(value_enum, long, default_value_t = FieldType::Fp32BitPrime, help = "Convert the input into the given field before sending to helpers")]
     field: FieldType,
+
+    #[arg(
+        long,
+        conflicts_with = "input_file",
+        help = "Instead of taking input from a file, generate the given number of field values for input"
+    )]
+    generate: Option<u64>,
 }
 
 impl From<&CommandInput> for InputSource {
     fn from(source: &CommandInput) -> Self {
         if let Some(ref file_name) = source.input_file {
             InputSource::from_file(file_name)
+        } else if let Some(count) = source.generate {
+            InputSource::from_generator(count)
         } else {
             InputSource::from_stdin()
         }
@@ -69,15 +81,10 @@ impl From<&CommandInput> for InputSource {
 enum TestAction {
     /// Execute end-to-end multiplication.
     Multiply,
-}
-
-#[derive(Debug, clap::Args)]
-struct GenInputArgs {
-    /// Maximum records per user
-    #[clap(long)]
-    max_per_user: u32,
-    /// number of breakdowns
-    breakdowns: u32,
+    /// Execute end-to-end simple addition circuit that uses prime fields.
+    /// All helpers add their shares locally and set the resulting share to be the
+    /// sum. No communication is required to run the circuit.
+    Add,
 }
 
 #[tokio::main]
@@ -94,6 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (clients, _) = make_clients(args.network.as_deref(), scheme, args.wait).await;
     match args.action {
         TestAction::Multiply => multiply(&args, &clients).await,
+        TestAction::Add => add(&args, &clients).await,
     };
 
     Ok(())
@@ -120,5 +128,33 @@ async fn multiply(args: &Args, helper_clients: &[MpcHelperClient; 3]) {
     match args.input.field {
         FieldType::Fp31 => multiply_in_field::<Fp31>(args, helper_clients).await,
         FieldType::Fp32BitPrime => multiply_in_field::<Fp32BitPrime>(args, helper_clients).await,
+    };
+}
+
+async fn add_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient; 3])
+where
+    F: Field + U128Conversions + IntoShares<AdditiveShare<F>>,
+    <F as Serializable>::Size: Add<<F as Serializable>::Size>,
+    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength,
+{
+    let input = InputSource::from(&args.input);
+    // compute the sum as we are iterating through the input. That avoid cloning the iterator
+    let mut expected = F::ZERO;
+    let input_rows = input.known_size_iter().map(F::truncate_from).map(|v| {
+        expected += v;
+        v
+    });
+    let query_config = QueryConfig::new(TestAdd, args.input.field, input_rows.len()).unwrap();
+
+    let query_id = helper_clients[0].create_query(query_config).await.unwrap();
+    let actual = secure_add(input_rows, helper_clients, query_id).await;
+
+    validate(&vec![expected], &vec![actual]);
+}
+
+async fn add(args: &Args, helper_clients: &[MpcHelperClient; 3]) {
+    match args.input.field {
+        FieldType::Fp31 => add_in_field::<Fp31>(args, helper_clients).await,
+        FieldType::Fp32BitPrime => add_in_field::<Fp32BitPrime>(args, helper_clients).await,
     };
 }

--- a/ipa-core/src/bin/test_mpc.rs
+++ b/ipa-core/src/bin/test_mpc.rs
@@ -11,7 +11,7 @@ use ipa_core::{
     ff::{Field, FieldType, Fp31, Fp32BitPrime, Serializable, U128Conversions},
     helpers::query::{
         QueryConfig,
-        QueryType::{TestAdd, TestMultiply},
+        QueryType::{TestAddInPrimeField, TestMultiply},
     },
     net::MpcHelperClient,
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
@@ -144,7 +144,8 @@ where
         expected += v;
         v
     });
-    let query_config = QueryConfig::new(TestAdd, args.input.field, input_rows.len()).unwrap();
+    let query_config =
+        QueryConfig::new(TestAddInPrimeField, args.input.field, input_rows.len()).unwrap();
 
     let query_id = helper_clients[0].create_query(query_config).await.unwrap();
     let actual = secure_add(input_rows, helper_clients, query_id).await;

--- a/ipa-core/src/cli/playbook/add.rs
+++ b/ipa-core/src/cli/playbook/add.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "web-app")]
+
+use std::ops::Add;
+
+use futures::future::try_join_all;
+use generic_array::{ArrayLength, GenericArray};
+use typenum::Unsigned;
+
+use crate::{
+    ff::{Field, Serializable},
+    helpers::{query::QueryInput, BodyStream},
+    net::MpcHelperClient,
+    protocol::QueryId,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
+    test_fixture::Reconstruct,
+};
+
+/// Secure addition.
+#[allow(clippy::missing_panics_doc, clippy::disallowed_methods)]
+pub async fn secure_add<F>(
+    input: impl Iterator<Item = F>,
+    clients: &[MpcHelperClient; 3],
+    query_id: QueryId,
+) -> F
+where
+    F: Field + IntoShares<Replicated<F>>,
+    <F as Serializable>::Size: Add<<F as Serializable>::Size>,
+    <<F as Serializable>::Size as Add<<F as Serializable>::Size>>::Output: ArrayLength,
+{
+    // prepare inputs
+    let inputs = input.share().map(|vec| {
+        let r = vec
+            .into_iter()
+            .flat_map(|item| {
+                let mut slice = vec![0u8; <Replicated<F> as Serializable>::Size::USIZE];
+                item.serialize(GenericArray::from_mut_slice(&mut slice));
+                slice
+            })
+            .collect::<Vec<_>>();
+
+        BodyStream::from(r)
+    });
+
+    // send inputs
+    try_join_all(
+        inputs
+            .into_iter()
+            .zip(clients)
+            .map(|(input_stream, client)| {
+                client.query_input(QueryInput {
+                    query_id,
+                    input_stream,
+                })
+            }),
+    )
+    .await
+    .unwrap();
+
+    // wait until helpers have processed the query and get the results from them
+    let results: [_; 3] = try_join_all(clients.iter().map(|client| client.query_results(query_id)))
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    results
+        .map(|bytes| Replicated::<F>::deserialize(GenericArray::from_slice(&bytes)).unwrap())
+        .reconstruct()
+}

--- a/ipa-core/src/cli/playbook/generator.rs
+++ b/ipa-core/src/cli/playbook/generator.rs
@@ -1,0 +1,34 @@
+use std::io::{Cursor, Read, Write};
+
+/// This generator generates random u128 values
+/// and implements [`Read`] trait to return those values.
+///
+/// This allows numbers to be generated in a streaming
+/// fashion, making it possible to generate large amounts
+pub(super) struct U128Generator {
+    pos: usize,
+    max: usize,
+}
+
+impl U128Generator {
+    pub fn new(count: u64) -> Self {
+        Self {
+            pos: 0,
+            max: usize::try_from(count).unwrap(),
+        }
+    }
+}
+
+impl Read for U128Generator {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let sz = u64::try_from(buf.len()).unwrap();
+        let mut cur = Cursor::new(buf);
+        while cur.position() < sz && self.pos < self.max {
+            let l: u128 = rand::random();
+            assert_eq!(16, cur.write(&l.to_le_bytes())?);
+            self.pos += 1;
+        }
+
+        Ok(usize::try_from(cur.position()).unwrap())
+    }
+}

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -1,3 +1,5 @@
+mod add;
+mod generator;
 mod input;
 mod ipa;
 mod multiply;
@@ -5,6 +7,7 @@ mod multiply;
 use core::fmt::Debug;
 use std::{fs, path::Path, time::Duration};
 
+pub use add::secure_add;
 use comfy_table::{Cell, Color, Table};
 use hyper::http::uri::Scheme;
 pub use input::InputSource;

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -68,7 +68,8 @@ pub use transport::{
     make_owned_handler, query, routing, ApiError, BodyStream, BytesStream, HandlerBox, HandlerRef,
     HelperResponse, Identity as TransportIdentity, LengthDelimitedStream, LogErrors, NoQueryId,
     NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords, RecordsStream, RequestHandler,
-    RouteParams, StepBinding, StreamCollection, StreamKey, Transport, WrappedBoxBodyStream,
+    RouteParams, SingleRecordStream, StepBinding, StreamCollection, StreamKey, Transport,
+    WrappedBoxBodyStream,
 };
 #[cfg(feature = "in-memory-infra")]
 pub use transport::{InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -202,11 +202,15 @@ impl Debug for QueryInput {
 pub enum QueryType {
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
     TestMultiply,
+    #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
+    TestAdd,
     OprfIpa(IpaQueryConfig),
 }
 
 impl QueryType {
+    /// TODO: strum
     pub const TEST_MULTIPLY_STR: &'static str = "test-multiply";
+    pub const TEST_ADD_STR: &'static str = "test-add";
     pub const OPRF_IPA_STR: &'static str = "oprf_ipa";
 }
 
@@ -216,6 +220,8 @@ impl AsRef<str> for QueryType {
         match self {
             #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
             QueryType::TestMultiply => Self::TEST_MULTIPLY_STR,
+            #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+            QueryType::TestAdd => Self::TEST_ADD_STR,
             QueryType::OprfIpa(_) => Self::OPRF_IPA_STR,
         }
     }

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -203,7 +203,7 @@ pub enum QueryType {
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
     TestMultiply,
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
-    TestAdd,
+    TestAddInPrimeField,
     OprfIpa(IpaQueryConfig),
 }
 
@@ -221,7 +221,7 @@ impl AsRef<str> for QueryType {
             #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
             QueryType::TestMultiply => Self::TEST_MULTIPLY_STR,
             #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-            QueryType::TestAdd => Self::TEST_ADD_STR,
+            QueryType::TestAddInPrimeField => Self::TEST_ADD_STR,
             QueryType::OprfIpa(_) => Self::OPRF_IPA_STR,
         }
     }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -120,6 +120,8 @@ pub mod query {
             let query_type = match query_type.as_str() {
                 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
                 QueryType::TEST_MULTIPLY_STR => Ok(QueryType::TestMultiply),
+                #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+                QueryType::TEST_ADD_STR => Ok(QueryType::TestAdd),
                 QueryType::OPRF_IPA_STR => {
                     let Query(q) = req.extract().await?;
                     Ok(QueryType::OprfIpa(q))
@@ -145,7 +147,7 @@ pub mod query {
             )?;
             match self.query_type {
                 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
-                QueryType::TestMultiply => Ok(()),
+                QueryType::TestMultiply | QueryType::TestAdd => Ok(()),
                 QueryType::OprfIpa(config) => {
                     write!(
                         f,

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -121,7 +121,7 @@ pub mod query {
                 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
                 QueryType::TEST_MULTIPLY_STR => Ok(QueryType::TestMultiply),
                 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-                QueryType::TEST_ADD_STR => Ok(QueryType::TestAdd),
+                QueryType::TEST_ADD_STR => Ok(QueryType::TestAddInPrimeField),
                 QueryType::OPRF_IPA_STR => {
                     let Query(q) = req.extract().await?;
                     Ok(QueryType::OprfIpa(q))
@@ -147,7 +147,7 @@ pub mod query {
             )?;
             match self.query_type {
                 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
-                QueryType::TestMultiply | QueryType::TestAdd => Ok(()),
+                QueryType::TestMultiply | QueryType::TestAddInPrimeField => Ok(()),
                 QueryType::OprfIpa(config) => {
                     write!(
                         f,

--- a/ipa-core/src/protocol/step.rs
+++ b/ipa-core/src/protocol/step.rs
@@ -8,7 +8,7 @@ pub enum ProtocolStep {
     #[step(child = crate::protocol::ipa_prf::step::IpaPrfStep)]
     IpaPrf,
     Multiply,
-    Add,
+    PrimeFieldAddition,
     #[cfg(any(test, feature = "test-fixture"))]
     #[step(count = 10, child = crate::test_fixture::step::TestExecutionStep)]
     Test(usize),

--- a/ipa-core/src/protocol/step.rs
+++ b/ipa-core/src/protocol/step.rs
@@ -8,6 +8,7 @@ pub enum ProtocolStep {
     #[step(child = crate::protocol::ipa_prf::step::IpaPrfStep)]
     IpaPrf,
     Multiply,
+    Add,
     #[cfg(any(test, feature = "test-fixture"))]
     #[step(count = 10, child = crate::test_fixture::step::TestExecutionStep)]
     Test(usize),

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -20,7 +20,9 @@ use shuttle::future as tokio;
 use typenum::Unsigned;
 
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-use crate::{ff::Fp32BitPrime, query::runner::execute_test_multiply, query::runner::test_add};
+use crate::{
+    ff::Fp32BitPrime, query::runner::execute_test_multiply, query::runner::test_add_in_prime_field,
+};
 use crate::{
     ff::{boolean_array::BA16, FieldType, Serializable},
     helpers::{
@@ -82,15 +84,19 @@ pub fn execute(
             })
         }
         #[cfg(any(test, feature = "weak-field"))]
-        (QueryType::TestAdd, FieldType::Fp31) => {
+        (QueryType::TestAddInPrimeField, FieldType::Fp31) => {
             do_query(config, gateway, input, |prss, gateway, _config, input| {
-                Box::pin(test_add::<crate::ff::Fp31>(prss, gateway, input))
+                Box::pin(test_add_in_prime_field::<crate::ff::Fp31>(
+                    prss, gateway, input,
+                ))
             })
         }
         #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-        (QueryType::TestAdd, FieldType::Fp32BitPrime) => {
+        (QueryType::TestAddInPrimeField, FieldType::Fp32BitPrime) => {
             do_query(config, gateway, input, |prss, gateway, _config, input| {
-                Box::pin(test_add::<Fp32BitPrime>(prss, gateway, input))
+                Box::pin(test_add_in_prime_field::<Fp32BitPrime>(
+                    prss, gateway, input,
+                ))
             })
         }
         // TODO(953): This is really using BA32, not Fp32bitPrime. The `FieldType` mechanism needs

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -20,7 +20,7 @@ use shuttle::future as tokio;
 use typenum::Unsigned;
 
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-use crate::{ff::Fp32BitPrime, query::runner::execute_test_multiply};
+use crate::{ff::Fp32BitPrime, query::runner::execute_test_multiply, query::runner::test_add};
 use crate::{
     ff::{boolean_array::BA16, FieldType, Serializable},
     helpers::{
@@ -79,6 +79,18 @@ pub fn execute(
         (QueryType::TestMultiply, FieldType::Fp32BitPrime) => {
             do_query(config, gateway, input, |prss, gateway, _config, input| {
                 Box::pin(execute_test_multiply::<Fp32BitPrime>(prss, gateway, input))
+            })
+        }
+        #[cfg(any(test, feature = "weak-field"))]
+        (QueryType::TestAdd, FieldType::Fp31) => {
+            do_query(config, gateway, input, |prss, gateway, _config, input| {
+                Box::pin(test_add::<crate::ff::Fp31>(prss, gateway, input))
+            })
+        }
+        #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+        (QueryType::TestAdd, FieldType::Fp32BitPrime) => {
+            do_query(config, gateway, input, |prss, gateway, _config, input| {
+                Box::pin(test_add::<Fp32BitPrime>(prss, gateway, input))
             })
         }
         // TODO(953): This is really using BA32, not Fp32bitPrime. The `FieldType` mechanism needs

--- a/ipa-core/src/query/runner/add_in_prime_field.rs
+++ b/ipa-core/src/query/runner/add_in_prime_field.rs
@@ -15,8 +15,8 @@ use crate::{
     secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
 };
 
-#[tracing::instrument("test-add", skip_all)]
-pub async fn add<'a, F>(
+#[tracing::instrument("add_in_prime_field", skip_all)]
+pub async fn execute<'a, F>(
     prss: &'a PrssEndpoint,
     gateway: &'a Gateway,
     input: BodyStream,
@@ -25,11 +25,11 @@ where
     F: PrimeField,
     Replicated<F>: Serializable,
 {
-    let ctx = SemiHonestContext::new(prss, gateway).narrow(&ProtocolStep::Add);
-    Ok(Box::new(add_internal::<F>(ctx, input).await?))
+    let ctx = SemiHonestContext::new(prss, gateway).narrow(&ProtocolStep::PrimeFieldAddition);
+    Ok(Box::new(execute_internal::<F>(ctx, input).await?))
 }
 
-async fn add_internal<F>(
+async fn execute_internal<F>(
     _ctx: SemiHonestContext<'_>,
     input_stream: BodyStream,
 ) -> Result<Vec<Replicated<F>>, Error>
@@ -90,7 +90,7 @@ mod tests {
             helper_shares
                 .into_iter()
                 .zip(contexts)
-                .map(|(shares, context)| add_internal::<Fp31>(context, shares)),
+                .map(|(shares, context)| execute_internal::<Fp31>(context, shares)),
         )
         .await;
 

--- a/ipa-core/src/query/runner/mod.rs
+++ b/ipa-core/src/query/runner/mod.rs
@@ -1,7 +1,10 @@
 mod oprf_ipa;
+mod test_add;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_multiply;
 
+#[cfg(any(test, feature = "cli", feature = "test-fixture"))]
+pub(super) use test_add::add as test_add;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 pub(super) use test_multiply::execute_test_multiply;
 

--- a/ipa-core/src/query/runner/mod.rs
+++ b/ipa-core/src/query/runner/mod.rs
@@ -1,11 +1,11 @@
-mod oprf_ipa;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-mod test_add;
+mod add_in_prime_field;
+mod oprf_ipa;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_multiply;
 
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-pub(super) use test_add::add as test_add;
+pub(super) use add_in_prime_field::execute as test_add_in_prime_field;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 pub(super) use test_multiply::execute_test_multiply;
 

--- a/ipa-core/src/query/runner/mod.rs
+++ b/ipa-core/src/query/runner/mod.rs
@@ -1,4 +1,5 @@
 mod oprf_ipa;
+#[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_add;
 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
 mod test_multiply;

--- a/ipa-core/src/query/runner/test_add.rs
+++ b/ipa-core/src/query/runner/test_add.rs
@@ -1,0 +1,101 @@
+use std::pin::pin;
+
+use futures::StreamExt;
+
+use crate::{
+    error::Error,
+    ff::{PrimeField, Serializable},
+    helpers::{BodyStream, Gateway, SingleRecordStream},
+    protocol::{
+        context::{Context, SemiHonestContext},
+        prss::Endpoint as PrssEndpoint,
+        step::ProtocolStep,
+    },
+    query::runner::QueryResult,
+    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+};
+
+#[tracing::instrument("test-add", skip_all)]
+pub async fn add<'a, F>(
+    prss: &'a PrssEndpoint,
+    gateway: &'a Gateway,
+    input: BodyStream,
+) -> QueryResult
+where
+    F: PrimeField,
+    Replicated<F>: Serializable,
+{
+    let ctx = SemiHonestContext::new(prss, gateway).narrow(&ProtocolStep::Add);
+    Ok(Box::new(add_internal::<F>(ctx, input).await?))
+}
+
+pub async fn add_internal<F>(
+    _ctx: SemiHonestContext<'_>,
+    input_stream: BodyStream,
+) -> Result<Vec<Replicated<F>>, Error>
+where
+    F: PrimeField,
+    Replicated<F>: Serializable,
+{
+    let mut input_stream = pin!(SingleRecordStream::<Replicated<F>, _>::new(input_stream));
+    let mut sum = Replicated::ZERO;
+    while let Some(Ok(record)) = input_stream.next().await {
+        sum += record;
+    }
+
+    Ok(vec![sum])
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use generic_array::GenericArray;
+    use typenum::Unsigned;
+
+    use super::*;
+    use crate::{
+        ff::{Fp31, U128Conversions},
+        secret_sharing::IntoShares,
+        test_fixture::{join3v, Reconstruct, TestWorld},
+    };
+
+    #[tokio::test]
+    async fn add() {
+        let world = TestWorld::default();
+        let contexts = world.contexts();
+        let input = vec![
+            Fp31::truncate_from(4_u128),
+            Fp31::truncate_from(5_u128),
+            Fp31::truncate_from(6_u128),
+            Fp31::truncate_from(7_u128),
+            Fp31::truncate_from(8_u128),
+            Fp31::truncate_from(9_u128),
+        ];
+
+        let shares: [Vec<Replicated<Fp31>>; 3] = input.into_iter().share();
+
+        let helper_shares = shares.map(|shares| {
+            const SIZE: usize = <Replicated<Fp31> as Serializable>::Size::USIZE;
+            shares
+                .into_iter()
+                .flat_map(|share| {
+                    let mut slice = [0_u8; SIZE];
+                    share.serialize(GenericArray::from_mut_slice(&mut slice));
+                    slice
+                })
+                .collect::<Vec<_>>()
+                .into()
+        });
+
+        let results = join3v(
+            helper_shares
+                .into_iter()
+                .zip(contexts)
+                .map(|(shares, context)| add_internal::<Fp31>(context, shares)),
+        )
+        .await;
+
+        let results = results.reconstruct();
+
+        assert_eq!(vec![Fp31::truncate_from(8_u128)], results);
+    }
+}

--- a/ipa-core/src/query/runner/test_add.rs
+++ b/ipa-core/src/query/runner/test_add.rs
@@ -29,7 +29,7 @@ where
     Ok(Box::new(add_internal::<F>(ctx, input).await?))
 }
 
-pub async fn add_internal<F>(
+async fn add_internal<F>(
     _ctx: SemiHonestContext<'_>,
     input_stream: BodyStream,
 ) -> Result<Vec<Replicated<F>>, Error>

--- a/ipa-core/tests/common/mod.rs
+++ b/ipa-core/tests/common/mod.rs
@@ -211,7 +211,7 @@ pub fn test_network(https: bool, protocol: QueryType) {
 
     match protocol {
         QueryType::TestMultiply => test_multiply(path, https),
-        QueryType::TestAdd => test_add(path, https),
+        QueryType::TestAddInPrimeField => test_add(path, https),
         QueryType::OprfIpa(_) => {
             panic!("Only test protocols are supported.")
         }

--- a/ipa-core/tests/helper_networks.rs
+++ b/ipa-core/tests/helper_networks.rs
@@ -27,7 +27,7 @@ fn https_network_multiply() {
 #[test]
 #[cfg(all(test, web_test))]
 fn http_network_add() {
-    test_network(false, QueryType::TestAdd);
+    test_network(false, QueryType::TestAddInPrimeField);
 }
 
 #[test]

--- a/ipa-core/tests/helper_networks.rs
+++ b/ipa-core/tests/helper_networks.rs
@@ -6,18 +6,28 @@ use common::{
     spawn_helpers, tempdir::TempDir, test_ipa, test_multiply, test_network, CommandExt,
     UnwrapStatusExt, HELPER_BIN,
 };
-use ipa_core::{cli::CliPaths, helpers::HelperIdentity, test_fixture::ipa::IpaSecurityModel};
+use ipa_core::{
+    cli::CliPaths,
+    helpers::{query::QueryType, HelperIdentity},
+    test_fixture::ipa::IpaSecurityModel,
+};
 
 #[test]
 #[cfg(all(test, web_test))]
-fn http_network() {
-    test_network(false);
+fn http_network_multiply() {
+    test_network(false, QueryType::TestMultiply);
 }
 
 #[test]
 #[cfg(all(test, web_test))]
-fn https_network() {
-    test_network(true);
+fn https_network_multiply() {
+    test_network(true, QueryType::TestMultiply);
+}
+
+#[test]
+#[cfg(all(test, web_test))]
+fn http_network_add() {
+    test_network(false, QueryType::TestAdd);
 }
 
 #[test]


### PR DESCRIPTION
This change adds a new simple test circuit and integration tests for it. This circuit does not do anything sophisticated and the need for it is dictated by #1141 where I need to test that inputs of size > 2Gb can be handled by our MPC helpers. 

I tried to use `test-multiply` but it just takes too long to process inputs of this size. I estimated ~300M field value pairs need to be submitted to exceed $2^{31}-1$ input size and that makes that circuit to run for 8+ mins. 

This circuit is much faster for two reasons. First, it does not require communication. Second, it generates input and shares it using iterators. That makes a big difference - my experiments showed that it takes roughly 9 mins to get `test-multiply` inputs delivered and ~50 seconds for `test-add`. It can be further optimized because we collect everything. in `.share`, but this implementation is good enough for me.

My goal is to use this circuit in a integration test that we run only in CI and that checks inputs greater than $2^31-1$ can be sent via our `report_collector` client