### PR TITLE
Improve pre-commit runtime by running fewer checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Clippy
         if: ${{ success() || failure() }}
-        run: cargo clippy --tests
+        run: cargo clippy --features "cli test-fixture" --tests
 
       - name: Clippy concurrency tests
         if: ${{ success() || failure() }}

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -537,7 +537,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
 
     #[tokio::test]
     async fn encrypt_and_execute_query() {
-        const EXPECTED: &[u128] = &[0, 8, 5];
+        const EXPECTED: &[u128] = &[0, 2, 5];
 
         let records = vec![
             TestRawDataRecord {
@@ -567,20 +567,6 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
                 is_trigger_report: true,
                 breakdown_key: 0,
                 trigger_value: 2,
-            },
-            TestRawDataRecord {
-                timestamp: 20,
-                user_id: 68362,
-                is_trigger_report: false,
-                breakdown_key: 1,
-                trigger_value: 0,
-            },
-            TestRawDataRecord {
-                timestamp: 30,
-                user_id: 68362,
-                is_trigger_report: true,
-                breakdown_key: 1,
-                trigger_value: 7,
             },
         ];
         let query_size = QuerySize::try_from(records.len()).unwrap();

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -594,7 +594,12 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
 
         let output_dir = tempdir().unwrap();
         let network_file = write_network_file();
-        encrypt(&build_encrypt_args(input_file.path(), output_dir.path(), network_file.path())).unwrap();
+        encrypt(&build_encrypt_args(
+            input_file.path(),
+            output_dir.path(),
+            network_file.path(),
+        ))
+        .unwrap();
 
         let files = [
             &output_dir.path().join("helper1.enc"),

--- a/ipa-core/src/cli/crypto.rs
+++ b/ipa-core/src/cli/crypto.rs
@@ -539,7 +539,7 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
     async fn encrypt_and_execute_query() {
         const EXPECTED: &[u128] = &[0, 8, 5];
 
-        let records: Vec<TestRawDataRecord> = vec![
+        let records = vec![
             TestRawDataRecord {
                 timestamp: 0,
                 user_id: 12345,
@@ -587,62 +587,50 @@ public_key = "cfdbaaff16b30aa8a4ab07eaad2cdd80458208a1317aefbb807e46dce596617e"
         let mut input_file = NamedTempFile::new().unwrap();
 
         for event in records {
-            let _ = event.to_csv(input_file.as_file_mut());
+            event.to_csv(input_file.as_file_mut()).unwrap();
             writeln!(input_file.as_file()).unwrap();
         }
-        input_file.as_file_mut().flush().unwrap();
+        input_file.flush().unwrap();
 
         let output_dir = tempdir().unwrap();
         let network_file = write_network_file();
-        let encrypt_args =
-            build_encrypt_args(input_file.path(), output_dir.path(), network_file.path());
-        let _ = encrypt(&encrypt_args);
+        encrypt(&build_encrypt_args(input_file.path(), output_dir.path(), network_file.path())).unwrap();
 
         let files = [
             &output_dir.path().join("helper1.enc"),
             &output_dir.path().join("helper2.enc"),
             &output_dir.path().join("helper3.enc"),
         ];
-        let encrypted_oprf_report_streams = EncryptedOprfReportStreams::from(files);
 
         let world = TestWorld::default();
-        let contexts = world.contexts();
 
-        let mk_private_keys = vec![
-            hex::decode("53d58e022981f2edbf55fec1b45dbabd08a3442cb7b7c598839de5d7a5888bff")
-                .expect("manually provided for test"),
-            hex::decode("3a0a993a3cfc7e8d381addac586f37de50c2a14b1a6356d71e94ca2afaeb2569")
-                .expect("manually provided for test"),
-            hex::decode("1fb5c5274bf85fbe6c7935684ef05499f6cfb89ac21640c28330135cc0e8a0f7")
-                .expect("manually provided for test"),
+        let mk_private_keys = [
+            "53d58e022981f2edbf55fec1b45dbabd08a3442cb7b7c598839de5d7a5888bff",
+            "3a0a993a3cfc7e8d381addac586f37de50c2a14b1a6356d71e94ca2afaeb2569",
+            "1fb5c5274bf85fbe6c7935684ef05499f6cfb89ac21640c28330135cc0e8a0f7",
         ];
 
         #[allow(clippy::large_futures)]
         let results = join3v(
-            encrypted_oprf_report_streams
+            EncryptedOprfReportStreams::from(files)
                 .streams
                 .into_iter()
-                .zip(contexts)
-                .zip(mk_private_keys)
+                .zip(world.contexts())
+                .zip(mk_private_keys.into_iter())
                 .map(|((input, ctx), mk_private_key)| {
+                    let mk_private_key = hex::decode(mk_private_key)
+                        .map(|bytes| IpaPrivateKey::from_bytes(&bytes).unwrap())
+                        .unwrap();
                     let query_config = IpaQueryConfig {
-                        per_user_credit_cap: 8,
-                        attribution_window_seconds: None,
                         max_breakdown_key: 3,
                         with_dp: 0,
                         epsilon: 1.0,
-                        plaintext_match_keys: false,
+                        ..Default::default()
                     };
 
-                    let private_registry =
-                        Arc::new(KeyRegistry::<PrivateKeyOnly>::from_keys([PrivateKeyOnly(
-                            IpaPrivateKey::from_bytes(&mk_private_key)
-                                .expect("manually constructed for test"),
-                        )]));
-
-                    OprfIpaQuery::<_, BA16, KeyRegistry<PrivateKeyOnly>>::new(
+                    OprfIpaQuery::<_, BA16, _>::new(
                         query_config,
-                        private_registry,
+                        Arc::new(KeyRegistry::from_keys([PrivateKeyOnly(mk_private_key)])),
                     )
                     .execute(ctx, query_size, input)
                 }),

--- a/ipa-core/src/cli/playbook/input.rs
+++ b/ipa-core/src/cli/playbook/input.rs
@@ -203,13 +203,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "ParseIntError")]
     fn parse_negative() {
         Fp31::from_str("-1");
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "ParseIntError")]
     fn parse_empty() {
         Fp31::from_str("");
     }
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "ParseIntError")]
     fn tuple_parse_error() {
         <(Fp31, Fp31)>::from_str("20,");
     }

--- a/ipa-core/src/hpke/registry.rs
+++ b/ipa-core/src/hpke/registry.rs
@@ -93,13 +93,9 @@ impl<K> KeyRegistry<K> {
         Self { keys: Box::new([]) }
     }
 
-    pub fn from_keys<const N: usize, I: Into<K>>(pairs: [I; N]) -> Self {
+    pub fn from_keys<const N: usize>(pairs: [K; N]) -> Self {
         Self {
-            keys: pairs
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
+            keys: pairs.into_iter().collect::<Vec<_>>().into_boxed_slice(),
         }
     }
 

--- a/pre-commit
+++ b/pre-commit
@@ -82,40 +82,41 @@ check() {
     fi
 }
 
-check "Benchmark compilation" \
-    cargo build --benches --no-default-features --features "enable-benches compact-gate"
-
 check "Clippy checks" \
-    cargo clippy --tests -- -D warnings
-
-check "Clippy concurrency checks" \
-    cargo clippy --tests --features shuttle -- -D warnings
-
-check "Clippy web checks" \
-    cargo clippy --tests --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate" -- -D warnings
-
-# The tests here need to be kept in sync with scripts/coverage-ci.
+    cargo clippy --features="cli test-fixture" --tests -- -D warnings
 
 check "Tests" \
     cargo test --features="cli test-fixture"
 
-check "Web tests" \
-    cargo test -p ipa-core --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
-
-check "Web tests (descriptive gate)" \
-    cargo test -p ipa-core --no-default-features --features "cli web-app real-world-infra test-fixture"
-
-check "Concurrency tests" \
-    cargo test -p ipa-core --release --features "shuttle multi-threading"
-
-check "IPA benchmark" \
-    cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches compact-gate" -- -n 62 -c 16
-
-check "Arithmetic circuit benchmark" \
-    cargo bench --bench oneshot_arithmetic --no-default-features --features "enable-benches compact-gate"
-
 if [ -z "$EXEC_SLOW_TESTS" ]
 then
+
+  check "Benchmark compilation" \
+      cargo build --benches --no-default-features --features "enable-benches compact-gate"
+
+  check "Clippy concurrency checks" \
+      cargo clippy --tests --features shuttle -- -D warnings
+
+  check "Clippy web checks" \
+      cargo clippy --tests --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate" -- -D warnings
+
+  # The tests here need to be kept in sync with scripts/coverage-ci.
+
+  check "Web tests" \
+      cargo test -p ipa-core --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
+
+  check "Web tests (descriptive gate)" \
+      cargo test -p ipa-core --no-default-features --features "cli web-app real-world-infra test-fixture"
+
+  check "Concurrency tests" \
+      cargo test -p ipa-core --release --features "shuttle multi-threading"
+
+  check "IPA benchmark" \
+      cargo bench --bench oneshot_ipa --no-default-features --features="enable-benches compact-gate" -- -n 62 -c 16
+
+  check "Arithmetic circuit benchmark" \
+      cargo bench --bench oneshot_arithmetic --no-default-features --features "enable-benches compact-gate"
+
   check "Slow tests" \
       cargo test --release --test "*" --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
 fi


### PR DESCRIPTION
Our observation it takes 10+ minutes for all tests to pass and it is blocking people from working on other things. This change intends to keep only basic checks where we see the majority of failures: formatting, clippy and basic tests.

It is still possible to run all checks by setting  `EXEC_SLOW_TESTS` environment variable to 1