### PR TITLE
Introduce IpaRuntime and plumb it all the way down to executor

### DIFF
--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -3,6 +3,7 @@ use std::{num::NonZeroUsize, sync::Weak};
 use async_trait::async_trait;
 
 use crate::{
+    executor::IpaRuntime,
     helpers::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         routing::{Addr, RouteId},
@@ -19,6 +20,7 @@ use crate::{
 pub struct AppConfig {
     active_work: Option<NonZeroUsize>,
     key_registry: Option<KeyRegistry<PrivateKeyOnly>>,
+    runtime: IpaRuntime,
 }
 
 impl AppConfig {
@@ -31,6 +33,12 @@ impl AppConfig {
     #[must_use]
     pub fn with_key_registry(mut self, key_registry: KeyRegistry<PrivateKeyOnly>) -> Self {
         self.key_registry = Some(key_registry);
+        self
+    }
+
+    #[must_use]
+    pub fn with_runtime(mut self, runtime: IpaRuntime) -> Self {
+        self.runtime = runtime;
         self
     }
 }
@@ -60,7 +68,7 @@ impl Setup {
     #[must_use]
     pub fn new(config: AppConfig) -> (Self, HandlerRef) {
         let key_registry = config.key_registry.unwrap_or_else(KeyRegistry::empty);
-        let query_processor = QueryProcessor::new(key_registry, config.active_work);
+        let query_processor = QueryProcessor::new(key_registry, config.active_work, config.runtime);
         let handler = HandlerBox::empty();
         let this = Self {
             query_processor,

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 
 use crate::{
     error::Error as ProtocolError,
+    executor::IpaRuntime,
     helpers::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment,
@@ -45,6 +46,7 @@ pub struct Processor {
     queries: RunningQueries,
     key_registry: Arc<KeyRegistry<PrivateKeyOnly>>,
     active_work: Option<NonZeroUsize>,
+    runtime: IpaRuntime,
 }
 
 impl Default for Processor {
@@ -53,6 +55,7 @@ impl Default for Processor {
             queries: RunningQueries::default(),
             key_registry: Arc::new(KeyRegistry::<PrivateKeyOnly>::empty()),
             active_work: None,
+            runtime: IpaRuntime::current(),
         }
     }
 }
@@ -119,11 +122,13 @@ impl Processor {
     pub fn new(
         key_registry: KeyRegistry<PrivateKeyOnly>,
         active_work: Option<NonZeroUsize>,
+        runtime: IpaRuntime,
     ) -> Self {
         Self {
             queries: RunningQueries::default(),
             key_registry: Arc::new(key_registry),
             active_work,
+            runtime,
         }
     }
 
@@ -249,6 +254,7 @@ impl Processor {
                     queries.insert(
                         input.query_id,
                         QueryState::Running(executor::execute(
+                            &self.runtime,
                             config,
                             Arc::clone(&self.key_registry),
                             gateway,
@@ -584,6 +590,7 @@ mod tests {
         use std::sync::Arc;
 
         use crate::{
+            executor::IpaRuntime,
             ff::FieldType,
             helpers::{
                 query::{
@@ -603,11 +610,13 @@ mod tests {
 
         #[test]
         fn non_existent_query() {
-            let processor = Processor::default();
-            assert!(matches!(
-                processor.kill(QueryId),
-                Err(QueryKillStatus::NoSuchQuery(QueryId))
-            ));
+            run(|| async {
+                let processor = Processor::default();
+                assert!(matches!(
+                    processor.kill(QueryId),
+                    Err(QueryKillStatus::NoSuchQuery(QueryId))
+                ));
+            });
         }
 
         #[test]
@@ -650,7 +659,7 @@ mod tests {
                 let processor = Processor::default();
                 let (_tx, rx) = tokio::sync::oneshot::channel();
                 let counter = Arc::new(1);
-                let task = tokio::spawn({
+                let task = IpaRuntime::current().spawn({
                     let counter = Arc::clone(&counter);
                     async move {
                         loop {

--- a/ipa-core/src/query/state.rs
+++ b/ipa-core/src/query/state.rs
@@ -10,11 +10,11 @@ use futures::{ready, FutureExt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    executor::IpaJoinHandle,
     helpers::{query::QueryConfig, RoleAssignment},
     protocol::QueryId,
     query::runner::QueryResult,
     sync::Mutex,
-    task::JoinHandle,
 };
 
 /// The status of query processing
@@ -87,7 +87,7 @@ pub struct RunningQuery {
     ///
     /// We could return the result via the `JoinHandle`, except that we want to check the status
     /// of the task, and shuttle doesn't implement `JoinHandle::is_finished`.
-    pub join_handle: JoinHandle<()>,
+    pub join_handle: IpaJoinHandle<()>,
 }
 
 impl RunningQuery {


### PR DESCRIPTION
The time has come to have a need to have a precise control over which runtime is used to run queries. The reason for that is that we had another occurrence of HTTP keep-alive timeout that aligns with OPRF computation.

https://draft-mpc.vercel.app/query/view/nervy-fret2024-10-05T0245
```
2024-10-05T03:57:35.203964 - 2024-10-05T03:57:35.203922Z  INFO oprf_ipa_query{sz=50000000}:compute_prf_for_inputs: ipa_core::protocol::context::batcher: batch 30 is ready for validation
2024-10-05T03:57:35.206943 - 2024-10-05T03:57:35.206901Z  INFO oprf_ipa_query{sz=50000000}:compute_prf_for_inputs: ipa_core::protocol::context::batcher: batch 31 is ready for validation
2024-10-05T03:57:35.209813 - 2024-10-05T03:57:35.209777Z  INFO oprf_ipa_query{sz=50000000}:compute_prf_for_inputs: ipa_core::protocol::context::batcher: batch 32 is ready for validation
2024-10-05T03:58:28.720077 - 2024-10-05T03:58:28.715520Z ERROR ipa_core::error: ThreadId(9) "tokio-runtime-worker" panicked at ipa-core/src/helpers/gateway/send.rs:222:30:
2024-10-05T03:58:28.720653 - {channel_id:?} receiving end should be accepted by transport: SendToRoleError(H1, ConnectError { dest: "helper1.ipa-helper.dev", inner: hyper_util::client::legacy::Error(SendRequest,>
2024-10-05T03:58:28.720957 - stack trace:
2024-10-05T03:58:28.721250 -    0: ipa_core::error::set_global_panic_hook::{{closure}}
2024-10-05T03:58:28.721524 -    1: std::panicking::rust_panic_with_hook
2024-10-05T03:58:28.721776 -    2: std::panicking::begin_panic_handler::{{closure}}
2024-10-05T03:58:28.722034 -    3: std::sys_common::backtrace::__rust_end_short_backtrace
2024-10-05T03:58:28.722281 -    4: rust_begin_unwind
2024-10-05T03:58:28.722522 -    5: core::panicking::panic_fmt
2024-10-05T03:58:28.722764 -    6: core::result::unwrap_failed
2024-10-05T03:58:28.723006 -    7: ipa_core::helpers::gateway::send::GatewaySenders<I>::get::{{closure}}
2024-10-05T03:58:28.723246 -    8: tokio::runtime::task::core::Core<T,S>::poll
2024-10-05T03:58:28.723490 -    9: tokio::runtime::task::harness::Harness<T,S>::poll
2024-10-05T03:58:28.723749 -   10: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
2024-10-05T03:58:28.723986 -   11: tokio::runtime::scheduler::multi_thread::worker::Context::run
2024-10-05T03:58:28.724235 -   12: tokio::runtime::context::runtime::enter_runtime
2024-10-05T03:58:28.724484 -   13: tokio::runtime::scheduler::multi_thread::worker::run
2024-10-05T03:58:28.724732 -   14: tokio::runtime::task::core::Core<T,S>::poll
2024-10-05T03:58:28.724974 -   15: tokio::runtime::task::harness::Harness<T,S>::poll
2024-10-05T03:58:28.725221 -   16: tokio::runtime::blocking::pool::Inner::run
2024-10-05T03:58:28.725462 -   17: std::sys_common::backtrace::__rust_begin_short_backtrace
2024-10-05T03:58:28.725705 -   18: core::ops::function::FnOnce::call_once{{vtable.shim}}
2024-10-05T03:58:28.725946 -   19: std::sys::pal::unix::thread::Thread::new::thread_start
2024-10-05T03:58:28.726193 -   20: start_thread
2024-10-05T03:58:28.726422 -   21: __clone3
```

The root cause for this is PRF computation blocking scheduler for too long, so it does not schedule Hyper task to respond to `status` requests from RC, or to accept data from another peer. While it deserves to be fixed (I believe @danielmasny was looking into why we trash CPU so badly in PRF), it is not OK to crash if that happens.

This change just does the plumbing to allow dedicated runtime to be provided for query executors.