### PR TITLE
Increase active work size to 32k

### DIFF
--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -232,7 +232,7 @@ impl Gateway {
 impl Default for GatewayConfig {
     fn default() -> Self {
         Self {
-            active: 1024.try_into().unwrap(),
+            active: 32768.try_into().unwrap(),
             read_size: 2048.try_into().unwrap(),
             // In-memory tests are fast, so progress check intervals can be lower.
             // Real world scenarios currently over-report stalls because of inefficiencies inside


### PR DESCRIPTION
For inputs smaller than 32k, this changes nothing. For inputs larger than 32k, this improves the latency of IPA as shown in #1118