### PR TITLE
Vectorize malicious shares

### DIFF
--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -5,16 +5,14 @@ use generic_array::GenericArray;
 use typenum::{U2, U32};
 
 use crate::{
-    ff::{boolean_array::BA256, Expand, Field, Serializable},
+    ff::{boolean_array::BA256, Field, Serializable},
     impl_shared_value_common,
     protocol::{
         ipa_prf::PRF_CHUNK,
         prss::{FromPrss, FromRandom, PrssIndex, SharedRandomness},
     },
     secret_sharing::{
-        replicated::{
-            malicious::ExtendableField, semi_honest::AdditiveShare, ReplicatedSecretSharing,
-        },
+        replicated::{malicious::ExtendableField, semi_honest::AdditiveShare},
         Block, FieldVectorizable, SharedValue, StdArray, Vectorizable,
     },
 };
@@ -136,20 +134,6 @@ impl std::ops::MulAssign for Fp25519 {
     #[allow(clippy::assign_op_pattern)]
     fn mul_assign(&mut self, rhs: Self) {
         *self = *self * rhs;
-    }
-}
-
-impl<const N: usize> Expand for AdditiveShare<Fp25519, N>
-where
-    Fp25519: Vectorizable<N>,
-{
-    type Input = AdditiveShare<Fp25519>;
-
-    fn expand(v: &Self::Input) -> Self {
-        AdditiveShare::new_arr(
-            <Fp25519 as Vectorizable<N>>::Array::expand(&v.left()),
-            <Fp25519 as Vectorizable<N>>::Array::expand(&v.right()),
-        )
     }
 }
 

--- a/ipa-core/src/protocol/basics/mul/malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/malicious.rs
@@ -9,12 +9,12 @@ use crate::{
             SecureMul,
         },
         context::{Context, UpgradedMaliciousContext},
+        prss::FromPrss,
         RecordId,
     },
     secret_sharing::replicated::{
-        malicious::{AdditiveShare as MaliciousReplicated, ExtendableField},
+        malicious::{AdditiveShare as MaliciousReplicated, ExtendableFieldSimd},
         semi_honest::AdditiveShare as Replicated,
-        ReplicatedSecretSharing,
     },
 };
 
