### PR TITLE
Implement reveal for upgraded contexts only

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -13,7 +13,7 @@ pub use check_zero::check_zero;
 pub use if_else::select;
 pub use mul::{BooleanArrayMul, SecureMul};
 pub use reshare::Reshare;
-pub use reveal::{partial_reveal, reveal, Reveal};
+pub use reveal::{malicious_reveal, partial_reveal, reveal, semi_honest_reveal, Reveal};
 pub use share_known_value::ShareKnownValue;
 
 use crate::{
@@ -22,7 +22,7 @@ use crate::{
     protocol::{
         context::{
             Context, DZKPUpgradedMaliciousContext, DZKPUpgradedSemiHonestContext,
-            SemiHonestContext, UpgradedSemiHonestContext,
+            UpgradedSemiHonestContext,
         },
         ipa_prf::{AGG_CHUNK, PRF_CHUNK},
         prss::FromPrss,
@@ -82,12 +82,6 @@ impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Bool
 
 impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, PRF_CHUNK>
     for AdditiveShare<Boolean, PRF_CHUNK>
-{
-}
-
-// TODO: remove this (protocols should use upgraded contexts)
-impl<'a, B: ShardBinding> BooleanProtocols<SemiHonestContext<'a, B>, AGG_CHUNK>
-    for AdditiveShare<Boolean, AGG_CHUNK>
 {
 }
 

--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -9,7 +9,6 @@ pub mod step;
 
 use std::ops::Not;
 
-pub use check_zero::check_zero;
 pub use if_else::select;
 pub use mul::{BooleanArrayMul, SecureMul};
 pub use reshare::Reshare;

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -517,6 +517,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::ptr_arg)] // to match StreamInterceptor trait
     fn interceptor<F: Field>(ctx: &MaliciousHelperContext, data: &mut Vec<u8>) {
         // H3 runs an additive attack against H1 (on the right) by
         // adding a 1 to the left part of share it is holding
@@ -538,9 +539,7 @@ mod tests {
             let world = TestWorld::new_with(config);
             let input: Fp31 = rng.gen();
             world
-                .upgraded_malicious(input, |ctx, share| async move {
-                    do_malicious_reveal(ctx, partial, share).await
-                })
+                .upgraded_malicious(input, |ctx, share| do_malicious_reveal(ctx, partial, share))
                 .await;
         });
     }
@@ -557,9 +556,7 @@ mod tests {
             let world = TestWorld::new_with(config);
             let input: Fp31 = rng.gen();
             world
-                .upgraded_malicious(input, move |ctx, share| {
-                    do_malicious_reveal(ctx, partial, share)
-                })
+                .upgraded_malicious(input, |ctx, share| do_malicious_reveal(ctx, partial, share))
                 .await;
         });
     }
@@ -576,9 +573,7 @@ mod tests {
             let world = TestWorld::new_with(config);
             let input: Boolean = rng.gen();
             world
-                .dzkp_malicious(input, |ctx, share| async move {
-                    do_malicious_reveal(ctx, partial, share).await
-                })
+                .dzkp_malicious(input, |ctx, share| do_malicious_reveal(ctx, partial, share))
                 .await;
         });
     }
@@ -595,9 +590,7 @@ mod tests {
             let world = TestWorld::new_with(config);
             let input: Boolean = rng.gen();
             world
-                .dzkp_malicious(input, move |ctx, share| {
-                    do_malicious_reveal(ctx, partial, share)
-                })
+                .dzkp_malicious(input, |ctx, share| do_malicious_reveal(ctx, partial, share))
                 .await;
         });
     }

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -5,9 +5,13 @@ use futures::TryFutureExt;
 
 use crate::{
     error::Error,
+    ff::boolean::Boolean,
     helpers::{Direction, MaybeFuture, Role},
     protocol::{
-        context::{Context, UpgradedMaliciousContext},
+        context::{
+            Context, DZKPUpgradedMaliciousContext, DZKPUpgradedSemiHonestContext,
+            UpgradedMaliciousContext, UpgradedSemiHonestContext,
+        },
         RecordId,
     },
     secret_sharing::{
@@ -17,6 +21,7 @@ use crate::{
         },
         SharedValue, Vectorizable,
     },
+    sharding::ShardBinding,
 };
 
 /// Trait for reveal protocol to open a shared secret to all helpers inside the MPC ring.
