### PR TITLE
 update feature flags for relaxed DP

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -183,7 +183,7 @@ async fn ipa(
     let query_type: QueryType;
     match (security_model, &query_style) {
         (IpaSecurityModel::SemiHonest, IpaQueryStyle::Oprf) => {
-            query_type = QueryType::OprfIpaRelaxedDpPadding(ipa_query_config);
+            query_type = QueryType::OprfIpa(ipa_query_config);
         }
         (IpaSecurityModel::Malicious, IpaQueryStyle::Oprf) => {
             panic!("OPRF for malicious is not implemented as yet")

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -198,8 +198,6 @@ pub enum QueryType {
     TestMultiply,
     #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
     TestAddInPrimeField,
-    #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
-    OprfIpaRelaxedDpPadding(IpaQueryConfig),
     OprfIpa(IpaQueryConfig),
 }
 
@@ -207,7 +205,6 @@ impl QueryType {
     /// TODO: strum
     pub const TEST_MULTIPLY_STR: &'static str = "test-multiply";
     pub const TEST_ADD_STR: &'static str = "test-add";
-    pub const OPRF_IPA_RELAXED_DP_PADDING_STR: &'static str = "oprf_ipa_relaxed_dp_padding";
     pub const OPRF_IPA_STR: &'static str = "oprf_ipa";
 }
 
@@ -219,8 +216,6 @@ impl AsRef<str> for QueryType {
             QueryType::TestMultiply => Self::TEST_MULTIPLY_STR,
             #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
             QueryType::TestAddInPrimeField => Self::TEST_ADD_STR,
-            #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-            QueryType::OprfIpaRelaxedDpPadding(_) => Self::OPRF_IPA_RELAXED_DP_PADDING_STR,
             QueryType::OprfIpa(_) => Self::OPRF_IPA_STR,
         }
     }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -122,11 +122,6 @@ pub mod query {
                 QueryType::TEST_MULTIPLY_STR => Ok(QueryType::TestMultiply),
                 #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
                 QueryType::TEST_ADD_STR => Ok(QueryType::TestAddInPrimeField),
-                #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-                QueryType::OPRF_IPA_RELAXED_DP_PADDING_STR => {
-                    let Query(q) = req.extract().await?;
-                    Ok(QueryType::OprfIpaRelaxedDpPadding(q))
-                }
                 QueryType::OPRF_IPA_STR => {
                     let Query(q) = req.extract().await?;
                     Ok(QueryType::OprfIpa(q))
@@ -153,27 +148,6 @@ pub mod query {
             match self.query_type {
                 #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
                 QueryType::TestMultiply | QueryType::TestAddInPrimeField => Ok(()),
-                #[cfg(any(test, feature = "test-fixture", feature = "cli"))]
-                QueryType::OprfIpaRelaxedDpPadding(config) => {
-                    write!(
-                        f,
-                        "&per_user_credit_cap={}&max_breakdown_key={}&with_dp={}&epsilon={}",
-                        config.per_user_credit_cap,
-                        config.max_breakdown_key,
-                        config.with_dp,
-                        config.epsilon,
-                    )?;
-
-                    if config.plaintext_match_keys {
-                        write!(f, "&plaintext_match_keys=true")?;
-                    }
-
-                    if let Some(window) = config.attribution_window_seconds {
-                        write!(f, "&attribution_window_seconds={}", window.get())?;
-                    }
-
-                    Ok(())
-                }
                 QueryType::OprfIpa(config) => {
                     write!(
                         f,

--- a/ipa-core/src/net/server/handlers/query/create.rs
+++ b/ipa-core/src/net/server/handlers/query/create.rs
@@ -90,7 +90,7 @@ mod tests {
     async fn create_test_ipa_no_attr_window() {
         create_test(
             QueryConfig::new(
-                QueryType::OprfIpaRelaxedDpPadding(IpaQueryConfig {
+                QueryType::OprfIpa(IpaQueryConfig {
                     per_user_credit_cap: 1,
                     max_breakdown_key: 1,
                     attribution_window_seconds: None,
@@ -108,26 +108,6 @@ mod tests {
 
     #[tokio::test]
     async fn create_test_ipa_no_attr_window_with_dp() {
-        create_test(
-            QueryConfig::new(
-                QueryType::OprfIpaRelaxedDpPadding(IpaQueryConfig {
-                    per_user_credit_cap: 8,
-                    max_breakdown_key: 20,
-                    attribution_window_seconds: None,
-                    with_dp: 1,
-                    epsilon: 5.0,
-                    plaintext_match_keys: true,
-                }),
-                FieldType::Fp32BitPrime,
-                1,
-            )
-            .unwrap(),
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn create_test_ipa_no_attr_window_with_dp_default_padding() {
         create_test(
             QueryConfig::new(
                 QueryType::OprfIpa(IpaQueryConfig {
@@ -151,7 +131,7 @@ mod tests {
         create_test(QueryConfig {
             size: 1.try_into().unwrap(),
             field_type: FieldType::Fp32BitPrime,
-            query_type: QueryType::OprfIpaRelaxedDpPadding(IpaQueryConfig {
+            query_type: QueryType::OprfIpa(IpaQueryConfig {
                 per_user_credit_cap: 1,
                 max_breakdown_key: 1,
                 attribution_window_seconds: NonZeroU32::new(86_400),
@@ -258,7 +238,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 field_type: format!("{:?}", FieldType::Fp32BitPrime),
-                query_type: QueryType::OPRF_IPA_RELAXED_DP_PADDING_STR.to_string(),
+                query_type: QueryType::OPRF_IPA_STR.to_string(),
                 per_user_credit_cap: "1".into(),
                 max_breakdown_key: "1".into(),
                 attribution_window_seconds: None,

--- a/ipa-core/src/query/executor.rs
+++ b/ipa-core/src/query/executor.rs
@@ -101,22 +101,6 @@ pub fn execute<R: PrivateKeyRegistry>(
         }
         // TODO(953): This is really using BA32, not Fp32bitPrime. The `FieldType` mechanism needs
         // to be reworked.
-        #[cfg(any(test, feature = "cli", feature = "test-fixture"))]
-        (QueryType::OprfIpaRelaxedDpPadding(ipa_config), FieldType::Fp32BitPrime) => do_query(
-            config,
-            gateway,
-            input,
-            move |prss, gateway, config, input| {
-                let ctx = SemiHonestContext::new(prss, gateway);
-                Box::pin(
-                    OprfIpaQuery::<BA32, R>::new(ipa_config, key_registry)
-                        .execute(ctx, config.size, input)
-                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
-                )
-            },
-        ),
-        // TODO(953): This is really using BA32, not Fp32bitPrime. The `FieldType` mechanism needs
-        // to be reworked.
         (QueryType::OprfIpa(ipa_config), FieldType::Fp32BitPrime) => do_query(
             config,
             gateway,
@@ -132,13 +116,8 @@ pub fn execute<R: PrivateKeyRegistry>(
         ),
         // TODO(953): This is not doing anything differently than the Fp32BitPrime case, except
         // using 16 bits for histogram values
-        #[cfg(any(
-            test,
-            feature = "cli",
-            feature = "test-fixture",
-            feature = "weak-field"
-        ))]
-        (QueryType::OprfIpaRelaxedDpPadding(ipa_config), FieldType::Fp31) => do_query(
+        #[cfg(any(test, feature = "weak-field"))]
+        (QueryType::OprfIpa(ipa_config), FieldType::Fp31) => do_query(
             config,
             gateway,
             input,
@@ -151,22 +130,6 @@ pub fn execute<R: PrivateKeyRegistry>(
                     )
                     .execute(ctx, config.size, input)
                     .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
-                )
-            },
-        ),
-        // TODO(953): This is really using BA32, not Fp32bitPrime. The `FieldType` mechanism needs
-        // to be reworked.
-        #[cfg(any(test, feature = "weak-field"))]
-        (QueryType::OprfIpa(ipa_config), FieldType::Fp31) => do_query(
-            config,
-            gateway,
-            input,
-            move |prss, gateway, config, input| {
-                let ctx = SemiHonestContext::new(prss, gateway);
-                Box::pin(
-                    OprfIpaQuery::<BA32, R>::new(ipa_config, key_registry)
-                        .execute(ctx, config.size, input)
-                        .then(|res| ready(res.map(|out| Box::new(out) as Box<dyn Result>))),
                 )
             },
         ),

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -677,7 +677,7 @@ mod tests {
                     QueryConfig {
                         size: record_count.try_into().unwrap(),
                         field_type: FieldType::Fp31,
-                        query_type: QueryType::OprfIpaRelaxedDpPadding(IpaQueryConfig {
+                        query_type: QueryType::OprfIpa(IpaQueryConfig {
                             per_user_credit_cap: 8,
                             max_breakdown_key: 3,
                             attribution_window_seconds: None,


### PR DESCRIPTION
simpler way to have a feature flag for relaxed padding DP parameters.  should fix draft crashing.  