### PR TITLE
Increase number of steps for DZKP proof to 600 from 192

### DIFF
--- a/ipa-core/src/protocol/context/step.rs
+++ b/ipa-core/src/protocol/context/step.rs
@@ -31,7 +31,7 @@ pub(crate) enum ValidateStep {
 // This really is only for DZKPs and not for MACs. The MAC protocol uses record IDs to
 // count batches. DZKP probably should do the same to avoid the fixed upper limit.
 #[derive(CompactStep)]
-#[step(count = 192, child = DzkpValidationProtocolStep)]
+#[step(count = 600, child = DzkpValidationProtocolStep)]
 pub(crate) struct DzkpBatchStep(pub usize);
 
 // This is used when we don't do batched verification, to avoid paying for x256 as many

--- a/ipa-core/src/protocol/ipa_prf/aggregation/step.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/step.rs
@@ -12,15 +12,7 @@ pub(crate) enum AggregationStep {
     RevealStep,
     #[step(child = AggregateChunkStep)]
     SumContributions,
-    #[step(child = crate::protocol::context::step::DzkpBatchStep)]
-    AggregateValidate,
 }
-
-/// the number of steps must be kept in sync with `MAX_BREAKDOWNS` defined
-/// [here](https://tinyurl.com/mwnbbnj6)
-#[derive(CompactStep)]
-#[step(count = 512, child = crate::protocol::boolean::step::EightBitStep, name = "b")]
-pub struct BucketStep(usize);
 
 #[derive(CompactStep)]
 #[step(count = 32, child = AggregateValuesStep, name = "depth")]

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -744,7 +744,7 @@ mod compact_gate_tests {
     fn step_count_limit() {
         // This is an arbitrary limit intended to catch changes that unintentionally
         // blow up the step count. It can be increased, within reason.
-        const STEP_COUNT_LIMIT: u32 = 20_000;
+        const STEP_COUNT_LIMIT: u32 = 24_000;
         assert!(
             ProtocolStep::STEP_COUNT < STEP_COUNT_LIMIT,
             "Step count of {actual} exceeds limit of {STEP_COUNT_LIMIT}.",

--- a/ipa-core/src/protocol/step.rs
+++ b/ipa-core/src/protocol/step.rs
@@ -31,16 +31,6 @@ impl<'de> serde::Deserialize<'de> for ProtocolGate {
 
 #[derive(CompactStep)]
 pub enum DeadCodeStep {
-    #[step(child = crate::protocol::basics::step::CheckZeroStep)]
-    CheckZero,
-    #[step(child = crate::protocol::basics::mul::step::MaliciousMultiplyStep)]
-    MaliciousMultiply,
-    #[step(child = crate::protocol::context::step::UpgradeStep)]
-    UpgradeShare,
-    #[step(child = crate::protocol::context::step::MaliciousProtocolStep)]
-    MaliciousProtocol,
-    #[step(child = crate::protocol::context::step::ValidateStep)]
-    MaliciousValidation,
     #[step(child = crate::protocol::ipa_prf::boolean_ops::step::SaturatedSubtractionStep)]
     SaturatedSubtraction,
     #[step(child = crate::protocol::ipa_prf::prf_sharding::step::FeatureLabelDotProductStep)]


### PR DESCRIPTION
Running Draft on 50M records revealed that we don't have sufficient number of steps for zero-knowledge proof runs.

I tried to keep the step limit under 20k, so I did some cleanup as well, but I think I failed and I had to bump it.