### PR TITLE
Detect out-of-bounds step indices

### DIFF
--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -98,7 +98,7 @@ where
         ctx.parallel_join(zip(&**self, repeat(ctx.clone())).enumerate().map(
             |(i, (bit, ctx))| async move {
                 generic_reveal(
-                    ctx.narrow(&TwoHundredFiftySixBitOpStep::Bit(i)),
+                    ctx.narrow(&TwoHundredFiftySixBitOpStep::from(i)),
                     record_id,
                     excluded,
                     bit,

--- a/ipa-core/src/protocol/boolean/and.rs
+++ b/ipa-core/src/protocol/boolean/and.rs
@@ -51,7 +51,7 @@ where
 
     BitDecomposed::try_from(
         ctx.parallel_join(zip(a.iter(), b).enumerate().map(|(i, (a, b))| {
-            let ctx = ctx.narrow(&EightBitStep::Bit(i));
+            let ctx = ctx.narrow(&EightBitStep::from(i));
             a.multiply(b, ctx, record_id)
         }))
         .await?,

--- a/ipa-core/src/protocol/boolean/or.rs
+++ b/ipa-core/src/protocol/boolean/or.rs
@@ -52,7 +52,7 @@ where
 
     BitDecomposed::try_from(
         ctx.parallel_join(zip(a.iter(), b).enumerate().map(|(i, (a, b))| {
-            let ctx = ctx.narrow(&SixteenBitStep::Bit(i));
+            let ctx = ctx.narrow(&SixteenBitStep::from(i));
             async move {
                 let ab = a.multiply(b, ctx, record_id).await?;
                 Ok::<_, Error>(-ab + a + b)

--- a/ipa-core/src/protocol/boolean/step.rs
+++ b/ipa-core/src/protocol/boolean/step.rs
@@ -1,63 +1,22 @@
 use ipa_step_derive::CompactStep;
 
 #[derive(CompactStep)]
-pub enum EightBitStep {
-    #[step(count = 8)]
-    Bit(usize),
-}
-
-impl From<usize> for EightBitStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
-}
+#[step(count = 8, name = "bit")]
+pub struct EightBitStep(usize);
 
 #[derive(CompactStep)]
-pub enum SixteenBitStep {
-    #[step(count = 16)]
-    Bit(usize),
-}
-
-impl From<usize> for SixteenBitStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
-}
+#[step(count = 16, name = "bit")]
+pub struct SixteenBitStep(usize);
 
 #[derive(CompactStep)]
-pub enum ThirtyTwoBitStep {
-    #[step(count = 32)]
-    Bit(usize),
-}
-
-impl From<usize> for ThirtyTwoBitStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
-}
+#[step(count = 32, name = "bit")]
+pub struct ThirtyTwoBitStep(usize);
 
 #[derive(CompactStep)]
-pub enum TwoHundredFiftySixBitOpStep {
-    #[step(count = 256)]
-    Bit(usize),
-}
-
-impl From<usize> for TwoHundredFiftySixBitOpStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
-}
+#[step(count = 256, name = "bit")]
+pub struct TwoHundredFiftySixBitOpStep(usize);
 
 #[cfg(test)]
 #[derive(CompactStep)]
-pub enum DefaultBitStep {
-    #[step(count = 256)]
-    Bit(usize),
-}
-
-#[cfg(test)]
-impl From<usize> for DefaultBitStep {
-    fn from(v: usize) -> Self {
-        Self::Bit(v)
-    }
-}
+#[step(count = 256, name = "bit")]
+pub struct DefaultBitStep(usize);

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -234,8 +234,8 @@ where
         let stream = aggregation_input.by_ref().take(chunk);
         let validator = ctx.clone().dzkp_validator(
             MaliciousProtocolSteps {
-                protocol: &Step::AggregateChunk(chunk_counter),
-                validate: &Step::AggregateChunkValidate(chunk_counter),
+                protocol: &Step::aggregate_chunk(chunk_counter),
+                validate: &Step::aggregate_chunk_validate(chunk_counter),
             },
             agg_proof_chunk,
         );
@@ -333,7 +333,7 @@ where
         // number of outputs (`next_num_rows`) gets rounded up. If calculating an explicit total
         // records, that would get rounded down.
         let par_agg_ctx = ctx
-            .narrow(&AggregateChunkStep::Aggregate(depth))
+            .narrow(&AggregateChunkStep::from(depth))
             .set_total_records(TotalRecords::Indeterminate);
         let next_num_rows = (num_rows + 1) / 2;
         aggregated_stream = Box::pin(

--- a/ipa-core/src/protocol/ipa_prf/aggregation/step.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/step.rs
@@ -26,17 +26,9 @@ pub(crate) enum AggregationStep {
 #[step(count = 512, child = crate::protocol::boolean::step::EightBitStep, name = "b")]
 pub struct BucketStep(usize);
 
-impl From<usize> for BucketStep {
-    fn from(v: usize) -> Self {
-        Self(v)
-    }
-}
-
 #[derive(CompactStep)]
-pub(crate) enum AggregateChunkStep {
-    #[step(count = 32, child = AggregateValuesStep)]
-    Aggregate(usize),
-}
+#[step(count = 32, child = AggregateValuesStep, name = "depth")]
+pub(crate) struct AggregateChunkStep(usize);
 
 #[derive(CompactStep)]
 pub(crate) enum AggregateValuesStep {

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -1166,7 +1166,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "v < usize::try_from(64usize).unwrap()")]
+    #[should_panic(expected = "Step index 64 out of bounds for UserNthRowStep with count 64.")]
     fn attribution_too_many_records_per_user() {
         run(|| async move {
             let world = TestWorld::default();

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -899,6 +899,7 @@ pub mod tests {
             boolean_array::{BooleanArray, BA16, BA20, BA3, BA5, BA8},
             Field, U128Conversions,
         },
+        helpers::repeat_n,
         protocol::ipa_prf::prf_sharding::attribute_cap_aggregate,
         rand::Rng,
         secret_sharing::{
@@ -909,6 +910,7 @@ pub mod tests {
         test_fixture::{Reconstruct, Runner, TestWorld},
     };
 
+    #[derive(Clone)]
     struct PreShardedAndSortedOPRFTestInput<BK: SharedValue, TV: SharedValue, TS: SharedValue> {
         prf_of_match_key: u64,
         is_trigger_bit: Boolean,
@@ -1102,6 +1104,7 @@ pub mod tests {
             );
         });
     }
+
     #[test]
     fn semi_honest_aggregation_capping_attribution_with_attribution_window() {
         const ATTRIBUTION_WINDOW_SECONDS: u32 = 200;
@@ -1162,6 +1165,32 @@ pub mod tests {
         });
     }
 
+    #[test]
+    #[should_panic(expected = "v < usize::try_from(64usize).unwrap()")]
+    fn attribution_too_many_records_per_user() {
+        run(|| async move {
+            let world = TestWorld::default();
+
+            let records: Vec<PreShardedAndSortedOPRFTestInput<BA5, BA3, BA20>> =
+                repeat_n(oprf_test_input(123, false, 17, 0), 65).collect();
+
+            let histogram = repeat_n(1, 65).collect::<Vec<_>>();
+            let histogram_ref = histogram.as_slice();
+
+            world
+                .malicious(records.into_iter(), |ctx, input_rows| async move {
+                    attribute_cap_aggregate::<_, BA5, BA3, BA16, BA20, 5, 32>(
+                        ctx,
+                        input_rows,
+                        None,
+                        histogram_ref,
+                    )
+                    .await
+                    .unwrap()
+                })
+                .await;
+        });
+    }
     #[test]
     fn capping_bugfix() {
         const HISTOGRAM: [usize; 10] = [5, 5, 5, 5, 5, 5, 5, 2, 1, 1];

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/step.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/step.rs
@@ -1,16 +1,8 @@
 use ipa_step_derive::CompactStep;
 
 #[derive(CompactStep)]
-pub enum UserNthRowStep {
-    #[step(count = 64, child = AttributionPerRowStep)]
-    Row(usize),
-}
-
-impl From<usize> for UserNthRowStep {
-    fn from(v: usize) -> Self {
-        Self::Row(v)
-    }
-}
+#[step(count = 64, child = AttributionPerRowStep, name = "row")]
+pub struct UserNthRowStep(usize);
 
 #[derive(CompactStep)]
 pub(crate) enum AttributionStep {

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -171,8 +171,8 @@ where
             .expect("num_comparisons_needed should not be zero");
         let v = ctx.set_total_records(total_records).dzkp_validator(
             MaliciousProtocolSteps {
-                protocol: &Step::QuicksortPass(quicksort_pass),
-                validate: &Step::QuicksortPassValidate(quicksort_pass),
+                protocol: &Step::quicksort_pass(quicksort_pass),
+                validate: &Step::quicksort_pass_validate(quicksort_pass),
             },
             // TODO: use something like this when validating in chunks
             // `TARGET_PROOF_SIZE / usize::try_from(K::BITS).unwrap() / SORT_CHUNK``

--- a/ipa-step-derive/src/lib.rs
+++ b/ipa-step-derive/src/lib.rs
@@ -118,7 +118,7 @@ fn derive_step_impl(ast: &DeriveInput) -> Result<TokenStream, syn::Error> {
     let mut g = Generator::default();
     let attr = match &ast.data {
         Data::Enum(data) => {
-            for v in VariantAttribute::parse_variants(data)? {
+            for v in VariantAttribute::parse_variants(ident, data)? {
                 g.add_variant(&v);
             }
             VariantAttribute::parse_outer(ident, &ast.attrs, None)?
@@ -404,7 +404,10 @@ mod test {
 
                 impl ManyArms {
                     pub fn arm(v: u8) -> Self {
-                        assert!(v < u8::try_from(3usize).unwrap());
+                        assert!(
+                            v < u8::try_from(3usize).unwrap(),
+                            "Step index {v} out of bounds for ManyArms::Arm with count 3.",
+                        );
                         Self::Arm(v)
                     }
                 }
@@ -432,7 +435,7 @@ mod test {
                     fn base_index (& self) -> ::ipa_step::CompactGateIndex {
                         match self {
                             Self::Arm (i) if *i < u8::try_from(3usize).unwrap() => ::ipa_step::CompactGateIndex::try_from(*i).unwrap(),
-                            _ => panic!("Index out of range in ManyArms. Consider using bounds-checked step constructors."),
+                            Self::Arm (i) => panic!("Step index {i} out of bounds for ManyArms::Arm with count 3. Consider using bounds-checked step constructors."),
                         }
                     }
                     fn step_string(i: ::ipa_step::CompactGateIndex) -> String {
@@ -461,7 +464,10 @@ mod test {
 
                 impl ManyArms {
                     pub fn arm(v: u8) -> Self {
-                        assert!(v < u8::try_from(3usize).unwrap());
+                        assert!(
+                            v < u8::try_from(3usize).unwrap(),
+                            "Step index {v} out of bounds for ManyArms::Arm with count 3.",
+                        );
                         Self::Arm(v)
                     }
                 }
@@ -489,7 +495,7 @@ mod test {
                     fn base_index (& self) -> ::ipa_step::CompactGateIndex {
                         match self {
                             Self::Arm (i) if *i < u8::try_from(3usize).unwrap() => ::ipa_step::CompactGateIndex::try_from(*i).unwrap(),
-                            _ => panic!("Index out of range in ManyArms. Consider using bounds-checked step constructors."),
+                            Self::Arm (i) => panic!("Step index {i} out of bounds for ManyArms::Arm with count 3. Consider using bounds-checked step constructors."),
                         }
                     }
                     fn step_string(i: ::ipa_step::CompactGateIndex) -> String {
@@ -660,7 +666,10 @@ mod test {
 
                 impl Parent {
                     pub fn offspring(v: u8) -> Self {
-                        assert!(v < u8::try_from(5usize).unwrap());
+                        assert!(
+                            v < u8::try_from(5usize).unwrap(),
+                            "Step index {v} out of bounds for Parent::Offspring with count 5.",
+                        );
                         Self::Offspring(v)
                     }
                 }
@@ -690,7 +699,7 @@ mod test {
                     fn base_index(&self) -> ::ipa_step::CompactGateIndex {
                         match self {
                             Self::Offspring(i) if *i < u8::try_from(5usize).unwrap() => (<Child as ::ipa_step::CompactStep>::STEP_COUNT + 1) * ::ipa_step::CompactGateIndex::try_from(*i).unwrap(),
-                            _ => panic!("Index out of range in Parent. Consider using bounds-checked step constructors."),
+                            Self::Offspring(i) => panic!("Step index {i} out of bounds for Parent::Offspring with count 5. Consider using bounds-checked step constructors."),
                         }
                     }
                     fn step_string(i: ::ipa_step::CompactGateIndex) -> String {
@@ -751,7 +760,10 @@ mod test {
 
                 impl AllArms {
                     pub fn int(v: usize) -> Self {
-                        assert!(v < usize::try_from(3usize).unwrap());
+                        assert!(
+                            v < usize::try_from(3usize).unwrap(),
+                            "Step index {v} out of bounds for AllArms::Int with count 3.",
+                        );
                         Self::Int(v)
                     }
                 }
@@ -783,9 +795,9 @@ mod test {
                         match self {
                             Self::Empty => 0,
                             Self::Int(i) if *i < usize::try_from(3usize).unwrap() => ::ipa_step::CompactGateIndex::try_from(*i).unwrap() + 1,
+                            Self::Int(i) => panic!("Step index {i} out of bounds for AllArms::Int with count 3. Consider using bounds-checked step constructors."),
                             Self::Child => 4,
                             Self::Final => <::some::other::StepEnum as ::ipa_step::CompactStep>::STEP_COUNT + 5,
-                            _ => panic!("Index out of range in AllArms. Consider using bounds-checked step constructors."),
                         }
                     }
                     fn step_string(i: ::ipa_step::CompactGateIndex) -> String {
@@ -898,7 +910,10 @@ mod test {
 
                 impl From<u8> for StructInt {
                     fn from(v: u8) -> Self {
-                        assert!(v < u8::try_from(3usize).unwrap());
+                        assert!(
+                            v < u8::try_from(3usize).unwrap(),
+                            "Step index {v} out of bounds for StructInt with count 3.",
+                        );
                         Self(v)
                     }
                 }
@@ -927,7 +942,7 @@ mod test {
                     fn base_index(&self) -> ::ipa_step::CompactGateIndex {
                         match self {
                             Self(i) if *i < u8::try_from(3usize).unwrap() => ::ipa_step::CompactGateIndex::try_from(*i).unwrap(),
-                            _ => panic!("Index out of range in StructInt. Consider using bounds-checked step constructors."),
+                            Self(i) => panic!("Step index {i} out of bounds for StructInt with count 3. Consider using bounds-checked step constructors."),
                         }
                     }
 

--- a/ipa-step-test/src/lib.rs
+++ b/ipa-step-test/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
     /// (rather than produce an incorrect output gate).
     #[test]
     #[should_panic(
-        expected = "Index out of range in ComplexStep. Consider using bounds-checked step constructors."
+        expected = "Step index 10 out of bounds for ComplexStep::Two with count 10. Consider using bounds-checked step constructors."
     )]
     fn index_out_of_range() {
         _ = ComplexGate::default().narrow(&ComplexStep::Two(10));

--- a/ipa-step-test/src/lib.rs
+++ b/ipa-step-test/src/lib.rs
@@ -55,6 +55,16 @@ mod tests {
         _ = ComplexGate::from("/two2/one").narrow(&BasicStep::Two);
     }
 
+    /// Attempts to narrow with an out-of-range index should panic
+    /// (rather than produce an incorrect output gate).
+    #[test]
+    #[should_panic(
+        expected = "Index out of range in ComplexStep. Consider using bounds-checked step constructors."
+    )]
+    fn index_out_of_range() {
+        _ = ComplexGate::default().narrow(&ComplexStep::Two(10));
+    }
+
     /// Test that the alpha and beta gates work.
     #[test]
     fn alpha_and_beta() {


### PR DESCRIPTION
This does a few things:
* Adds (panicking) `From<int>` impls for tuple struct steps, converts a few single-variant-enum steps to tuple struct steps, and adds (also panicking) `Step::variant(int)` constructors for enum variant indexed steps.
* Adds a check for out-of-range index in the low-level `base_index` function in the generated compact gate code. The error message suggests using the bounds-checked constructors of the previous bullet. The tuple struct member is private, so can't be constructed directly, but in the enum variant case, we can't prevent constructing it directly with an out-of-range index.
* Adds tests for the preceding two items, and a test for the panic message when invoking attribution with more than 64 records per user.