### PR TITLE
Tests for result length

### DIFF
--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bitvec::macros::internal::funty::Fundamental;
 use futures_util::future::try_join_all;
 use generic_array::GenericArray;
 use rand::rngs::StdRng;
@@ -159,6 +160,12 @@ where
         .reconstruct();
 
     let lat = mpc_time.elapsed();
+    let result_len = results.len().as_u128();
+    let max_breakdown_key = query_config.max_breakdown_key.as_u128();
+    assert!(
+        result_len == max_breakdown_key,
+        "result len = {result_len} and max breakdown key = {max_breakdown_key}"
+    );
 
     tracing::info!("Running IPA for {query_size:?} records took {t:?}", t = lat);
     let mut breakdowns = vec![0; usize::try_from(query_config.max_breakdown_key).unwrap()];


### PR DESCRIPTION
adding an assert that results.len() == max_breakdown_key, breaks 4 compact gate tests (result len = 256 and max breakdown key = 20).  We probably want to add a check for this and figure out why it wouldn't always be true already.  

Current code ignores extra breakdown key values if they are zero, but with DP noise coming those end up non-zero.  Probably the solution is to not return too long a result at any time. 

![image](https://github.com/private-attribution/ipa/assets/35273659/05f81cad-a3a9-4cb1-876a-b298ea5a0938)
