### PR TITLE
add new PrivateKeyOnly struct to handle KeyRegistry with only a private key

### DIFF
--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -39,7 +39,7 @@ struct Inner {
 impl Setup {
     #[must_use]
     pub fn new() -> (Self, HandlerRef) {
-        Self::with_key_registry(KeyRegistry::empty())
+        Self::with_key_registry(KeyRegistry::<PrivateKeyOnly>::empty())
     }
 
     #[must_use]

--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -9,7 +9,7 @@ use crate::{
         ApiError, BodyStream, HandlerBox, HandlerRef, HelperIdentity, HelperResponse,
         MpcTransportImpl, RequestHandler, ShardTransportImpl, Transport,
     },
-    hpke::{KeyPair, KeyRegistry},
+    hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
     query::{NewQueryError, QueryProcessor, QueryStatus},
     sync::Arc,
@@ -43,7 +43,7 @@ impl Setup {
     }
 
     #[must_use]
-    pub fn with_key_registry(key_registry: KeyRegistry<KeyPair>) -> (Self, HandlerRef) {
+    pub fn with_key_registry(key_registry: KeyRegistry<PrivateKeyOnly>) -> (Self, HandlerRef) {
         let query_processor = QueryProcessor::new(key_registry);
         let handler = HandlerBox::empty();
         let this = Self {

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -125,13 +125,9 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         _ => panic!("should have been rejected by clap"),
     };
 
-    let mk_encryption = args
-        .mk_public_key
-        .zip(args.mk_private_key)
-        .map(|(pk_path, sk_path)| HpkeServerConfig::File {
-            public_key_file: pk_path,
-            private_key_file: sk_path,
-        });
+    let mk_encryption = args.mk_private_key.map(|sk_path| HpkeServerConfig::File {
+        private_key_file: sk_path,
+    });
 
     let key_registry = hpke_registry(mk_encryption.as_ref()).await?;
     let (setup, handler) = AppSetup::with_key_registry(key_registry);

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -19,7 +19,8 @@ use crate::{
     error::BoxError,
     helpers::HelperIdentity,
     hpke::{
-        Deserializable as _, IpaPrivateKey, IpaPublicKey, KeyPair, KeyRegistry, Serializable as _,
+        Deserializable as _, IpaPrivateKey, IpaPublicKey, KeyRegistry, PrivateKeyOnly,
+        Serializable as _,
     },
 };
 
@@ -215,16 +216,10 @@ pub enum TlsConfig {
 #[derive(Clone, Debug)]
 pub enum HpkeServerConfig {
     File {
-        /// Path to file containing public key which encrypts match keys
-        public_key_file: PathBuf,
-
         /// Path to file containing private key which decrypts match keys
         private_key_file: PathBuf,
     },
     Inline {
-        /// Public key in hex format
-        public_key: String,
-
         // Private key in hex format
         private_key: String,
     },
@@ -234,32 +229,22 @@ pub enum HpkeServerConfig {
 /// If there is a problem with the HPKE configuration.
 pub async fn hpke_registry(
     config: Option<&HpkeServerConfig>,
-) -> Result<KeyRegistry<KeyPair>, BoxError> {
-    let (pk_str, sk_str) = match config {
-        None => return Ok(KeyRegistry::empty()),
-        Some(HpkeServerConfig::Inline {
-            public_key,
-            private_key,
-        }) => (
-            Cow::Borrowed(public_key.trim().as_bytes()),
-            Cow::Borrowed(private_key.trim().as_bytes()),
-        ),
-        Some(HpkeServerConfig::File {
-            public_key_file,
-            private_key_file,
-        }) => (
-            Cow::Owned(fs::read_to_string(public_key_file).await?.trim().into()),
-            Cow::Owned(fs::read_to_string(private_key_file).await?.trim().into()),
-        ),
+) -> Result<KeyRegistry<PrivateKeyOnly>, BoxError> {
+    let sk_str = match config {
+        None => return Ok(KeyRegistry::<PrivateKeyOnly>::empty()),
+        Some(HpkeServerConfig::Inline { private_key }) => {
+            Cow::Borrowed(private_key.trim().as_bytes())
+        }
+        Some(HpkeServerConfig::File { private_key_file }) => {
+            Cow::Owned(fs::read_to_string(private_key_file).await?.trim().into())
+        }
     };
 
-    let pk = hex::decode(pk_str)?;
     let sk = hex::decode(sk_str)?;
 
-    Ok(KeyRegistry::from_keys([KeyPair::from((
+    Ok(KeyRegistry::from_keys([PrivateKeyOnly(
         IpaPrivateKey::from_bytes(&sk)?,
-        IpaPublicKey::from_bytes(&pk)?,
-    ))]))
+    )]))
 }
 
 /// Configuration information for launching an instance of the helper party web service.
@@ -274,7 +259,7 @@ pub struct ServerConfig {
     /// TLS configuration for helper-to-helper communication
     pub tls: Option<TlsConfig>,
 
-    /// Configuration needed for encrypting and decrypting match keys
+    /// Configuration needed for decrypting match keys
     pub hpke_config: Option<HpkeServerConfig>,
 }
 

--- a/ipa-core/src/hpke/mod.rs
+++ b/ipa-core/src/hpke/mod.rs
@@ -16,7 +16,7 @@ mod info;
 mod registry;
 
 pub use info::Info;
-pub use registry::{KeyPair, KeyRegistry, PublicKeyOnly, PublicKeyRegistry};
+pub use registry::{KeyPair, KeyRegistry, PrivateKeyOnly, PrivateKeyRegistry, PublicKeyRegistry};
 
 use crate::{
     ff::{GaloisField, Serializable as IpaSerializable},
@@ -94,8 +94,8 @@ impl From<io::Error> for CryptError {
 /// If ciphertext cannot be opened for any reason.
 ///
 /// [`HPKE decryption`]: https://datatracker.ietf.org/doc/html/rfc9180#name-encryption-and-decryption
-pub fn open_in_place<'a>(
-    key_registry: &KeyRegistry<KeyPair>,
+pub fn open_in_place<'a, R: PrivateKeyRegistry>(
+    key_registry: &R,
     enc: &[u8],
     ciphertext: &'a mut [u8],
     info: &Info,
@@ -214,7 +214,7 @@ mod tests {
 
         pub fn new(keys: usize, mut rng: R) -> Self {
             Self {
-                registry: KeyRegistry::random(keys, &mut rng),
+                registry: KeyRegistry::<KeyPair>::random(keys, &mut rng),
                 rng,
                 epoch: 0,
             }

--- a/ipa-core/src/hpke/mod.rs
+++ b/ipa-core/src/hpke/mod.rs
@@ -96,7 +96,7 @@ impl From<io::Error> for CryptError {
 /// If ciphertext cannot be opened for any reason.
 ///
 /// [`HPKE decryption`]: https://datatracker.ietf.org/doc/html/rfc9180#name-encryption-and-decryption
-pub fn open_in_place<'a, R: PrivateKeyRegistry + ?Sized>(
+pub fn open_in_place<'a, R: PrivateKeyRegistry>(
     key_registry: &R,
     enc: &[u8],
     ciphertext: &'a mut [u8],

--- a/ipa-core/src/hpke/mod.rs
+++ b/ipa-core/src/hpke/mod.rs
@@ -16,7 +16,9 @@ mod info;
 mod registry;
 
 pub use info::Info;
-pub use registry::{KeyPair, KeyRegistry, PrivateKeyOnly, PrivateKeyRegistry, PublicKeyRegistry};
+pub use registry::{
+    KeyPair, KeyRegistry, PrivateKeyOnly, PrivateKeyRegistry, PublicKeyOnly, PublicKeyRegistry,
+};
 
 use crate::{
     ff::{GaloisField, Serializable as IpaSerializable},

--- a/ipa-core/src/hpke/mod.rs
+++ b/ipa-core/src/hpke/mod.rs
@@ -96,7 +96,7 @@ impl From<io::Error> for CryptError {
 /// If ciphertext cannot be opened for any reason.
 ///
 /// [`HPKE decryption`]: https://datatracker.ietf.org/doc/html/rfc9180#name-encryption-and-decryption
-pub fn open_in_place<'a, R: PrivateKeyRegistry>(
+pub fn open_in_place<'a, R: PrivateKeyRegistry + ?Sized>(
     key_registry: &R,
     enc: &[u8],
     ciphertext: &'a mut [u8],

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -58,13 +58,57 @@ impl Deref for PublicKeyOnly {
     }
 }
 
+// This newtype is necessary because IpaPrivateKey is an associated type from another crate (hpke).
+// The coherence rules prohibit us from implementing `PrivateKeyRegistry` both for our concrete type
+// `KeyPair` and for `IpaPrivateKey`, because the impls would overlap if hpke chose to define
+// `IpaPrivateKey` to be the same as `KeyPair`.
+pub struct PrivateKeyOnly(pub IpaPrivateKey);
+
+impl Deref for PrivateKeyOnly {
+    type Target = IpaPrivateKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&KeyRegistry<KeyPair>> for KeyRegistry<PrivateKeyOnly> {
+    fn from(key_registry: &KeyRegistry<KeyPair>) -> Self {
+        let keys = key_registry
+            .keys
+            .iter()
+            .map(|k| PrivateKeyOnly(k.sk.clone()))
+            .collect::<Vec<_>>();
+        Self {
+            keys: keys.into_boxed_slice(),
+        }
+    }
+}
+
 pub trait PublicKeyRegistry {
     fn public_key(&self, key_id: KeyIdentifier) -> Option<&IpaPublicKey>;
+}
+
+pub trait PrivateKeyRegistry {
+    fn private_key(&self, key_id: KeyIdentifier) -> Option<&IpaPrivateKey>;
 }
 
 /// A registry that holds all the keys available for helper/UA to use.
 pub struct KeyRegistry<K> {
     keys: Box<[K]>,
+}
+
+impl KeyRegistry<PrivateKeyOnly> {
+    // #[cfg(any(test, feature = "test-fixture"))]
+    pub fn random<R: rand::RngCore + rand::CryptoRng>(keys_count: usize, r: &mut R) -> Self {
+        let keys = (0..keys_count)
+            .map(|_| PrivateKeyOnly(KeyPair::gen(r).sk))
+            .collect::<Vec<_>>();
+
+        Self {
+            keys: keys.into_boxed_slice(),
+        }
+    }
 }
 
 impl<K> KeyRegistry<K> {
@@ -102,10 +146,19 @@ impl KeyRegistry<KeyPair> {
             keys: keys.into_boxed_slice(),
         }
     }
+}
 
+impl PrivateKeyRegistry for KeyRegistry<KeyPair> {
     #[must_use]
-    pub(super) fn private_key(&self, key_id: KeyIdentifier) -> Option<&IpaPrivateKey> {
+    fn private_key(&self, key_id: KeyIdentifier) -> Option<&IpaPrivateKey> {
         self.key(key_id).map(|v| &v.sk)
+    }
+}
+
+impl PrivateKeyRegistry for KeyRegistry<PrivateKeyOnly> {
+    #[must_use]
+    fn private_key(&self, key_id: KeyIdentifier) -> Option<&IpaPrivateKey> {
+        self.key(key_id).map(|sk| &**sk)
     }
 }
 
@@ -172,7 +225,7 @@ mod tests {
         let keypair1 = KeyPair::gen(&mut rng);
         let keypair2 = KeyPair::gen(&mut rng);
 
-        let registry = KeyRegistry::from_keys([keypair1, keypair2]);
+        let registry = KeyRegistry::<KeyPair>::from_keys([keypair1, keypair2]);
         let pt = b"This is a plaintext.";
         let ct_payload = encrypt(registry.public_key(0).unwrap(), pt, &mut rng);
         assert_eq!(

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -89,7 +89,7 @@ pub trait PublicKeyRegistry {
     fn public_key(&self, key_id: KeyIdentifier) -> Option<&IpaPublicKey>;
 }
 
-pub trait PrivateKeyRegistry {
+pub trait PrivateKeyRegistry: Send + Sync + 'static {
     fn private_key(&self, key_id: KeyIdentifier) -> Option<&IpaPrivateKey>;
 }
 

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -211,5 +211,14 @@ mod tests {
             HpkeError::OpenError,
             decrypt(registry.private_key(1).unwrap(), &ct_payload).unwrap_err()
         );
+
+        let keypair3 = KeyPair::gen(&mut rng);
+        let private_registry =
+            KeyRegistry::<PrivateKeyOnly>::from_keys([PrivateKeyOnly(keypair3.sk)]);
+
+        assert_eq!(
+            HpkeError::OpenError,
+            decrypt(private_registry.private_key(0).unwrap(), &ct_payload).unwrap_err()
+        );
     }
 }

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -72,19 +72,6 @@ impl Deref for PrivateKeyOnly {
     }
 }
 
-impl From<&KeyRegistry<KeyPair>> for KeyRegistry<PrivateKeyOnly> {
-    fn from(key_registry: &KeyRegistry<KeyPair>) -> Self {
-        let keys = key_registry
-            .keys
-            .iter()
-            .map(|k| PrivateKeyOnly(k.sk.clone()))
-            .collect::<Vec<_>>();
-        Self {
-            keys: keys.into_boxed_slice(),
-        }
-    }
-}
-
 pub trait PublicKeyRegistry {
     fn public_key(&self, key_id: KeyIdentifier) -> Option<&IpaPublicKey>;
 }

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -98,19 +98,6 @@ pub struct KeyRegistry<K> {
     keys: Box<[K]>,
 }
 
-impl KeyRegistry<PrivateKeyOnly> {
-    // #[cfg(any(test, feature = "test-fixture"))]
-    pub fn random<R: rand::RngCore + rand::CryptoRng>(keys_count: usize, r: &mut R) -> Self {
-        let keys = (0..keys_count)
-            .map(|_| PrivateKeyOnly(KeyPair::gen(r).sk))
-            .collect::<Vec<_>>();
-
-        Self {
-            keys: keys.into_boxed_slice(),
-        }
-    }
-}
-
 impl<K> KeyRegistry<K> {
     /// Create a key registry with no keys. Since the registry is immutable, it is useless,
     /// but this avoids `Option<KeyRegistry>` when the registry is ultimately not optional.

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -55,7 +55,6 @@ impl Default for TestConfig {
 fn get_dummy_matchkey_encryption_info(matchkey_encryption: bool) -> Option<HpkeServerConfig> {
     if matchkey_encryption {
         Some(HpkeServerConfig::Inline {
-            public_key: TEST_HPKE_PUBLIC_KEY.to_owned(),
             private_key: TEST_HPKE_PRIVATE_KEY.to_owned(),
         })
     } else {

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -28,7 +28,7 @@ use crate::{
         query::{QueryConfig, QueryType},
         BodyStream, Gateway,
     },
-    hpke::{KeyRegistry, PrivateKeyOnly},
+    hpke::PrivateKeyRegistry,
     protocol::{context::SemiHonestContext, prss::Endpoint as PrssEndpoint, Gate},
     query::{
         runner::{OprfIpaQuery, QueryResult},
@@ -60,9 +60,9 @@ where
 
 /// Needless pass by value because IPA v3 does not make use of key registry yet.
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
-pub fn execute(
+pub fn execute<R: PrivateKeyRegistry>(
     config: QueryConfig,
-    key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
+    key_registry: Arc<R>,
     gateway: Gateway,
     input: BodyStream,
 ) -> RunningQuery {
@@ -90,7 +90,7 @@ pub fn execute(
             move |prss, gateway, config, input| {
                 let ctx = SemiHonestContext::new(prss, gateway);
                 Box::pin(
-                    OprfIpaQuery::<BA16>::new(ipa_config, key_registry)
+                    OprfIpaQuery::<BA16, R>::new(ipa_config, key_registry)
                         .execute(ctx, config.size, input)
                         .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
                 )
@@ -105,7 +105,7 @@ pub fn execute(
             move |prss, gateway, config, input| {
                 let ctx = SemiHonestContext::new(prss, gateway);
                 Box::pin(
-                    OprfIpaQuery::<BA16>::new(ipa_config, key_registry)
+                    OprfIpaQuery::<BA16, R>::new(ipa_config, key_registry)
                         .execute(ctx, config.size, input)
                         .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
                 )

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -28,7 +28,7 @@ use crate::{
         query::{QueryConfig, QueryType},
         BodyStream, Gateway,
     },
-    hpke::{KeyPair, KeyRegistry},
+    hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::{context::SemiHonestContext, prss::Endpoint as PrssEndpoint, Gate},
     query::{
         runner::{OprfIpaQuery, QueryResult},
@@ -62,7 +62,7 @@ where
 #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
 pub fn execute(
     config: QueryConfig,
-    key_registry: Arc<KeyRegistry<KeyPair>>,
+    key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
     gateway: Gateway,
     input: BodyStream,
 ) -> RunningQuery {

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -12,7 +12,7 @@ use crate::{
         Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment,
         ShardTransportImpl, Transport,
     },
-    hpke::{KeyPair, KeyRegistry},
+    hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
     query::{
         executor,
@@ -41,14 +41,14 @@ use crate::{
 /// [`AdditiveShare`]: crate::secret_sharing::replicated::semi_honest::AdditiveShare
 pub struct Processor {
     queries: RunningQueries,
-    key_registry: Arc<KeyRegistry<KeyPair>>,
+    key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
 }
 
 impl Default for Processor {
     fn default() -> Self {
         Self {
             queries: RunningQueries::default(),
-            key_registry: Arc::new(KeyRegistry::<KeyPair>::empty()),
+            key_registry: Arc::new(KeyRegistry::<PrivateKeyOnly>::empty()),
         }
     }
 }
@@ -112,7 +112,7 @@ impl Debug for Processor {
 
 impl Processor {
     #[must_use]
-    pub fn new(key_registry: KeyRegistry<KeyPair>) -> Self {
+    pub fn new(key_registry: KeyRegistry<PrivateKeyOnly>) -> Self {
         Self {
             queries: RunningQueries::default(),
             key_registry: Arc::new(key_registry),

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -14,7 +14,7 @@ use crate::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
     },
-    hpke::{KeyPair, KeyRegistry},
+    hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::{
         basics::ShareKnownValue,
         context::{Context, SemiHonestContext},
@@ -31,12 +31,12 @@ use crate::{
 
 pub struct OprfIpaQuery<'a, HV> {
     config: IpaQueryConfig,
-    key_registry: Arc<KeyRegistry<KeyPair>>,
+    key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
     phantom_data: PhantomData<&'a HV>,
 }
 
 impl<'a, HV> OprfIpaQuery<'a, HV> {
-    pub fn new(config: IpaQueryConfig, key_registry: Arc<KeyRegistry<KeyPair>>) -> Self {
+    pub fn new(config: IpaQueryConfig, key_registry: Arc<KeyRegistry<PrivateKeyOnly>>) -> Self {
         Self {
             config,
             key_registry,
@@ -142,7 +142,7 @@ mod tests {
             query::{IpaQueryConfig, QuerySize},
             BodyStream,
         },
-        hpke::KeyRegistry,
+        hpke::{KeyPair, KeyRegistry, PrivateKeyOnly},
         query::runner::OprfIpaQuery,
         report::{OprfReport, DEFAULT_KEY_ID},
         secret_sharing::IntoShares,
@@ -202,7 +202,7 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(42);
         let key_id = DEFAULT_KEY_ID;
-        let key_registry = Arc::new(KeyRegistry::random(1, &mut rng));
+        let key_registry = Arc::new(KeyRegistry::<KeyPair>::random(1, &mut rng));
 
         let mut buffers: [_; 3] = std::array::from_fn(|_| Vec::new());
 
@@ -227,7 +227,8 @@ mod tests {
                 plaintext_match_keys: false,
             };
             let input = BodyStream::from(buffer);
-            OprfIpaQuery::<BA16>::new(query_config, Arc::clone(&key_registry))
+            let private_key_registry = KeyRegistry::<PrivateKeyOnly>::from(key_registry.as_ref());
+            OprfIpaQuery::<BA16>::new(query_config, Arc::new(private_key_registry))
                 .execute(ctx, query_size, input)
         }))
         .await;

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -14,7 +14,6 @@ use crate::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
     },
-    hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::{
         basics::ShareKnownValue,
         context::{Context, SemiHonestContext},
@@ -28,15 +27,16 @@ use crate::{
     },
     sync::Arc,
 };
+use crate::hpke::PrivateKeyRegistry;
 
 pub struct OprfIpaQuery<'a, HV> {
     config: IpaQueryConfig,
-    key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
+    key_registry: Arc<dyn PrivateKeyRegistry>,
     phantom_data: PhantomData<&'a HV>,
 }
 
 impl<'a, HV> OprfIpaQuery<'a, HV> {
-    pub fn new(config: IpaQueryConfig, key_registry: Arc<KeyRegistry<PrivateKeyOnly>>) -> Self {
+    pub fn new(config: IpaQueryConfig, key_registry: Arc<dyn PrivateKeyRegistry>) -> Self {
         Self {
             config,
             key_registry,

--- a/ipa-core/src/query/runner/oprf_ipa.rs
+++ b/ipa-core/src/query/runner/oprf_ipa.rs
@@ -14,6 +14,7 @@ use crate::{
         query::{IpaQueryConfig, QuerySize},
         BodyStream, LengthDelimitedStream, RecordsStream,
     },
+    hpke::PrivateKeyRegistry,
     protocol::{
         basics::ShareKnownValue,
         context::{Context, SemiHonestContext},
@@ -27,7 +28,6 @@ use crate::{
     },
     sync::Arc,
 };
-use crate::hpke::PrivateKeyRegistry;
 
 pub struct OprfIpaQuery<'a, HV> {
     config: IpaQueryConfig,
@@ -227,6 +227,7 @@ mod tests {
                 plaintext_match_keys: false,
             };
             let input = BodyStream::from(buffer);
+
             let private_key_registry = KeyRegistry::<PrivateKeyOnly>::from(key_registry.as_ref());
             OprfIpaQuery::<BA16>::new(query_config, Arc::new(private_key_registry))
                 .execute(ctx, query_size, input)

--- a/ipa-core/src/report.rs
+++ b/ipa-core/src/report.rs
@@ -530,7 +530,7 @@ mod test {
     use super::*;
     use crate::{
         ff::boolean_array::{BA20, BA3, BA8},
-        hpke::{Deserializable, IpaPrivateKey, IpaPublicKey, KeyPair, KeyRegistry, PrivateKeyOnly},
+        hpke::{Deserializable, IpaPrivateKey, IpaPublicKey, KeyPair, KeyRegistry},
         report,
         report::EventType::{Source, Trigger},
         secret_sharing::replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
@@ -589,7 +589,7 @@ mod test {
 
         let enc_key_registry = KeyRegistry::<KeyPair>::random(1, &mut rng);
         let enc_key_id = 0;
-        let dec_key_registry = KeyRegistry::<PrivateKeyOnly>::random(1, &mut rng);
+        let dec_key_registry = KeyRegistry::<KeyPair>::random(1, &mut rng);
 
         let enc_report_bytes = report
             .encrypt(enc_key_id, &enc_key_registry, &mut rng)

--- a/ipa-core/src/report.rs
+++ b/ipa-core/src/report.rs
@@ -308,7 +308,7 @@ where
     /// ## Panics
     /// Should not panic. Only panics if a `Report` constructor failed to validate the
     /// contents properly, which would be a bug.
-    pub fn decrypt<P: PrivateKeyRegistry + Send + 'static + ?Sized>(
+    pub fn decrypt<P: PrivateKeyRegistry>(
         &self,
         key_registry: &P,
     ) -> Result<OprfReport<BK, TV, TS>, InvalidReportError> {

--- a/ipa-core/src/report.rs
+++ b/ipa-core/src/report.rs
@@ -308,9 +308,9 @@ where
     /// ## Panics
     /// Should not panic. Only panics if a `Report` constructor failed to validate the
     /// contents properly, which would be a bug.
-    pub fn decrypt(
+    pub fn decrypt<P: PrivateKeyRegistry + Send + 'static + ?Sized>(
         &self,
-        key_registry: &impl PrivateKeyRegistry,
+        key_registry: &P,
     ) -> Result<OprfReport<BK, TV, TS>, InvalidReportError> {
         type CTMKLength = Sum<<Replicated<BA64> as Serializable>::Size, TagSize>;
         type CTBTTLength<BK, TV, TS> = Sum<


### PR DESCRIPTION
This adds a new struct `PublicKeyOnly`, similar to the existing `PrivateKeyOnly`, allowing us to only provide a private key for the current helper. A helpers own public key should not need to be known when running.