### PR TITLE
Allow PRSS to generate randomness shared with only one helper

### DIFF
--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -552,7 +552,7 @@ mod tests {
 
     use crate::{
         ff::{
-            boolean_array::{BA3, BA8},
+            boolean_array::{BA3, BA64, BA8},
             Field, Fp31, Serializable, U128Conversions,
         },
         helpers::{Direction, Role},
@@ -864,6 +864,29 @@ mod tests {
                 .collect::<Vec<_>>();
 
             assert_eq!(input, r);
+        });
+    }
+
+    #[test]
+    fn prss_one_side() {
+        run(|| async {
+            let input = ();
+            let world = TestWorld::default();
+
+            world
+                .semi_honest(input, |ctx, ()| async move {
+                    let left_value: BA64 = ctx
+                        .prss()
+                        .generate_one_side(RecordId::FIRST, Direction::Left);
+                    let right_value = ctx
+                        .prss()
+                        .generate_one_side(RecordId::FIRST, Direction::Right);
+
+                    Replicated::new(left_value, right_value)
+                })
+                .await
+                // reconstruct validates that sharings are valid
+                .reconstruct();
         });
     }
 }

--- a/ipa-core/src/protocol/context/prss.rs
+++ b/ipa-core/src/protocol/context/prss.rs
@@ -94,8 +94,8 @@ impl<Z: ArrayLength> Iterator for InstrumentedChunksIter<'_, IndexedSharedRandom
     type Item = (GenericArray<u128, Z>, GenericArray<u128, Z>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let l = self.left.next_chunk();
-        let r = self.right.next_chunk();
+        let l = self.left.next()?;
+        let r = self.right.next()?;
 
         let step = self.instrumented.step.as_ref().to_string();
         // TODO: what we really want here is a gauge indicating the maximum index used to generate

--- a/ipa-core/src/protocol/context/prss.rs
+++ b/ipa-core/src/protocol/context/prss.rs
@@ -1,10 +1,10 @@
 //! Metric-aware PRSS decorators
 
-use generic_array::ArrayLength;
+use generic_array::{ArrayLength, GenericArray};
 use rand_core::{Error, RngCore};
 
 use crate::{
-    helpers::Role,
+    helpers::{Direction, Role},
     protocol::{
         prss::{IndexedSharedRandomness, PrssIndex, SequentialSharedRandomness, SharedRandomness},
         Gate,
@@ -35,29 +35,43 @@ impl<'a> InstrumentedIndexedSharedRandomness<'a> {
 }
 
 impl SharedRandomness for InstrumentedIndexedSharedRandomness<'_> {
-    type ChunksIter<'a, Z: ArrayLength> = InstrumentedChunksIter<
+    type ChunkIter<'a, Z: ArrayLength> = InstrumentedChunkIter<
         'a,
-        <IndexedSharedRandomness as SharedRandomness>::ChunksIter<'a, Z>,
+        <IndexedSharedRandomness as SharedRandomness>::ChunkIter<'a, Z>,
     >
     where Self: 'a;
+
+    fn generate_chunks_one_side<I: Into<PrssIndex>, Z: ArrayLength>(
+        &self,
+        index: I,
+        direction: Direction,
+    ) -> Self::ChunkIter<'_, Z> {
+        InstrumentedChunkIter {
+            instrumented: self,
+            inner: self.inner.generate_chunks_one_side(index, direction),
+        }
+    }
 
     fn generate_chunks_iter<I: Into<PrssIndex>, Z: ArrayLength>(
         &self,
         index: I,
-    ) -> Self::ChunksIter<'_, Z> {
+    ) -> impl Iterator<Item = (GenericArray<u128, Z>, GenericArray<u128, Z>)> {
+        let index = index.into();
+
         InstrumentedChunksIter {
             instrumented: self,
-            inner: self.inner.generate_chunks_iter(index),
+            left: self.inner.generate_chunks_one_side(index, Direction::Left),
+            right: self.inner.generate_chunks_one_side(index, Direction::Right),
         }
     }
 }
 
-pub struct InstrumentedChunksIter<'a, I: Iterator> {
+pub struct InstrumentedChunkIter<'a, I: Iterator> {
     instrumented: &'a InstrumentedIndexedSharedRandomness<'a>,
     inner: I,
 }
 
