### PR TITLE
Isolate reveal operation inside PRF evaluation

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -1,9 +1,15 @@
 use std::iter::zip;
 
+use futures::{
+    future::try_join,
+    stream,
+    stream::{StreamExt, TryStreamExt},
+};
+
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, curve_points::RP25519, ec_prime_field::Fp25519, Expand},
-    helpers::TotalRecords,
+    ff::{curve_points::RP25519, ec_prime_field::Fp25519, Expand},
+    helpers::stream::{Chunk, TryFlattenItersExt},
     protocol::{
         basics::{Reveal, SecureMul},
         context::Context,
@@ -12,31 +18,8 @@ use crate::{
         RecordId,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare, Sendable, StdArray, Vectorizable},
+    seq_join::seq_join,
 };
-
-/// generates match key pseudonyms from match keys (in Fp25519 format) and PRF key
-/// PRF key needs to be generated separately using `gen_prf_key`
-///
-/// `gen_prf_key` is not included such that `compute_match_key_pseudonym` can be tested for correctness
-/// # Errors
-/// Propagates errors from multiplications
-pub async fn compute_match_key_pseudonym<C>(
-    sh_ctx: C,
-    prf_key: AdditiveShare<Fp25519>,
-    input_match_keys: Vec<AdditiveShare<Fp25519>>,
-) -> Result<Vec<u64>, Error>
-where
-    C: Context,
-    AdditiveShare<Boolean, 1>: SecureMul<C>,
-    AdditiveShare<Fp25519>: SecureMul<C>,
-{
-    let ctx = sh_ctx.set_total_records(TotalRecords::specified(input_match_keys.len())?);
-    let futures = input_match_keys
-        .into_iter()
-        .enumerate()
-        .map(|(i, x)| eval_dy_prf(ctx.clone(), i.into(), &prf_key, x));
-    Ok(ctx.try_join(futures).await?.into_iter().flatten().collect())
-}
 
 impl<const N: usize> From<AdditiveShare<Fp25519, N>> for AdditiveShare<RP25519, N>
 where
@@ -54,60 +37,144 @@ where
     }
 }
 
-/// generates PRF key k as secret sharing over Fp25519
-pub fn gen_prf_key<C>(ctx: &C) -> AdditiveShare<Fp25519>
-where
-    C: Context,
-{
-    ctx.narrow(&Step::PRFKeyGen).prss().generate(RecordId(0))
-}
-
-/// evaluates the Dodis-Yampolski PRF g^(1/(k+x))
-/// the input x and k are secret shared over finite field Fp25519, i.e. the scalar field of curve 25519
-/// PRF key k needs to be generated using `gen_prf_key`
-///  x is the match key in Fp25519 format
-/// outputs a u64 as specified in `protocol/prf_sharding/mod.rs`, all parties learn the output
+/// Evaluates the Dodis-Yampolski PRF g^(1/(k+x)) on every element of the input.
+/// Generates a random key using PRSS and then calls [`eval_dy_prf_with_key`].
+/// See the documentation
+///
 /// # Errors
 /// Propagates errors from multiplications, reveal and scalar multiplication
-/// # Panics
-/// Never as of when this comment was written, but the compiler didn't know that.
 pub async fn eval_dy_prf<C, const N: usize>(
     ctx: C,
-    record_id: RecordId,
-    k: &AdditiveShare<Fp25519>,
-    x: AdditiveShare<Fp25519, N>,
-) -> Result<[u64; N], Error>
+    curve_points: Vec<Chunk<AdditiveShare<Fp25519, N>, N>>,
+) -> Result<Vec<u64>, Error>
 where
     C: Context,
-    Fp25519: Vectorizable<N>,
-    RP25519: Vectorizable<N, Array = StdArray<RP25519, N>>,
-    AdditiveShare<Fp25519, N>: SecureMul<C> + FromPrss,
+    Fp25519: Vectorizable<N> + Send,
+    RP25519: Vectorizable<N, Array = StdArray<RP25519, N>> + Send,
+    AdditiveShare<Fp25519, N>: SecureMul<C> + FromPrss + Send,
     StdArray<RP25519, N>: Sendable,
 {
-    let sh_r: AdditiveShare<Fp25519, N> =
-        ctx.narrow(&Step::GenRandomMask).prss().generate(record_id);
+    let prf_key = &ctx
+        .narrow(&Step::PRFKeyGen)
+        .prss()
+        .generate(RecordId::FIRST);
+    eval_dy_prf_with_key(ctx, prf_key, curve_points).await
+}
 
