### PR TITLE
Split large request bodies into chunks of size not exceeding 1 MB 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -147,6 +147,30 @@ jobs:
 
       - name: Run compact gate tests
         run: cargo test --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
+  slow:
+    name: Slow tests
+    env:
+      EXEC_SLOW_TESTS: 1
+      RUSTFLAGS: -C target-cpu=native
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: End-to-end tests
+        run: cargo test --release --test "*" --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
 
   # sanitizers currently require nightly https://github.com/rust-lang/rust/issues/39699
   sanitize:

--- a/ipa-core/src/bin/test_mpc.rs
+++ b/ipa-core/src/bin/test_mpc.rs
@@ -84,7 +84,7 @@ enum TestAction {
     /// Execute end-to-end simple addition circuit that uses prime fields.
     /// All helpers add their shares locally and set the resulting share to be the
     /// sum. No communication is required to run the circuit.
-    Add,
+    AddInPrimeField,
 }
 
 #[tokio::main]
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (clients, _) = make_clients(args.network.as_deref(), scheme, args.wait).await;
     match args.action {
         TestAction::Multiply => multiply(&args, &clients).await,
-        TestAction::Add => add(&args, &clients).await,
+        TestAction::AddInPrimeField => add(&args, &clients).await,
     };
 
     Ok(())

--- a/ipa-core/src/helpers/transport/stream/box_body.rs
+++ b/ipa-core/src/helpers/transport/stream/box_body.rs
@@ -11,10 +11,6 @@ use crate::helpers::{transport::stream::BoxBytesStream, BytesStream};
 pub struct WrappedBoxBodyStream(BoxBytesStream);
 
 impl WrappedBoxBodyStream {
-    /// Wrap an axum body stream, returning an instance of `crate::helpers::BodyStream`.
-    /// If the given byte chunk exceeds [`super::MAX_HTTP_CHUNK_SIZE`],
-    /// it will be split into multiple parts, each not exceeding that size.
-    /// See #ipa/1141
     #[must_use]
     pub fn new(bytes: bytes::Bytes) -> Self {
         let stream = futures::stream::once(futures::future::ready(Ok(bytes)));

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -303,7 +303,7 @@ mod tests {
 
         let TestServer { transport, .. } = TestServer::default().await;
 
-        let body = BodyStream::from_receiver_stream(Box::new(ReceiverStream::new(rx)));
+        let body = BodyStream::from_bytes_stream(ReceiverStream::new(rx));
 
         // Register the stream with the transport (normally called by step data HTTP API handler)
         Arc::clone(&transport).receive_stream(QueryId, STEP.clone(), HelperIdentity::TWO, body);

--- a/ipa-core/tests/common/mod.rs
+++ b/ipa-core/tests/common/mod.rs
@@ -12,9 +12,7 @@ use std::{
 
 use command_fds::CommandFdExt;
 use ipa_core::{
-    cli::IpaQueryResult,
-    helpers::query::{IpaQueryConfig, QueryType},
-    test_fixture::ipa::IpaSecurityModel,
+    cli::IpaQueryResult, helpers::query::IpaQueryConfig, test_fixture::ipa::IpaSecurityModel,
 };
 use rand::thread_rng;
 use rand_core::RngCore;
@@ -186,22 +184,22 @@ pub fn test_multiply(config_dir: &Path, https: bool) {
     test_mpc.wait().unwrap_status();
 }
 
-pub fn test_add(config_dir: &Path, https: bool) {
+pub fn test_add_in_prime_field(config_dir: &Path, https: bool, count: u32) {
     let mut command = Command::new(TEST_MPC_BIN);
     command
         .args(["--network".into(), config_dir.join("network.toml")])
         .args(["--wait", "2"])
-        .args(["--generate", "10"]);
+        .args(["--generate", &count.to_string()]);
     if !https {
         command.arg("--disable-https");
     }
-    command.silent().arg("add");
+    command.silent().arg("add-in-prime-field");
 
     let test_mpc = command.spawn().unwrap().terminate_on_drop();
     test_mpc.wait().unwrap_status();
 }
 
-pub fn test_network(https: bool, protocol: QueryType) {
+pub fn test_network<T: NetworkTest>(https: bool) {
     let dir = TempDir::new_delete_on_drop();
     let path = dir.path();
 
@@ -209,13 +207,7 @@ pub fn test_network(https: bool, protocol: QueryType) {
     let sockets = test_setup(path);
     let _helpers = spawn_helpers(path, &sockets, https);
 
-    match protocol {
-        QueryType::TestMultiply => test_multiply(path, https),
-        QueryType::TestAddInPrimeField => test_add(path, https),
-        QueryType::OprfIpa(_) => {
-            panic!("Only test protocols are supported.")
-        }
-    }
+    T::execute(path, https);
 }
 
 pub fn test_ipa(mode: IpaSecurityModel, https: bool) {
@@ -298,4 +290,24 @@ pub fn test_ipa_with_config(mode: IpaSecurityModel, https: bool, config: IpaQuer
         "Number of breakdowns does not match the expected",
     );
     assert_eq!(INPUT_SIZE, usize::from(output.input_size));
+}
+
+pub trait NetworkTest {
+    fn execute(config_path: &Path, https: bool);
+}
+
+pub struct Multiply;
+
+impl NetworkTest for Multiply {
+    fn execute(config_path: &Path, https: bool) {
+        test_multiply(config_path, https)
+    }
+}
+
+pub struct AddInPrimeField<const N: u32>;
+
+impl<const N: u32> NetworkTest for AddInPrimeField<N> {
+    fn execute(config_path: &Path, https: bool) {
+        test_add_in_prime_field(config_path, https, N)
+    }
 }

--- a/pre-commit
+++ b/pre-commit
@@ -106,3 +106,9 @@ check "IPA benchmark" \
 
 check "Arithmetic circuit benchmark" \
     cargo bench --bench oneshot_arithmetic --no-default-features --features "enable-benches compact-gate"
+
+if [ -z "$EXEC_SLOW_TESTS" ]
+then
+  check "Slow tests" \
+      cargo test --release --test "*" --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
+fi


### PR DESCRIPTION
This fixes #1141 and adds a test that verifies that clients can submit inputs larger than 2GB ($2^{31}$ - 1). The test is quite slow (40 seconds), so I gated it behind an environment variable and only run it on Github. The probability of breaking it is quite low, so it is fine if it fails on CI only. 

IPA uses two different stream types for in-memory and real-world infrastructure to submit bodies - one is Axum type and another one is just boxed byte stream. The fix must be applied to both because **report_collector** uses in-memory streams and **helper** binary and **integration tests** use Axum stream.

In order to have only one place that splits the incoming byte, both streams had to be hidden behind an umbrella type `BodyStream` that works for both.  