@@ -80,41 +85,77 @@ pub trait Reveal<C: Context, const N: usize>: Sized {
 /// Each helper sends their left share to the right helper. The helper then reconstructs their secret by adding the three shares
 /// i.e. their own shares and received share.
 #[embed_doc_image("reveal", "images/reveal.png")]
-impl<C: Context, V: SharedValue + Vectorizable<N>, const N: usize> Reveal<C, N>
-    for Replicated<V, N>
+pub async fn semi_honest_reveal<'fut, C, V, const N: usize>(
+    ctx: C,
+    record_id: RecordId,
+    excluded: Option<Role>,
+    share: &'fut Replicated<V, N>,
+) -> Result<Option<<V as Vectorizable<N>>::Array>, Error>
+where
+    C: Context + 'fut,
+    V: SharedValue + Vectorizable<N>,
+{
+    let left = share.left_arr();
+    let right = share.right_arr();
+
+    // Send shares, unless the target helper is excluded
+    if Some(ctx.role().peer(Direction::Right)) != excluded {
+        ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right))
+            .send(record_id, left)
+            .await?;
+    }
+
+    if Some(ctx.role()) == excluded {
+        Ok(None)
+    } else {
+        // Sleep until `helper's left` sends their share
+        let share: <V as Vectorizable<N>>::Array = ctx
+            .recv_channel(ctx.role().peer(Direction::Left))
+            .receive(record_id)
+            .await?;
+
+        Ok(Some(share + left + right))
+    }
+}
+
+impl<'a, B, V, const N: usize> Reveal<UpgradedSemiHonestContext<'a, B, V>, N> for Replicated<V, N>
+where
+    B: ShardBinding,
+    V: SharedValue + Vectorizable<N> + ExtendableField,
 {
     type Output = <V as Vectorizable<N>>::Array;
 
     async fn generic_reveal<'fut>(
         &'fut self,
-        ctx: C,
+        ctx: UpgradedSemiHonestContext<'a, B, V>,
         record_id: RecordId,
         excluded: Option<Role>,
-    ) -> Result<Option<<V as Vectorizable<N>>::Array>, Error>
+    ) -> Result<Option<Self::Output>, Error>
     where
-        C: 'fut,
+        UpgradedSemiHonestContext<'a, B, V>: 'fut,
     {
-        let left = self.left_arr();
-        let right = self.right_arr();
+        semi_honest_reveal(ctx, record_id, excluded, self).await
+    }
+}
 
-        // Send shares, unless the target helper is excluded
-        if Some(ctx.role().peer(Direction::Right)) != excluded {
-            ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right))
-                .send(record_id, left)
-                .await?;
-        }
+impl<'a, B, const N: usize> Reveal<DZKPUpgradedSemiHonestContext<'a, B>, N>
+    for Replicated<Boolean, N>
+where
+    B: ShardBinding,
+    Boolean: Vectorizable<N>,
+{
+    type Output = <Boolean as Vectorizable<N>>::Array;
 
-        if Some(ctx.role()) == excluded {
-            Ok(None)
-        } else {
-            // Sleep until `helper's left` sends their share
-            let share: <V as Vectorizable<N>>::Array = ctx
-                .recv_channel(ctx.role().peer(Direction::Left))
-                .receive(record_id)
-                .await?;
-
-            Ok(Some(share + left + right))
-        }
+    async fn generic_reveal<'fut>(
+        &'fut self,
+        ctx: DZKPUpgradedSemiHonestContext<'a, B>,
+        record_id: RecordId,
+        excluded: Option<Role>,
+    ) -> Result<Option<Self::Output>, Error>
+    where
+        DZKPUpgradedSemiHonestContext<'a, B>: 'fut,
+    {
+        semi_honest_reveal(ctx, record_id, excluded, self).await
     }
 }
 
@@ -122,7 +163,62 @@ impl<C: Context, V: SharedValue + Vectorizable<N>, const N: usize> Reveal<C, N>
 /// It works similarly to semi-honest reveal, the key difference is that each helper sends its share
 /// to both helpers (right and left) and upon receiving 2 shares from peers it validates that they
 /// indeed match.
-impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>, 1> for MaliciousReplicated<F> {
+pub async fn malicious_reveal<'fut, C, V, const N: usize>(
+    ctx: C,
+    record_id: RecordId,
+    excluded: Option<Role>,
+    share: &'fut Replicated<V, N>,
+) -> Result<Option<<V as Vectorizable<N>>::Array>, Error>
+where
+    C: Context + 'fut,
+    V: SharedValue + Vectorizable<N>,
+{
+    use futures::future::try_join;
+
+    let left = share.left_arr();
+    let right = share.right_arr();
+    let left_sender =
+        ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Left));
+    let left_receiver =
+        ctx.recv_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Left));
+    let right_sender =
+        ctx.send_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right));
+    let right_receiver =
+        ctx.recv_channel::<<V as Vectorizable<N>>::Array>(ctx.role().peer(Direction::Right));
+
+    // Send shares to the left and right helpers, unless excluded.
+    let send_left_fut =
+        MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Left)) != excluded, || {
+            left_sender.send(record_id, right)
+        });
+
+    let send_right_fut =
+        MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Right)) != excluded, || {
+            right_sender.send(record_id, left)
+        });
+    try_join(send_left_fut, send_right_fut).await?;
+
+    if Some(ctx.role()) == excluded {
+        Ok(None)
+    } else {
+        let (share_from_left, share_from_right) = try_join(
+            left_receiver.receive(record_id),
+            right_receiver.receive(record_id),
+        )
+        .await?;
+
+        if share_from_left == share_from_right {
+            Ok(Some(share_from_left + left + right))
+        } else {
+            Err(Error::MaliciousRevealFailed)
+        }
+    }
+}
+
+impl<'a, F> Reveal<UpgradedMaliciousContext<'a, F>, 1> for Replicated<F>
+where
+    F: ExtendableField,
+{
     type Output = <F as Vectorizable<1>>::Array;
 
     async fn generic_reveal<'fut>(
@@ -134,43 +230,48 @@ impl<'a, F: ExtendableField> Reveal<UpgradedMaliciousContext<'a, F>, 1> for Mali
     where
         UpgradedMaliciousContext<'a, F>: 'fut,
     {
-        use futures::future::try_join;
+        malicious_reveal(ctx, record_id, excluded, self).await
+    }
+}
 
+impl<'a, F> Reveal<UpgradedMaliciousContext<'a, F>, 1> for MaliciousReplicated<F>
+where
+    F: ExtendableField,
+{
+    type Output = <F as Vectorizable<1>>::Array;
+
+    async fn generic_reveal<'fut>(
+        &'fut self,
+        ctx: UpgradedMaliciousContext<'a, F>,
+        record_id: RecordId,
+        excluded: Option<Role>,
+    ) -> Result<Option<<F as Vectorizable<1>>::Array>, Error>
+    where
+        UpgradedMaliciousContext<'a, F>: 'fut,
+    {
         use crate::secret_sharing::replicated::malicious::ThisCodeIsAuthorizedToDowngradeFromMalicious;
 
-        let (left, right) = self.x().access_without_downgrade().as_tuple();
-        let left_sender = ctx.send_channel(ctx.role().peer(Direction::Left));
-        let left_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Left));
-        let right_sender = ctx.send_channel(ctx.role().peer(Direction::Right));
-        let right_receiver = ctx.recv_channel::<F>(ctx.role().peer(Direction::Right));
+        let x_share = self.x().access_without_downgrade();
+        malicious_reveal(ctx, record_id, excluded, x_share).await
+    }
+}
 
