### PR TITLE
Encrypted Input Buffer

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -196,7 +196,7 @@ bench = false
 
 [[bin]]
 name = "crypto_util"
-required-features = ["cli", "test-fixture", "web-app", "in-memory-infra"]
+required-features = ["cli", "test-fixture", "web-app"]
 bench = false
 
 [[bench]]

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -25,7 +25,7 @@ use ipa_core::{
     ff::{boolean_array::BA32, FieldType},
     helpers::query::{DpMechanism, IpaQueryConfig, QueryConfig, QuerySize, QueryType},
     net::MpcHelperClient,
-    report::{EncryptedOprfReportFiles, DEFAULT_KEY_ID},
+    report::{EncryptedOprfReportStreams, DEFAULT_KEY_ID},
     test_fixture::{
         ipa::{ipa_in_the_clear, CappingOrder, IpaQueryStyle, IpaSecurityModel, TestRawDataRecord},
         EventGenerator, EventGeneratorConfig,
@@ -322,7 +322,7 @@ async fn ipa(
         &encrypted_inputs.enc_input_file3,
     ];
 
-    let encrypted_oprf_report_files = EncryptedOprfReportFiles::from(files);
+    let encrypted_oprf_report_files = EncryptedOprfReportStreams::from(files);
 
     let query_config = QueryConfig {
         size: QuerySize::try_from(encrypted_oprf_report_files.query_size).unwrap(),
@@ -342,7 +342,7 @@ async fn ipa(
             // implementation, otherwise a runtime reconstruct error will be generated.
             // see ipa-core/src/query/executor.rs
             run_query_and_validate::<BA32>(
-                encrypted_oprf_report_files.stream,
+                encrypted_oprf_report_files.streams,
                 encrypted_oprf_report_files.query_size,
                 helper_clients,
                 query_id,

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -249,7 +249,7 @@ fn get_query_type(
 ) -> QueryType {
     match (security_model, query_style) {
         (IpaSecurityModel::SemiHonest, IpaQueryStyle::Oprf) => {
-            QueryType::OprfIpaRelaxedDpPadding(ipa_query_config)
+            QueryType::SemiHonestOprfIpa(ipa_query_config)
         }
         (IpaSecurityModel::Malicious, IpaQueryStyle::Oprf) => {
             QueryType::MaliciousOprfIpa(ipa_query_config)

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -259,12 +259,10 @@ mod tests {
             CsvSerializer,
         },
         ff::{boolean_array::BA16, U128Conversions},
-        helpers::{
-            query::{IpaQueryConfig, QuerySize},
-            BodyStream,
-        },
+        helpers::query::{IpaQueryConfig, QuerySize},
         hpke::{IpaPrivateKey, KeyRegistry, PrivateKeyOnly},
         query::OprfIpaQuery,
+        report::EncryptedOprfReportSteams,
         test_fixture::{
             ipa::TestRawDataRecord, join3v, EventGenerator, EventGeneratorConfig, Reconstruct,
             TestWorld,
@@ -540,6 +538,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
 
     #[tokio::test]
     async fn encrypt_and_execute_query() {
+        panic!("is this run?");
         const EXPECTED: &[u128] = &[0, 8, 5];
 
         let records: Vec<TestRawDataRecord> = vec![
@@ -606,7 +605,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
             output_dir.path().join("helper2.enc"),
             output_dir.path().join("helper3.enc"),
         ];
-        let encrypted_oprf_report_files = EncryptedOprfReportFiles::from(files);
+        let encrypted_oprf_report_files = EncryptedOprfReportStreams::from(files);
 
         let world = TestWorld::default();
         let contexts = world.contexts();
@@ -623,7 +622,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
         #[allow(clippy::large_futures)]
         let results = join3v(
             encrypted_oprf_report_files
-                .stream
+                .streams
                 .into_iter()
                 .zip(contexts)
                 .zip(mk_private_keys)

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -238,7 +238,7 @@ pub async fn decrypt_and_reconstruct(args: DecryptArgs) -> Result<(), BoxError> 
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "in-memory-infra"))]
 mod tests {
     use std::{
         fs::File,

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -601,22 +601,12 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
             build_encrypt_args(input_file.path(), output_dir.path(), network_file.path());
         let _ = encrypt(&encrypt_args);
 
-        let enc1 = output_dir.path().join("helper1.enc");
-        let enc2 = output_dir.path().join("helper2.enc");
-        let enc3 = output_dir.path().join("helper3.enc");
-
-        let mut buffers: [_; 3] = std::array::from_fn(|_| Vec::new());
-        for (i, path) in [enc1, enc2, enc3].iter().enumerate() {
-            let file = File::open(path).unwrap();
-            let reader = BufReader::new(file);
-            for line in reader.lines() {
-                let line = line.unwrap();
-                let encrypted_report_bytes = hex::decode(line.trim()).unwrap();
-                println!("{}", encrypted_report_bytes.len());
-                buffers[i].put_u16_le(encrypted_report_bytes.len().try_into().unwrap());
-                buffers[i].put_slice(encrypted_report_bytes.as_slice());
-            }
-        }
+        let files = [
+            output_dir.path().join("helper1.enc"),
+            output_dir.path().join("helper2.enc"),
+            output_dir.path().join("helper3.enc"),
+        ];
+        let encrypted_oprf_report_files = EncryptedOprfReportFiles::from(files);
 
         let world = TestWorld::default();
         let contexts = world.contexts();
@@ -631,31 +621,35 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
         ];
 
         #[allow(clippy::large_futures)]
-        let results = join3v(buffers.into_iter().zip(contexts).zip(mk_private_keys).map(
-            |((buffer, ctx), mk_private_key)| {
-                let query_config = IpaQueryConfig {
-                    per_user_credit_cap: 8,
-                    attribution_window_seconds: None,
-                    max_breakdown_key: 3,
-                    with_dp: 0,
-                    epsilon: 1.0,
-                    plaintext_match_keys: false,
-                };
-                let input = BodyStream::from(buffer);
+        let results = join3v(
+            encrypted_oprf_report_files
+                .stream
+                .into_iter()
+                .zip(contexts)
+                .zip(mk_private_keys)
+                .map(|((input, ctx), mk_private_key)| {
+                    let query_config = IpaQueryConfig {
+                        per_user_credit_cap: 8,
+                        attribution_window_seconds: None,
+                        max_breakdown_key: 3,
+                        with_dp: 0,
+                        epsilon: 1.0,
+                        plaintext_match_keys: false,
+                    };
 
-                let private_registry =
-                    Arc::new(KeyRegistry::<PrivateKeyOnly>::from_keys([PrivateKeyOnly(
-                        IpaPrivateKey::from_bytes(&mk_private_key)
-                            .expect("manually constructed for test"),
-                    )]));
+                    let private_registry =
+                        Arc::new(KeyRegistry::<PrivateKeyOnly>::from_keys([PrivateKeyOnly(
+                            IpaPrivateKey::from_bytes(&mk_private_key)
+                                .expect("manually constructed for test"),
+                        )]));
 
-                OprfIpaQuery::<_, BA16, KeyRegistry<PrivateKeyOnly>>::new(
-                    query_config,
-                    private_registry,
-                )
-                .execute(ctx, query_size, input)
-            },
-        ))
+                    OprfIpaQuery::<_, BA16, KeyRegistry<PrivateKeyOnly>>::new(
+                        query_config,
+                        private_registry,
+                    )
+                    .execute(ctx, query_size, input)
+                }),
+        )
         .await;
 
         assert_eq!(

--- a/ipa-core/src/cli/mod.rs
+++ b/ipa-core/src/cli/mod.rs
@@ -1,11 +1,6 @@
 #[cfg(feature = "web-app")]
 mod clientconf;
-#[cfg(all(
-    feature = "test-fixture",
-    feature = "web-app",
-    feature = "cli",
-    feature = "in-memory-infra"
-))]
+#[cfg(all(feature = "test-fixture", feature = "web-app", feature = "cli",))]
 pub mod crypto;
 mod csv;
 mod ipa_output;

--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -95,6 +95,8 @@ where
     run_query_and_validate::<HV>(inputs, query_size, clients, query_id, query_config).await
 }
 
+/// # Panics
+/// if results are invalid
 #[allow(clippy::disallowed_methods)] // allow try_join_all
 pub async fn run_query_and_validate<HV>(
     inputs: [BodyStream; 3],

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -14,7 +14,7 @@ pub use input::InputSource;
 pub use multiply::secure_mul;
 use tokio::time::sleep;
 
-pub use self::ipa::playbook_oprf_ipa;
+pub use self::ipa::{playbook_oprf_ipa, run_query_and_validate};
 use crate::{
     config::{ClientConfig, NetworkConfig, PeerConfig},
     ff::boolean_array::{BA20, BA3, BA8},

--- a/ipa-core/tests/common/mod.rs
+++ b/ipa-core/tests/common/mod.rs
@@ -24,6 +24,7 @@ pub mod tempdir;
 pub const HELPER_BIN: &str = env!("CARGO_BIN_EXE_helper");
 pub const TEST_MPC_BIN: &str = env!("CARGO_BIN_EXE_test_mpc");
 pub const TEST_RC_BIN: &str = env!("CARGO_BIN_EXE_report_collector");
+pub const CRYPTO_UTIL_BIN: &str = env!("CARGO_BIN_EXE_crypto_util");
 
 pub trait UnwrapStatusExt {
     fn unwrap_status(self);
@@ -216,17 +217,27 @@ pub fn test_network<T: NetworkTest>(https: bool) {
     T::execute(path, https);
 }
 
-pub fn test_ipa(mode: IpaSecurityModel, https: bool) {
+pub fn test_ipa(mode: IpaSecurityModel, https: bool, encrypted_inputs: bool) {
     test_ipa_with_config(
         mode,
         https,
         IpaQueryConfig {
             ..Default::default()
         },
+        encrypted_inputs,
     );
 }
 
-pub fn test_ipa_with_config(mode: IpaSecurityModel, https: bool, config: IpaQueryConfig) {
+pub fn test_ipa_with_config(
+    mode: IpaSecurityModel,
+    https: bool,
+    config: IpaQueryConfig,
+    encrypted_inputs: bool,
+) {
+    if encrypted_inputs & !https {
+        panic!("encrypted_input requires https")
+    };
+
     const INPUT_SIZE: usize = 100;
     // set to true to always keep the temp dir after test finishes
     let dir = TempDir::new_delete_on_drop();
@@ -250,11 +261,25 @@ pub fn test_ipa_with_config(mode: IpaSecurityModel, https: bool, config: IpaQuer
         .stdin(Stdio::piped());
     command.status().unwrap_status();
 
+    if encrypted_inputs {
+        // Encrypt Input
+        let mut command = Command::new(CRYPTO_UTIL_BIN);
+        command
+            .arg("encrypt")
+            .args(["--input-file".as_ref(), inputs_file.as_os_str()])
+            .args(["--output-dir".as_ref(), path.as_os_str()])
+            .args(["--network".into(), dir.path().join("network.toml")])
+            .stdin(Stdio::piped());
+        command.status().unwrap_status();
+    }
+
     // Run IPA
     let mut command = Command::new(TEST_RC_BIN);
+    if !encrypted_inputs {
+        command.args(["--input-file".as_ref(), inputs_file.as_os_str()]);
+    }
     command
         .args(["--network".into(), dir.path().join("network.toml")])
-        .args(["--input-file".as_ref(), inputs_file.as_os_str()])
         .args(["--output-file".as_ref(), output_file.as_os_str()])
         .args(["--wait", "2"])
         .silent();
@@ -264,11 +289,26 @@ pub fn test_ipa_with_config(mode: IpaSecurityModel, https: bool, config: IpaQuer
     }
 
     let protocol = match mode {
-        IpaSecurityModel::SemiHonest => "semi-honest-oprf-ipa",
+        IpaSecurityModel::SemiHonest => {
+            if encrypted_inputs {
+                "semi-honest-oprf-ipa"
+            } else {
+                "oprf-ipa-test"
+            }
+        }
         IpaSecurityModel::Malicious => "malicious-oprf-ipa",
     };
+    command.arg(protocol);
+    if encrypted_inputs {
+        let enc1 = dir.path().join("helper1.enc");
+        let enc2 = dir.path().join("helper2.enc");
+        let enc3 = dir.path().join("helper3.enc");
+        command
+            .args(["--enc-input-file1".as_ref(), enc1.as_os_str()])
+            .args(["--enc-input-file2".as_ref(), enc2.as_os_str()])
+            .args(["--enc-input-file3".as_ref(), enc3.as_os_str()]);
+    }
     command
-        .arg(protocol)
         .args(["--max-breakdown-key", &config.max_breakdown_key.to_string()])
         .args([
             "--per-user-credit-cap",

--- a/ipa-core/tests/common/mod.rs
+++ b/ipa-core/tests/common/mod.rs
@@ -288,15 +288,11 @@ pub fn test_ipa_with_config(
         command.arg("--disable-https");
     }
 
-    let protocol = match mode {
-        IpaSecurityModel::SemiHonest => {
-            if encrypted_inputs {
-                "semi-honest-oprf-ipa"
-            } else {
-                "oprf-ipa-test"
-            }
-        }
-        IpaSecurityModel::Malicious => "malicious-oprf-ipa",
+    let protocol = match (mode, encrypted_inputs) {
+        (IpaSecurityModel::SemiHonest, true) => "semi-honest-oprf-ipa",
+        (IpaSecurityModel::SemiHonest, false) => "semi-honest-oprf-ipa-test",
+        (IpaSecurityModel::Malicious, true) => "malicious-oprf-ipa",
+        (IpaSecurityModel::Malicious, false) => "malicious-oprf-ipa-test",
     };
     command.arg(protocol);
     if encrypted_inputs {

--- a/ipa-core/tests/compact_gate.rs
+++ b/ipa-core/tests/compact_gate.rs
@@ -37,6 +37,7 @@ fn compact_gate_cap_8_no_window_malicious() {
     test_compact_gate(IpaSecurityModel::Malicious, 8, 0, true);
 }
 
+#[test]
 fn compact_gate_cap_8_no_window_semi_honest_plaintext_input() {
     test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0, false);
 }

--- a/ipa-core/tests/compact_gate.rs
+++ b/ipa-core/tests/compact_gate.rs
@@ -32,14 +32,20 @@ fn compact_gate_cap_8_no_window_semi_honest_encryped_input() {
 }
 
 #[test]
+fn compact_gate_cap_8_no_window_semi_honest_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0, false);
+}
+
+#[test]
 #[ignore] // TODO
-fn compact_gate_cap_8_no_window_malicious() {
+fn compact_gate_cap_8_no_window_malicious_encrypted_input() {
     test_compact_gate(IpaSecurityModel::Malicious, 8, 0, true);
 }
 
 #[test]
-fn compact_gate_cap_8_no_window_semi_honest_plaintext_input() {
-    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0, false);
+#[ignore] // TODO
+fn compact_gate_cap_8_no_window_malicious_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::Malicious, 8, 0, false);
 }
 
 #[test]

--- a/ipa-core/tests/compact_gate.rs
+++ b/ipa-core/tests/compact_gate.rs
@@ -12,6 +12,7 @@ fn test_compact_gate<I: TryInto<NonZeroU32>>(
     mode: IpaSecurityModel,
     per_user_credit_cap: u32,
     attribution_window_seconds: I,
+    encrypted_input: bool,
 ) {
     let config = IpaQueryConfig {
         per_user_credit_cap,
@@ -20,31 +21,52 @@ fn test_compact_gate<I: TryInto<NonZeroU32>>(
         ..Default::default()
     };
 
-    test_ipa_with_config(mode, false, config);
+    // test https with encrypted input
+    // and http with plaintest input
+    test_ipa_with_config(mode, encrypted_input, config, encrypted_input);
 }
 
 #[test]
-fn compact_gate_cap_8_no_window_semi_honest() {
-    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0);
+fn compact_gate_cap_8_no_window_semi_honest_encryped_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0, true);
 }
 
 #[test]
 #[ignore] // TODO
 fn compact_gate_cap_8_no_window_malicious() {
-    test_compact_gate(IpaSecurityModel::Malicious, 8, 0);
+    test_compact_gate(IpaSecurityModel::Malicious, 8, 0, true);
+}
+
+fn compact_gate_cap_8_no_window_semi_honest_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 0, false);
 }
 
 #[test]
-fn compact_gate_cap_8_with_window_semi_honest() {
-    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 86400);
+fn compact_gate_cap_8_with_window_semi_honest_encryped_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 86400, true);
 }
 
 #[test]
-fn compact_gate_cap_16_no_window_semi_honest() {
-    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 0);
+fn compact_gate_cap_8_with_window_semi_honest_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 8, 86400, false);
 }
 
 #[test]
-fn compact_gate_cap_16_with_window_semi_honest() {
-    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 86400);
+fn compact_gate_cap_16_no_window_semi_honest_encryped_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 0, true);
+}
+
+#[test]
+fn compact_gate_cap_16_no_window_semi_honest_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 0, false);
+}
+
+#[test]
+fn compact_gate_cap_16_with_window_semi_honest_encryped_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 86400, true);
+}
+
+#[test]
+fn compact_gate_cap_16_with_window_semi_honest_plaintext_input() {
+    test_compact_gate(IpaSecurityModel::SemiHonest, 16, 86400, false);
 }

