### PR TITLE
Fix pre-commit script

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -88,7 +88,7 @@ check "Clippy checks" \
 check "Tests" \
     cargo test --features="cli test-fixture"
 
-if [ -z "$EXEC_SLOW_TESTS" ]
+if [ -n "$EXEC_SLOW_TESTS" ]
 then
 
   check "Benchmark compilation" \


### PR DESCRIPTION
This fix makes pre-commit not to run checks behind environment variable flag if it is not set