### PR TITLE
New in the clear implementation for Hybrid

### DIFF
--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -1,0 +1,127 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq)]
+pub enum TestHybridRecord {
+    TestImpression { match_key: u64, breakdown_key: u32 },
+    TestConversion { match_key: u64, value: u32 },
+}
+
+pub fn hybrid_in_the_clear(input_rows: &[TestHybridRecord], max_breakdown: usize) -> Vec<u32> {
+    let mut conversion_match_keys = HashSet::<u64>::new();
+    let mut impression_match_keys = HashSet::<u64>::new();
+
+    for input in input_rows {
+        match input {
+            TestHybridRecord::TestImpression { match_key, .. } => {
+                impression_match_keys.insert(*match_key);
+            }
+            TestHybridRecord::TestConversion { match_key, .. } => {
+                conversion_match_keys.insert(*match_key);
+            }
+        }
+    }
+
+    let mut attributed_conversions = HashMap::<u64, (u32, u32), _>::new();
+
+    for input in input_rows {
+        match input {
+            TestHybridRecord::TestImpression {
+                match_key,
+                breakdown_key,
+            } => {
+                if let Some(_) = conversion_match_keys.get(match_key) {
+                    attributed_conversions
+                        .entry(*match_key)
+                        .and_modify(|e| e.0 = *breakdown_key)
+                        .or_insert((*breakdown_key, 0));
+                }
+            }
+            TestHybridRecord::TestConversion { match_key, value } => {
+                if let Some(_) = impression_match_keys.get(match_key) {
+                    attributed_conversions
+                        .entry(*match_key)
+                        .and_modify(|e| e.1 += value)
+                        .or_insert((0, *value));
+                }
+            }
+        }
+    }
+
+    let mut output = vec![0; max_breakdown];
+    for (_, (breakdown_key, value)) in attributed_conversions {
+        output[usize::try_from(breakdown_key).unwrap()] += value;
+    }
+
+    return output;
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use super::TestHybridRecord;
+    use crate::test_fixture::hybrid::hybrid_in_the_clear;
+
+    #[test]
+    fn basic() {
+        let test_data = vec![
+            TestHybridRecord::TestImpression {
+                match_key: 12345,
+                breakdown_key: 2,
+            },
+            TestHybridRecord::TestImpression {
+                match_key: 23456,
+                breakdown_key: 4,
+            },
+            TestHybridRecord::TestConversion {
+                match_key: 23456,
+                value: 25,
+            }, // attributed
+            TestHybridRecord::TestImpression {
+                match_key: 34567,
+                breakdown_key: 1,
+            },
+            TestHybridRecord::TestImpression {
+                match_key: 45678,
+                breakdown_key: 3,
+            },
+            TestHybridRecord::TestConversion {
+                match_key: 45678,
+                value: 13,
+            }, // attributed
+            TestHybridRecord::TestImpression {
+                match_key: 56789,
+                breakdown_key: 5,
+            },
+            TestHybridRecord::TestConversion {
+                match_key: 67890,
+                value: 14,
+            }, // NOT attributed
+            TestHybridRecord::TestImpression {
+                match_key: 78901,
+                breakdown_key: 2,
+            },
+            TestHybridRecord::TestConversion {
+                match_key: 78901,
+                value: 12,
+            }, // attributed
+            TestHybridRecord::TestConversion {
+                match_key: 78901,
+                value: 31,
+            }, // attributed
+            TestHybridRecord::TestImpression {
+                match_key: 89012,
+                breakdown_key: 4,
+            },
+            TestHybridRecord::TestConversion {
+                match_key: 89012,
+                value: 8,
+            }, // attributed
+        ];
+        let expected = vec![
+            0, 0, 43, // 12 + 31
+            13, 33, // 25 + 8
+            0,
+        ];
+        let result = hybrid_in_the_clear(&test_data, 6);
+        assert_eq!(result, expected);
+    }
+}

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -24,8 +24,8 @@ impl HashmapEntry {
 /// It won't, so long as you can convert a u32 to a usize
 #[must_use]
 pub fn hybrid_in_the_clear(input_rows: &[TestHybridRecord], max_breakdown: usize) -> Vec<u32> {
-    let mut conversion_match_keys = HashSet::<u64>::new();
-    let mut impression_match_keys = HashSet::<u64>::new();
+    let mut conversion_match_keys = HashSet::new();
+    let mut impression_match_keys = HashSet::new();
 
     for input in input_rows {
         match input {
@@ -39,7 +39,7 @@ pub fn hybrid_in_the_clear(input_rows: &[TestHybridRecord], max_breakdown: usize
     }
 
     // The key is the "match key" and the value stores both the breakdown and total attributed value
-    let mut attributed_conversions = HashMap::<u64, HashmapEntry, _>::new();
+    let mut attributed_conversions = HashMap::new();
 
     for input in input_rows {
         match input {
@@ -48,10 +48,10 @@ pub fn hybrid_in_the_clear(input_rows: &[TestHybridRecord], max_breakdown: usize
                 breakdown_key,
             } => {
                 if conversion_match_keys.contains(match_key) {
-                    attributed_conversions
+                    let v = attributed_conversions
                         .entry(*match_key)
-                        .and_modify(|e| e.breakdown_key = *breakdown_key)
                         .or_insert(HashmapEntry::new(*breakdown_key, 0));
+                    v.breakdown_key = *breakdown_key;
                 }
             }
             TestHybridRecord::TestConversion { match_key, value } => {

--- a/ipa-core/src/test_fixture/mod.rs
+++ b/ipa-core/src/test_fixture/mod.rs
@@ -12,6 +12,7 @@ mod app;
 pub mod circuit;
 mod event_gen;
 pub mod ipa;
+pub mod hybrid;
 pub mod logging;
 pub mod metrics;
 pub(crate) mod step;

--- a/ipa-core/src/test_fixture/mod.rs
+++ b/ipa-core/src/test_fixture/mod.rs
@@ -11,8 +11,8 @@ mod app;
 #[cfg(feature = "in-memory-infra")]
 pub mod circuit;
 mod event_gen;
-pub mod ipa;
 pub mod hybrid;
+pub mod ipa;
 pub mod logging;
 pub mod metrics;
 pub(crate) mod step;


### PR DESCRIPTION
To write tests for the "Hybrid" protocol, we need to compare the results generated to some kind of "ground truth" correct answer. This provides that.