### PR TITLE
split validate into validate and validate_chunks

### DIFF
--- a/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
@@ -113,7 +113,7 @@ mod test {
                 assert!(matches!(mctx.is_verified(), Err(Error::ContextUnsafe(_))));
 
                 // validate all elements in the batch
-                validator.validate(0usize).await.unwrap();
+                validator.validate().await.unwrap();
 
                 // batch is empty now
                 assert!(mctx.is_verified().is_ok());

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -559,9 +559,20 @@ pub trait DZKPValidator<B: UpgradableContext> {
     /// to `DZKPBatch`.
     /// Currently only allows `Fp61BitPrime` and is not generic over `DZKPBaseFields`.
     ///
+    /// Can only be called once per validator
+    /// due to uniqueness requirement of contexts in PRSS and networking.
+    async fn validate(&self) -> Result<(), Error> {
+        Self::validate_chunk(self, 0usize).await
+    }
+
+    /// Allows to validate the current `DZKPBatch` and empties it. The associated context is then
+    /// considered safe until another multiplication is performed and thus new values are added
+    /// to `DZKPBatch`.
+    /// Currently only allows `Fp61BitPrime` and is not generic over `DZKPBaseFields`.
+    ///
     /// `context_counter` allows to create distinct contexts
     /// when calling validate multiple times for the same base context.
-    async fn validate(&self, chunk_counter: usize) -> Result<(), Error>;
+    async fn validate_chunk(&self, chunk_counter: usize) -> Result<(), Error>;
 
     /// `is_verified` checks that there are no `MultiplicationInputs` that have not been verified
     /// within the associated `DZKPBatch`
@@ -590,7 +601,9 @@ pub trait DZKPValidator<B: UpgradableContext> {
         seq_join::<'st, S, F, O>(self.context().active_work(), source)
             .chunks(chunk_size)
             .enumerate()
-            .then(move |(context_counter, chunk)| self.validate(context_counter).map_ok(|()| chunk))
+            .then(move |(context_counter, chunk)| {
+                self.validate_chunk(context_counter).map_ok(|()| chunk)
+            })
             .try_flatten_iters()
     }
 }
@@ -615,7 +628,7 @@ impl<'a, B: ShardBinding> DZKPValidator<SemiHonestContext<'a, B>>
         self.context.clone()
     }
 
-    async fn validate(&self, _context_counter: usize) -> Result<(), Error> {
+    async fn validate_chunk(&self, _context_counter: usize) -> Result<(), Error> {
         Ok(())
     }
 
@@ -642,7 +655,7 @@ impl<'a> DZKPValidator<MaliciousContext<'a>> for MaliciousDZKPValidator<'a> {
 
     /// ## Panics
     /// Panics when `context_counter` exceeds 256.
-    async fn validate(&self, context_counter: usize) -> Result<(), Error> {
+    async fn validate_chunk(&self, context_counter: usize) -> Result<(), Error> {
         assert!(context_counter <= 256);
         // LOCK BEGIN
         let mut batch = self.batch_ref.lock().unwrap();

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -111,7 +111,7 @@ where
     Vec<AdditiveShare<BA256>>: for<'a> TransposeFrom<&'a BitDecomposed<AdditiveShare<Boolean, NC>>>,
     Vec<BA256>:
         for<'a> TransposeFrom<&'a [<Boolean as Vectorizable<NC>>::Array; 256], Error = Infallible>,
-    <C as UpgradableContext>::DZKPValidator: Send,
+    <C as UpgradableContext>::DZKPValidator: Send + Sync,
 {
     // `BITS` is the number of bits in the memory representation of Fp25519 field elements. It does
     // not vary with vectorization. Where the type `BA256` appears literally in the source of this
@@ -173,7 +173,7 @@ where
     .await?;
 
     // validate before reveal
-    validator.validate(0).await?;
+    validator.validate().await?;
 
     // this leaks information, but with negligible probability
     let mut y = (m_ctx.role() != Role::H3).then(|| Vec::with_capacity(NC));

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -280,7 +280,7 @@ async fn compute_prf_for_inputs<C, BK, TV, TS>(
 ) -> Result<Vec<PrfShardedIpaInputRow<BK, TV, TS>>, Error>
 where
     C: UpgradableContext,
-    <C as UpgradableContext>::DZKPValidator: Send,
+    <C as UpgradableContext>::DZKPValidator: Send + Sync,
     C::UpgradedContext<Boolean>: UpgradedContext<Field = Boolean, Share = Replicated<Boolean>>,
     BK: BooleanArray,
     TV: BooleanArray,

--- a/ipa-core/src/secret_sharing/vector/impls.rs
+++ b/ipa-core/src/secret_sharing/vector/impls.rs
@@ -101,7 +101,7 @@ macro_rules! boolean_vector {
                             )
                             .await?;
 
-                            v.validate(0usize).await?;
+                            v.validate().await?;
 
                             Ok::<_, Error>(result)
                         });
@@ -141,7 +141,7 @@ macro_rules! boolean_vector {
                             )
                             .await?;
 
-                            v.validate(0usize).await?;
+                            v.validate().await?;
 
                             Ok::<_, Error>(result)
                         });


### PR DESCRIPTION
cleans up validate such that it doesn't use a counter as input anymore