### PR TITLE
fix precommit bug when using zsh

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -73,7 +73,7 @@ check() {
         res=$?
         echo "-----------------------"
         echo "$msg: FAILED ($res)"
-        echo "  ${@@Q}"
+        echo "  ${*}"
         exit $res
     fi
 }

--- a/pre-commit
+++ b/pre-commit
@@ -80,9 +80,6 @@ check() {
     fi
 }
 
-check "Fail fast" \
-    python fail_fast.py --foo "bar"
-
 check "Benchmark compilation" \
     cargo build --benches --no-default-features --features "enable-benches compact-gate"
 

--- a/pre-commit
+++ b/pre-commit
@@ -75,6 +75,8 @@ check() {
         echo "$msg: FAILED ($res)"
         if [[ "$BASH_VERSINFO" -ge 4 ]]; then
             echo " ${@@Q}"
+        else
+            echo "$*"
         fi
         exit $res
     fi

--- a/pre-commit
+++ b/pre-commit
@@ -73,10 +73,15 @@ check() {
         res=$?
         echo "-----------------------"
         echo "$msg: FAILED ($res)"
-        echo "  ${*}"
+        if [[ "$BASH_VERSINFO" -ge 4 ]]; then
+            echo " ${@@Q}"
+        fi
         exit $res
     fi
 }
+
+check "Fail fast" \
+    python fail_fast.py --foo "bar"
 
 check "Benchmark compilation" \
     cargo build --benches --no-default-features --features "enable-benches compact-gate"


### PR DESCRIPTION
`echo " ${@@Q}"` causes a `Bad Substitution error` in zsh (now the default on macOS), which very unfortunately gives a 0 exit code.  `echo " ${*}"` still prints the command that it failed on, and it should work with bash and zsh.