-    //compute x+k
-    let mut y = x + AdditiveShare::<Fp25519, N>::expand(k);
+/// evaluates the Dodis-Yampolski PRF g^(1/(k+x)) on every element of the input
+/// using the provided key `k`.
+/// outputs an 8 byte value as specified in `protocol/prf_sharding/mod.rs` per curve point,
+/// all parties learn the output.
+///
+/// # Errors
+/// Propagates errors from multiplications, reveal and scalar multiplication
+async fn eval_dy_prf_with_key<C, const N: usize>(
+    ctx: C,
+    prf_key: &AdditiveShare<Fp25519>,
+    curve_points: Vec<Chunk<AdditiveShare<Fp25519, N>, N>>,
+) -> Result<Vec<u64>, Error>
+where
+    C: Context,
+    Fp25519: Vectorizable<N> + Send,
+    RP25519: Vectorizable<N, Array = StdArray<RP25519, N>> + Send,
+    AdditiveShare<Fp25519, N>: SecureMul<C> + FromPrss + Send,
+    StdArray<RP25519, N>: Sendable,
+{
+    let z_and_r_values = seq_join(
+        ctx.active_work(),
+        stream::iter(curve_points)
+            .enumerate()
+            .map(|(i, curve_pts)| {
+                let record_id = RecordId::from(i);
+                let eval_ctx = ctx.clone();
+                curve_pts.then(move |pts| ZR::compute(eval_ctx, record_id, prf_key, pts))
+            }),
+    )
+    .try_collect::<Vec<_>>()
+    .await?;
 
-    //compute y <- r*y
-    y = y
-        .multiply(&sh_r, ctx.narrow(&Step::MultMaskWithPRFInput), record_id)
-        .await?;
-
-    //compute (g^left, g^right)
-    let sh_gr = AdditiveShare::<RP25519, N>::from(sh_r);
+    // TODO: validate
 
     //reconstruct (z,R)
-    let gr = sh_gr.reveal(ctx.narrow(&Step::RevealR), record_id).await?;
-    let z = y.reveal(ctx.narrow(&Step::Revealz), record_id).await?;
+    let values = seq_join(
+        ctx.active_work(),
+        stream::iter(z_and_r_values).enumerate().map(|(i, chunk)| {
+            let record_id = RecordId::from(i);
+            let ctx = ctx.clone();
+            chunk.then(move |z_r| z_r.reveal(ctx, record_id))
+        }),
+    )
+    .try_flatten_iters()
+    .try_collect::<Vec<_>>()
+    .await?;
 
-    //compute R^(1/z) to u64
-    Ok(zip(gr, z)
-        .map(|(gr, z)| u64::from(gr * z.invert()))
-        .collect::<Vec<_>>()
-        .try_into()
-        .expect("iteration over arrays"))
+    Ok(values)
+}
+
+/// Container for vectorized `z` and `r` values. Revealing it produces the PRF values
+/// for each pair of elements.
+struct ZR<const N: usize>
+where
+    Fp25519: Vectorizable<N>,
+    RP25519: Vectorizable<N>,
+{
+    z: AdditiveShare<Fp25519, N>,
+    r: AdditiveShare<RP25519, N>,
+}
+
+impl<const N: usize> ZR<N>
+where
+    Fp25519: Vectorizable<N>,
+    RP25519: Vectorizable<N>,
+{
+    /// [`Reveal`] trait does not work here because we move the value of `self`. That allows
+    /// `seq_join` to work properly.
+    async fn reveal<C: Context>(self, ctx: C, record_id: RecordId) -> Result<[u64; N], Error> {
+        let r_ctx = ctx.narrow(&Step::RevealR);
+        let z_ctx = ctx.narrow(&Step::Revealz);
+
+        let (r, z) = try_join(
+            self.r.reveal(r_ctx, record_id),
+            self.z.reveal(z_ctx, record_id),
+        )
+        .await?;
+        let mut prf_values: [_; N] = [0_u64; N];
+
+        zip(&mut prf_values, zip(r, z)).for_each(|(prf, (r, z))| *prf = u64::from(r * z.invert()));
+
+        Ok(prf_values)
+    }
+
+    async fn compute<C>(
+        ctx: C,
+        record_id: RecordId,
+        k: &AdditiveShare<Fp25519>,
+        x: AdditiveShare<Fp25519, N>,
+    ) -> Result<Self, Error>
+    where
+        C: Context,
+        AdditiveShare<Fp25519, N>: SecureMul<C> + FromPrss,
+        Fp25519: Vectorizable<N>,
+        RP25519: Vectorizable<N, Array = StdArray<RP25519, N>>,
+        StdArray<RP25519, N>: Sendable,
+    {
+        let sh_r: AdditiveShare<Fp25519, N> =
+            ctx.narrow(&Step::GenRandomMask).prss().generate(record_id);
+
+        //compute x+k
+        let mut y = x + AdditiveShare::<Fp25519, N>::expand(k);
+
+        //compute y <- r*y
+        y = y
+            .multiply(&sh_r, ctx.narrow(&Step::MultMaskWithPRFInput), record_id)
+            .await?;
+
+        Ok(Self {
+            z: y,
+            // compute (g^left, g^right)
+            r: sh_r.into(),
+        })
+    }
 }
 
 #[cfg(all(test, unit_test))]
