### PR TITLE
Upgrade OPRF Conversion to Malicious using DZKPs

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -20,7 +20,9 @@ use crate::{
     const_assert_eq,
     ff::{boolean::Boolean, ec_prime_field::Fp25519, PrimeField},
     protocol::{
-        context::{Context, SemiHonestContext, UpgradedSemiHonestContext},
+        context::{
+            dzkp_semi_honest::DZKPUpgraded, Context, SemiHonestContext, UpgradedSemiHonestContext,
+        },
         ipa_prf::{AGG_CHUNK, PRF_CHUNK},
         prss::FromPrss,
     },
@@ -89,6 +91,13 @@ impl<'a, B: ShardBinding> BooleanProtocols<SemiHonestContext<'a, B>, AGG_CHUNK>
 }
 
 impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, AGG_CHUNK>
+    for AdditiveShare<Boolean, AGG_CHUNK>
+{
+}
+
+// This implementation also implements `BooleanProtocols` for `CONV_CHUNK`
+// since `CONV_CHUNK = AGG_CHUNK`
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgraded<'a, B>, AGG_CHUNK>
     for AdditiveShare<Boolean, AGG_CHUNK>
 {
 }

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -12,7 +12,7 @@ use crate::{
     protocol::{
         basics::{partial_reveal, BooleanProtocols},
         boolean::step::TwoHundredFiftySixBitOpStep,
-        context::Context,
+        context::{dzkp_validator::DZKPValidator, Context, UpgradableContext},
         ipa_prf::boolean_ops::{
             addition_sequential::integer_add, step::Fp25519ConversionStep as Step,
         },
@@ -93,23 +93,25 @@ use crate::{
 /// a vector of (NC / NP) shares, each with dimension `NP`.
 ///
 /// # Errors
-/// Propagates Errors from Integer Subtraction and Partial Reveal
+/// Propagates Errors from Integer Subtraction, Partial Reveal and Validate
 /// # Panics
 /// If values processed by this function is smaller than 256 bits.
+/// If vectorization is too large, i.e. `NC>=100k`.
 pub async fn convert_to_fp25519<C, const NC: usize, const NP: usize>(
     ctx: C,
     record_id: RecordId,
     x: BitDecomposed<AdditiveShare<Boolean, NC>>,
 ) -> Result<Vec<AdditiveShare<Fp25519, NP>>, Error>
 where
-    C: Context,
+    C: UpgradableContext,
     Fp25519: Vectorizable<NP>,
     Boolean: FieldSimd<NC>,
     BitDecomposed<AdditiveShare<Boolean, NC>>: FromPrss<usize>,
-    AdditiveShare<Boolean, NC>: BooleanProtocols<C, NC>,
+    AdditiveShare<Boolean, NC>: BooleanProtocols<<C as UpgradableContext>::DZKPUpgradedContext, NC>,
     Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, NC>>>,
     Vec<BA256>:
         for<'a> TransposeFrom<&'a [<Boolean as Vectorizable<NC>>::Array; 256], Error = Infallible>,
+    <C as UpgradableContext>::DZKPValidator: Send,
 {
     // `BITS` is the number of bits in the memory representation of Fp25519 field elements. It does
     // not vary with vectorization. Where the type `BA256` appears literally in the source of this
@@ -131,11 +133,21 @@ where
     let (sh_r, sh_s) =
         gen_sh_r_and_sh_s::<_, BITS, NC>(&ctx.narrow(&Step::GenerateSecretSharing), record_id);
 
+    // generate upgraded context
+    // we expect 2*256 = 512 gates in total for two additions
+    // the vectorization factor is NC
+    // the total amount of multiplications is therefore NC*512
+    // make sure proof does not get too big, i.e. less that 100k
+    // (such that there are less than 50m multiplications)
+    assert!(NC < 100_000);
+    let validator = ctx.dzkp_validator(NC);
+    let m_ctx = validator.context();
+
     // addition r+s might cause carry,
     // this is no problem since we have set bit 254 of sh_r and sh_s to 0
     let sh_rs = {
         let (mut rs_with_higherorderbits, _) = integer_add::<_, TwoHundredFiftySixBitOpStep, NC>(
-            ctx.narrow(&Step::IntegerAddBetweenMasks),
+            m_ctx.narrow(&Step::IntegerAddBetweenMasks),
             record_id,
             &sh_r,
             &sh_s,
@@ -153,18 +165,21 @@ where
     // addition x+rs, where rs=r+s might cause carry
     // this is not a problem since bit 255 of rs is set to 0
     let (sh_y, _) = integer_add::<_, TwoHundredFiftySixBitOpStep, NC>(
-        ctx.narrow(&Step::IntegerAddMaskToX),
+        m_ctx.narrow(&Step::IntegerAddMaskToX),
         record_id,
         &sh_rs,
         &x,
     )
     .await?;
 
+    // validate before reveal
+    validator.validate(0).await?;
+
     // this leaks information, but with negligible probability
-    let mut y = (ctx.role() != Role::H3).then(|| Vec::with_capacity(NC));
+    let mut y = (m_ctx.role() != Role::H3).then(|| Vec::with_capacity(NC));
     for i in 0..BITS {
         let y_bit = partial_reveal(
-            ctx.narrow(&Step::RevealY(i)),
+            m_ctx.narrow(&Step::RevealY(i)),
             record_id,
             Role::H3,
             sh_y.get(i).unwrap(),
@@ -188,7 +203,7 @@ where
         .ok()
         .expect("sh_s was constructed with the correct number of bits");
 
-    output_shares::<_, NC, NP>(&ctx, &sh_r, &sh_s, y)
+    output_shares::<_, NC, NP>(&m_ctx, &sh_r, &sh_s, y)
 }
 
 /// Generates `sh_r` and `sh_s` from PRSS randomness (`r`).
@@ -421,7 +436,7 @@ mod tests {
                 .collect::<Vec<_>>();
 
             let [res0, res1, res2] = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, records| async move {
+                .semi_honest(records.into_iter(), |ctx, records| async move {
                     seq_join(
                         ctx.active_work(),
                         process_slice_by_chunks(

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -280,11 +280,13 @@ async fn compute_prf_for_inputs<C, BK, TV, TS>(
 ) -> Result<Vec<PrfShardedIpaInputRow<BK, TV, TS>>, Error>
 where
     C: UpgradableContext,
+    <C as UpgradableContext>::DZKPValidator: Send,
     C::UpgradedContext<Boolean>: UpgradedContext<Field = Boolean, Share = Replicated<Boolean>>,
     BK: BooleanArray,
     TV: BooleanArray,
     TS: BooleanArray,
-    Replicated<Boolean, CONV_CHUNK>: BooleanProtocols<C, CONV_CHUNK>,
+    Replicated<Boolean, CONV_CHUNK>:
+        BooleanProtocols<<C as UpgradableContext>::DZKPUpgradedContext, CONV_CHUNK>,
     Replicated<Fp25519, PRF_CHUNK>: SecureMul<C> + FromPrss,
 {
     let conv_records =


### PR DESCRIPTION
upgrades the conversion that uses Boolean integer addition to malicious security by using upgraded contexts.

It still needs to be generalized to use traits, such that it works for DZKP semi honest as well as DZKP malicious. The most important structure is already in the PR.