-        // Send shares to the left and right helpers, unless excluded.
-        let send_left_fut =
-            MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Left)) != excluded, || {
-                left_sender.send(record_id, right)
-            });
+impl<'a, const N: usize> Reveal<DZKPUpgradedMaliciousContext<'a>, N> for Replicated<Boolean, N>
+where
+    Boolean: Vectorizable<N>,
+{
+    type Output = <Boolean as Vectorizable<N>>::Array;
 
-        let send_right_fut =
-            MaybeFuture::future_or_ok(Some(ctx.role().peer(Direction::Right)) != excluded, || {
-                right_sender.send(record_id, left)
-            });
-        try_join(send_left_fut, send_right_fut).await?;
-
-        if Some(ctx.role()) == excluded {
-            Ok(None)
-        } else {
-            let (share_from_left, share_from_right) = try_join(
-                left_receiver.receive(record_id),
-                right_receiver.receive(record_id),
-            )
-            .await?;
-
-            if share_from_left == share_from_right {
-                Ok(Some((left + right + share_from_left).into_array()))
-            } else {
-                Err(Error::MaliciousRevealFailed)
-            }
-        }
+    async fn generic_reveal<'fut>(
+        &'fut self,
+        ctx: DZKPUpgradedMaliciousContext<'a>,
+        record_id: RecordId,
+        excluded: Option<Role>,
+    ) -> Result<Option<Self::Output>, Error>
+    where
+        DZKPUpgradedMaliciousContext<'a>: 'fut,
+    {
+        malicious_reveal(ctx, record_id, excluded, self).await
     }
 }
 
@@ -210,15 +311,21 @@ mod tests {
 
     use crate::{
         error::Error,
-        ff::{Field, Fp31, Fp32BitPrime, Serializable},
-        helpers::{in_memory_config::MaliciousHelper, Role},
+        ff::{boolean::Boolean, Field, Fp31, Fp32BitPrime},
+        helpers::{
+            in_memory_config::{MaliciousHelper, MaliciousHelperContext},
+            Role,
+        },
         protocol::{
-            basics::Reveal,
+            basics::{partial_reveal, reveal, Reveal},
             context::{Context, UpgradableContext, UpgradedContext, Validator},
             RecordId,
         },
         rand::{thread_rng, Rng},
-        secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares, SharedValue},
+        secret_sharing::{
+            replicated::semi_honest::AdditiveShare, IntoShares, SecretSharing, SharedValue,
+            Vectorizable,
+        },
         test_executor::run,
         test_fixture::{join3v, Runner, TestWorld, TestWorldConfig},
     };
