### PR TITLE
Support sharding in MAC and ZKP validations

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -89,7 +89,10 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>>
 {
 }
 
-impl<'a> BooleanProtocols<DZKPUpgradedMaliciousContext<'a>> for AdditiveShare<Boolean> {}
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>>
+    for AdditiveShare<Boolean>
+{
+}
 
 // Used for aggregation tests
 impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 8>
@@ -107,7 +110,7 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>,
 {
 }
 
-impl<'a> BooleanProtocols<DZKPUpgradedMaliciousContext<'a>, PRF_CHUNK>
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>, PRF_CHUNK>
     for AdditiveShare<Boolean, PRF_CHUNK>
 {
 }
@@ -124,7 +127,7 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>,
 {
 }
 
-impl<'a> BooleanProtocols<DZKPUpgradedMaliciousContext<'a>, AGG_CHUNK>
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>, AGG_CHUNK>
     for AdditiveShare<Boolean, AGG_CHUNK>
 {
 }
@@ -159,7 +162,10 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>,
 {
 }
 
-impl<'a> BooleanProtocols<DZKPUpgradedMaliciousContext<'a>, 32> for AdditiveShare<Boolean, 32> {}
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>, 32>
+    for AdditiveShare<Boolean, 32>
+{
+}
 
 const_assert_eq!(
     AGG_CHUNK,

--- a/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/dzkp_malicious.rs
@@ -13,6 +13,7 @@ use crate::{
         RecordId,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Vectorizable},
+    sharding::{NotSharded, ShardBinding},
 };
 
 /// This function implements an MPC multiply using the standard strategy, i.e. via computing the
@@ -27,13 +28,14 @@ use crate::{
 /// back via the error response
 /// ## Panics
 /// Panics if the mutex is found to be poisoned
-pub async fn zkp_multiply<'a, F, const N: usize>(
-    ctx: DZKPUpgradedMaliciousContext<'a>,
+pub async fn zkp_multiply<'a, B, F, const N: usize>(
+    ctx: DZKPUpgradedMaliciousContext<'a, B>,
     record_id: RecordId,
     a: &Replicated<F, N>,
     b: &Replicated<F, N>,
 ) -> Result<Replicated<F, N>, Error>
 where
+    B: ShardBinding,
     F: Field + DZKPCompatibleField<N>,
 {
     // Shared randomness used to mask the values that are sent.
@@ -62,17 +64,17 @@ where
 
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
-impl<'a, F: Field + DZKPCompatibleField<N>, const N: usize>
-    SecureMul<DZKPUpgradedMaliciousContext<'a>> for Replicated<F, N>
+impl<'a, B: ShardBinding, F: Field + DZKPCompatibleField<N>, const N: usize>
+    SecureMul<DZKPUpgradedMaliciousContext<'a, B>> for Replicated<F, N>
 {
     async fn multiply<'fut>(
         &self,
         rhs: &Self,
-        ctx: DZKPUpgradedMaliciousContext<'a>,
+        ctx: DZKPUpgradedMaliciousContext<'a, B>,
         record_id: RecordId,
     ) -> Result<Self, Error>
     where
-        DZKPUpgradedMaliciousContext<'a>: 'fut,
+        DZKPUpgradedMaliciousContext<'a, NotSharded>: 'fut,
     {
         zkp_multiply(ctx, record_id, self, rhs).await
     }

--- a/ipa-core/src/protocol/basics/mul/mod.rs
+++ b/ipa-core/src/protocol/basics/mul/mod.rs
@@ -123,17 +123,19 @@ macro_rules! boolean_array_mul {
             }
         }
 
