### PR TITLE
chunk_array

### DIFF
--- a/ipa-core/src/utils/arraychunks.rs
+++ b/ipa-core/src/utils/arraychunks.rs
@@ -2,6 +2,9 @@ use crate::{ff::Fp61BitPrime, secret_sharing::SharedValue};
 
 #[allow(dead_code)]
 pub trait ArrayChunkIterator: Iterator {
+    /// This function returns an iterator that yields arrays of size `L`.
+    /// When the amount of items in the iterator is not a multiple of `L`
+    /// the iterator fills the last array with zero elements.
     fn chunk_array<const L: usize>(self) -> ArrayChunk<Self, L>
     where
         Self: Sized,

--- a/ipa-core/src/utils/arraychunks.rs
+++ b/ipa-core/src/utils/arraychunks.rs
@@ -1,0 +1,70 @@
+use crate::{ff::Fp61BitPrime, secret_sharing::SharedValue};
+
+#[allow(dead_code)]
+pub trait ArrayChunkIterator: Iterator {
+    fn chunk_array<const L: usize>(self) -> ArrayChunk<Self, L>
+    where
+        Self: Sized,
+    {
+        ArrayChunk { iter: self }
+    }
+}
+
+pub struct ArrayChunk<I, const L: usize> {
+    iter: I,
+}
+
+impl<I: Iterator<Item = Fp61BitPrime>> ArrayChunkIterator for I {}
+
+#[allow(clippy::while_let_on_iterator)]
+impl<I, const L: usize> Iterator for ArrayChunk<I, L>
+where
+    I: Iterator<Item = Fp61BitPrime>,
+{
+    type Item = [I::Item; L];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut array = [Fp61BitPrime::ZERO; L];
+        let mut counter = 0usize;
+        while let Some(element) = self.iter.next() {
+            array[counter] = element;
+            counter += 1;
+            if counter == L {
+                break;
+            }
+        }
+        if counter == 0 {
+            None
+        } else {
+            Some(array)
+        }
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use crate::{
+        ff::{Field, Fp61BitPrime},
+        secret_sharing::SharedValue,
+        utils::arraychunks::ArrayChunkIterator,
+    };
+
+    #[test]
+    fn array_chunk_iter() {
+        let elements = vec![Fp61BitPrime::ONE; 4];
+
+        let mut array_chunk_iterator = elements.into_iter().chunk_array::<3>();
+
+        assert_eq!(array_chunk_iterator.next().unwrap(), [Fp61BitPrime::ONE; 3]);
+        assert_eq!(
+            array_chunk_iterator.next().unwrap(),
+            [Fp61BitPrime::ONE, Fp61BitPrime::ZERO, Fp61BitPrime::ZERO]
+        );
+    }
+
+    #[test]
+    fn array_chunk_empty() {
+        let elements = Vec::<Fp61BitPrime>::new();
+        assert!(elements.into_iter().chunk_array::<1>().next().is_none());
+    }
+}

--- a/ipa-core/src/utils/mod.rs
+++ b/ipa-core/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod array;
+pub mod arraychunks;


### PR DESCRIPTION
adding chunk methods that returns iterator over arrays

this allows us to use iterators instead of streams when chunks is needed during the DZKP validation.

It resolves issues with Mutex and await points in https://github.com/private-attribution/ipa/pull/1164