-impl<'a, I: Iterator> Iterator for InstrumentedChunksIter<'a, I> {
+impl<'a, I: Iterator> Iterator for InstrumentedChunkIter<'a, I> {
     type Item = <I as Iterator>::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -67,6 +81,29 @@ impl<'a, I: Iterator> Iterator for InstrumentedChunksIter<'a, I> {
         // handle gauges
         metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.instrumented.role.as_static_str());
         self.inner.next()
+    }
+}
+
+struct InstrumentedChunksIter<'a, S: SharedRandomness + 'a, Z: ArrayLength> {
+    instrumented: &'a InstrumentedIndexedSharedRandomness<'a>,
+    left: S::ChunkIter<'a, Z>,
+    right: S::ChunkIter<'a, Z>,
+}
+
+impl<Z: ArrayLength> Iterator for InstrumentedChunksIter<'_, IndexedSharedRandomness, Z> {
+    type Item = (GenericArray<u128, Z>, GenericArray<u128, Z>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let l = self.left.next_chunk();
+        let r = self.right.next_chunk();
+
+        let step = self.instrumented.step.as_ref().to_string();
+        // TODO: what we really want here is a gauge indicating the maximum index used to generate
+        // PRSS. Gauge infrastructure is not supported yet, `Metrics` struct needs to be able to
+        // handle gauges
+        metrics::increment_counter!(INDEXED_PRSS_GENERATED, STEP => step, ROLE => self.instrumented.role.as_static_str());
+
+        Some((l, r))
     }
 }
 

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -221,7 +221,7 @@ pub trait SharedRandomness {
         T::from_random(
             self.generate_chunks_one_side(index, direction)
                 .next()
-                .unwrap_or_else(|| panic!("Can generate randomness for index {index:?}")),
+                .unwrap_or_else(|| panic!("Can't generate randomness for index {index:?}")),
         )
     }
 

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -11,7 +11,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 
 use crate::{
     ff::Field,
-    protocol::prss::PrssIndex,
+    protocol::prss::{PrssIndex, PrssIndex128},
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
         SharedValue,
@@ -259,21 +259,30 @@ impl GeneratorFactory {
         self.kdf.expand(context, &mut k).unwrap();
         Generator {
             cipher: Aes256::new(&k),
+            #[cfg(debug_assertions)]
+            used: UsedSet::new(context.to_vec()),
         }
     }
 }
 
 /// The basic generator.  This generates values based on an arbitrary index.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Generator {
     cipher: Aes256,
