### PR TITLE
add 3 public keys when encrypting to files

### DIFF
--- a/in-market-test/v2/hpke/encrypt_report.py
+++ b/in-market-test/v2/hpke/encrypt_report.py
@@ -186,6 +186,7 @@ class IPAShare:
     def __str__(self) -> str:
         return f"({self.left})({self.right})"
 
+
 class IPAReport:
     __slots__ = [
         "mk_encap_key_ciphertext",
@@ -223,9 +224,6 @@ class IPAReport:
             self.info.helper_domain,
         )
 
-        print("mk_encap_key_ciphertext: ", len(self.mk_encap_key_ciphertext))
-        print("enc bytes: ", len(encrypted.encrypted_to_bytes()))
-        print("report info: ",len(encrypted.ipa_report_info_to_bytes()))
         return (
             self.mk_encap_key_ciphertext
             + encrypted.encrypted_to_bytes()
@@ -306,11 +304,6 @@ def encrypt_to_file(
             tv_share = IPAShare.create_shares(
                 trigger_value.to_bytes(1, "little"), ShareType.TRIGGER_VALUE
             )
-
-            print("mk: ", mk_share[0])
-            print("ts: ", ts_share[0])
-            print("bk: ", bk_share[0])
-            print("tv: ", tv_share[0])
 
             encrypted_reports_1.append(
                 generate_report_per_helper(


### PR DESCRIPTION
This updates the python script so that it can encrypt with 3 different helper public keys.

I updated this so that I could test decryption, but it's not working unfortuantely.

## Encrypt and Decrypt in Rust (Working)
```
./target/debug/crypto_util encrypt --input-file tmp/raw_reports.txt --output-dir tmp --network tmp/keys/network.toml
```
```
./target/debug/crypto_util decrypt --input-file1 tmp/helper1.enc --input-file2 tmp/helper2.enc --input-file3 tmp/helper3.enc --mk-private-key1 tmp/keys/h1_mk.key --mk-private-key2 tmp/keys/h2_mk.key --mk-private-key3 tmp/keys/h3_mk.key  --output-file tmp/out.dec
```

produces no diff between `tmp/raw_reports.txt` and `tmp/out.dec`.

## Encrypt in Python, Decrypt in Rust (Not working)
```
./in-market-test/v2/hpke/.venv/bin/python in-market-test/v2/hpke/encrypt_report.py --pub_key 92a6fb666c37c008defd74abf3204ebea685742eab8347b08e2f7c759893947a --pub_key2 cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e --pub_key3 b900be35da06106a83ed73c33f733e03e4ea5888b7ea4c912ab270b0b0f8381e --file_in tmp/raw_reports.txt --dir_out tmp
```
```
./target/debug/crypto_util decrypt --input-file1 tmp/encrypted_report__h1 --input-file2 tmp/encrypted_report__h2 --input-file3 tmp/encrypted_report__h3 --mk-private-key1 tmp/keys/h1_mk.key --mk-private-key2 tmp/keys/h2_mk.key --mk-private-key3 tmp/keys/h3_mk.key  --output-file tmp_out.dec
thread 'main' panicked at ipa-core/src/cli/crypto.rs:158:56:
called `Result::unwrap()` on an `Err` value: Crypt(Other)
```
The error message isn't super clear, but it fails on 
```
let dec_report: OprfReport<BA8, BA3, BA20> = enc_report.decrypt(&self.key_registry).unwrap();
```
so it seems there's an issue with the encrypted report.

## Reproducing
`raw_reports.txt`:
```
191958,921234857874,0,19,0
592939,730337324166,1,0,1
145897,128708412085,0,10,0
449139,647185686192,1,0,5
394161,647185686192,0,18,0
542478,25696631791,0,6,0
81260,976336366452,1,0,2
401583,326283105732,0,6,0
250139,729192353751,0,7,0
240416,25696631791,0,19,0
```

`network.toml`:
```
[[peers]]
url = "helper1.test"

[peers.hpke]
public_key = "92a6fb666c37c008defd74abf3204ebea685742eab8347b08e2f7c759893947a"

[[peers]]
url = "helper2.test"

[peers.hpke]
public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"

[[peers]]
url = "helper3.test"

[peers.hpke]
public_key = "b900be35da06106a83ed73c33f733e03e4ea5888b7ea4c912ab270b0b0f8381e"
```

Private Keys
```
53d58e022981f2edbf55fec1b45dbabd08a3442cb7b7c598839de5d7a5888bff
```

```
3a0a993a3cfc7e8d381addac586f37de50c2a14b1a6356d71e94ca2afaeb2569
```

```
1fb5c5274bf85fbe6c7935684ef05499f6cfb89ac21640c28330135cc0e8a0f7
```