### PR TITLE
Pinning shuffle futures that are too large for Shuttle

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -7,3 +7,5 @@ disallowed-methods = [
   { path = "std::mem::ManuallyDrop::new", reason = "Not running the destructors on futures created inside seq_join module will cause UB in IPA. Make sure you don't leak any of those." },
   { path = "std::vec::Vec::leak", reason = "Not running the destructors on futures created inside seq_join module will cause UB in IPA. Make sure you don't leak any of those." },
 ]
+
+future-size-threshold = 8192

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -972,7 +972,7 @@ mod tests {
         test_select_malicious::<BA20>().await;
         test_select_malicious::<BA32>().await;
         test_select_malicious::<BA64>().await;
-        test_select_malicious::<BA256>().await;
+        Box::pin(test_select_malicious::<BA256>()).await;
     }
 
     #[tokio::test]

--- a/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
@@ -62,9 +62,9 @@ where
     let zs = generate_random_tables_with_peers(shares_len, &ctx_z);
 
     match ctx.role() {
-        Role::H1 => run_h1(&ctx, shares_len, shares, zs).await,
-        Role::H2 => run_h2(&ctx, shares_len, shares, zs).await,
-        Role::H3 => run_h3(&ctx, shares_len, zs).await,
+        Role::H1 => Box::pin(run_h1(&ctx, shares_len, shares, zs)).await,
+        Role::H2 => Box::pin(run_h2(&ctx, shares_len, shares, zs)).await,
+        Role::H3 => Box::pin(run_h3(&ctx, shares_len, zs)).await,
     }
 }
 


### PR DESCRIPTION
This code was written to address a failure observed in `protocol::ipa_prf::aggregation::breakdown_reveal::tests::semi_honest_happy_path` tests. After some investigating I realized the issue only manifested when using the Shuttle crate (not the `multithreading` feature). Shuttle sets a [limit on the stack of 32kb](https://github.com/awslabs/shuttle/blob/main/src/lib.rs#L248) instead of the usual 2MBs.

Instead of just increasing that threshold, I used a few tools (Like the crate [TopTypeSizes](https://docs.rs/top-type-sizes/latest/top_type_sizes/) and [size_of_val](https://doc.rust-lang.org/std/mem/fn.size_of_val.html)) to analize what types could be causing the stack to grow too large, focusing on Futures which tend to be the culprits in these cases. The root stems from `shuffle_protocol` and to address the problem I moved the future to a `Box`. Moreover, we expect to move to Sharded Shuffle which follows a different code path.