+    #[cfg(debug_assertions)]
+    used: UsedSet,
 }
 
 impl Generator {
     /// Generate the value at the given index.
     /// This uses the MMO^{\pi} function described in <https://eprint.iacr.org/2019/074>.
     #[must_use]
-    pub fn generate(&self, index: u128) -> u128 {
+    pub(crate) fn generate<I: Into<PrssIndex128>>(&self, index: I) -> u128 {
+        let index = index.into();
+        #[cfg(debug_assertions)]
+        self.used.use_index(index).unwrap();
+        let index = u128::from(index);
+
         let mut buf = index.to_le_bytes();
         self.cipher
             .encrypt_block(aes::cipher::generic_array::GenericArray::from_mut_slice(
@@ -281,5 +290,63 @@ impl Generator {
             ));
 
         u128::from_le_bytes(buf) ^ index
+    }
+}
+
+/// Keeps track of all indices used to generate shared randomness inside [`Generator`].
+/// Any two indices provided to [`Generator::generate`] must be unique. This essentially
+/// enforces there is always unique IV used per generator.
+#[cfg(debug_assertions)]
+#[derive(Default, Debug)]
+struct UsedSet {
+    key: String,
+    used: crate::sync::Mutex<std::collections::HashSet<PrssIndex128>>,
+}
+
+#[cfg(debug_assertions)]
+impl UsedSet {
+    pub fn new(key: Vec<u8>) -> Self {
+        use std::collections::HashSet;
+
+        use crate::sync::Mutex;
+
+        Self {
+            key: String::from_utf8(key).unwrap_or_else(|e| {
+                panic!("PRSS key is not a valid UTF8 string: {}", e.utf8_error())
+            }),
+            used: Mutex::new(HashSet::default()),
+        }
+    }
+
+    pub fn use_index(&self, index: PrssIndex128) -> Result<(), String> {
+        if self.used.lock().unwrap().insert(index) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Generated randomness for index '{index}' twice using the same key '{}'",
+                self.key
+            ))
+        }
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::protocol::prss::KeyExchange;
+
+    #[test]
+    #[should_panic(
+        expected = "Generated randomness for index '0:0' twice using the same key 'foo'"
+    )]
+    fn rejects_the_same_index() {
+        let other_gen = KeyExchange::new(&mut thread_rng());
+        let gen = KeyExchange::new(&mut thread_rng())
+            .key_exchange(&other_gen.public_key())
+            .generator("foo".as_bytes());
+
+        let _ = gen.generate(0);
+        let _ = gen.generate(0);
     }
 }

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -11,6 +11,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 
 use crate::{
     ff::Field,
+    helpers::Direction,
     protocol::prss::{PrssIndex, PrssIndex128},
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
@@ -139,15 +140,25 @@ impl<T: FromRandom + SharedValue> FromPrss<usize> for AdditiveShare<T> {
 }
 
 pub trait SharedRandomness {
-    type ChunksIter<'a, Z: ArrayLength>: Iterator<
-        Item = (GenericArray<u128, Z>, GenericArray<u128, Z>),
-    >
+    type ChunkIter<'a, Z: ArrayLength>: Iterator<Item = GenericArray<u128, Z>>
     where
         Self: 'a;
 
     /// Return an iterator over chunks of generated randomness.
     ///
-    /// The iterator returns 2-tuples of `GenericArray<u128, Z>` chunks, one that is known to the
+    /// The iterator returns `GenericArray<u128, Z>` chunks known to the helper
+    /// specified in `direction` parameter.
+    ///
+    /// This functionality is intended for use generating large vectorized values.
+    #[must_use]
+    fn generate_chunks_one_side<I: Into<PrssIndex>, Z: ArrayLength>(
+        &self,
+        index: I,
+        direction: Direction,
+    ) -> Self::ChunkIter<'_, Z>;
+
+    /// Same as [`Self::generate_chunks_one_side`], but returns 2-tuples
+    /// of `GenericArray<u128, Z>` chunks, one that is known to the
     /// left helper and one that is known to the right helper.
     ///
     /// This functionality is intended for use generating large vectorized values.
@@ -155,7 +166,7 @@ pub trait SharedRandomness {
     fn generate_chunks_iter<I: Into<PrssIndex>, Z: ArrayLength>(
         &self,
         index: I,
-    ) -> Self::ChunksIter<'_, Z>;
+    ) -> impl Iterator<Item = (GenericArray<u128, Z>, GenericArray<u128, Z>)>;
 
     /// Generate two random values, one that is known to the left helper
     /// and one that is known to the right helper.
@@ -191,6 +202,27 @@ pub trait SharedRandomness {
     #[must_use]
     fn generate<T: FromPrss, I: Into<PrssIndex>>(&self, index: I) -> T {
         T::from_prss(self, index)
+    }
+
+    /// Generate some value that can be sampled from PRSS shared with the helper
+    /// specified via `direction` argument. This may be convenient and more efficient,
+    /// in cases when only value shared with one helper is required.
+    ///
+    /// Functionally, it is equivalent to calling [`Self::generate`] and dropping either
+    /// left or the right variable. Performance-wise, this method should be preferred
+    /// to use because it will do 50% of the work compared to regular [`Self::generate`].
+    #[must_use]
+    fn generate_one_side<T: FromRandom, I: Into<PrssIndex>>(
+        &self,
+        index: I,
+        direction: Direction,
+    ) -> T {
+        let index = index.into();
+        T::from_random(
+            self.generate_chunks_one_side(index, direction)
+                .next()
+                .unwrap_or_else(|| panic!("Can generate randomness for index {index:?}")),
+        )
     }
 
     /// Generate something that implements the `FromPrss` trait, passing parameters.

--- a/ipa-core/src/protocol/prss/mod.rs
+++ b/ipa-core/src/protocol/prss/mod.rs
@@ -15,6 +15,7 @@ use generic_array::{sequence::GenericSequence, ArrayLength, GenericArray};
 use x25519_dalek::PublicKey;
 
 use crate::{
+    helpers::Direction,
     protocol::{Gate, RecordId},
     rand::{CryptoRng, RngCore},
     sync::{Arc, Mutex},
@@ -79,7 +80,7 @@ impl TryFrom<u128> for PrssIndex128 {
 /// PRSS indexes are used to ensure that distinct pseudo-randomness is generated for every value
 /// output by PRSS. It is often sufficient to use record IDs as PRSS indexes, and
 /// `impl From<RecordId> for PrssIndex` is provided for that purpose.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default, Debug)]
 pub struct PrssIndex(u32);
 
 impl From<u32> for PrssIndex {
@@ -136,42 +137,92 @@ pub struct IndexedSharedRandomness {
 }
 
 impl SharedRandomness for IndexedSharedRandomness {
-    type ChunksIter<'a, Z: ArrayLength> = ChunksIter<'a, Z>;
+    type ChunkIter<'a, Z: ArrayLength> = ChunkIter<'a, Z>;
 
+    fn generate_chunks_one_side<I: Into<PrssIndex>, Z: ArrayLength>(
+        &self,
+        index: I,
+        direction: Direction,
+    ) -> Self::ChunkIter<'_, Z> {
+        Self::ChunkIter::new(self, index, direction)
+    }
+
+    /// Override the generic implementation for performance reasons.
+    /// We need to hint the compiler that calls to `left.generate` and `right.generate` can be
+    /// interleaved. See [`ChunksIter`] documentation for more details
     fn generate_chunks_iter<I: Into<PrssIndex>, Z: ArrayLength>(
         &self,
         index: I,
-    ) -> Self::ChunksIter<'_, Z> {
+    ) -> impl Iterator<Item = (GenericArray<u128, Z>, GenericArray<u128, Z>)> {
+        let index = index.into();
         ChunksIter {
-            inner: self,
-            index: index.into(),
-            offset: 0,
-            phantom_data: PhantomData,
+            left: Self::ChunkIter::new(self, index, Direction::Left),
+            right: Self::ChunkIter::new(self, index, Direction::Right),
         }
     }
 }
 
-pub struct ChunksIter<'a, Z: ArrayLength> {
-    inner: &'a IndexedSharedRandomness,
-    index: PrssIndex,
-    offset: usize,
-    phantom_data: PhantomData<Z>,
+/// Specialized implementation for chunks that are generated using both left and right
+/// randomness. The functionality is the same as [`std::iter::zip`], but it does not use
+/// `Iterator` trait to call `left` and `right` next. It uses inlined method calls to
+/// allow rustc to interleave these calls and improve performance.
+///
+/// Comparing this implementation vs [`std::iter::zip`] showed that this one is
+/// 15% faster in benchmarks generating [`crate::ff::BA256`] values.
+struct ChunksIter<'a, Z: ArrayLength> {
+    left: ChunkIter<'a, Z>,
+    right: ChunkIter<'a, Z>,
 }
 
 impl<'a, Z: ArrayLength> Iterator for ChunksIter<'a, Z> {
     type Item = (GenericArray<u128, Z>, GenericArray<u128, Z>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        let l = GenericArray::generate(|i| {
-            self.inner.left.generate(self.index.offset(self.offset + i))
-        });
-        let r = GenericArray::generate(|i| {
-            self.inner
-                .right
-                .generate(self.index.offset(self.offset + i))
-        });
-        self.offset += Z::USIZE;
+        let l = self.left.next_chunk();
+        let r = self.right.next_chunk();
         Some((l, r))
+    }
+}
+
+pub struct ChunkIter<'a, Z: ArrayLength> {
+    inner: &'a Generator,
+    index: PrssIndex,
+    offset: usize,
+    phantom_data: PhantomData<Z>,
+}
+
+impl<'a, Z: ArrayLength> Iterator for ChunkIter<'a, Z> {
+    type Item = GenericArray<u128, Z>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.next_chunk())
+    }
+}
+
+impl<'a, Z: ArrayLength> ChunkIter<'a, Z> {
+    #[inline]
+    pub fn next_chunk(&mut self) -> GenericArray<u128, Z> {
+        let chunk =
+            GenericArray::generate(|i| self.inner.generate(self.index.offset(self.offset + i)));
+
+        self.offset += Z::USIZE;
+        chunk
+    }
+
+    pub fn new<I: Into<PrssIndex>>(
+        prss: &'a IndexedSharedRandomness,
+        index: I,
+        direction: Direction,
+    ) -> Self {
+        Self {
+            inner: match direction {
+                Direction::Left => &prss.left,
+                Direction::Right => &prss.right,
+            },
+            index: index.into(),
+            offset: 0,
+            phantom_data: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
Builds on top of #1185

This closes https://github.com/private-attribution/ipa/issues/1029 by adding a method to PRSS implementation that allows callers to specify which randomness they want to obtain: shared with the helper on the right or on the left. This saves 50% of computation in cases where only one side of PRSS is required. https://github.com/private-attribution/ipa/issues/1029 lists the cases where it is useful.

Happy to bikeshed on naming, it gets harder and harder to find good names