@@ -49,14 +49,15 @@ use crate::{
 /// back via the error response
 /// ## Panics
 /// Panics if the mutex is found to be poisoned
-pub async fn mac_multiply<F>(
+pub async fn mac_multiply<F, const N: usize>(
     ctx: UpgradedMaliciousContext<'_, F>,
     record_id: RecordId,
-    a: &MaliciousReplicated<F>,
-    b: &MaliciousReplicated<F>,
-) -> Result<MaliciousReplicated<F>, Error>
+    a: &MaliciousReplicated<F, N>,
+    b: &MaliciousReplicated<F, N>,
+) -> Result<MaliciousReplicated<F, N>, Error>
 where
-    F: ExtendableField,
+    F: ExtendableFieldSimd<N>,
+    Replicated<F::ExtendedField, N>: FromPrss,
 {
     use crate::{
         protocol::context::SpecialAccessToUpgradedContext,
@@ -82,7 +83,7 @@ where
     // (b) The parties locally compute the induced share [[y]] = f([y], 0, . . . , 0).
     // (c) The parties call `Ḟ_mult` on `[[ȓ · x]]` and `[[y]]` to receive `[[ȓ · x · y]]`.
     //
-    let b_induced_share = Replicated::new(b_x.left().to_extended(), b_x.right().to_extended());
+    let b_induced_share = b_x.induced();
     let (ab, rab) = try_join(
         semi_honest_multiply(
             ctx.base_context(),
@@ -107,7 +108,11 @@ where
 
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
-impl<'a, F: ExtendableField> SecureMul<UpgradedMaliciousContext<'a, F>> for MaliciousReplicated<F> {
+impl<'a, F: ExtendableFieldSimd<N>, const N: usize> SecureMul<UpgradedMaliciousContext<'a, F>>
+    for MaliciousReplicated<F, N>
+where
+    Replicated<F::ExtendedField, N>: FromPrss,
+{
     async fn multiply<'fut>(
         &self,
         rhs: &Self,

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -23,11 +23,11 @@ use crate::{
             Base, Context as ContextTrait, InstrumentedSequentialSharedRandomness,
             SpecialAccessToUpgradedContext, UpgradableContext, UpgradedContext,
         },
-        prss::Endpoint as PrssEndpoint,
+        prss::{Endpoint as PrssEndpoint, FromPrss},
         Gate, RecordId,
     },
     secret_sharing::replicated::{
-        malicious::{AdditiveShare as MaliciousReplicated, ExtendableField},
+        malicious::{AdditiveShare as MaliciousReplicated, ExtendableField, ExtendableFieldSimd},
         semi_honest::AdditiveShare as Replicated,
         ReplicatedSecretSharing,
     },
@@ -230,6 +230,20 @@ impl<'a, F: ExtendableField> Upgraded<'a, F> {
             &self.inner.r_share * value.to_extended(),
         )
     }
+
+    /// Take a secret sharing and add it to the running MAC that this context maintains (if any).
+    pub fn accumulate_macs<const N: usize>(
+        self,
+        record_id: RecordId,
+        share: &MaliciousReplicated<F, N>,
+    ) where
+        F: ExtendableFieldSimd<N>,
+        Replicated<F::ExtendedField, N>: FromPrss,
+    {
+        self.inner
+            .accumulator
+            .accumulate_macs(&self.prss(), record_id, share);
+    }
 }
 
 #[async_trait]
@@ -348,12 +362,6 @@ impl<'a, F: ExtendableField> SeqJoin for Upgraded<'a, F> {
 /// this implementation makes it easier to reinterpret the context as semi-honest.
 impl<'a, F: ExtendableField> SpecialAccessToUpgradedContext<F> for Upgraded<'a, F> {
     type Base = Base<'a>;
-
-    fn accumulate_macs(self, record_id: RecordId, x: &MaliciousReplicated<F>) {
-        self.inner
-            .accumulator
-            .accumulate_macs(&self.prss(), record_id, x);
-    }
 
     fn base_context(self) -> Self::Base {
         self.as_base()

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -183,9 +183,6 @@ pub trait SpecialAccessToUpgradedContext<F: ExtendableField>: UpgradedContext {
     /// associated with the `Base` struct.
     type Base: Context;
 
-    /// Take a secret sharing and add it to the running MAC that this context maintains (if any).
-    fn accumulate_macs(self, record_id: RecordId, x: &Self::Share);
-
     /// Get a base context that is an exact copy of this malicious
     /// context, so it will be tied up to the same step and prss.
     #[must_use]

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -282,10 +282,6 @@ impl<'a, B: ShardBinding, F: ExtendableField> SpecialAccessToUpgradedContext<F>
 {
     type Base = Base<'a, B>;
 
-    fn accumulate_macs(self, _record_id: RecordId, _x: &Replicated<F>) {
-        // noop
-    }
-
     fn base_context(self) -> Self::Base {
         self.inner
     }

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -88,7 +88,7 @@ where
         ctx.narrow(&Step::GenRandomMask).prss().generate(record_id);
 
     //compute x+k
-    let mut y = x + AdditiveShare::<Fp25519>::expand(k);
+    let mut y = x + k.expand();
 
     //compute y <- r*y
     y = y

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 
 use crate::{
     error::Error,
-    ff::{boolean::Boolean, curve_points::RP25519, ec_prime_field::Fp25519, Expand},
+    ff::{boolean::Boolean, curve_points::RP25519, ec_prime_field::Fp25519},
     helpers::TotalRecords,
     protocol::{
         basics::{malicious_reveal, SecureMul},
@@ -88,7 +88,7 @@ where
         ctx.narrow(&Step::GenRandomMask).prss().generate(record_id);
 
     //compute x+k
-    let mut y = x + AdditiveShare::<Fp25519, N>::expand(k);
+    let mut y = x + AdditiveShare::<Fp25519>::expand(k);
 
     //compute y <- r*y
     y = y

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -5,7 +5,7 @@ use futures_util::{future::try_join, stream::unfold, Stream, StreamExt};
 
 use crate::{
     error::{Error, LengthError, UnwrapInfallible},
-    ff::{boolean::Boolean, boolean_array::BooleanArray, Expand, Field, U128Conversions},
+    ff::{boolean::Boolean, boolean_array::BooleanArray, Field, U128Conversions},
     helpers::{repeat_n, stream::TryFlattenItersExt, TotalRecords},
     protocol::{
         basics::{SecureMul, ShareKnownValue},
@@ -18,11 +18,8 @@ use crate::{
         BooleanProtocols, RecordId,
     },
     secret_sharing::{
-        replicated::{
-            semi_honest::{AdditiveShare as Replicated, AdditiveShare},
-            ReplicatedSecretSharing,
-        },
-        BitDecomposed, FieldSimd, SharedValue, TransposeFrom, Vectorizable,
+        replicated::semi_honest::{AdditiveShare as Replicated, AdditiveShare},
+        BitDecomposed, FieldSimd, SharedValue, TransposeFrom,
     },
     seq_join::seq_join,
 };
@@ -103,10 +100,7 @@ impl InputsRequiredFromPrevRow {
         )
         .await?;
 
-        let condition = Replicated::new_arr(
-            <Boolean as Vectorizable<B>>::Array::expand(&capped_label.left()),
-            <Boolean as Vectorizable<B>>::Array::expand(&capped_label.right()),
-        );
+        let condition = capped_label.expand();
         let bit_decomposed_output =
             BitDecomposed::transposed_from(&input_row.feature_vector).unwrap_infallible();
         let capped_attributed_feature_vector = bool_and_8_bit(

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -129,7 +129,6 @@ where
     S: Send + Sync,
     F: Fn(&S) -> &AdditiveShare<K> + Sync + Send + Copy,
     K: BooleanArray,
-    <Boolean as Vectorizable<SORT_CHUNK>>::Array: Expand<Input = Boolean>,
     AdditiveShare<Boolean, SORT_CHUNK>: BooleanProtocols<C::DZKPUpgradedContext, SORT_CHUNK>,
     BitDecomposed<AdditiveShare<Boolean, SORT_CHUNK>>:
         for<'a> TransposeFrom<&'a [AdditiveShare<K>; SORT_CHUNK], Error = Infallible>,

--- a/ipa-core/src/secret_sharing/replicated/malicious/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/malicious/additive_share.rs
@@ -17,7 +17,7 @@ use crate::{
     protocol::prss::FromRandom,
     secret_sharing::{
         replicated::semi_honest::AdditiveShare as SemiHonestAdditiveShare, BitDecomposed,
-        Linear as LinearSecretSharing, SecretSharing, SharedValue,
+        FieldSimd, Linear as LinearSecretSharing, SecretSharing, SharedValue,
     },
     seq_join::seq_join,
 };
@@ -35,14 +35,26 @@ use crate::{
 /// This makes it possible to minimize communication overhead required to reach a desired level of statistical security.
 ///
 #[derive(Clone, PartialEq, Eq)]
-pub struct AdditiveShare<V: SharedValue + ExtendableField> {
-    x: SemiHonestAdditiveShare<V>,
-    rx: SemiHonestAdditiveShare<V::ExtendedField>,
+pub struct AdditiveShare<V: SharedValue + ExtendableFieldSimd<N>, const N: usize = 1> {
+    x: SemiHonestAdditiveShare<V, N>,
+    rx: SemiHonestAdditiveShare<V::ExtendedField, N>,
 }
 
 pub trait ExtendableField: Field {
     type ExtendedField: Field + FromRandom;
     fn to_extended(&self) -> Self::ExtendedField;
+}
+
+/// Trait for extendable vectorized fields
+pub trait ExtendableFieldSimd<const N: usize>:
+    ExtendableField<ExtendedField: FieldSimd<N>> + FieldSimd<N>
+{
+}
+
+/// Blanket implementation for all fields that implement [`ExtendableField`] and [`FieldSimd`].
+impl<F: ExtendableField<ExtendedField: FieldSimd<N>> + FieldSimd<N>, const N: usize>
+    ExtendableFieldSimd<N> for F
+{
 }
 
 impl<F: PrimeField> ExtendableField for F {
@@ -67,11 +79,11 @@ impl ExtendableField for Gf2 {
     }
 }
 
-impl<V: SharedValue + ExtendableField> SecretSharing<V> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> SecretSharing<V> for AdditiveShare<V, N> {
     const ZERO: Self = AdditiveShare::ZERO;
 }
 
-impl<V: SharedValue + ExtendableField> LinearSecretSharing<V> for AdditiveShare<V> {}
+impl<V: ExtendableFieldSimd<N>, const N: usize> LinearSecretSharing<V> for AdditiveShare<V, N> {}
 
 /// A trait that is implemented for various collections of `replicated::malicious::AdditiveShare`.
 /// This allows a protocol to downgrade to ordinary `replicated::semi_honest::AdditiveShare`
@@ -98,7 +110,7 @@ impl<V: SharedValue + ExtendableField>
     }
 }
 
-impl<V: SharedValue + Debug + ExtendableField> Debug for AdditiveShare<V> {
+impl<V: Debug + ExtendableFieldSimd<N>, const N: usize> Debug for AdditiveShare<V, N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "x: {:?}, rx: {:?}", self.x, self.rx)
     }
@@ -113,24 +125,36 @@ impl<V: SharedValue + ExtendableField> Default for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> AdditiveShare<V, N> {
     #[must_use]
     pub fn new(
-        x: SemiHonestAdditiveShare<V>,
-        rx: SemiHonestAdditiveShare<V::ExtendedField>,
+        x: SemiHonestAdditiveShare<V, N>,
+        rx: SemiHonestAdditiveShare<V::ExtendedField, N>,
     ) -> Self {
         Self { x, rx }
     }
+}
 
-    pub fn x(&self) -> UnauthorizedDowngradeWrapper<&SemiHonestAdditiveShare<V>> {
-        UnauthorizedDowngradeWrapper(&self.x)
+impl<V: ExtendableFieldSimd<N>, const N: usize> SemiHonestAdditiveShare<V, N> {
+    /// Returns a secret sharing over [`V::ExtendedField`] by converting `V` into
+    /// the extended field.
+    pub fn induced(&self) -> SemiHonestAdditiveShare<V::ExtendedField, N> {
+        self.clone().transform(|v| v.to_extended())
     }
+}
 
+impl<V: ExtendableField> AdditiveShare<V> {
     pub fn downgrade(self) -> UnauthorizedDowngradeWrapper<SemiHonestAdditiveShare<V>> {
         UnauthorizedDowngradeWrapper(self.x)
     }
+}
 
-    pub fn rx(&self) -> &SemiHonestAdditiveShare<V::ExtendedField> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> AdditiveShare<V, N> {
+    pub fn x(&self) -> UnauthorizedDowngradeWrapper<&SemiHonestAdditiveShare<V, N>> {
+        UnauthorizedDowngradeWrapper(&self.x)
+    }
+
+    pub fn rx(&self) -> &SemiHonestAdditiveShare<V::ExtendedField, N> {
         &self.rx
     }
 
@@ -140,10 +164,12 @@ impl<V: SharedValue + ExtendableField> AdditiveShare<V> {
     };
 }
 
-impl<'a, 'b, V: SharedValue + ExtendableField> Add<&'b AdditiveShare<V>> for &'a AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<'a, 'b, V: ExtendableFieldSimd<N>, const N: usize> Add<&'b AdditiveShare<V, N>>
+    for &'a AdditiveShare<V, N>
+{
+    type Output = AdditiveShare<V, N>;
 
-    fn add(self, rhs: &'b AdditiveShare<V>) -> Self::Output {
+    fn add(self, rhs: &'b AdditiveShare<V, N>) -> Self::Output {
         AdditiveShare {
             x: &self.x + &rhs.x,
             rx: &self.rx + &rhs.rx,
@@ -151,7 +177,7 @@ impl<'a, 'b, V: SharedValue + ExtendableField> Add<&'b AdditiveShare<V>> for &'a
     }
 }
 
-impl<V: SharedValue + ExtendableField> Add<Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Add<Self> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -159,15 +185,15 @@ impl<V: SharedValue + ExtendableField> Add<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Add<AdditiveShare<V>> for &AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<V: ExtendableFieldSimd<N>, const N: usize> Add<AdditiveShare<V, N>> for &AdditiveShare<V, N> {
+    type Output = AdditiveShare<V, N>;
 
-    fn add(self, rhs: AdditiveShare<V>) -> Self::Output {
+    fn add(self, rhs: AdditiveShare<V, N>) -> Self::Output {
         Add::add(self, &rhs)
     }
 }
 
-impl<V: SharedValue + ExtendableField> Add<&AdditiveShare<V>> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Add<&AdditiveShare<V, N>> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn add(self, rhs: &Self) -> Self::Output {
@@ -175,20 +201,20 @@ impl<V: SharedValue + ExtendableField> Add<&AdditiveShare<V>> for AdditiveShare<
     }
 }
 
-impl<V: SharedValue + ExtendableField> AddAssign<&Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> AddAssign<&Self> for AdditiveShare<V, N> {
     fn add_assign(&mut self, rhs: &Self) {
         self.x += &rhs.x;
         self.rx += &rhs.rx;
     }
 }
 
-impl<V: SharedValue + ExtendableField> AddAssign<Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> AddAssign<Self> for AdditiveShare<V, N> {
     fn add_assign(&mut self, rhs: Self) {
         AddAssign::add_assign(self, &rhs);
     }
 }
 
-impl<V: SharedValue + ExtendableField> Neg for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Neg for AdditiveShare<V, N> {
     type Output = Self;
 
     fn neg(self) -> Self {
@@ -199,8 +225,8 @@ impl<V: SharedValue + ExtendableField> Neg for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Sub<Self> for &AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<V: ExtendableFieldSimd<N>, const N: usize> Sub<Self> for &AdditiveShare<V, N> {
+    type Output = AdditiveShare<V, N>;
 
     fn sub(self, rhs: Self) -> Self::Output {
         AdditiveShare {
@@ -210,7 +236,7 @@ impl<V: SharedValue + ExtendableField> Sub<Self> for &AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Sub<Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Sub<Self> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -218,7 +244,7 @@ impl<V: SharedValue + ExtendableField> Sub<Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Sub<&Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Sub<&Self> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn sub(self, rhs: &Self) -> Self::Output {
@@ -226,29 +252,29 @@ impl<V: SharedValue + ExtendableField> Sub<&Self> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Sub<AdditiveShare<V>> for &AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<V: ExtendableFieldSimd<N>, const N: usize> Sub<AdditiveShare<V, N>> for &AdditiveShare<V, N> {
+    type Output = AdditiveShare<V, N>;
 
-    fn sub(self, rhs: AdditiveShare<V>) -> Self::Output {
+    fn sub(self, rhs: AdditiveShare<V, N>) -> Self::Output {
         Sub::sub(self, &rhs)
     }
 }
 
-impl<V: SharedValue + ExtendableField> SubAssign<&Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> SubAssign<&Self> for AdditiveShare<V, N> {
     fn sub_assign(&mut self, rhs: &Self) {
         self.x -= &rhs.x;
         self.rx -= &rhs.rx;
     }
 }
 
-impl<V: SharedValue + ExtendableField> SubAssign<Self> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> SubAssign<Self> for AdditiveShare<V, N> {
     fn sub_assign(&mut self, rhs: Self) {
         SubAssign::sub_assign(self, &rhs);
     }
 }
 
-impl<'a, 'b, V: SharedValue + ExtendableField> Mul<&'b V> for &'a AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<'a, 'b, V: ExtendableFieldSimd<N>, const N: usize> Mul<&'b V> for &'a AdditiveShare<V, N> {
+    type Output = AdditiveShare<V, N>;
 
     fn mul(self, rhs: &'b V) -> Self::Output {
         AdditiveShare {
@@ -258,7 +284,7 @@ impl<'a, 'b, V: SharedValue + ExtendableField> Mul<&'b V> for &'a AdditiveShare<
     }
 }
 
-impl<V: SharedValue + ExtendableField> Mul<V> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Mul<V> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn mul(self, rhs: V) -> Self::Output {
@@ -266,7 +292,7 @@ impl<V: SharedValue + ExtendableField> Mul<V> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Mul<&V> for AdditiveShare<V> {
+impl<V: ExtendableFieldSimd<N>, const N: usize> Mul<&V> for AdditiveShare<V, N> {
     type Output = Self;
 
     fn mul(self, rhs: &V) -> Self::Output {
@@ -274,8 +300,8 @@ impl<V: SharedValue + ExtendableField> Mul<&V> for AdditiveShare<V> {
     }
 }
 
-impl<V: SharedValue + ExtendableField> Mul<V> for &AdditiveShare<V> {
-    type Output = AdditiveShare<V>;
+impl<V: ExtendableFieldSimd<N>, const N: usize> Mul<V> for &AdditiveShare<V, N> {
+    type Output = AdditiveShare<V, N>;
 
     fn mul(self, rhs: V) -> Self::Output {
         Mul::mul(self, &rhs)

--- a/ipa-core/src/secret_sharing/replicated/malicious/mod.rs
+++ b/ipa-core/src/secret_sharing/replicated/malicious/mod.rs
@@ -1,4 +1,6 @@
 mod additive_share;
 
 pub(crate) use additive_share::ThisCodeIsAuthorizedToDowngradeFromMalicious;
-pub use additive_share::{AdditiveShare, Downgrade as DowngradeMalicious, ExtendableField};
+pub use additive_share::{
+    AdditiveShare, Downgrade as DowngradeMalicious, ExtendableField, ExtendableFieldSimd,
+};

--- a/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
+++ b/ipa-core/src/secret_sharing/replicated/semi_honest/additive_share.rs
@@ -51,6 +51,25 @@ impl<V: SharedValue + Vectorizable<N>, const N: usize> Default for AdditiveShare
     }
 }
 
+impl<V: SharedValue + Vectorizable<1>> AdditiveShare<V> {
+    /// Replicates this secret share `N` times, converting the resulting value
+    /// into a vectorized replicated share with vectorization factor `N`.
+    /// This is not the same operation as padding.
+    ///
+    /// ## Example
+    /// Secret share of a single bit (0, 1) can be expanded into a secret share
+    /// of `N` bits, by copying (0, 1) `N` times.
+    pub(crate) fn expand<const N: usize>(&self) -> AdditiveShare<V, N>
+    where
+        V: Vectorizable<N>,
+    {
+        AdditiveShare(
+            <V as Vectorizable<N>>::Array::from_fn(|_| self.left()),
+            <V as Vectorizable<N>>::Array::from_fn(|_| self.right()),
+        )
+    }
+}
+
 impl<V: SharedValue + Vectorizable<N>, const N: usize> AdditiveShare<V, N> {
     /// Replicated secret share where both left and right values are `V::ZERO`
     pub const ZERO: Self = Self(
@@ -118,6 +137,27 @@ impl<V: SharedValue + Vectorizable<N>, const N: usize> AdditiveShare<V, N> {
     pub fn into_unpacking_iter(self) -> UnpackIter<V, N> {
         let Self(left, right) = self;
         UnpackIter(left.into_iter(), right.into_iter())
+    }
+
+    /// Transforms this into an additive sharing of another type, provided there exists
+    /// a deterministic way to go from `V` to `T`. Both values can be vectorized, but
+    /// vectorization factor must be the same.
+    pub fn transform<F, T>(self, mut f: F) -> AdditiveShare<T, N>
+    where
+        F: FnMut(V) -> T,
+        T: SharedValue + Vectorizable<N>,
+    {
+        let (l, r) = (self.0, self.1);
+        let left_arr = l
+            .into_iter()
+            .map(&mut f)
+            .collect::<<T as Vectorizable<N>>::Array>();
+        let right_arr = r
+            .into_iter()
+            .map(&mut f)
+            .collect::<<T as Vectorizable<N>>::Array>();
+
+        AdditiveShare::new_arr(left_arr, right_arr)
     }
 }
 

--- a/ipa-core/src/secret_sharing/vector/array.rs
+++ b/ipa-core/src/secret_sharing/vector/array.rs
@@ -11,7 +11,7 @@ use typenum::{U16, U256, U32, U64};
 use crate::{
     const_assert_eq,
     error::LengthError,
-    ff::{ec_prime_field::Fp25519, Expand, Field, Fp32BitPrime, Serializable},
+    ff::{ec_prime_field::Fp25519, Field, Fp32BitPrime, Serializable},
     protocol::{ipa_prf::PRF_CHUNK, prss::FromRandom},
     secret_sharing::{FieldArray, Sendable, SharedValue, SharedValueArray},
 };
@@ -136,14 +136,6 @@ impl<V: SharedValue, const N: usize> IntoIterator for StdArray<V, N> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
-    }
-}
-
-impl<V: SharedValue, const N: usize> Expand for StdArray<V, N> {
-    type Input = V;
-
-    fn expand(v: &Self::Input) -> Self {
-        Self(array::from_fn(|_| *v))
     }
 }
 

--- a/ipa-core/src/secret_sharing/vector/traits.rs
+++ b/ipa-core/src/secret_sharing/vector/traits.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     error::LengthError,
-    ff::{Expand, Field},
+    ff::Field,
     protocol::prss::FromRandom,
     secret_sharing::{Sendable, SharedValue},
 };
@@ -96,7 +96,6 @@ pub trait SharedValueArray<V>:
     + for<'a> Sub<&'a Self, Output = Self>
     + SubAssign<Self>
     + for<'a> SubAssign<&'a Self>
-    + Expand<Input = V>
 {
     const ZERO_ARRAY: Self;
 


### PR DESCRIPTION
This change gets us closer to running maliciously secure PRF evaluation. As semi-honest protocols are vectorized at this point, malicious functionality needs to be upgraded to match it. This change does that and a few more things

* Vectorize MAC computations
* Vectorize malicious multiply
* Add a few helper methods (induce, expand, transform) to secret sharings