### PR TITLE
Interface for test infrastructure to inspect streams

### DIFF
--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -90,6 +90,46 @@ pub trait Serializable: Sized {
             .map_err(Into::into)
             .unwrap_infallible()
     }
+
+    /// This method provides the same functionality as [`Self::deserialize`] without
+    /// compile-time guarantees on the size of `buf`. Therefore, it is not appropriate
+    /// to use in production code. It is provided as convenience method
+    /// for tests that are ok to panic.
+    ///
+    /// ## Panics
+    /// If the size of `buf` is not equal to `Self::Size` or if `buf` bytes
+    /// are not a valid representation of this instance. See [`Self::deserialize`] for
+    /// more details.
+    ///
+    /// [`Self::deserialize`]: Self::deserialize
+    #[cfg(test)]
+    #[must_use]
+    fn deserialize_from_slice(buf: &[u8]) -> Self {
+        use typenum::Unsigned;
+
+        assert_eq!(buf.len(), Self::Size::USIZE);
+
+        let mut arr = GenericArray::default();
+        arr.copy_from_slice(buf);
+        Self::deserialize(&arr).unwrap()
+    }
+
+    /// This method provides the same functionality as [`Self::serialize`] without
+    /// compile-time guarantees on the size of `buf`. Therefore, it is not appropriate
+    /// to use in production code. It is provided as convenience method
+    /// for tests that are ok to panic.
+    ///
+    /// ## Panics
+    /// If the size of `buf` is not equal to `Self::Size`.
+    #[cfg(test)]
+    fn serialize_to_slice(&self, buf: &mut [u8]) {
+        use typenum::Unsigned;
+
+        assert_eq!(buf.len(), Self::Size::USIZE);
+
+        let dest = GenericArray::<_, Self::Size>::from_mut_slice(buf);
+        self.serialize(dest);
+    }
 }
 
 pub trait ArrayAccess {

--- a/ipa-core/src/helpers/transport/in_memory/config.rs
+++ b/ipa-core/src/helpers/transport/in_memory/config.rs
@@ -1,0 +1,148 @@
+use std::borrow::Cow;
+
+use crate::{
+    helpers::{HelperIdentity, Role, RoleAssignment},
+    protocol::Gate,
+    sharding::ShardIndex,
+    sync::Arc,
+};
+
+pub type DynStreamInterceptor = Arc<dyn StreamInterceptor<Context = InspectContext>>;
+
+/// The interface for stream interceptors.
+///
+/// It is used in test infrastructure to inspect
+/// incoming streams and perform actions based on
+/// their contents.
+///
+/// The `peek` method takes a context object and a mutable reference
+/// to the data buffer. It is responsible for inspecting the data
+/// and performing any necessary actions based on the context.
+pub trait StreamInterceptor: Send + Sync {
+    /// The context type for the stream peeker.
+    /// See [`InspectContext`] and [`MaliciousHelperContext`] for
+    /// details.
+    type Context;
+
+    /// Inspects the stream data and performs any necessary actions.
+    /// The `data` buffer may be modified in-place.
+    ///
+    /// ## Implementation considerations
+    /// This method is free to mutate the `data` buffer
+    /// however it wants, but it needs to account for the following:
+    ///
+    /// ### Prime field streams
+    /// Corrupting streams that send data as sequences of serialized
+    /// [`PrimeField`] may cause `GreaterThanPrimeError` errors at
+    /// the serialization layer, instead of maybe intended malicious
+    /// validation failures.
+    ///
+    /// ### Boolean fields
+    /// Flipping bits in fixed-size bit strings is indistinguishable
+    /// from additive attacks without additional measures implemented
+    /// at the transport layer, like checksumming, share consistency
+    /// checks, etc.
+    fn peek(&self, ctx: &Self::Context, data: &mut Vec<u8>);
+}
+
+impl<F: Fn(&InspectContext, &mut Vec<u8>) + Send + Sync + 'static> StreamInterceptor for F {
+    type Context = InspectContext;
+
+    fn peek(&self, ctx: &Self::Context, data: &mut Vec<u8>) {
+        (self)(ctx, data);
+    }
+}
+
+/// The general context provided to stream inspectors.
+#[derive(Debug)]
+pub struct InspectContext {
+    /// The shard index of this instance.
+    /// This is `None` for non-sharded helpers.
+    pub shard_index: Option<ShardIndex>,
+    /// The MPC identity of this instance.
+    /// The combination (`shard_index`, `identity`)
+    /// uniquely identifies a single shard within
+    /// a multi-sharded MPC system.
+    pub identity: HelperIdentity,
+    /// Helper that will receive this stream.
+    pub dest: Cow<'static, str>,
+    /// Circuit gate this stream is tied to.
+    pub gate: Gate,
+}
+
+/// The no-op stream peeker, which does nothing.
+/// This is used as a default value for stream
+/// peekers that don't do anything.
+#[inline]
+#[must_use]
+pub fn passthrough() -> Arc<dyn StreamInterceptor<Context = InspectContext>> {
+    Arc::new(|_ctx: &InspectContext, _data: &mut Vec<u8>| {})
+}
+
+/// This narrows the implementation of stream seeker
+/// to a specific helper role. Only streams sent from
+/// that helper will be inspected by the provided closure.
+/// Other helper's streams will be left untouched.
+///
+/// It does not support sharded environments and will panic
+/// if used in a sharded test infrastructure.
+#[derive(Debug)]
+pub struct MaliciousHelper<F> {
+    identity: HelperIdentity,
+    role_assignment: RoleAssignment,
+    inner: F,
+}
+
+impl<F: Fn(&MaliciousHelperContext, &mut Vec<u8>) + Send + Sync> MaliciousHelper<F> {
+    pub fn new(role: Role, role_assignment: &RoleAssignment, peeker: F) -> Arc<Self> {
+        Arc::new(Self {
+            identity: role_assignment.identity(role),
+            role_assignment: role_assignment.clone(),
+            inner: peeker,
+        })
+    }
+
+    fn context(&self, ctx: &InspectContext) -> MaliciousHelperContext {
+        let dest = HelperIdentity::try_from(ctx.dest.as_ref()).unwrap_or_else(|_| {
+            panic!(
+                "MaliciousServerContext::from: invalid destination: {}",
+                ctx.dest
+            )
+        });
+        let dest = self.role_assignment.role(dest);
+
+        MaliciousHelperContext {
+            shard_index: ctx.shard_index,
+            dest,
+            gate: ctx.gate.clone(),
+        }
+    }
+}
+
+/// Special contexts for stream inspectors
+/// created with [`MaliciousHelper`].
+/// It provides convenient access to the
+/// destination role and assumes a single MPC
+/// helper intercepting streams.
+#[derive(Debug)]
+pub struct MaliciousHelperContext {
+    /// The shard index of this instance.
+    /// This is `None` for non-sharded helpers.
+    pub shard_index: Option<ShardIndex>,
+    /// Helper that will receive this stream.
+    pub dest: Role,
+    /// Circuit gate this stream is tied to.
+    pub gate: Gate,
+}
+
+impl<F: Fn(&MaliciousHelperContext, &mut Vec<u8>) + Send + Sync> StreamInterceptor
+    for MaliciousHelper<F>
+{
+    type Context = InspectContext;
+
+    fn peek(&self, ctx: &Self::Context, data: &mut Vec<u8>) {
+        if ctx.identity == self.identity {
+            (self.inner)(&self.context(ctx), data);
+        }
+    }
+}

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -1,6 +1,7 @@
 use crate::{
     helpers::{
-        transport::in_memory::transport::{InMemoryTransport, Setup},
+        in_memory_config::{passthrough, DynStreamInterceptor},
+        transport::in_memory::transport::{InMemoryTransport, Setup, TransportConfigBuilder},
         HelperIdentity,
     },
     sharding::ShardIndex,
@@ -22,9 +23,22 @@ pub struct InMemoryShardNetwork {
 
 impl InMemoryShardNetwork {
     pub fn with_shards<I: Into<ShardIndex>>(shard_count: I) -> Self {
+        Self::with_stream_interceptor(shard_count, &passthrough())
+    }
+
+    pub fn with_stream_interceptor<I: Into<ShardIndex>>(
+        shard_count: I,
+        interceptor: &DynStreamInterceptor,
+    ) -> Self {
         let shard_count = shard_count.into();
         let shard_network: [_; 3] = HelperIdentity::make_three().map(|h| {
-            let mut shard_connections = shard_count.iter().map(Setup::new).collect::<Vec<_>>();
+            let mut config_builder = TransportConfigBuilder::for_helper(h);
+            config_builder.with_interceptor(interceptor);
+
+            let mut shard_connections = shard_count
+                .iter()
+                .map(|i| Setup::with_config(i, config_builder.bind_to_shard(i)))
+                .collect::<Vec<_>>();
             for i in 0..shard_connections.len() {
                 let (lhs, rhs) = shard_connections.split_at_mut(i);
                 if let Some((a, _)) = lhs.split_last_mut() {

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -24,7 +24,7 @@ pub use handler::{
     make_owned_handler, Error as ApiError, HandlerBox, HandlerRef, HelperResponse, RequestHandler,
 };
 #[cfg(feature = "in-memory-infra")]
-pub use in_memory::{InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};
+pub use in_memory::{config, InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};
 pub use receive::{LogErrors, ReceiveRecords};
 #[cfg(feature = "web-app")]
 pub use stream::WrappedAxumBodyStream;
@@ -53,7 +53,12 @@ impl Identity for ShardIndex {
 }
 impl Identity for HelperIdentity {
     fn as_str(&self) -> Cow<'static, str> {
-        Cow::Owned(self.id.to_string())
+        Cow::Borrowed(match *self {
+            Self::ONE => "A",
+            Self::TWO => "B",
+            Self::THREE => "C",
+            _ => unreachable!(),
+        })
     }
 }
 

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -170,7 +170,6 @@ impl<F: ExtendableField> MaliciousAccumulator<F> {
         // Then, the parties call `Ḟ_product` on vectors
         // `([[ᾶ_1]], . . . , [[ᾶ_N ]], [[β_1]], . . . , [[β_M]])` and `([[z_1]], . . . , [[z_N]], [[v_1]], . . . , [[v_M]])` to receive `[[ŵ]]`
         let induced_share = Replicated::new(x.left().to_extended(), x.right().to_extended());
-
         let random_constant = prss.generate(record_id);
         let u_contribution: F::ExtendedField =
             Self::compute_dot_product_contribution(&random_constant, input.rx());

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -13,6 +13,7 @@ use tracing::{Instrument, Level, Span};
 
 use crate::{
     helpers::{
+        in_memory_config::{passthrough, DynStreamInterceptor},
         Gateway, GatewayConfig, HelperIdentity, InMemoryMpcNetwork, InMemoryShardNetwork,
         InMemoryTransport, Role, RoleAssignment, Transport,
     },
@@ -109,6 +110,32 @@ pub struct TestWorldConfig {
     /// performance and want to use compact gates, you set this to the gate narrowed to root step
     /// of the protocol being tested.
     pub initial_gate: Option<Gate>,
+
+    /// An optional interceptor to be put inside the in-memory stream
+    /// module. This allows inspecting and modifying stream content
+    /// for each communication round between any pair of helpers.
+    /// The application include:
+    /// * Malicious behavior. This can help simulating a malicious
+    /// actor being present in the system by running one or several
+    /// additive attacks.
+    /// * Data corruption. Tests can simulate bit flips that occur
+    /// at the network layer and check whether IPA can recover from
+    /// these (checksums, etc).
+    ///
+    /// The interface is pretty low level because of the layer
+    /// where it operates. [`StreamInterceptor`] interface provides
+    /// access to the circuit gate and raw bytes being
+    /// sent between helpers and/or shards. [`MaliciousHelper`]
+    /// is one example of helper that could be built on top
+    /// of this generic interface. It is recommended to build
+    /// a custom interceptor for repeated use-cases that is less
+    /// generic than [`StreamInterceptor`].
+    ///
+    /// If not set, all streams will be processed unchanged.
+    ///
+    /// [`StreamInterceptor`]: crate::helpers::in_memory_config::StreamInterceptor
+    /// [`MaliciousHelper`]: crate::helpers::in_memory_config::MaliciousHelper
+    pub stream_interceptor: DynStreamInterceptor,
 }
 
 impl ShardingScheme for NotSharded {
@@ -236,7 +263,8 @@ impl<S: ShardingScheme> TestWorld<S> {
         println!("TestWorld random seed {seed}", seed = config.seed);
 
         let shard_count = ShardIndex::try_from(S::SHARDS).unwrap();
-        let shard_network = InMemoryShardNetwork::with_shards(shard_count);
+        let shard_network =
+            InMemoryShardNetwork::with_stream_interceptor(shard_count, &config.stream_interceptor);
 
         let shards = shard_count
             .iter()
@@ -285,6 +313,7 @@ impl Default for TestWorldConfig {
             role_assignment: None,
             seed: thread_rng().next_u64(),
             initial_gate: None,
+            stream_interceptor: passthrough(),
         }
     }
 }
@@ -602,9 +631,11 @@ impl<B: ShardBinding> ShardWorld<B> {
         shard_seed: u64,
         transports: [InMemoryTransport<ShardIndex>; 3],
     ) -> Self {
-        // todo: B -> seed
         let participants = make_participants(&mut StdRng::seed_from_u64(config.seed + shard_seed));
-        let network = InMemoryMpcNetwork::default();
+        let network = InMemoryMpcNetwork::with_stream_interceptor(
+            InMemoryMpcNetwork::noop_handlers(),
+            &config.stream_interceptor,
+        );
 
         let mut gateways = zip3_ref(&network.transports(), &transports).map(|(mpc, shard)| {
             Gateway::new(
@@ -720,9 +751,19 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
+    use futures_util::future::try_join4;
+
     use crate::{
-        ff::{boolean_array::BA3, U128Conversions},
-        protocol::{context::Context, prss::SharedRandomness},
+        ff::{boolean_array::BA3, Field, Fp31, U128Conversions},
+        helpers::{
+            in_memory_config::{MaliciousHelper, MaliciousHelperContext},
+            Direction, Role,
+        },
+        protocol::{context::Context, prss::SharedRandomness, RecordId},
+        secret_sharing::{
+            replicated::{semi_honest::AdditiveShare, ReplicatedSecretSharing},
+            SharedValue,
+        },
         sharding::ShardConfiguration,
         test_executor::run,
         test_fixture::{world::WithShards, Reconstruct, Runner, TestWorld, TestWorldConfig},
@@ -783,6 +824,69 @@ mod tests {
                     }
                 })
                 .await.into_iter().map(|v| v.reconstruct()).collect::<Vec<_>>();
+        });
+    }
+
+    #[test]
+    fn peeker_can_corrupt_data() {
+        const STEP: &str = "corruption";
+        run(|| async move {
+            fn corrupt_byte(data: &mut u8) {
+                // flipping the bit may result in prime overflow,
+                // so we just set the value to be 0 or 1 if it was 0
+                if *data == 0 {
+                    *data = 1;
+                } else {
+                    *data = 0;
+                }
+            }
+
+            let mut config = TestWorldConfig::default();
+            config.stream_interceptor = MaliciousHelper::new(
+                Role::H1,
+                config.role_assignment(),
+                |ctx: &MaliciousHelperContext, data: &mut Vec<u8>| {
+                    if ctx.gate.as_ref().contains(STEP) {
+                        corrupt_byte(&mut data[0]);
+                    }
+                },
+            );
+
+            let world = TestWorld::new_with(config);
+
+            let shares = world
+                .semi_honest((), |ctx, ()| async move {
+                    let ctx = ctx.narrow(STEP).set_total_records(1);
+                    let (l, r): (Fp31, Fp31) = ctx.prss().generate(RecordId::FIRST);
+
+                    let ((), (), r, l) = try_join4(
+                        ctx.send_channel(ctx.role().peer(Direction::Right))
+                            .send(RecordId::FIRST, r),
+                        ctx.send_channel(ctx.role().peer(Direction::Left))
+                            .send(RecordId::FIRST, l),
+                        ctx.recv_channel::<Fp31>(ctx.role().peer(Direction::Right))
+                            .receive(RecordId::FIRST),
+                        ctx.recv_channel::<Fp31>(ctx.role().peer(Direction::Left))
+                            .receive(RecordId::FIRST),
+                    )
+                    .await
+                    .unwrap();
+
+                    AdditiveShare::new(l, r)
+                })
+                .await;
+
+            println!("{shares:?}");
+            // shares received from H1 must be corrupted
+            assert_ne!(shares[0].right(), shares[1].left());
+            assert_ne!(shares[0].left(), shares[2].right());
+
+            // and must be set to either 0 or 1
+            assert!([Fp31::ZERO, Fp31::ONE].contains(&shares[1].left()));
+            assert!([Fp31::ZERO, Fp31::ONE].contains(&shares[2].right()));
+
+            // values shared between H2 and H3 must be consistent
+            assert_eq!(shares[1].right(), shares[2].left());
         });
     }
 }


### PR DESCRIPTION
This change implements #1195 by providing a means for unit tests to intercept send requests that send circuit-specific data between MPC helpers.

This change also updates the existing unit tests for malicious `reshare` and `reveal` protocols to showcase the API and test it in real scenarios. In both cases, using it, led to significant reduction in code redundancy. The key improvement is that now tests are not required to re-implement the basic protocol to inject additive attacks. It can now be done outside the circuit being tested.

The support for sharding exists at the API level, but no actual implementation allows intercepting traffic between shards. There is currently not a lot of sharded protocols, so this can be postponed until later.