@@ -115,8 +182,13 @@ mod test {
     use rand::Rng;
 
     use crate::{
-        ff::{curve_points::RP25519, ec_prime_field::Fp25519},
-        protocol::ipa_prf::prf_eval::compute_match_key_pseudonym,
+        error::Error,
+        ff::{boolean::Boolean, curve_points::RP25519, ec_prime_field::Fp25519},
+        helpers::{
+            stream::{Chunk, ChunkType},
+            TotalRecords,
+        },
+        protocol::{basics::SecureMul, context::Context, ipa_prf::prf_eval::eval_dy_prf_with_key},
         secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
         test_executor::run,
         test_fixture::{Reconstruct, Runner, TestWorld},
@@ -156,6 +228,35 @@ mod test {
                 },
             }
         }
+    }
+
+    /// generates match key pseudonyms from match keys (in Fp25519 format) and PRF key
+    /// PRF key needs to be generated separately using `gen_prf_key`
+    ///
+    /// `gen_prf_key` is not included such that `compute_match_key_pseudonym` can be tested for correctness
+    /// # Errors
+    /// Propagates errors from multiplications
+    pub async fn compute_match_key_pseudonym<C>(
+        sh_ctx: C,
+        prf_key: AdditiveShare<Fp25519>,
+        input_match_keys: Vec<AdditiveShare<Fp25519>>,
+    ) -> Result<Vec<u64>, Error>
+    where
+        C: Context,
+        AdditiveShare<Boolean, 1>: SecureMul<C>,
+        AdditiveShare<Fp25519>: SecureMul<C>,
+    {
+        let ctx = sh_ctx.set_total_records(TotalRecords::specified(input_match_keys.len())?);
+
+        eval_dy_prf_with_key::<_, 1>(
+            ctx,
+            &prf_key,
+            input_match_keys
+                .into_iter()
+                .map(|mk| Chunk::new(ChunkType::Full, mk))
+                .collect(),
+        )
+        .await
     }
 
     ///testing correctness of DY PRF evaluation


### PR DESCRIPTION
In order to get malicious security using MAC, all helpers must run `validate` before revealing any information.

In order to be efficient, validate must check data in batches, so PRF evaluation needs to do all the processing before calling validate.

In terms of efficiency, even the semi-honest implementation will be less efficient. There is an extra step to hold all $z$ and $r$ values in memory before validating them. But that seems necessary to achieve security against active adversaries.

There is no new functionality, just restructuring to prepare for MAC-based validation