### PR TITLE
Support sharded malicious protocols inside the test infrastructure

### DIFF
--- a/ipa-core/src/protocol/basics/mul/malicious.rs
+++ b/ipa-core/src/protocol/basics/mul/malicious.rs
@@ -16,6 +16,7 @@ use crate::{
         malicious::{AdditiveShare as MaliciousReplicated, ExtendableFieldSimd},
         semi_honest::AdditiveShare as Replicated,
     },
+    sharding::ShardBinding,
 };
 
 ///
@@ -49,8 +50,8 @@ use crate::{
 /// back via the error response
 /// ## Panics
 /// Panics if the mutex is found to be poisoned
-pub async fn mac_multiply<F, const N: usize>(
-    ctx: UpgradedMaliciousContext<'_, F>,
+pub async fn mac_multiply<F, B: ShardBinding, const N: usize>(
+    ctx: UpgradedMaliciousContext<'_, F, B>,
     record_id: RecordId,
     a: &MaliciousReplicated<F, N>,
     b: &MaliciousReplicated<F, N>,
@@ -108,19 +109,19 @@ where
 
 /// Implement secure multiplication for malicious contexts with replicated secret sharing.
 #[async_trait]
-impl<'a, F: ExtendableFieldSimd<N>, const N: usize> SecureMul<UpgradedMaliciousContext<'a, F>>
-    for MaliciousReplicated<F, N>
+impl<'a, F: ExtendableFieldSimd<N>, B: ShardBinding, const N: usize>
+    SecureMul<UpgradedMaliciousContext<'a, F, B>> for MaliciousReplicated<F, N>
 where
     Replicated<F::ExtendedField, N>: FromPrss,
 {
     async fn multiply<'fut>(
         &self,
         rhs: &Self,
-        ctx: UpgradedMaliciousContext<'a, F>,
+        ctx: UpgradedMaliciousContext<'a, F, B>,
         record_id: RecordId,
     ) -> Result<Self, Error>
     where
-        UpgradedMaliciousContext<'a, F>: 'fut,
+        UpgradedMaliciousContext<'a, F, B>: 'fut,
     {
         mac_multiply(ctx, record_id, self, rhs).await
     }

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -26,6 +26,7 @@ pub type SemiHonestContext<'a, B = NotSharded> = semi_honest::Context<'a, B>;
 pub type ShardedSemiHonestContext<'a> = semi_honest::Context<'a, Sharded>;
 
 pub type MaliciousContext<'a, B = NotSharded> = malicious::Context<'a, B>;
+pub type ShardedMaliciousContext<'a> = malicious::Context<'a, Sharded>;
 pub type UpgradedMaliciousContext<'a, F, B = NotSharded> = malicious::Upgraded<'a, F, B>;
 
 #[cfg(all(feature = "in-memory-infra", any(test, feature = "test-fixture")))]

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -302,14 +302,14 @@ impl<B: ShardBinding, F: ExtendableField> Debug for Upgraded<'_, B, F> {
 }
 
 #[async_trait]
-impl<'a, V: ExtendableField + Vectorizable<N>, const N: usize>
-    Upgradable<Upgraded<'a, NotSharded, V>> for Replicated<V, N>
+impl<'a, V: ExtendableField + Vectorizable<N>, B: ShardBinding, const N: usize>
+    Upgradable<Upgraded<'a, B, V>> for Replicated<V, N>
 {
     type Output = Replicated<V, N>;
 
     async fn upgrade(
         self,
-        _context: Upgraded<'a, NotSharded, V>,
+        _context: Upgraded<'a, B, V>,
         _record_id: RecordId,
     ) -> Result<Self::Output, Error> {
         Ok(self)

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -851,8 +851,7 @@ impl<const SEED: u64> Distribute for Random<SEED> {
     }
 }
 
-// #[cfg(all(test, unit_test))]
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 mod tests {
     use std::{
         collections::{HashMap, HashSet},


### PR DESCRIPTION
This is the final PR in the series (#1333, #1315) that enables writing sharded malicious protocols.

The support is added for `Runner::malicious` function, and it can be used to execute malicious circuits. Other methods like `upgraded_semi_honest` and `upgraded_malicious` haven't been touched yet - I am not convinced that these are necessary and we can update them as we go.

The core goal here is to unblock efforts to implement Hybrid protocol