### PR TITLE
add tracing to the apply_dp_noise fn

### DIFF
--- a/ipa-core/src/protocol/dp/mod.rs
+++ b/ipa-core/src/protocol/dp/mod.rs
@@ -168,6 +168,7 @@ where
 /// asserts in `gen_binomial_noise` may panic
 /// # Errors
 /// Result error case could come from transpose
+#[tracing::instrument(name = "apply_dp_noise", skip_all)]
 pub async fn apply_dp_noise<C, const B: usize, OV>(
     ctx: C,
     histogram_bin_values: BitDecomposed<Replicated<Boolean, B>>,


### PR DESCRIPTION
very small PR to help understand if cross cloud testing is stuck in `apply_dp_noise` or at some point after it.