@@ -232,7 +339,7 @@ mod tests {
 
         let input = rng.gen::<TestField>();
         let results = world
-            .semi_honest(input, |ctx, share| async move {
+            .upgraded_semi_honest(input, |ctx, share| async move {
                 TestField::from_array(
                     &share
                         .reveal(ctx.set_total_records(1), RecordId::from(0))
@@ -259,7 +366,7 @@ mod tests {
         for &excluded in Role::all() {
             let input = rng.gen::<TestField>();
             let results = world
-                .semi_honest(input, |ctx, share| async move {
+                .upgraded_semi_honest(input, |ctx, share| async move {
                     share
                         .partial_reveal(ctx.set_total_records(1), RecordId::from(0), excluded)
                         .await
@@ -289,7 +396,7 @@ mod tests {
 
         let input = rng.gen::<TestField>();
         let results = world
-            .semi_honest(
+            .upgraded_semi_honest(
                 input,
                 |ctx, share: AdditiveShare<Fp32BitPrime, 32>| async move {
                     share
@@ -383,61 +490,113 @@ mod tests {
         Ok(())
     }
 
+    const MALICIOUS_REVEAL_STEP: &str = "malicious-reveal";
+
+    async fn do_malicious_reveal<'ctx, C, F, S>(ctx: C, partial: bool, share: S)
+    where
+        C: Context + 'ctx,
+        F: Field,
+        S: SecretSharing<F> + Reveal<C, 1, Output = <F as Vectorizable<1>>::Array>,
+    {
+        let ctx = ctx.set_total_records(1);
+        let my_role = ctx.role();
+        let ctx = ctx.narrow(MALICIOUS_REVEAL_STEP);
+
+        let r = if partial {
+            partial_reveal(ctx, RecordId::FIRST, Role::H3, &share).await
+        } else {
+            reveal(ctx, RecordId::FIRST, &share).await.map(Some)
+        };
+
+        // H1 should be able to see the mismatch
+        if my_role == Role::H1 {
+            assert!(matches!(r, Err(Error::MaliciousRevealFailed)));
+        } else {
+            // sanity check
+            r.unwrap();
+        }
+    }
+
+    fn interceptor<F: Field>(ctx: &MaliciousHelperContext, data: &mut Vec<u8>) {
+        // H3 runs an additive attack against H1 (on the right) by
+        // adding a 1 to the left part of share it is holding
+        if ctx.gate.as_ref().contains(MALICIOUS_REVEAL_STEP) && ctx.dest == Role::H1 {
+            let v = F::deserialize_from_slice(data) + F::ONE;
+            v.serialize_to_slice(data);
+        }
+    }
+
     #[test]
     pub fn malicious_generic_validation_fail() {
-        let partial = false;
-        malicious_validation_fail(partial);
-    }
-
-    #[test]
-    pub fn malicious_partial_validation_fail() {
-        let partial = true;
-        malicious_validation_fail(partial);
-    }
-
-    pub fn malicious_validation_fail(partial: bool) {
-        const STEP: &str = "malicious-reveal";
-
         run(move || async move {
+            let partial = false;
             let mut rng = thread_rng();
             let mut config = TestWorldConfig::default();
             config.stream_interceptor =
-                MaliciousHelper::new(Role::H3, config.role_assignment(), move |ctx, data| {
-                    // H3 runs an additive attack against H1 (on the right) by
-                    // adding a 1 to the left part of share it is holding
-                    if ctx.gate.as_ref().contains(STEP) && ctx.dest == Role::H1 {
-                        let v = Fp31::deserialize_from_slice(data) + Fp31::ONE;
-                        v.serialize_to_slice(data);
-                    }
-                });
+                MaliciousHelper::new(Role::H3, config.role_assignment(), interceptor::<Fp31>);
 
             let world = TestWorld::new_with(config);
             let input: Fp31 = rng.gen();
             world
-                .malicious(input, |ctx, share| async move {
-                    let v = ctx.validator();
-                    let m_ctx = v.context().set_total_records(1);
-                    let malicious_share = v.context().upgrade(share).await.unwrap();
-                    let m_ctx = m_ctx.narrow(STEP);
-                    let my_role = m_ctx.role();
+                .upgraded_malicious(input, |ctx, share| async move {
+                    do_malicious_reveal(ctx, partial, share).await
+                })
+                .await;
+        });
+    }
 
-                    let r = if partial {
-                        malicious_share
-                            .partial_reveal(m_ctx, RecordId::FIRST, Role::H3)
-                            .await
-                    } else {
-                        malicious_share
-                            .generic_reveal(m_ctx, RecordId::FIRST, None)
-                            .await
-                    };
+    #[test]
+    pub fn malicious_partial_validation_fail() {
+        run(move || async move {
+            let partial = true;
+            let mut rng = thread_rng();
+            let mut config = TestWorldConfig::default();
+            config.stream_interceptor =
+                MaliciousHelper::new(Role::H3, config.role_assignment(), interceptor::<Fp31>);
 
-                    // H1 should be able to see the mismatch
-                    if my_role == Role::H1 {
-                        assert!(matches!(r, Err(Error::MaliciousRevealFailed)));
-                    } else {
-                        // sanity check
-                        r.unwrap();
-                    }
+            let world = TestWorld::new_with(config);
+            let input: Fp31 = rng.gen();
+            world
+                .upgraded_malicious(input, move |ctx, share| {
+                    do_malicious_reveal(ctx, partial, share)
+                })
+                .await;
+        });
+    }
+
+    #[test]
+    pub fn dzkp_malicious_generic_validation_fail() {
+        run(move || async move {
+            let partial = false;
+            let mut rng = thread_rng();
+            let mut config = TestWorldConfig::default();
+            config.stream_interceptor =
+                MaliciousHelper::new(Role::H3, config.role_assignment(), interceptor::<Boolean>);
+
+            let world = TestWorld::new_with(config);
+            let input: Boolean = rng.gen();
+            world
+                .dzkp_malicious(input, |ctx, share| async move {
+                    do_malicious_reveal(ctx, partial, share).await
+                })
+                .await;
+        });
+    }
+
+    #[test]
+    pub fn dzkp_malicious_partial_validation_fail() {
+        run(move || async move {
+            let partial = true;
+            let mut rng = thread_rng();
+            let mut config = TestWorldConfig::default();
+            config.stream_interceptor =
+                MaliciousHelper::new(Role::H3, config.role_assignment(), interceptor::<Boolean>);
+
+            let world = TestWorld::new_with(config);
+            let input: Boolean = rng.gen();
+            world
+                .dzkp_malicious(input, move |ctx, share| {
+                    do_malicious_reveal(ctx, partial, share)
                 })
                 .await;
         });

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -732,13 +732,13 @@ mod tests {
         let input_size = input.len();
         let snapshot = world.metrics_snapshot();
 
-        // Malicious protocol has an amplification factor of 3 and constant overhead of 3. For each input row it
+        // Malicious protocol has an amplification factor of 3 and constant overhead of 5. For each input row it
         // (input size) upgrades input to malicious
         // (input size) executes toy protocol
         // (input size) propagates u and w
         // (1) multiply r * share of zero
-        // (2) reveals r (1 for check_zero, 1 for validate)
-        let comm_factor = |input_size| 3 * input_size + 3;
+        // (4) reveals r (2 for check_zero, 2 for validate)
+        let comm_factor = |input_size| 3 * input_size + 5;
         let records_sent_assert = snapshot
             .assert_metric(RECORDS_SENT)
             .total(3 * comm_factor(input_size))

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -12,7 +12,7 @@ use crate::{
     ff::Field,
     helpers::{Direction, TotalRecords},
     protocol::{
-        basics::malicious_reveal,
+        basics::{check_zero::malicious_check_zero, malicious_reveal},
         context::{
             step::{MaliciousProtocolStep as Step, ValidateStep},
             Base, Context, MaliciousContext, UpgradableContext, UpgradedMaliciousContext,
@@ -232,8 +232,7 @@ where
             .validate_ctx
             .narrow(&ValidateStep::CheckZero)
             .set_total_records(TotalRecords::ONE);
-        let is_valid =
-            crate::protocol::basics::check_zero(check_zero_ctx, RecordId::FIRST, &t).await?;
+        let is_valid = malicious_check_zero(check_zero_ctx, RecordId::FIRST, &t).await?;
 
         if is_valid {
             // Yes, we're allowed to downgrade here.

--- a/ipa-core/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -351,6 +351,14 @@ impl<F: ExtendableField> Downgrade for SemiHonestAdditiveShare<F> {
 }
 
 #[async_trait]
+impl Downgrade for () {
+    type Target = ();
+    async fn downgrade(self) -> UnauthorizedDowngradeWrapper<Self::Target> {
+        UnauthorizedDowngradeWrapper(())
+    }
+}
+
+#[async_trait]
 impl<T, U> Downgrade for (T, U)
 where
     T: Downgrade,

--- a/ipa-core/src/test_fixture/sharing.rs
+++ b/ipa-core/src/test_fixture/sharing.rs
@@ -207,6 +207,13 @@ pub trait ValidateMalicious<F: ExtendableField> {
     fn validate(&self, r: F::ExtendedField);
 }
 
+impl<F> ValidateMalicious<F> for [(); 3]
+where
+    F: ExtendableField,
+{
+    fn validate(&self, _r: F::ExtendedField) {}
+}
+
 impl<F, T> ValidateMalicious<F> for [T; 3]
 where
     F: ExtendableField,


### PR DESCRIPTION
Another piece of #1112. This modifies the reveal implementations so that reveal is implemented only for upgraded contexts, and not for any `C: Context`. The danger of `impl Reveal<C: Context> for /* semi honest */ AdditiveShare<F>` is that it could accidentally be invoked by a protocol intending to have DZKP malicious security.

This changes the `check_zero` protocol used for MAC-based malicious security to use a malicious reveal, however, there is still a problem with the zero check, see https://github.com/private-attribution/ipa/issues/1204#issuecomment-2261313344.

The reveals in PRF evaluation are changed to call `malicious_reveal` directly because the PRF doesn't yet take a context of an appropriate type. I've added a TODO, which can be cleaned up with the changes for malicious security in the PRF.