-        impl<'a> BooleanArrayMul<DZKPUpgradedMaliciousContext<'a>> for Replicated<$vec> {
+        impl<'a, B: sharding::ShardBinding> BooleanArrayMul<DZKPUpgradedMaliciousContext<'a, B>>
+            for Replicated<$vec>
+        {
             type Vectorized = Replicated<Boolean, $dim>;
 
             fn multiply<'fut>(
-                ctx: DZKPUpgradedMaliciousContext<'a>,
+                ctx: DZKPUpgradedMaliciousContext<'a, B>,
                 record_id: RecordId,
                 a: &'fut Self::Vectorized,
                 b: &'fut Self::Vectorized,
             ) -> impl Future<Output = Result<Self::Vectorized, Error>> + Send + 'fut
             where
-                DZKPUpgradedMaliciousContext<'a>: 'fut,
+                DZKPUpgradedMaliciousContext<'a, B>: 'fut,
             {
                 use crate::protocol::basics::mul::dzkp_malicious::zkp_multiply;
                 zkp_multiply(ctx, record_id, a, b)

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -321,20 +321,21 @@ where
     }
 }
 
-impl<'a, const N: usize> Reveal<DZKPUpgradedMaliciousContext<'a>> for Replicated<Boolean, N>
+impl<'a, B, const N: usize> Reveal<DZKPUpgradedMaliciousContext<'a, B>> for Replicated<Boolean, N>
 where
+    B: ShardBinding,
     Boolean: Vectorizable<N>,
 {
     type Output = <Boolean as Vectorizable<N>>::Array;
 
     async fn generic_reveal<'fut>(
         &'fut self,
-        ctx: DZKPUpgradedMaliciousContext<'a>,
+        ctx: DZKPUpgradedMaliciousContext<'a, B>,
         record_id: RecordId,
         excluded: Option<Role>,
     ) -> Result<Option<Self::Output>, Error>
     where
