### PR TITLE
Fix a corner case in stall detection

### DIFF
--- a/ipa-core/src/helpers/buffers/unordered_receiver.rs
+++ b/ipa-core/src/helpers/buffers/unordered_receiver.rs
@@ -271,7 +271,9 @@ where
             .enumerate()
             .filter_map(|(i, waker)| waker.as_ref().map(|_| i))
             .map(move |i| {
-                if i < start {
+                // We don't save a waker at `self.next`, so `start` is actually the last waker, and
+                // `start + 1` is the first.
+                if i <= start {
                     self.next + (self.wakers.len() - start + i)
                 } else {
                     self.next + (i - start)


### PR DESCRIPTION
The waker at `start` is actually for `self.next + wakers.len()`, not `self.next`. The `max_polled_idx` case (line 284) can also put `self.next` in the list. Having two zeros in the list (when `self.next` is zero) results in an underflow computing `num - 1` in `to_ranges`.

I am not sure how best to test this (either a regression test for the fix, or to make sure the change doesn't break anything else). But opening a PR anyways so it's less likely the issue just gets lost.