### PR TITLE
align variable and struct naming

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -322,10 +322,10 @@ async fn ipa(
         &encrypted_inputs.enc_input_file3,
     ];
 
-    let encrypted_oprf_report_files = EncryptedOprfReportStreams::from(files);
+    let encrypted_oprf_report_streams = EncryptedOprfReportStreams::from(files);
 
     let query_config = QueryConfig {
-        size: QuerySize::try_from(encrypted_oprf_report_files.query_size).unwrap(),
+        size: QuerySize::try_from(encrypted_oprf_report_streams.query_size).unwrap(),
         field_type: FieldType::Fp32BitPrime,
         query_type,
     };
@@ -342,8 +342,8 @@ async fn ipa(
             // implementation, otherwise a runtime reconstruct error will be generated.
             // see ipa-core/src/query/executor.rs
             run_query_and_validate::<BA32>(
-                encrypted_oprf_report_files.streams,
-                encrypted_oprf_report_files.query_size,
+                encrypted_oprf_report_streams.streams,
+                encrypted_oprf_report_streams.query_size,
                 helper_clients,
                 query_id,
                 ipa_query_config,

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -605,7 +605,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
             output_dir.path().join("helper2.enc"),
             output_dir.path().join("helper3.enc"),
         ];
-        let encrypted_oprf_report_files = EncryptedOprfReportStreams::from(files);
+        let encrypted_oprf_report_streams = EncryptedOprfReportStreams::from(files);
 
         let world = TestWorld::default();
         let contexts = world.contexts();
@@ -621,7 +621,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
 
         #[allow(clippy::large_futures)]
         let results = join3v(
-            encrypted_oprf_report_files
+            encrypted_oprf_report_streams
                 .streams
                 .into_iter()
                 .zip(contexts)


### PR DESCRIPTION
missed this when renaming in the last PR. inconsequential but good to have names aligned.