### PR TITLE
Speed up dp tests

### DIFF
--- a/ipa-core/src/protocol/dp/mod.rs
+++ b/ipa-core/src/protocol/dp/mod.rs
@@ -505,6 +505,9 @@ mod test {
         type OutputValue = BA16;
         const NUM_BREAKDOWNS: u32 = 16;
         let num_bernoulli: u32 = 10000;
+        if std::env::var("EXEC_SLOW_TESTS").is_err() {
+            return;
+        }
         let world = TestWorld::default();
         let result: [Vec<Replicated<OutputValue>>; 3] = world
             .upgraded_semi_honest((), |ctx, ()| async move {

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -432,7 +432,7 @@ pub mod tests {
 
     #[test]
     fn semi_honest_with_dp() {
-        const SS_BITS: usize = 2;
+        const SS_BITS: usize = 1;
         semi_honest_with_dp_internal::<SS_BITS>();
     }
     #[test]


### PR DESCRIPTION
change parameters in `semi_honest_with_dp` to make faster. 

Move `gen_binomial_noise_16_breakdowns` to be a slow test. 