### PR TITLE
Fix send buffer misalignment [No 2]

### DIFF
--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -86,6 +86,7 @@ impl Args {
         self.active_work
             .map(NonZeroUsize::get)
             .unwrap_or_else(|| self.query_size.clamp(16, 1024))
+            .next_power_of_two()
     }
 
     fn attribution_window(&self) -> Option<NonZeroU32> {

--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, sync::Weak};
+use std::sync::Weak;
 
 use async_trait::async_trait;
 
@@ -13,17 +13,18 @@ use crate::{
     protocol::QueryId,
     query::{NewQueryError, QueryProcessor, QueryStatus},
     sync::Arc,
+    utils::NonZeroU32PowerOfTwo,
 };
 
 #[derive(Default)]
 pub struct AppConfig {
-    active_work: Option<NonZeroUsize>,
+    active_work: Option<NonZeroU32PowerOfTwo>,
     key_registry: Option<KeyRegistry<PrivateKeyOnly>>,
 }
 
 impl AppConfig {
     #[must_use]
-    pub fn with_active_work(mut self, active_work: Option<NonZeroUsize>) -> Self {
+    pub fn with_active_work(mut self, active_work: Option<NonZeroU32PowerOfTwo>) -> Self {
         self.active_work = active_work;
         self
     }

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -2,7 +2,6 @@ use std::{
     fs,
     io::BufReader,
     net::TcpListener,
-    num::NonZeroUsize,
     os::fd::{FromRawFd, RawFd},
     path::{Path, PathBuf},
     process,
@@ -18,7 +17,7 @@ use ipa_core::{
     error::BoxError,
     helpers::HelperIdentity,
     net::{ClientIdentity, HttpShardTransport, HttpTransport, MpcHelperClient},
-    AppConfig, AppSetup,
+    AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tracing::{error, info};
 
@@ -93,7 +92,7 @@ struct ServerArgs {
 
     /// Override the amount of active work processed in parallel
     #[arg(long)]
-    active_work: Option<NonZeroUsize>,
+    active_work: Option<NonZeroU32PowerOfTwo>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/ipa-core/src/helpers/gateway/send.rs
+++ b/ipa-core/src/helpers/gateway/send.rs
@@ -436,6 +436,7 @@ mod test {
         read_size: usize,
         record_size: usize,
     ) {
+        #[allow(clippy::needless_update)] // stall detection feature wants default value
         let gateway_config = GatewayConfig {
             active: active.next_power_of_two().try_into().unwrap(),
             read_size: read_size.try_into().unwrap(),

--- a/ipa-core/src/helpers/gateway/send.rs
+++ b/ipa-core/src/helpers/gateway/send.rs
@@ -286,7 +286,7 @@ impl SendChannelConfig {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 mod test {
     use std::num::NonZeroUsize;
 

--- a/ipa-core/src/helpers/gateway/stall_detection.rs
+++ b/ipa-core/src/helpers/gateway/stall_detection.rs
@@ -67,7 +67,6 @@ impl<T: ObserveState> Observed<T> {
 }
 
 mod gateway {
-    use std::num::NonZeroUsize;
 
     use delegate::delegate;
 
@@ -81,6 +80,7 @@ mod gateway {
         protocol::QueryId,
         sharding::ShardIndex,
         sync::Arc,
+        utils::NonZeroU32PowerOfTwo,
     };
 
     pub struct InstrumentedGateway {
@@ -154,7 +154,7 @@ mod gateway {
             &self,
             channel_id: &HelperChannelId,
             total_records: TotalRecords,
-            active_work: NonZeroUsize,
+            active_work: NonZeroU32PowerOfTwo,
         ) -> SendingEnd<Role, M> {
             Observed::wrap(
                 Weak::clone(self.get_sn()),

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -817,7 +817,7 @@ mod concurrency_tests {
                     let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                     let config = TestWorldConfig {
                         gateway_config: GatewayConfig {
-                            active: input.len().try_into().unwrap(),
+                            active: input.len().next_power_of_two().try_into().unwrap(),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -875,7 +875,7 @@ mod concurrency_tests {
                     let input = (0u32..11).map(TestField::truncate_from).collect::<Vec<_>>();
                     let config = TestWorldConfig {
                         gateway_config: GatewayConfig {
-                            active: input.len().try_into().unwrap(),
+                            active: input.len().next_power_of_two().try_into().unwrap(),
                             ..Default::default()
                         },
                         ..Default::default()

--- a/ipa-core/src/helpers/prss_protocol.rs
+++ b/ipa-core/src/helpers/prss_protocol.rs
@@ -24,12 +24,12 @@ pub async fn negotiate<R: RngCore + CryptoRng>(
     let left_sender = gateway.get_mpc_sender::<PublicKey>(
         &left_channel,
         TotalRecords::ONE,
-        gateway.config().active_work(),
+        gateway.config().active_work_as_power_of_two(),
     );
     let right_sender = gateway.get_mpc_sender::<PublicKey>(
         &right_channel,
         TotalRecords::ONE,
-        gateway.config().active_work(),
+        gateway.config().active_work_as_power_of_two(),
     );
     let left_receiver = gateway.get_mpc_receiver::<PublicKey>(&left_channel);
     let right_receiver = gateway.get_mpc_receiver::<PublicKey>(&right_channel);

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -32,8 +32,8 @@ mod seq_join;
 mod serde;
 pub mod sharding;
 mod utils;
-
 pub use app::{AppConfig, HelperApp, Setup as AppSetup};
+pub use utils::NonZeroU32PowerOfTwo;
 
 extern crate core;
 #[cfg(all(feature = "shuttle", test))]

--- a/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
@@ -101,7 +101,7 @@ mod test {
 
         let res = world
             .malicious((a, b), |ctx, (a, b)| async move {
-                let validator = ctx.dzkp_validator(TEST_DZKP_STEPS, 10);
+                let validator = ctx.dzkp_validator(TEST_DZKP_STEPS, 8);
                 let mctx = validator.context();
                 let result = a
                     .multiply(&b, mctx.set_total_records(1), RecordId::from(0))

--- a/ipa-core/src/protocol/context/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/context/dzkp_malicious.rs
@@ -61,8 +61,11 @@ impl<'a> DZKPUpgraded<'a> {
             // This overrides the active work for this context and all children
             // created from it by using narrow, clone, etc.
             // This allows all steps participating in malicious validation
-            // to use the same active work window and prevent deadlocks
-            base_ctx: base_ctx.set_active_work(active_work),
+            // to use the same active work window and prevent deadlocks.
+            //
+            // This also checks that active work is a power of two and
+            // panics if it is not.
+            base_ctx: base_ctx.set_active_work(active_work.get().try_into().unwrap()),
         }
     }
 

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -1197,10 +1197,7 @@ mod tests {
 
     fn max_multiplications_per_gate_strategy(record_count: usize) -> impl Strategy<Value = usize> {
         let max_max_mults = record_count.min(128);
-        prop_oneof![
-            1usize..=max_max_mults,
-            (0u32..=max_max_mults.ilog2()).prop_map(|i| 1usize << i)
-        ]
+        (0u32..=max_max_mults.ilog2()).prop_map(|i| 1usize << i)
     }
 
     prop_compose! {
@@ -1546,7 +1543,7 @@ mod tests {
 
         let [h1_batch, h2_batch, h3_batch] = world
             .malicious((a, b), |ctx, (a, b)| async move {
-                let mut validator = ctx.dzkp_validator(TEST_DZKP_STEPS, 10);
+                let mut validator = ctx.dzkp_validator(TEST_DZKP_STEPS, 8);
                 let mctx = validator.context();
                 let _ = a
                     .multiply(&b, mctx.set_total_records(1), RecordId::from(0))

--- a/ipa-core/src/protocol/context/malicious.rs
+++ b/ipa-core/src/protocol/context/malicious.rs
@@ -80,7 +80,7 @@ impl<'a> Context<'a> {
     }
 
     #[must_use]
-    pub fn set_active_work(self, new_active_work: NonZeroUsize) -> Self {
+    pub fn set_active_work(self, new_active_work: NonZeroU32PowerOfTwo) -> Self {
         Self {
             inner: self.inner.set_active_work(new_active_work),
         }
@@ -171,7 +171,10 @@ impl Debug for Context<'_> {
     }
 }
 
-use crate::sync::{Mutex, Weak};
+use crate::{
+    sync::{Mutex, Weak},
+    utils::NonZeroU32PowerOfTwo,
+};
 
 pub(super) type MacBatcher<'a, F> = Mutex<Batcher<'a, validator::Malicious<'a, F>>>;
 

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -308,8 +308,10 @@ where
 // We expect 2*256 = 512 gates in total for two additions per conversion. The vectorization factor
 // is CONV_CHUNK. Let `len` equal the number of converted shares. The total amount of
 // multiplications is CONV_CHUNK*512*len. We want CONV_CHUNK*512*len ≈ 50M, or len ≈ 381, for a
-// reasonably-sized proof.
-const CONV_PROOF_CHUNK: usize = 400;
+// reasonably-sized proof. There is also a constraint on proof chunks to be powers of two, so
+// we pick the closest power of two close to 381 but less than that value. 256 gives us around 33M
+// multiplications per batch
+const CONV_PROOF_CHUNK: usize = 256;
 
 #[tracing::instrument(name = "compute_prf_for_inputs", skip_all)]
 async fn compute_prf_for_inputs<C, BK, TV, TS>(

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs
@@ -512,7 +512,7 @@ where
         },
         // TODO: this should not be necessary, but probably can't be removed
         // until we align read_size with the batch size.
-        std::cmp::min(sh_ctx.active_work().get(), chunk_size),
+        std::cmp::min(sh_ctx.active_work().get(), chunk_size.next_power_of_two()),
     );
     dzkp_validator.set_total_records(TotalRecords::specified(histogram[1]).unwrap());
     let ctx_for_row_number = set_up_contexts(&dzkp_validator.context(), histogram)?;
@@ -541,7 +541,7 @@ where
             protocol: &Step::Aggregate,
             validate: &Step::AggregateValidate,
         },
-        aggregate_values_proof_chunk(B, usize::try_from(TV::BITS).unwrap()),
+        aggregate_values_proof_chunk(B, usize::try_from(TV::BITS).unwrap()).next_power_of_two(),
     );
     let user_contributions = flattened_user_results.try_collect::<Vec<_>>().await?;
     let result =

--- a/ipa-core/src/protocol/ipa_prf/quicksort.rs
+++ b/ipa-core/src/protocol/ipa_prf/quicksort.rs
@@ -176,7 +176,7 @@ where
             },
             // TODO: use something like this when validating in chunks
             // `TARGET_PROOF_SIZE / usize::try_from(K::BITS).unwrap() / SORT_CHUNK``
-            total_records_usize,
+            total_records_usize.next_power_of_two(),
         );
         let c = v.context();
         let cmp_ctx = c.narrow(&QuicksortPassStep::Compare);

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::hash_map::Entry,
     fmt::{Debug, Formatter},
-    num::NonZeroUsize,
 };
 
 use futures::{future::try_join, stream};
@@ -22,6 +21,7 @@ use crate::{
         CompletionHandle, ProtocolResult,
     },
     sync::Arc,
+    utils::NonZeroU32PowerOfTwo,
 };
 
 /// `Processor` accepts and tracks requests to initiate new queries on this helper party
@@ -44,7 +44,7 @@ use crate::{
 pub struct Processor {
     queries: RunningQueries,
     key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
-    active_work: Option<NonZeroUsize>,
+    active_work: Option<NonZeroU32PowerOfTwo>,
 }
 
 impl Default for Processor {
@@ -118,7 +118,7 @@ impl Processor {
     #[must_use]
     pub fn new(
         key_registry: KeyRegistry<PrivateKeyOnly>,
-        active_work: Option<NonZeroUsize>,
+        active_work: Option<NonZeroU32PowerOfTwo>,
     ) -> Self {
         Self {
             queries: RunningQueries::default(),

--- a/ipa-core/src/test_fixture/circuit.rs
+++ b/ipa-core/src/test_fixture/circuit.rs
@@ -1,4 +1,4 @@
-use std::{array, num::NonZeroUsize};
+use std::array;
 
 use futures::{future::join3, stream, StreamExt};
 use ipa_step::StepNarrow;
@@ -17,7 +17,7 @@ use crate::{
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, FieldSimd, IntoShares},
     seq_join::seq_join,
     test_fixture::{ReconstructArr, TestWorld, TestWorldConfig},
-    utils::array::zip3,
+    utils::{array::zip3, NonZeroU32PowerOfTwo},
 };
 
 pub struct Inputs<F: Field + FieldSimd<N>, const N: usize> {
@@ -76,7 +76,7 @@ pub async fn arithmetic<F, const N: usize>(
     [F; N]: IntoShares<Replicated<F, N>>,
     Standard: Distribution<F>,
 {
-    let active = NonZeroUsize::new(active_work).unwrap();
+    let active = NonZeroU32PowerOfTwo::try_from(active_work.next_power_of_two()).unwrap();
     let config = TestWorldConfig {
         gateway_config: GatewayConfig {
             active,
@@ -85,7 +85,7 @@ pub async fn arithmetic<F, const N: usize>(
         initial_gate: Some(Gate::default().narrow(&ProtocolStep::Test)),
         ..Default::default()
     };
-    let world = TestWorld::new_with(config);
+    let world = TestWorld::new_with(&config);
 
     // Re-use contexts for the entire execution because record identifiers are contiguous.
     let contexts = world.contexts();
@@ -96,7 +96,7 @@ pub async fn arithmetic<F, const N: usize>(
         // accumulated. This gives the best performance for vectorized operation.
         let ctx = ctx.set_total_records(TotalRecords::Indeterminate);
         seq_join(
-            active,
+            config.gateway_config.active_work(),
             stream::iter((0..(width / u32::try_from(N).unwrap())).zip(col_data)).map(
                 move |(record, Inputs { a, b })| {
                     circuit(ctx.clone(), RecordId::from(record), depth, a, b)

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -676,7 +676,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         R: Future<Output = O> + Send,
     {
         self.malicious(input, |ctx, share| async {
-            let v = ctx.dzkp_validator(TEST_DZKP_STEPS, 10);
+            let v = ctx.dzkp_validator(TEST_DZKP_STEPS, 8);
             let m_ctx = v.context();
             let m_result = helper_fn(m_ctx, share).await;
             v.validate().await.unwrap();

--- a/ipa-core/src/utils/mod.rs
+++ b/ipa-core/src/utils/mod.rs
@@ -1,2 +1,7 @@
 pub mod array;
 pub mod arraychunks;
+#[cfg(target_pointer_width = "64")]
+mod power_of_two;
+
+#[cfg(target_pointer_width = "64")]
+pub use power_of_two::NonZeroU32PowerOfTwo;

--- a/ipa-core/src/utils/power_of_two.rs
+++ b/ipa-core/src/utils/power_of_two.rs
@@ -1,0 +1,110 @@
+use std::{fmt::Display, num::NonZeroUsize, str::FromStr};
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0} is not a power of two or not within the 1..u32::MAX range")]
+pub struct ConvertError<I: Display>(I);
+
+impl<I: PartialEq + Display> PartialEq for ConvertError<I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+/// This construction guarantees the value to be a power of two and
+/// within the range 0..2^32-1
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NonZeroU32PowerOfTwo(u32);
+
+impl Display for NonZeroU32PowerOfTwo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", u32::from(*self))
+    }
+}
+
+impl TryFrom<usize> for NonZeroU32PowerOfTwo {
+    type Error = ConvertError<usize>;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value > 0 && value < usize::try_from(u32::MAX).unwrap() && value.is_power_of_two() {
+            Ok(NonZeroU32PowerOfTwo(u32::try_from(value).unwrap()))
+        } else {
+            Err(ConvertError(value))
+        }
+    }
+}
+
+impl From<NonZeroU32PowerOfTwo> for usize {
+    fn from(value: NonZeroU32PowerOfTwo) -> Self {
+        // we are using 64 bit registers
+        usize::try_from(value.0).unwrap()
+    }
+}
+
+impl From<NonZeroU32PowerOfTwo> for u32 {
+    fn from(value: NonZeroU32PowerOfTwo) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for NonZeroU32PowerOfTwo {
+    type Err = ConvertError<String>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let v = s.parse::<usize>().map_err(|_| ConvertError(s.to_owned()))?;
+        NonZeroU32PowerOfTwo::try_from(v).map_err(|_| ConvertError(s.to_owned()))
+    }
+}
+
+impl NonZeroU32PowerOfTwo {
+    #[must_use]
+    pub fn to_non_zero_usize(self) -> NonZeroUsize {
+        let v = usize::from(self);
+        NonZeroUsize::new(v).unwrap_or_else(|| unreachable!())
+    }
+
+    #[must_use]
+    pub fn get(self) -> usize {
+        usize::from(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConvertError, NonZeroU32PowerOfTwo};
+
+    #[test]
+    fn rejects_invalid_values() {
+        assert!(matches!(
+            NonZeroU32PowerOfTwo::try_from(0),
+            Err(ConvertError(0))
+        ));
+        assert!(matches!(
+            NonZeroU32PowerOfTwo::try_from(3),
+            Err(ConvertError(3))
+        ));
+
+        assert!(matches!(
+            NonZeroU32PowerOfTwo::try_from(1_usize << 33),
+            Err(ConvertError(_))
+        ));
+    }
+
+    #[test]
+    fn accepts_valid() {
+        assert_eq!(4, u32::from(NonZeroU32PowerOfTwo::try_from(4).unwrap()));
+        assert_eq!(16, u32::from(NonZeroU32PowerOfTwo::try_from(16).unwrap()));
+    }
+
+    #[test]
+    fn parse_from_str() {
+        assert_eq!(NonZeroU32PowerOfTwo(4), "4".parse().unwrap());
+        assert_eq!(
+            ConvertError("0".to_owned()),
+            "0".parse::<NonZeroU32PowerOfTwo>().unwrap_err()
+        );
+        assert_eq!(
+            ConvertError("3".to_owned()),
+            "3".parse::<NonZeroU32PowerOfTwo>().unwrap_err()
+        );
+    }
+}

--- a/ipa-core/src/utils/power_of_two.rs
+++ b/ipa-core/src/utils/power_of_two.rs
@@ -68,7 +68,7 @@ impl NonZeroU32PowerOfTwo {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 mod tests {
     use super::{ConvertError, NonZeroU32PowerOfTwo};
 


### PR DESCRIPTION
## Overview

This is the second attempt to mitigate send buffer misalignment. Previous one (https://github.com/private-attribution/ipa/pull/1307) didn't handle all the edge cases and was abandoned in favour of this PR.

What I believe makes this change work is the new requirement for active work to be a power of two. With this constraint, it is much easier to align the read size with it. Given that `total_capacity = active * record_size`, we can represent `read_size` as a multiple of `record_size` too:
`read_size = X * record_size`. If X is a power of two and active_work is a power of two, then they will always be aligned with each other.

For example, if active work is 16, read size is 10 bytes and record size is 3 bytes, then:

```
total_capacity = 16*3
read_size = X*3 (close to 10)
X = 2 (power of two that satisfies the requirement)
```

when picking up the read size, we are rounding down to avoid buffer overflows. In the example above, setting X=3 would make it closer to the desired read size, but it is greater than 10, so we pick 2 instead.

## What is included in this change?

* Send buffer now enforces the active work to be a power of two
* Subsequently, Gateway interface now puts the same restriction on `GatewayConfig`
* Fix for unit tests that use ZKP - batch sizes now need to be a power of two as well (after #1316 active work and batch size must be aligned now)
