### PR TITLE
Add a handler to kill a query

### DIFF
--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -203,6 +203,10 @@ impl RequestHandler for Inner {
                 let query_id = ext_query_id(&req)?;
                 HelperResponse::from(qp.complete(query_id).await?)
             }
+            RouteId::KillQuery => {
+                let query_id = ext_query_id(&req)?;
+                HelperResponse::from(qp.kill(query_id)?)
+            }
         })
     }
 }

--- a/ipa-core/src/helpers/transport/handler.rs
+++ b/ipa-core/src/helpers/transport/handler.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     query::{
         NewQueryError, PrepareQueryError, ProtocolResult, QueryCompletionError, QueryInputError,
-        QueryStatus, QueryStatusError,
+        QueryKillStatus, QueryKilled, QueryStatus, QueryStatusError,
     },
     sync::{Arc, Mutex, Weak},
 };
@@ -135,6 +135,13 @@ impl From<QueryStatus> for HelperResponse {
     }
 }
 
+impl From<QueryKilled> for HelperResponse {
+    fn from(value: QueryKilled) -> Self {
+        let v = serde_json::to_vec(&json!({"query_id": value.0, "status": "killed"})).unwrap();
+        Self { body: v }
+    }
+}
+
 impl<R: AsRef<dyn ProtocolResult>> From<R> for HelperResponse {
     fn from(value: R) -> Self {
         let v = value.as_ref().to_bytes();
@@ -155,6 +162,8 @@ pub enum Error {
     QueryCompletion(#[from] QueryCompletionError),
     #[error(transparent)]
     QueryStatus(#[from] QueryStatusError),
+    #[error(transparent)]
+    QueryKill(#[from] QueryKillStatus),
     #[error(transparent)]
     DeserializationFailure(#[from] serde_json::Error),
     #[error("MalformedRequest: {0}")]

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -119,7 +119,8 @@ impl<I: TransportIdentity> InMemoryTransport<I> {
                             | RouteId::PrepareQuery
                             | RouteId::QueryInput
                             | RouteId::QueryStatus
-                            | RouteId::CompleteQuery => {
+                            | RouteId::CompleteQuery
+                            | RouteId::KillQuery => {
                                 handler
                                     .as_ref()
                                     .expect("Handler is set")

--- a/ipa-core/src/helpers/transport/routing.rs
+++ b/ipa-core/src/helpers/transport/routing.rs
@@ -16,6 +16,7 @@ pub enum RouteId {
     QueryInput,
     QueryStatus,
     CompleteQuery,
+    KillQuery,
 }
 
 /// The header/metadata of the incoming request.

--- a/ipa-core/src/helpers/transport/stream/collection.rs
+++ b/ipa-core/src/helpers/transport/stream/collection.rs
@@ -114,6 +114,26 @@ impl<I: TransportIdentity, S: Stream> StreamCollection<I, S> {
         let mut streams = self.inner.lock().unwrap();
         streams.clear();
     }
+
+    /// Returns the number of streams inside this collection.
+    ///
+    /// ## Panics
+    /// if mutex is poisoned.
+    #[cfg(test)]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    /// Returns `true` if this collection is empty.
+    ///
+    /// ## Panics
+    /// if mutex is poisoned.
+    #[must_use]
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Describes the lifecycle of records stream inside [`StreamCollection`]

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -569,12 +569,12 @@ pub mod query {
 
         impl Request {
             /// see above for the reason why this needs to be behind a feature flag
-            #[cfg(all(test, not(feature = "shuttle")))]
+            #[cfg(all(test, unit_test))]
             pub fn new(query_id: QueryId) -> Self {
                 Self { query_id }
             }
 
-            #[cfg(all(test, not(feature = "shuttle")))]
+            #[cfg(all(test, unit_test))]
             pub fn try_into_http_request(
                 self,
                 scheme: axum::http::uri::Scheme,

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -542,7 +542,6 @@ pub mod query {
             protocol::QueryId,
         };
 
-        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         pub struct Request {
             pub query_id: QueryId,
         }
@@ -568,7 +567,12 @@ pub mod query {
         }
 
         impl Request {
-            /// see above for the reason why this needs to be behind a feature flag
+            /// Currently, it is only possible to kill
+            /// a query by issuing an HTTP request manually.
+            /// Maybe report collector can support this API,
+            /// but for now, only tests exercise this path
+            /// hence methods here are hidden behind feature
+            /// flags
             #[cfg(all(test, unit_test))]
             pub fn new(query_id: QueryId) -> Self {
                 Self { query_id }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -533,4 +533,78 @@ pub mod query {
 
         pub const AXUM_PATH: &str = "/:query_id/complete";
     }
+
+    pub mod kill {
+        use serde::{Deserialize, Serialize};
+
+        use crate::{
+            helpers::{routing::RouteId, HelperResponse, NoStep, RouteParams},
+            protocol::QueryId,
+        };
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+        pub struct Request {
+            pub query_id: QueryId,
+        }
+
+        impl RouteParams<RouteId, QueryId, NoStep> for Request {
+            type Params = String;
+
+            fn resource_identifier(&self) -> RouteId {
+                RouteId::KillQuery
+            }
+
+            fn query_id(&self) -> QueryId {
+                self.query_id
+            }
+
+            fn gate(&self) -> NoStep {
+                NoStep
+            }
+
+            fn extra(&self) -> Self::Params {
+                String::new()
+            }
+        }
+
+        impl Request {
+            /// see above for the reason why this needs to be behind a feature flag
+            #[cfg(all(test, not(feature = "shuttle")))]
+            pub fn new(query_id: QueryId) -> Self {
+                Self { query_id }
+            }
+
+            #[cfg(all(test, not(feature = "shuttle")))]
+            pub fn try_into_http_request(
+                self,
+                scheme: axum::http::uri::Scheme,
+                authority: axum::http::uri::Authority,
+            ) -> crate::net::http_serde::OutgoingRequest {
+                let uri = axum::http::uri::Uri::builder()
+                    .scheme(scheme)
+                    .authority(authority)
+                    .path_and_query(format!(
+                        "{}/{}/kill",
+                        crate::net::http_serde::query::BASE_AXUM_PATH,
+                        self.query_id.as_ref()
+                    ))
+                    .build()?;
+                Ok(hyper::Request::get(uri).body(axum::body::Body::empty())?)
+            }
+        }
+
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        pub struct ResponseBody {
+            pub query_id: QueryId,
+            pub status: String,
+        }
+
+        impl From<HelperResponse> for ResponseBody {
+            fn from(value: HelperResponse) -> Self {
+                serde_json::from_slice(value.into_body().as_slice()).unwrap()
+            }
+        }
+
+        pub const AXUM_PATH: &str = "/:query_id/kill";
+    }
 }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -589,7 +589,7 @@ pub mod query {
                         self.query_id.as_ref()
                     ))
                     .build()?;
-                Ok(hyper::Request::get(uri).body(axum::body::Body::empty())?)
+                Ok(hyper::Request::post(uri).body(axum::body::Body::empty())?)
             }
         }
 

--- a/ipa-core/src/net/server/handlers/query/kill.rs
+++ b/ipa-core/src/net/server/handlers/query/kill.rs
@@ -1,0 +1,104 @@
+use axum::{extract::Path, routing::get, Extension, Json, Router};
+use hyper::StatusCode;
+
+use crate::{
+    helpers::{ApiError, BodyStream, Transport},
+    net::{
+        http_serde::query::{kill, kill::Request},
+        server::Error,
+        Error::QueryIdNotFound,
+        HttpTransport,
+    },
+    protocol::QueryId,
+    query::QueryKillStatus,
+    sync::Arc,
+};
+
+async fn handler(
+    transport: Extension<Arc<HttpTransport>>,
+    Path(query_id): Path<QueryId>,
+) -> Result<Json<kill::ResponseBody>, Error> {
+    let req = Request { query_id };
+    let transport = Transport::clone_ref(&*transport);
+    match transport.dispatch(req, BodyStream::empty()).await {
+        Ok(state) => Ok(Json(kill::ResponseBody::from(state))),
+        Err(ApiError::QueryKill(QueryKillStatus::NoSuchQuery(query_id))) => Err(
+            Error::application(StatusCode::NOT_FOUND, QueryIdNotFound(query_id)),
+        ),
+        Err(e) => Err(Error::application(StatusCode::INTERNAL_SERVER_ERROR, e)),
+    }
+}
+
+pub fn router(transport: Arc<HttpTransport>) -> Router {
+    Router::new()
+        .route(kill::AXUM_PATH, get(handler))
+        .layer(Extension(transport))
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use axum::{
+        body::Body,
+        http::uri::{Authority, Scheme},
+    };
+    use hyper::StatusCode;
+
+    use crate::{
+        helpers::{
+            make_owned_handler,
+            routing::{Addr, RouteId},
+            BodyStream, HelperIdentity, HelperResponse,
+        },
+        net::{
+            http_serde,
+            server::handlers::query::test_helpers::{assert_fails_with, assert_success_with},
+        },
+        protocol::QueryId,
+        query::QueryKilled,
+    };
+
+    #[tokio::test]
+    async fn calls_kill() {
+        let expected_query_id = QueryId;
+
+        let handler = make_owned_handler(
+            move |addr: Addr<HelperIdentity>, _data: BodyStream| async move {
+                let RouteId::KillQuery = addr.route else {
+                    panic!("unexpected call: {addr:?}");
+                };
+                assert_eq!(addr.query_id, Some(expected_query_id));
+                Ok(HelperResponse::from(QueryKilled(expected_query_id)))
+            },
+        );
+
+        let req = http_serde::query::kill::Request::new(QueryId);
+        let req = req
+            .try_into_http_request(Scheme::HTTP, Authority::from_static("localhost"))
+            .unwrap();
+        assert_success_with(req, handler).await;
+    }
+
+    struct OverrideReq {
+        query_id: String,
+    }
+
+    impl From<OverrideReq> for hyper::Request<Body> {
+        fn from(val: OverrideReq) -> Self {
+            let uri = format!(
+                "http://localhost{}/{}/kill",
+                http_serde::query::BASE_AXUM_PATH,
+                val.query_id
+            );
+            hyper::Request::get(uri).body(Body::empty()).unwrap()
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_query_id() {
+        let req = OverrideReq {
+            query_id: "not-a-query-id".into(),
+        };
+
+        assert_fails_with(req.into(), StatusCode::BAD_REQUEST).await;
+    }
+}

--- a/ipa-core/src/net/server/handlers/query/kill.rs
+++ b/ipa-core/src/net/server/handlers/query/kill.rs
@@ -1,4 +1,4 @@
-use axum::{extract::Path, routing::get, Extension, Json, Router};
+use axum::{extract::Path, routing::post, Extension, Json, Router};
 use hyper::StatusCode;
 
 use crate::{
@@ -31,7 +31,7 @@ async fn handler(
 
 pub fn router(transport: Arc<HttpTransport>) -> Router {
     Router::new()
-        .route(kill::AXUM_PATH, get(handler))
+        .route(kill::AXUM_PATH, post(handler))
         .layer(Extension(transport))
 }
 
@@ -89,7 +89,7 @@ mod tests {
                 http_serde::query::BASE_AXUM_PATH,
                 val.query_id
             );
-            hyper::Request::get(uri).body(Body::empty()).unwrap()
+            hyper::Request::post(uri).body(Body::empty()).unwrap()
         }
     }
 

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -141,6 +141,19 @@ pub mod test_helpers {
         assert_eq!(resp.status(), expected_status);
     }
 
+    pub async fn assert_fails_with_handler(
+        req: hyper::Request<Body>,
+        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
+        expected_status: StatusCode,
+    ) {
+        let test_server = TestServer::builder()
+            .with_request_handler(handler)
+            .build()
+            .await;
+        let resp = test_server.server.handle_req(req).await;
+        assert_eq!(resp.status(), expected_status);
+    }
+
     pub async fn assert_success_with(
         req: hyper::Request<Body>,
         handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -1,5 +1,6 @@
 mod create;
 mod input;
+mod kill;
 mod prepare;
 mod results;
 mod status;
@@ -31,6 +32,7 @@ pub fn query_router(transport: Arc<HttpTransport>) -> Router {
         .merge(create::router(Arc::clone(&transport)))
         .merge(input::router(Arc::clone(&transport)))
         .merge(status::router(Arc::clone(&transport)))
+        .merge(kill::router(Arc::clone(&transport)))
         .merge(results::router(transport))
 }
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -273,10 +273,7 @@ mod tests {
 
     use bytes::Bytes;
     use futures::stream::{poll_immediate, StreamExt};
-    use futures_util::{
-        future::{join_all, try_join_all},
-        stream,
-    };
+    use futures_util::future::{join_all, try_join_all};
     use generic_array::GenericArray;
     use once_cell::sync::Lazy;
     use tokio::sync::mpsc::channel;
@@ -290,14 +287,12 @@ mod tests {
         helpers::{
             make_owned_handler,
             query::{QueryInput, QueryType::TestMultiply},
-            HandlerBox,
         },
         net::{
             client::ClientIdentity,
             test::{get_test_identity, TestConfig, TestConfigBuilder, TestServer},
         },
         secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
-        test_executor::run,
         test_fixture::Reconstruct,
         AppConfig, AppSetup, HelperApp,
     };
@@ -306,12 +301,12 @@ mod tests {
 
     #[tokio::test]
     async fn clean_on_kill() {
-        let noop_handler = make_owned_handler(|addr, stream| async move {
+        let noop_handler = make_owned_handler(|_, _| async move {
             {
                 Ok(HelperResponse::ok())
             }
         });
-        let TestServer { mut transport, .. } = TestServer::builder()
+        let TestServer { transport, .. } = TestServer::builder()
             .with_request_handler(Arc::clone(&noop_handler))
             .build()
             .await;

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -135,7 +135,7 @@ impl HttpTransport {
             .expect("A Handler should be set by now")
             .handle(Addr::from_route(None, req), body);
 
-        if let RouteId::CompleteQuery = route_id {
+        if let RouteId::CompleteQuery | RouteId::KillQuery = route_id {
             ClearOnDrop {
                 transport: Arc::clone(&self),
                 inner: r,
@@ -210,7 +210,8 @@ impl Transport for Arc<HttpTransport> {
             evt @ (RouteId::QueryInput
             | RouteId::ReceiveQuery
             | RouteId::QueryStatus
-            | RouteId::CompleteQuery) => {
+            | RouteId::CompleteQuery
+            | RouteId::KillQuery) => {
                 unimplemented!(
                     "attempting to send client-specific request {evt:?} to another helper"
                 )
@@ -272,7 +273,10 @@ mod tests {
 
     use bytes::Bytes;
     use futures::stream::{poll_immediate, StreamExt};
-    use futures_util::future::{join_all, try_join_all};
+    use futures_util::{
+        future::{join_all, try_join_all},
+        stream,
+    };
     use generic_array::GenericArray;
     use once_cell::sync::Lazy;
     use tokio::sync::mpsc::channel;
@@ -283,17 +287,48 @@ mod tests {
     use crate::{
         config::{NetworkConfig, ServerConfig},
         ff::{FieldType, Fp31, Serializable},
-        helpers::query::{QueryInput, QueryType::TestMultiply},
+        helpers::{
+            make_owned_handler,
+            query::{QueryInput, QueryType::TestMultiply},
+            HandlerBox,
+        },
         net::{
             client::ClientIdentity,
             test::{get_test_identity, TestConfig, TestConfigBuilder, TestServer},
         },
         secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
+        test_executor::run,
         test_fixture::Reconstruct,
         AppConfig, AppSetup, HelperApp,
     };
 
     static STEP: Lazy<Gate> = Lazy::new(|| Gate::from("http-transport"));
+
+    #[tokio::test]
+    async fn clean_on_kill() {
+        let noop_handler = make_owned_handler(|addr, stream| async move {
+            {
+                Ok(HelperResponse::ok())
+            }
+        });
+        let TestServer { mut transport, .. } = TestServer::builder()
+            .with_request_handler(Arc::clone(&noop_handler))
+            .build()
+            .await;
+
+        transport.record_streams.add_stream(
+            (QueryId, HelperIdentity::ONE, Gate::default()),
+            BodyStream::empty(),
+        );
+        assert_eq!(1, transport.record_streams.len());
+
+        Transport::clone_ref(&transport)
+            .dispatch((RouteId::KillQuery, QueryId), BodyStream::empty())
+            .await
+            .unwrap();
+
+        assert!(transport.record_streams.is_empty());
+    }
 
     #[tokio::test]
     async fn receive_stream() {

--- a/ipa-core/src/query/mod.rs
+++ b/ipa-core/src/query/mod.rs
@@ -8,7 +8,7 @@ use completion::Handle as CompletionHandle;
 pub use executor::Result as ProtocolResult;
 pub use processor::{
     NewQueryError, PrepareQueryError, Processor as QueryProcessor, QueryCompletionError,
-    QueryInputError, QueryStatusError,
+    QueryInputError, QueryKillStatus, QueryKilled, QueryStatusError,
 };
 pub use runner::OprfIpaQuery;
 pub use state::QueryStatus;

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use futures::{future::try_join, stream};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::{
     error::Error as ProtocolError,
@@ -352,7 +352,7 @@ impl Processor {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize)]
 pub struct QueryKilled(pub QueryId);
 
 #[derive(thiserror::Error, Debug)]

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use futures::{future::try_join, stream};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     error::Error as ProtocolError,
@@ -328,6 +329,36 @@ impl Processor {
 
         Ok(handle.await?)
     }
+
+    /// Terminates a query with the given id. If query is running, then it
+    /// is unregistered and its task is terminated.
+    ///
+    /// ## Errors
+    /// if query is not registered on this helper.
+    ///
+    /// ## Panics
+    /// If failed to obtain exclusive access to the query collection.
+    pub fn kill(&self, query_id: QueryId) -> Result<QueryKilled, QueryKillStatus> {
+        let mut queries = self.queries.inner.lock().unwrap();
+        let Some(state) = queries.remove(&query_id) else {
+            return Err(QueryKillStatus::NoSuchQuery(query_id));
+        };
+
+        if let QueryState::Running(handle) = state {
+            handle.join_handle.abort();
+        }
+
+        Ok(QueryKilled(query_id))
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryKilled(pub QueryId);
+
+#[derive(thiserror::Error, Debug)]
+pub enum QueryKillStatus {
+    #[error("failed to kill a query: {0} does not exist.")]
+    NoSuchQuery(QueryId),
 }
 
 #[cfg(all(test, unit_test))]
@@ -546,6 +577,102 @@ mod tests {
                 processor.prepare(&transport, req),
                 Err(PrepareQueryError::AlreadyRunning)
             ));
+        }
+    }
+
+    mod kill {
+        use std::sync::Arc;
+
+        use crate::{
+            ff::FieldType,
+            helpers::{
+                query::{
+                    QueryConfig,
+                    QueryType::{TestAddInPrimeField, TestMultiply},
+                },
+                HandlerBox, HelperIdentity, InMemoryMpcNetwork, Transport,
+            },
+            protocol::QueryId,
+            query::{
+                processor::{tests::respond_ok, Processor},
+                state::{QueryState, RunningQuery},
+                QueryKillStatus,
+            },
+            test_executor::run,
+        };
+
+        #[test]
+        fn non_existent_query() {
+            let processor = Processor::default();
+            assert!(matches!(
+                processor.kill(QueryId),
+                Err(QueryKillStatus::NoSuchQuery(QueryId))
+            ));
+        }
+
+        #[test]
+        fn existing_query() {
+            run(|| async move {
+                let h2 = respond_ok();
+                let h3 = respond_ok();
+                let network = InMemoryMpcNetwork::new([
+                    None,
+                    Some(HandlerBox::owning_ref(&h2)),
+                    Some(HandlerBox::owning_ref(&h3)),
+                ]);
+                let identities = HelperIdentity::make_three();
+                let processor = Processor::default();
+                let transport = network.transport(identities[0]);
+                processor
+                    .new_query(
+                        Transport::clone_ref(&transport),
+                        QueryConfig::new(TestMultiply, FieldType::Fp31, 1).unwrap(),
+                    )
+                    .await
+                    .unwrap();
+
+                processor.kill(QueryId).unwrap();
+
+                // start query again - it should work because the query was killed
+                processor
+                    .new_query(
+                        transport,
+                        QueryConfig::new(TestAddInPrimeField, FieldType::Fp32BitPrime, 1).unwrap(),
+                    )
+                    .await
+                    .unwrap();
+            });
+        }
+
+        #[test]
+        fn aborts_protocol_task() {
+            run(|| async move {
+                let processor = Processor::default();
+                let (_tx, rx) = tokio::sync::oneshot::channel();
+                let counter = Arc::new(1);
+                let task = tokio::spawn({
+                    let counter = Arc::clone(&counter);
+                    async move {
+                        loop {
+                            tokio::task::yield_now().await;
+                            let _ = *counter.as_ref();
+                        }
+                    }
+                });
+                processor.queries.inner.lock().unwrap().insert(
+                    QueryId,
+                    QueryState::Running(RunningQuery {
+                        result: rx,
+                        join_handle: task,
+                    }),
+                );
+
+                assert_eq!(2, Arc::strong_count(&counter));
+                processor.kill(QueryId).unwrap();
+                while Arc::strong_count(&counter) > 1 {
+                    tokio::task::yield_now().await;
+                }
+            });
         }
     }
 


### PR DESCRIPTION
In our testing with external parties, it became quite evident that bouncing helpers if query fails is far from having good experience for people who run the test. We need to have an ability to kill queries that failed on one or more helper and restart the runs.

This change does exactly that - adding a `/query_id/kill` handler that will respond with immediately aborting the task that runs an IPA query.

### How to terminate a query?

if helper address is `helper.com`, one can terminate a query by sending a POST request to 

```
http(s)://helper.com/query/0/kill
```

For local testing it can be done easily with `curl`

```
curl -X POST http://localhost:3002/query/0/kill
```

if query is killed successfully, the following response is provided by the helper

```json
{"query_id":"0","status":"killed"}
```