-        DZKPUpgradedMaliciousContext<'a>: 'fut,
+        DZKPUpgradedMaliciousContext<'a, B>: 'fut,
     {
         malicious_reveal(ctx, record_id, excluded, self).await
     }

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -520,7 +520,7 @@ impl Batch {
 
     /// ## Panics
     /// If `usize` to `u128` conversion fails.
-    pub(super) async fn validate(self, ctx: Base<'_>) -> Result<(), Error> {
+    pub(super) async fn validate<B: ShardBinding>(self, ctx: Base<'_, B>) -> Result<(), Error> {
         let proof_ctx = ctx.narrow(&Step::GenerateProof);
 
         if self.is_empty() {
@@ -701,26 +701,26 @@ type DzkpBatcher<'a> = Batcher<'a, Batch>;
 
 /// The DZKP validator, and all associated contexts, each hold a reference to a single
 /// instance of `MaliciousDZKPValidatorInner`.
-pub(super) struct MaliciousDZKPValidatorInner<'a> {
+pub(super) struct MaliciousDZKPValidatorInner<'a, B: ShardBinding> {
     pub(super) batcher: Mutex<DzkpBatcher<'a>>,
-    pub(super) validate_ctx: Base<'a>,
+    pub(super) validate_ctx: Base<'a, B>,
 }
 
 /// `MaliciousDZKPValidator` corresponds to pub struct `Malicious` and implements the trait `DZKPValidator`
 /// The implementation of `validate` of the `DZKPValidator` trait depends on generic `DF`
-pub struct MaliciousDZKPValidator<'a> {
+pub struct MaliciousDZKPValidator<'a, B: ShardBinding> {
     // This is an `Option` because we want to consume it in `DZKPValidator::validate`,
     // but we also want to implement `Drop`. Note that the `is_verified` check in `Drop`
     // does nothing when `batcher_ref` is already `None`.
-    inner_ref: Option<Arc<MaliciousDZKPValidatorInner<'a>>>,
-    protocol_ctx: MaliciousDZKPUpgraded<'a>,
+    inner_ref: Option<Arc<MaliciousDZKPValidatorInner<'a, B>>>,
+    protocol_ctx: MaliciousDZKPUpgraded<'a, B>,
 }
 
 #[async_trait]
-impl<'a> DZKPValidator for MaliciousDZKPValidator<'a> {
-    type Context = MaliciousDZKPUpgraded<'a>;
+impl<'a, B: ShardBinding> DZKPValidator for MaliciousDZKPValidator<'a, B> {
+    type Context = MaliciousDZKPUpgraded<'a, B>;
 
-    fn context(&self) -> MaliciousDZKPUpgraded<'a> {
+    fn context(&self) -> MaliciousDZKPUpgraded<'a, B> {
         self.protocol_ctx.clone()
     }
 
@@ -774,11 +774,11 @@ impl<'a> DZKPValidator for MaliciousDZKPValidator<'a> {
     }
 }
 
-impl<'a> MaliciousDZKPValidator<'a> {
+impl<'a, B: ShardBinding> MaliciousDZKPValidator<'a, B> {
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
     pub fn new<S>(
-        ctx: MaliciousContext<'a>,
+        ctx: MaliciousContext<'a, B>,
         steps: MaliciousProtocolSteps<S>,
         max_multiplications_per_gate: usize,
     ) -> Self
@@ -808,7 +808,7 @@ impl<'a> MaliciousDZKPValidator<'a> {
     }
 }
 
-impl<'a> Drop for MaliciousDZKPValidator<'a> {
+impl<'a, B: ShardBinding> Drop for MaliciousDZKPValidator<'a, B> {
     fn drop(&mut self) {
         if self.inner_ref.is_some() {
             self.is_verified().unwrap();
@@ -922,7 +922,7 @@ mod tests {
     async fn test_select_malicious<V>()
     where
         V: BooleanArray,
-        for<'a> Replicated<V>: BooleanArrayMul<DZKPUpgradedMaliciousContext<'a>>,
+        for<'a> Replicated<V>: BooleanArrayMul<DZKPUpgradedMaliciousContext<'a, NotSharded>>,
         Standard: Distribution<V>,
     {
         let world = TestWorld::default();
@@ -1040,7 +1040,7 @@ mod tests {
     async fn multi_select_malicious<V>(count: usize, max_multiplications_per_gate: usize)
     where
         V: BooleanArray,
-        for<'a> Replicated<V>: BooleanArrayMul<DZKPUpgradedMaliciousContext<'a>>,
+        for<'a> Replicated<V>: BooleanArrayMul<DZKPUpgradedMaliciousContext<'a, NotSharded>>,
         Standard: Distribution<V>,
     {
         let mut rng = thread_rng();

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -26,7 +26,7 @@ pub type SemiHonestContext<'a, B = NotSharded> = semi_honest::Context<'a, B>;
 pub type ShardedSemiHonestContext<'a> = semi_honest::Context<'a, Sharded>;
 
 pub type MaliciousContext<'a, B = NotSharded> = malicious::Context<'a, B>;
-pub type UpgradedMaliciousContext<'a, F> = malicious::Upgraded<'a, F, NotSharded>;
+pub type UpgradedMaliciousContext<'a, F, B = NotSharded> = malicious::Upgraded<'a, F, B>;
 
 #[cfg(all(feature = "in-memory-infra", any(test, feature = "test-fixture")))]
 pub(crate) use malicious::TEST_DZKP_STEPS;

--- a/ipa-core/src/protocol/context/validator.rs
+++ b/ipa-core/src/protocol/context/validator.rs
@@ -199,18 +199,18 @@ impl<F: ExtendableField> MaliciousAccumulator<F> {
 /// When batch is validated, `r` is revealed and can never be
 /// used again. In fact, it gets out of scope after successful validation
 /// so no code can get access to it.
-pub struct BatchValidator<'a, F: ExtendableField> {
-    batches_ref: Arc<MacBatcher<'a, F>>,
-    protocol_ctx: MaliciousContext<'a>,
+pub struct BatchValidator<'a, F: ExtendableField, B: ShardBinding> {
+    batches_ref: Arc<MacBatcher<'a, F, B>>,
+    protocol_ctx: MaliciousContext<'a, B>,
 }
 
-impl<'a, F: ExtendableField> BatchValidator<'a, F> {
+impl<'a, F: ExtendableField, B: ShardBinding> BatchValidator<'a, F, B> {
     /// Create a new validator for malicious context.
     ///
     /// ## Panics
     /// If total records is not set.
     #[must_use]
-    pub fn new(ctx: MaliciousContext<'a>) -> Self {
+    pub fn new(ctx: MaliciousContext<'a, B>) -> Self {
         let TotalRecords::Specified(total_records) = ctx.total_records() else {
             panic!("Total records must be specified before creating the validator");
         };
@@ -230,14 +230,14 @@ impl<'a, F: ExtendableField> BatchValidator<'a, F> {
     }
 }
 
-pub struct Malicious<'a, F: ExtendableField> {
+pub struct Malicious<'a, F: ExtendableField, B: ShardBinding> {
     r_share: Replicated<F::ExtendedField>,
     pub(super) accumulator: MaliciousAccumulator<F>,
-    validate_ctx: Base<'a>,
+    validate_ctx: Base<'a, B>,
     offset: usize,
 }
 
-impl<F: ExtendableField> Malicious<'_, F> {
+impl<F: ExtendableField, B: ShardBinding> Malicious<'_, F, B> {
     /// ## Errors
     /// If the two information theoretic MACs are not equal (after multiplying by `r`), this indicates that one of the parties
     /// must have launched an additive attack. At this point the honest parties should abort the protocol. This method throws an
@@ -294,21 +294,21 @@ impl<F: ExtendableField> Malicious<'_, F> {
     }
 }
 
-impl<'a, F> Validator<F> for BatchValidator<'a, F>
+impl<'a, F, B: ShardBinding> Validator<F> for BatchValidator<'a, F, B>
 where
     F: ExtendableField,
 {
-    type Context = UpgradedMaliciousContext<'a, F>;
+    type Context = UpgradedMaliciousContext<'a, F, B>;
 
     fn context(&self) -> Self::Context {
         UpgradedMaliciousContext::new(&self.batches_ref, self.protocol_ctx.clone())
     }
 }
 
-impl<'a, F: ExtendableField> Malicious<'a, F> {
+impl<'a, F: ExtendableField, B: ShardBinding> Malicious<'a, F, B> {
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(ctx: MaliciousContext<'a>, offset: usize) -> Self {
+    pub fn new(ctx: MaliciousContext<'a, B>, offset: usize) -> Self {
         // Each invocation requires 3 calls to PRSS to generate the state.
         // Validation occurs in batches and `offset` indicates which batch
         // we're in right now.
@@ -386,7 +386,7 @@ impl<'a, F: ExtendableField> Malicious<'a, F> {
     }
 }
 
-impl<F: ExtendableField> Debug for Malicious<'_, F> {
+impl<F: ExtendableField, B: ShardBinding> Debug for Malicious<'_, F, B> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "MaliciousValidator<{:?}>", type_name::<F>())
     }

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -428,7 +428,7 @@ pub trait Runner<S: ShardingScheme> {
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
         O: Send + Debug,
-        H: Fn(DZKPUpgradedMaliciousContext<'a>, A) -> R + Send + Sync,
+        H: Fn(DZKPUpgradedMaliciousContext<'a, NotSharded>, A) -> R + Send + Sync,
         R: Future<Output = O> + Send;
 }
 
@@ -531,7 +531,7 @@ impl<const SHARDS: usize, D: Distribute> Runner<WithShards<SHARDS, D>>
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
         O: Send + Debug,
-        H: Fn(DZKPUpgradedMaliciousContext<'a>, A) -> R + Send + Sync,
+        H: Fn(DZKPUpgradedMaliciousContext<'a, NotSharded>, A) -> R + Send + Sync,
         R: Future<Output = O> + Send,
     {
         unimplemented!()
@@ -672,7 +672,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         I: IntoShares<A> + Send + 'static,
         A: Send + 'static,
         O: Send + Debug,
-        H: (Fn(DZKPUpgradedMaliciousContext<'a>, A) -> R) + Send + Sync,
+        H: (Fn(DZKPUpgradedMaliciousContext<'a, NotSharded>, A) -> R) + Send + Sync,
         R: Future<Output = O> + Send,
     {
         self.malicious(input, |ctx, share| async {


### PR DESCRIPTION
The next step to be able to run sharded protocols is to change the validators API and support both sharded and non-sharded contexts.

This is a fairly straightforward change that just propagates `ShardBinding` trait bound through MAC and ZKP contexts and validators