### PR TITLE
Use Upgradable trait in MAC module

### DIFF
--- a/ipa-core/src/protocol/basics/reshare.rs
+++ b/ipa-core/src/protocol/basics/reshare.rs
@@ -301,7 +301,7 @@ mod tests {
                         .malicious(a, |ctx, a| async move {
                             let v = ctx.validator();
                             let m_ctx = v.context().set_total_records(1);
-                            let m_a = a.upgrade(RecordId::FIRST, m_ctx.clone()).await.unwrap();
+                            let m_a = a.upgrade(m_ctx.clone(), RecordId::FIRST).await.unwrap();
 
                             let m_reshared_a = m_a
                                 .reshare(m_ctx.narrow(STEP), RecordId::FIRST, to_helper)

--- a/ipa-core/src/protocol/basics/reshare.rs
+++ b/ipa-core/src/protocol/basics/reshare.rs
@@ -208,7 +208,7 @@ mod tests {
             helpers::{in_memory_config::MaliciousHelper, Role},
             protocol::{
                 basics::Reshare,
-                context::{Context, UpgradableContext, UpgradedContext, Validator},
+                context::{upgrade::Upgradable, Context, UpgradableContext, Validator},
                 RecordId,
             },
             rand::{thread_rng, Rng},
@@ -301,7 +301,7 @@ mod tests {
                         .malicious(a, |ctx, a| async move {
                             let v = ctx.validator();
                             let m_ctx = v.context().set_total_records(1);
-                            let m_a = v.context().upgrade(a).await.unwrap();
+                            let m_a = a.upgrade(RecordId::FIRST, m_ctx.clone()).await.unwrap();
 
                             let m_reshared_a = m_a
                                 .reshare(m_ctx.narrow(STEP), RecordId::FIRST, to_helper)

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -510,7 +510,7 @@ mod tests {
 
         let m_shares = join3v(
             zip(m_ctx.iter(), input.share_with(&mut rng)).map(|(m_ctx, share)| async {
-                share.upgrade(RecordId::FIRST, m_ctx.clone()).await
+                share.upgrade(m_ctx.clone(), RecordId::FIRST).await
             }),
         )
         .await;
@@ -545,7 +545,7 @@ mod tests {
             let input: TestField = rng.gen();
 
             let m_shares = join3v(zip(m_ctx.iter(), input.share_with(&mut rng)).map(
-                |(m_ctx, share)| async { share.upgrade(RecordId::FIRST, m_ctx.clone()).await },
+                |(m_ctx, share)| async { share.upgrade(m_ctx.clone(), RecordId::FIRST).await },
             ))
             .await;
 

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -399,7 +399,7 @@ mod tests {
         },
         protocol::{
             basics::{partial_reveal, reveal, Reveal},
-            context::{Context, UpgradableContext, UpgradedContext, Validator},
+            context::{upgrade::Upgradable, Context, UpgradableContext, Validator},
             RecordId,
         },
         rand::{thread_rng, Rng},
@@ -509,8 +509,9 @@ mod tests {
         let input: TestField = rng.gen();
 
         let m_shares = join3v(
-            zip(m_ctx.iter(), input.share_with(&mut rng))
-                .map(|(m_ctx, share)| async { m_ctx.upgrade(share).await }),
+            zip(m_ctx.iter(), input.share_with(&mut rng)).map(|(m_ctx, share)| async {
+                share.upgrade(RecordId::FIRST, m_ctx.clone()).await
+            }),
         )
         .await;
 
@@ -543,10 +544,9 @@ mod tests {
             let record_id = RecordId::from(0);
             let input: TestField = rng.gen();
 
-            let m_shares = join3v(
-                zip(m_ctx.iter(), input.share_with(&mut rng))
-                    .map(|(m_ctx, share)| async { m_ctx.upgrade(share).await }),
-            )
+            let m_shares = join3v(zip(m_ctx.iter(), input.share_with(&mut rng)).map(
+                |(m_ctx, share)| async { share.upgrade(RecordId::FIRST, m_ctx.clone()).await },
+            ))
             .await;
 
             let results = join_all(zip(m_ctx.clone().into_iter(), m_shares).map(

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -380,8 +380,8 @@ where
 
     async fn upgrade(
         self,
-        record_id: RecordId,
         ctx: Upgraded<'a, V>,
+        record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         let ctx = ctx.narrow(&UpgradeStep);
         //
@@ -425,12 +425,12 @@ where
 
     async fn upgrade(
         self,
-        record_id: RecordId,
         ctx: Upgraded<'a, V>,
+        record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         let (l, r) = self;
-        let l = l.upgrade(record_id, ctx.narrow("upgrade_l")).await?;
-        let r = r.upgrade(record_id, ctx.narrow("upgrade_r")).await?;
+        let l = l.upgrade(ctx.narrow("upgrade_l"), record_id).await?;
+        let r = r.upgrade(ctx.narrow("upgrade_r"), record_id).await?;
         Ok((l, r))
     }
 }
@@ -442,8 +442,8 @@ impl<'a, V: ExtendableField> Upgradable<Upgraded<'a, V>> for () {
 
     async fn upgrade(
         self,
-        _record_id: RecordId,
         _context: Upgraded<'a, V>,
+        _record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         Ok(())
     }
@@ -460,8 +460,8 @@ where
 
     async fn upgrade(
         self,
-        record_id: RecordId,
         ctx: Upgraded<'a, V>,
+        record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         /// Need a standalone function to avoid GAT issue that apparently can manifest
         /// even with `async_trait`.
@@ -480,7 +480,7 @@ where
                     let ctx = ctx.narrow(&format!("upgrade-vec-{i}"));
                     // FQN syntax fixes the GAT issue, `item.upgrade` does not work
                     // (I know, its crazy)
-                    let v = Upgradable::upgrade(item, record_id, ctx).await?;
+                    let v = Upgradable::upgrade(item, ctx, record_id).await?;
                     upgraded.push(v);
                 }
                 Ok(upgraded)

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -19,6 +19,8 @@ use crate::{
             dzkp_malicious::DZKPUpgraded,
             dzkp_validator::{DZKPBatch, MaliciousDZKPValidator},
             prss::InstrumentedIndexedSharedRandomness,
+            step::UpgradeStep,
+            upgrade::Upgradable,
             validator::{Malicious as Validator, MaliciousAccumulator},
             Base, Context as ContextTrait, InstrumentedSequentialSharedRandomness,
             SpecialAccessToUpgradedContext, UpgradableContext, UpgradedContext,
@@ -29,7 +31,6 @@ use crate::{
     secret_sharing::replicated::{
         malicious::{AdditiveShare as MaliciousReplicated, ExtendableField, ExtendableFieldSimd},
         semi_honest::AdditiveShare as Replicated,
-        ReplicatedSecretSharing,
     },
     seq_join::SeqJoin,
     sharding::NotSharded,
@@ -242,46 +243,17 @@ impl<'a, F: ExtendableField> Upgraded<'a, F> {
             .accumulator
             .accumulate_macs(&self.prss(), record_id, share);
     }
+
+    /// It is intentionally not public, allows access to it only from within
+    /// this module
+    fn r_share(&self) -> &Replicated<F::ExtendedField> {
+        &self.inner.r_share
+    }
 }
 
 #[async_trait]
 impl<'a, F: ExtendableField> UpgradedContext for Upgraded<'a, F> {
     type Field = F;
-    type Share = MaliciousReplicated<F>;
-
-    async fn upgrade_one(
-        &self,
-        record_id: RecordId,
-        x: Replicated<F>,
-    ) -> Result<MaliciousReplicated<F>, Error> {
-        //
-        // This code is drawn from:
-        // "Field Extension in Secret-Shared Form and Its Applications to Efficient Secure Computation"
-        // R. Kikuchi, N. Attrapadung, K. Hamada, D. Ikarashi, A. Ishida, T. Matsuda, Y. Sakai, and J. C. N. Schuldt
-        // <https://eprint.iacr.org/2019/386.pdf>
-        //
-        // See protocol 4.15
-        // In Step 3: "Randomization of inputs:", it says:
-        //
-        // For each input wire sharing `[v_j]` (where j ∈ {1, . . . , M}), the parties locally
-        // compute the induced share `[[v_j]] = f([v_j], 0, . . . , 0)`.
-        // Then, the parties call `Ḟ_mult` on `[[ȓ]]` and `[[v_j]]` to receive `[[ȓ · v_j]]`
-        //
-        let induced_share = Replicated::new(x.left().to_extended(), x.right().to_extended());
-
-        let rx = semi_honest_multiply(
-            self.as_base(),
-            record_id,
-            &induced_share,
-            &self.inner.r_share,
-        )
-        .await?;
-        let m = MaliciousReplicated::new(x, rx);
-        let narrowed = self.narrow(&RandomnessForValidation);
-        let prss = narrowed.prss();
-        self.inner.accumulator.accumulate_macs(&prss, record_id, &m);
-        Ok(m)
-    }
 }
 
 impl<'a, F: ExtendableField> super::Context for Upgraded<'a, F> {
@@ -390,5 +362,131 @@ impl<'a, F: ExtendableField> UpgradedInner<'a, F> {
             accumulator,
             r_share,
         })
+    }
+
+    fn accumulator(&self) -> &MaliciousAccumulator<F> {
+        &self.accumulator
+    }
+}
+
+/// Upgrading a semi-honest replicated share using malicious context produces
+/// a MAC-secured share with the same vectorization factor.
+#[async_trait]
+impl<'a, V: ExtendableFieldSimd<N>, const N: usize> Upgradable<Upgraded<'a, V>> for Replicated<V, N>
+where
+    Replicated<<V as ExtendableField>::ExtendedField, N>: FromPrss,
+{
+    type Output = MaliciousReplicated<V, N>;
+
+    async fn upgrade(
+        self,
+        record_id: RecordId,
+        ctx: Upgraded<'a, V>,
+    ) -> Result<Self::Output, Error> {
+        let ctx = ctx.narrow(&UpgradeStep);
+        //
+        // This code is drawn from:
+        // "Field Extension in Secret-Shared Form and Its Applications to Efficient Secure Computation"
+        // R. Kikuchi, N. Attrapadung, K. Hamada, D. Ikarashi, A. Ishida, T. Matsuda, Y. Sakai, and J. C. N. Schuldt
+        // <https://eprint.iacr.org/2019/386.pdf>
+        //
+        // See protocol 4.15
+        // In Step 3: "Randomization of inputs:", it says:
+        //
+        // For each input wire sharing `[v_j]` (where j ∈ {1, . . . , M}), the parties locally
+        // compute the induced share `[[v_j]] = f([v_j], 0, . . . , 0)`.
+        // Then, the parties call `Ḟ_mult` on `[[ȓ]]` and `[[v_j]]` to receive `[[ȓ · v_j]]`
+        //
+        let induced_share = self.induced();
+        // expand r to match the vectorization factor of induced share
+        let r = ctx.r_share().expand();
+
+        let rx = semi_honest_multiply(ctx.as_base(), record_id, &induced_share, &r).await?;
+        let m = MaliciousReplicated::new(self, rx);
+        let narrowed = ctx.narrow(&RandomnessForValidation);
+        let prss = narrowed.prss();
+        let accumulator = narrowed.inner.accumulator();
+        accumulator.accumulate_macs(&prss, record_id, &m);
+
+        Ok(m)
+    }
+}
+
+/// Convenience trait implementations to upgrade test data.
+
+#[cfg(all(test, descriptive_gate))]
+#[async_trait]
+impl<'a, V: ExtendableFieldSimd<N>, const N: usize> Upgradable<Upgraded<'a, V>>
+    for (Replicated<V, N>, Replicated<V, N>)
+where
+    Replicated<<V as ExtendableField>::ExtendedField, N>: FromPrss,
+{
+    type Output = (MaliciousReplicated<V, N>, MaliciousReplicated<V, N>);
+
+    async fn upgrade(
+        self,
+        record_id: RecordId,
+        ctx: Upgraded<'a, V>,
+    ) -> Result<Self::Output, Error> {
+        let (l, r) = self;
+        let l = l.upgrade(record_id, ctx.narrow("upgrade_l")).await?;
+        let r = r.upgrade(record_id, ctx.narrow("upgrade_r")).await?;
+        Ok((l, r))
+    }
+}
+
+#[cfg(all(test, descriptive_gate))]
+#[async_trait]
+impl<'a, V: ExtendableField> Upgradable<Upgraded<'a, V>> for () {
+    type Output = ();
+
+    async fn upgrade(
+        self,
+        _record_id: RecordId,
+        _context: Upgraded<'a, V>,
+    ) -> Result<Self::Output, Error> {
+        Ok(())
+    }
+}
+
+#[cfg(all(test, descriptive_gate))]
+#[async_trait]
+impl<'a, V, U> Upgradable<Upgraded<'a, V>> for Vec<U>
+where
+    V: ExtendableField,
+    U: Upgradable<Upgraded<'a, V>, Output: Send> + Send + 'a,
+{
+    type Output = Vec<U::Output>;
+
+    async fn upgrade(
+        self,
+        record_id: RecordId,
+        ctx: Upgraded<'a, V>,
+    ) -> Result<Self::Output, Error> {
+        /// Need a standalone function to avoid GAT issue that apparently can manifest
+        /// even with `async_trait`.
+        fn upgrade_vec<'a, V, U>(
+            ctx: Upgraded<'a, V>,
+            record_id: RecordId,
+            input: Vec<U>,
+        ) -> impl std::future::Future<Output = Result<Vec<U::Output>, Error>> + 'a
+        where
+            V: ExtendableField,
+            U: Upgradable<Upgraded<'a, V>> + 'a,
+        {
+            let mut upgraded = Vec::with_capacity(input.len());
+            async move {
+                for (i, item) in input.into_iter().enumerate() {
+                    let ctx = ctx.narrow(&format!("upgrade-vec-{i}"));
+                    // FQN syntax fixes the GAT issue, `item.upgrade` does not work
+                    // (I know, its crazy)
+                    let v = Upgradable::upgrade(item, record_id, ctx).await?;
+                    upgraded.push(v);
+                }
+                Ok(upgraded)
+            }
+        }
+
+        crate::seq_join::assert_send(upgrade_vec(ctx, record_id, self)).await
     }
 }

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -728,12 +728,12 @@ mod tests {
                 let ctx = v.context().narrow("step1");
                 shares
                     .clone()
-                    .upgrade(RecordId::FIRST, ctx.set_total_records(1))
+                    .upgrade(ctx.set_total_records(1), RecordId::FIRST)
                     .await
                     .unwrap();
                 let ctx = v.context().narrow("step2");
                 shares
-                    .upgrade(RecordId::FIRST, ctx.set_total_records(1))
+                    .upgrade(ctx.set_total_records(1), RecordId::FIRST)
                     .await
                     .unwrap();
             })

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -296,8 +296,8 @@ impl<'a, V: ExtendableField + Vectorizable<N>, const N: usize>
 
     async fn upgrade(
         self,
-        _record_id: RecordId,
         _context: Upgraded<'a, NotSharded, V>,
+        _record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         Ok(self)
     }

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -16,15 +16,17 @@ use crate::{
     },
     protocol::{
         context::{
-            dzkp_validator::SemiHonestDZKPValidator, validator::SemiHonest as Validator, Base,
-            InstrumentedIndexedSharedRandomness, InstrumentedSequentialSharedRandomness,
-            ShardedContext, SpecialAccessToUpgradedContext, UpgradableContext, UpgradedContext,
+            dzkp_validator::SemiHonestDZKPValidator, upgrade::Upgradable,
+            validator::SemiHonest as Validator, Base, InstrumentedIndexedSharedRandomness,
+            InstrumentedSequentialSharedRandomness, ShardedContext, SpecialAccessToUpgradedContext,
+            UpgradableContext, UpgradedContext,
         },
         prss::Endpoint as PrssEndpoint,
         Gate, RecordId,
     },
-    secret_sharing::replicated::{
-        malicious::ExtendableField, semi_honest::AdditiveShare as Replicated,
+    secret_sharing::{
+        replicated::{malicious::ExtendableField, semi_honest::AdditiveShare as Replicated},
+        Vectorizable,
     },
     seq_join::SeqJoin,
     sharding::{NotSharded, ShardBinding, ShardConfiguration, ShardIndex, Sharded},
@@ -263,15 +265,6 @@ impl<'a, B: ShardBinding, F: ExtendableField> SeqJoin for Upgraded<'a, B, F> {
 #[async_trait]
 impl<'a, B: ShardBinding, F: ExtendableField> UpgradedContext for Upgraded<'a, B, F> {
     type Field = F;
-    type Share = Replicated<F>;
-
-    async fn upgrade_one(
-        &self,
-        _record_id: RecordId,
-        x: Replicated<F>,
-    ) -> Result<Self::Share, Error> {
-        Ok(x)
-    }
 }
 
 impl<'a, B: ShardBinding, F: ExtendableField> SpecialAccessToUpgradedContext<F>
@@ -292,5 +285,20 @@ impl<B: ShardBinding, F: ExtendableField> Debug for Upgraded<'_, B, F> {
             type_name::<B>(),
             type_name::<F>()
         )
+    }
+}
+
+#[async_trait]
+impl<'a, V: ExtendableField + Vectorizable<N>, const N: usize>
+    Upgradable<Upgraded<'a, NotSharded, V>> for Replicated<V, N>
+{
+    type Output = Replicated<V, N>;
+
+    async fn upgrade(
+        self,
+        _record_id: RecordId,
+        _context: Upgraded<'a, NotSharded, V>,
+    ) -> Result<Self::Output, Error> {
+        Ok(self)
     }
 }

--- a/ipa-core/src/protocol/context/upgrade.rs
+++ b/ipa-core/src/protocol/context/upgrade.rs
@@ -1,192 +1,27 @@
-use std::marker::PhantomData;
-
 use async_trait::async_trait;
-use futures::future::try_join;
-use ipa_step::{Step, StepNarrow};
 
 use crate::{
     error::Error,
-    ff::Field,
-    helpers::TotalRecords,
-    protocol::{
-        boolean::step::TwoHundredFiftySixBitOpStep, context::UpgradedContext, Gate, NoRecord,
-        RecordBinding, RecordId,
-    },
-    secret_sharing::{
-        replicated::{malicious::ExtendableField, semi_honest::AdditiveShare as Replicated},
-        Linear as LinearSecretSharing,
-    },
+    protocol::{context::UpgradedContext, RecordId},
 };
 
-/// Special context type used for malicious upgrades.
+/// This trait is implemented by secret sharing types that can be upgraded.
+/// Upgrade a share only makes sense for MAC-based security as it requires
+/// communication between helpers.
 ///
-/// The `B: RecordBinding` type parameter is used to prevent using the record ID multiple times to
-/// implement an upgrade. For example, trying to use the record ID to iterate over both the inner
-/// and outer vectors in a `Vec<Vec<T>>` is an error. Instead, one level of iteration can use the
-/// record ID and the other can use something like a `BitOpStep`.
-///
-#[cfg_attr(not(descriptive_gate), doc = "```ignore")]
-/// ```no_run
-/// use ipa_core::protocol::{context::{UpgradeContext, UpgradeToMalicious, UpgradedMaliciousContext as C}, NoRecord, RecordId};
-/// use ipa_core::ff::Fp32BitPrime as F;
-/// use ipa_core::secret_sharing::replicated::{
-///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
-/// };
-/// // Note: Unbound upgrades only work when testing.
-/// #[cfg(test)]
-/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, RecordId> as UpgradeToMalicious<Replicated<F>, _>>::upgrade;
-/// #[cfg(test)]
-/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<(Replicated<F>, Replicated<F>), _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
-/// let _ = <UpgradeContext<C<'_, F>, NoRecord> as UpgradeToMalicious<(Vec<Replicated<F>>, Vec<Replicated<F>>), _>>::upgrade;
-/// ```
-///
-/// ```compile_fail
-/// use ipa_core::protocol::{context::{UpgradeContext, UpgradeToMalicious, UpgradedMaliciousContext as C}, NoRecord, RecordId};
-/// use ipa_core::ff::Fp32BitPrime as F;
-/// use ipa_core::secret_sharing::replicated::{
-///     malicious::AdditiveShare as MaliciousReplicated, semi_honest::AdditiveShare as Replicated,
-/// };
-/// // This can't be upgraded with a record-bound context because the record ID
-/// // is used internally for vector indexing.
-/// let _ = <UpgradeContext<C<'_, F>, RecordId> as UpgradeToMalicious<Vec<Replicated<F>>, _>>::upgrade;
-pub struct UpgradeContext<C: UpgradedContext, B: RecordBinding = NoRecord> {
-    ctx: C,
-    record_binding: B,
-}
+/// This trait makes the vectorization factor opaque for upgrades.
+#[async_trait]
+pub trait Upgradable<C: UpgradedContext>: Send {
+    type Output;
 
-impl<C, B> UpgradeContext<C, B>
-where
-    C: UpgradedContext,
-    B: RecordBinding,
-{
-    pub fn new(ctx: C, record_binding: B) -> Self {
-        Self {
-            ctx,
-            record_binding,
-        }
-    }
-
-    fn narrow<SS: Step>(&self, step: &SS) -> Self
+    /// Upgrades this instance using the specified [`RecordId`].
+    /// This method expects context to be configured with
+    /// total records.
+    ///
+    /// ## Errors
+    /// When upgrade fails or if context provided does not have
+    /// total records setting configured.
+    async fn upgrade(self, record_id: RecordId, ctx: C) -> Result<Self::Output, Error>
     where
-        Gate: StepNarrow<SS>,
-    {
-        Self::new(self.ctx.narrow(step), self.record_binding)
-    }
-}
-
-#[async_trait]
-pub trait UpgradeToMalicious<T, M>
-where
-    T: Send,
-{
-    async fn upgrade(self, input: T) -> Result<M, Error>;
-}
-
-#[async_trait]
-impl<C> UpgradeToMalicious<(), ()> for UpgradeContext<C, NoRecord>
-where
-    C: UpgradedContext,
-{
-    async fn upgrade(self, _input: ()) -> Result<(), Error> {
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl<C, T, TM, U, UM> UpgradeToMalicious<(T, U), (TM, UM)> for UpgradeContext<C, NoRecord>
-where
-    C: UpgradedContext,
-    T: Send + 'static,
-    U: Send + 'static,
-    TM: Send + Sized + 'static,
-    UM: Send + Sized + 'static,
-    UpgradeContext<C, NoRecord>: UpgradeToMalicious<T, TM> + UpgradeToMalicious<U, UM>,
-{
-    async fn upgrade(self, input: (T, U)) -> Result<(TM, UM), Error> {
-        try_join(
-            self.narrow(&TwoHundredFiftySixBitOpStep::from(0))
-                .upgrade(input.0),
-            self.narrow(&TwoHundredFiftySixBitOpStep::from(1))
-                .upgrade(input.1),
-        )
-        .await
-    }
-}
-
-#[async_trait]
-impl<C, I, M> UpgradeToMalicious<I, Vec<M>> for UpgradeContext<C, NoRecord>
-where
-    C: UpgradedContext,
-    I: IntoIterator + Send + 'static,
-    I::IntoIter: ExactSizeIterator + Send,
-    I::Item: Send + 'static,
-    M: Send + 'static,
-    UpgradeContext<C, RecordId>: UpgradeToMalicious<I::Item, M>,
-{
-    async fn upgrade(self, input: I) -> Result<Vec<M>, Error> {
-        let iter = input.into_iter();
-        let ctx = self
-            .ctx
-            .set_total_records(TotalRecords::specified(iter.len())?);
-        let ctx_ref = &ctx;
-        ctx.try_join(iter.enumerate().map(|(i, share)| async move {
-            // TODO: make it a bit more ergonomic to call with record id bound
-            UpgradeContext::new(ctx_ref.clone(), RecordId::from(i))
-                .upgrade(share)
-                .await
-        }))
-        .await
-    }
-}
-
-#[async_trait]
-impl<C, F> UpgradeToMalicious<Replicated<F>, C::Share> for UpgradeContext<C, RecordId>
-where
-    C: UpgradedContext<Field = F>,
-    F: ExtendableField,
-{
-    async fn upgrade(self, input: Replicated<F>) -> Result<C::Share, Error> {
-        self.ctx.upgrade_one(self.record_binding, input).await
-    }
-}
-pub struct IPAModulusConvertedInputRowWrapper<F: Field, T: LinearSecretSharing<F>> {
-    pub timestamp: T,
-    pub is_trigger_bit: T,
-    pub trigger_value: T,
-    _marker: PhantomData<F>,
-}
-
-impl<F: Field, T: LinearSecretSharing<F>> IPAModulusConvertedInputRowWrapper<F, T> {
-    pub fn new(timestamp: T, is_trigger_bit: T, trigger_value: T) -> Self {
-        Self {
-            timestamp,
-            is_trigger_bit,
-            trigger_value,
-            _marker: PhantomData,
-        }
-    }
-}
-
-// Impl to upgrade a single `Replicated<F>` using a non-record-bound context. Used for tests.
-#[cfg(test)]
-#[async_trait]
-impl<C, F, M> UpgradeToMalicious<Replicated<F>, M> for UpgradeContext<C, NoRecord>
-where
-    C: UpgradedContext,
-    F: ExtendableField,
-    M: 'static,
-    UpgradeContext<C, RecordId>: UpgradeToMalicious<Replicated<F>, M>,
-{
-    async fn upgrade(self, input: Replicated<F>) -> Result<M, Error> {
-        let ctx = if self.ctx.total_records().is_specified() {
-            self.ctx
-        } else {
-            self.ctx.set_total_records(TotalRecords::ONE)
-        };
-        UpgradeContext::new(ctx, RecordId::FIRST)
-            .upgrade(input)
-            .await
-    }
+        C: 'async_trait;
 }

--- a/ipa-core/src/protocol/context/upgrade.rs
+++ b/ipa-core/src/protocol/context/upgrade.rs
@@ -21,7 +21,7 @@ pub trait Upgradable<C: UpgradedContext>: Send {
     /// ## Errors
     /// When upgrade fails or if context provided does not have
     /// total records setting configured.
-    async fn upgrade(self, record_id: RecordId, ctx: C) -> Result<Self::Output, Error>
+    async fn upgrade(self, ctx: C, record_id: RecordId) -> Result<Self::Output, Error>
     where
         C: 'async_trait;
 }

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -338,7 +338,7 @@ mod tests {
         helpers::Role,
         protocol::{
             basics::SecureMul,
-            context::{validator::Validator, Context, UpgradableContext, UpgradedContext},
+            context::{upgrade::Upgradable, validator::Validator, Context, UpgradableContext},
             RecordId,
         },
         rand::{thread_rng, Rng},
@@ -384,8 +384,10 @@ mod tests {
                 let v = ctx.validator();
                 let m_ctx = v.context();
 
-                let (a_malicious, b_malicious) =
-                    m_ctx.clone().upgrade((a_share, b_share)).await.unwrap();
+                let (a_malicious, b_malicious) = (a_share, b_share)
+                    .upgrade(RecordId::FIRST, m_ctx.set_total_records(1))
+                    .await
+                    .unwrap();
 
                 let m_result = a_malicious
                     .multiply(&b_malicious, m_ctx.set_total_records(1), RecordId::from(0))
@@ -425,7 +427,10 @@ mod tests {
         let result = world
             .malicious(a, |ctx, a| async move {
                 let v = ctx.validator();
-                let m = v.context().upgrade(a).await.unwrap();
+                let m = a
+                    .upgrade(RecordId::FIRST, v.context().set_total_records(1))
+                    .await
+                    .unwrap();
                 v.validate(m).await.unwrap()
             })
             .await;
@@ -449,7 +454,10 @@ mod tests {
                         a
                     };
                     let v = ctx.validator();
-                    let m = v.context().upgrade(a).await.unwrap();
+                    let m = a
+                        .upgrade(RecordId::FIRST, v.context().set_total_records(1))
+                        .await
+                        .unwrap();
                     match v.validate(m).await {
                         Ok(result) => panic!("Got a result {result:?}"),
                         Err(err) => assert!(matches!(err, Error::MaliciousSecurityCheckFailed)),
@@ -506,7 +514,10 @@ mod tests {
                 let v = ctx.validator();
                 let m_ctx = v.context();
 
-                let m_input = m_ctx.upgrade(input_shares).await.unwrap();
+                let m_input = input_shares
+                    .upgrade(RecordId::FIRST, m_ctx.set_total_records(1))
+                    .await
+                    .unwrap();
 
                 let m_results = m_ctx
                     .try_join(

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -385,7 +385,7 @@ mod tests {
                 let m_ctx = v.context();
 
                 let (a_malicious, b_malicious) = (a_share, b_share)
-                    .upgrade(RecordId::FIRST, m_ctx.set_total_records(1))
+                    .upgrade(m_ctx.set_total_records(1), RecordId::FIRST)
                     .await
                     .unwrap();
 
@@ -428,7 +428,7 @@ mod tests {
             .malicious(a, |ctx, a| async move {
                 let v = ctx.validator();
                 let m = a
-                    .upgrade(RecordId::FIRST, v.context().set_total_records(1))
+                    .upgrade(v.context().set_total_records(1), RecordId::FIRST)
                     .await
                     .unwrap();
                 v.validate(m).await.unwrap()
@@ -455,7 +455,7 @@ mod tests {
                     };
                     let v = ctx.validator();
                     let m = a
-                        .upgrade(RecordId::FIRST, v.context().set_total_records(1))
+                        .upgrade(v.context().set_total_records(1), RecordId::FIRST)
                         .await
                         .unwrap();
                     match v.validate(m).await {
@@ -515,7 +515,7 @@ mod tests {
                 let m_ctx = v.context();
 
                 let m_input = input_shares
-                    .upgrade(RecordId::FIRST, m_ctx.set_total_records(1))
+                    .upgrade(m_ctx.set_total_records(1), RecordId::FIRST)
                     .await
                     .unwrap();
 

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -15,17 +15,17 @@ use crate::{
     helpers::{
         in_memory_config::{passthrough, DynStreamInterceptor},
         Gateway, GatewayConfig, HelperIdentity, InMemoryMpcNetwork, InMemoryShardNetwork,
-        InMemoryTransport, Role, RoleAssignment, Transport,
+        InMemoryTransport, Role, RoleAssignment, TotalRecords, Transport,
     },
     protocol::{
         context::{
-            dzkp_validator::DZKPValidator, Context, DZKPUpgradedMaliciousContext, MaliciousContext,
-            SemiHonestContext, ShardedSemiHonestContext, UpgradableContext, UpgradeContext,
-            UpgradeToMalicious, UpgradedContext, UpgradedMaliciousContext,
+            dzkp_validator::DZKPValidator, upgrade::Upgradable, Context,
+            DZKPUpgradedMaliciousContext, MaliciousContext, SemiHonestContext,
+            ShardedSemiHonestContext, UpgradableContext, UpgradedMaliciousContext,
             UpgradedSemiHonestContext, Validator,
         },
         prss::Endpoint as PrssEndpoint,
-        Gate, QueryId,
+        Gate, QueryId, RecordId,
     },
     secret_sharing::{
         replicated::malicious::{DowngradeMalicious, ExtendableField},
@@ -410,8 +410,7 @@ pub trait Runner<S: ShardingScheme> {
     where
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
-        A: Send + 'static,
-        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
+        A: Send + 'static + Upgradable<UpgradedMaliciousContext<'a, F>, Output = M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,
@@ -511,8 +510,7 @@ impl<const SHARDS: usize, D: Distribute> Runner<WithShards<SHARDS, D>>
     where
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
-        A: Send + 'static,
-        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
+        A: Send + 'static + Upgradable<UpgradedMaliciousContext<'a, F>, Output = M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,
@@ -605,8 +603,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
     where
         F: ExtendableField,
         I: IntoShares<A> + Send + 'static,
-        A: Send + 'static,
-        UpgradeContext<UpgradedMaliciousContext<'a, F>>: UpgradeToMalicious<A, M>,
+        A: Send + 'static + Upgradable<UpgradedMaliciousContext<'a, F>, Output = M>,
         O: Send + Debug,
         M: Send + 'static,
         H: Fn(UpgradedMaliciousContext<'a, F>, M) -> R + Send + Sync,
@@ -619,7 +616,13 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
             self.malicious(input, |ctx, share| async {
                 let v = ctx.validator();
                 let m_ctx = v.context();
-                let m_share = m_ctx.upgrade(share).await.unwrap();
+                let m_share = share
+                    .upgrade(
+                        RecordId::FIRST,
+                        m_ctx.set_total_records(TotalRecords::specified(1).unwrap()),
+                    )
+                    .await
+                    .unwrap();
                 let m_result = helper_fn(m_ctx, m_share).await;
                 let m_result_clone = m_result.clone();
                 let r_share = v.r_share().clone();

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -618,8 +618,8 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
                 let m_ctx = v.context();
                 let m_share = share
                     .upgrade(
-                        RecordId::FIRST,
                         m_ctx.set_total_records(TotalRecords::specified(1).unwrap()),
+                        RecordId::FIRST,
                     )
                     .await
                     .unwrap();


### PR DESCRIPTION
When working on vectorizing malicious shares,
we noticed that the existing upgrade API does not work for vectorized shares. It either required contexts to be vectorization-aware which we tried to avoid up to this point, or a different mechanism to specify how upgrades occur for vectorized shares.

For example: `Replicated<F, N>` when upgraded, gets transformed to `MaliciousReplicated<F, N>` and different `N` values, require different bounds on functions.

That was a blocker for PRF evaluation upgrade and the solution we came up with was to introduce `Upgradable` trait.

The functionality of this trait is very similar to `UpgradeToMalicious` and `Upgrade` but upgrade now is bound explicitly to `RecordId`. This optimizes for protocols readability. Malicious upgrades in tests had to find a way around this limitation, and it is a bit hacky. I don't think it is significantly different from what we've been doing before though.