--- a/ipa-core/tests/helper_networks.rs
+++ b/ipa-core/tests/helper_networks.rs
@@ -57,7 +57,7 @@ fn https_semi_honest_ipa() {
 #[test]
 #[cfg(all(test, web_test, not(feature = "compact-gate")))] // TODO: enable for compact gate
 fn https_malicious_ipa() {
-    test_ipa(IpaSecurityModel::Malicious, true);
+    test_ipa(IpaSecurityModel::Malicious, true, true);
 }
 
 /// Similar to [`network`] tests, but it uses keygen + confgen CLIs to generate helper client config

--- a/ipa-core/tests/helper_networks.rs
+++ b/ipa-core/tests/helper_networks.rs
@@ -45,13 +45,13 @@ fn http_network_large_input() {
 #[test]
 #[cfg(all(test, web_test))]
 fn http_semi_honest_ipa() {
-    test_ipa(IpaSecurityModel::SemiHonest, false);
+    test_ipa(IpaSecurityModel::SemiHonest, false, false);
 }
 
 #[test]
 #[cfg(all(test, web_test))]
 fn https_semi_honest_ipa() {
-    test_ipa(IpaSecurityModel::SemiHonest, true);
+    test_ipa(IpaSecurityModel::SemiHonest, true, true);
 }
 
 #[test]


### PR DESCRIPTION
Here's an initial draft for how we can allow for encrypted inputs in 3 distinct files.

It moves the old way of running it into a new command "oprf-ipa-test". One open question here is if we should remove the idea of plaintext vs encrypted match keys, since we now expect the full event to be encrypted for the encrypted code path.

This still needs tests, and a little clean up, but wanted to open this to get feedback on the overall approach.