### PR TITLE
Add a test that demonstrates a successful additive attack against malicious reshare protocol

### DIFF
--- a/ipa-core/src/protocol/basics/reshare.rs
+++ b/ipa-core/src/protocol/basics/reshare.rs
@@ -423,19 +423,11 @@ mod tests {
                                 let random_constant_ctx = m_ctx.narrow(&RandomnessForValidation);
 
                                 // lets follow the reshare protocol to get validator to the right state
-                                let rx = m_share
-                                    .rx()
-                                    .reshare(m_ctx.narrow(&ReshareRx), RecordId::FIRST, Role::H1)
-                                    .await
-                                    .unwrap();
-                                let x = m_share
-                                    .x()
-                                    .access_without_downgrade()
-                                    .reshare(m_ctx, RecordId::FIRST, Role::H1)
-                                    .await
-                                    .unwrap();
+                                let x = m_ctx.prss().generate(RecordId::FIRST);
+                                let rx: Replicated<_> =
+                                    m_ctx.narrow(&ReshareRx).prss().generate(RecordId::FIRST);
 
-                                // cool. (x, rx) is the values that are consistent with other helpers
+                                // cool. (x, rx) is the values that will pass the validation check.
                                 // now lets launch an additive attack
                                 let expected_share = &MaliciousReplicated::new(x, rx.clone());
                                 // we set u and v values correctly


### PR DESCRIPTION
I am happy to be wrong, but there might be a problem with the reshare implementation for active security. The claim we made that it is secure against active adversaries because we are executing semi-honest reshare twice (once for `x` and for `rx`). However, the semi-honest protocol implementation makes one helper's work unchecked by others and they can launch an additive attack because of that. 



```rust
        // `to_helper.left` calculates part1 = (self.0 + self.1) - r1 and sends part1 to `to_helper.right`
        // This is same as (a1 + a2) - r2 in the diagram
        if ctx.role() == to_helper.peer(Direction::Left) {
            ... // some work to send and receive
            Ok(Replicated::new(part1 + part2, r.1)) <- ok, shares are checked by the right helper
        } else if ctx.role() == to_helper.peer(Direction::Right) {
            // `to_helper.right` calculates part2 = (self.left() - r0) and sends it to `to_helper.left`
            // This is same as (a3 - r3) in the diagram
            ... // some work to send and receive
            Ok(Replicated::new(r.0, part1 + part2)) <- ok, shares are checked by the left helper
        } else {
            Ok(Replicated::new(r.0, r.1)) // <- here is the problem. nobody checks these values
        }
```

This PR just adds a test that demonstrates the ability of one helper to successfully launch an additive attack.