### PR TITLE
Set up separate runtimes for HTTP and MPC queries

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -15,10 +15,12 @@ use ipa_core::{
     },
     config::{hpke_registry, HpkeServerConfig, NetworkConfig, ServerConfig, TlsConfig},
     error::BoxError,
+    executor::IpaRuntime,
     helpers::HelperIdentity,
     net::{ClientIdentity, HttpShardTransport, HttpTransport, MpcHelperClient},
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
+use tokio::runtime::Runtime;
 use tracing::{error, info};
 
 #[cfg(all(not(target_env = "msvc"), not(target_os = "macos")))]
@@ -133,9 +135,12 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         private_key_file: sk_path,
     });
 
+    let query_runtime = new_query_runtime();
     let app_config = AppConfig::default()
         .with_key_registry(hpke_registry(mk_encryption.as_ref()).await?)
-        .with_active_work(args.active_work);
+        .with_active_work(args.active_work)
+        .with_runtime(IpaRuntime::from_tokio_runtime(&query_runtime));
+
     let (setup, handler) = AppSetup::new(app_config);
 
     let server_config = ServerConfig {
@@ -155,7 +160,9 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         .override_scheme(&scheme);
     let clients = MpcHelperClient::from_conf(&network_config, &identity);
 
+    let http_runtime = new_http_runtime();
     let (transport, server) = HttpTransport::new(
+        IpaRuntime::from_tokio_runtime(&http_runtime),
         my_identity,
         server_config,
         network_config,
@@ -190,11 +197,59 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         .await;
 
     server_handle.await?;
+    query_runtime.shutdown_background();
 
     Ok(())
 }
 
-#[tokio::main]
+/// Creates a new runtime for HTTP stack. It is useful to provide a dedicated
+/// scheduler to HTTP tasks, to make sure IPA server can respond to requests,
+/// if for some reason query runtime becomes overloaded.
+/// When multi-threading feature is enabled it creates a runtime with thread-per-core,
+/// otherwise a single-threaded runtime is created.
+fn new_http_runtime() -> Runtime {
+    if cfg!(feature = "multi-threading") {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_name("http-worker")
+            .enable_all()
+            .build()
+            .unwrap()
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("http-worker")
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+}
+
+/// This function creates a runtime suitable for executing MPC queries.
+/// When multi-threading feature is enabled it creates a runtime with thread-per-core,
+/// otherwise a single-threaded runtime is created.
+fn new_query_runtime() -> Runtime {
+    // it is intentional that IO driver is not enabled here (enable_time() call only).
+    // query runtime is supposed to use CPU/memory only, no writes to disk and all
+    // network communication is handled by HTTP runtime.
+    if cfg!(feature = "multi-threading") {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_name("query-executor")
+            .enable_time()
+            .build()
+            .unwrap()
+    } else {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("query-executor")
+            .enable_time()
+            .build()
+            .unwrap()
+    }
+}
+
+/// A single thread is enough here, because server spawns additional
+/// runtimes to use in MPC queries and HTTP.
+#[tokio::main(flavor = "current_thread")]
 pub async fn main() {
     let args = Args::parse();
     let _handle = args.logging.setup_logging();

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -190,6 +190,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
 
     let (_addr, server_handle) = server
         .start_on(
+            &IpaRuntime::from_tokio_runtime(&http_runtime),
             listener,
             // TODO, trace based on the content of the query.
             None as Option<()>,

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -17,6 +17,7 @@ use tokio::time::sleep;
 pub use self::ipa::{playbook_oprf_ipa, run_query_and_validate};
 use crate::{
     config::{ClientConfig, NetworkConfig, PeerConfig},
+    executor::IpaRuntime,
     ff::boolean_array::{BA20, BA3, BA8},
     helpers::query::DpMechanism,
     net::{ClientIdentity, MpcHelperClient},
@@ -211,7 +212,8 @@ pub async fn make_clients(
 
     // Note: This closure is only called when the selected action uses clients.
 
-    let clients = MpcHelperClient::from_conf(&network, &ClientIdentity::None);
+    let clients =
+        MpcHelperClient::from_conf(&IpaRuntime::current(), &network, &ClientIdentity::None);
     while wait > 0 && !clients_ready(&clients).await {
         tracing::debug!("waiting for servers to come up");
         sleep(Duration::from_secs(1)).await;

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -153,6 +153,19 @@ pub mod executor {
         }
     }
 
+    /// allow using [`IpaRuntime`] as Hyper executor
+    impl<Fut> hyper::rt::Executor<Fut> for IpaRuntime
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        fn execute(&self, fut: Fut) {
+            // Dropping the handle does not terminate the task
+            // Clippy wants us to be explicit here.
+            drop(self.spawn(fut));
+        }
+    }
+
     impl<T> IpaJoinHandle<T> {
         pub fn abort(&self) {
             self.0.abort();

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod rand {
 
 #[cfg(all(feature = "shuttle", test))]
 pub(crate) mod task {
-    pub use shuttle::future::{JoinError, JoinHandle};
+    pub use shuttle::future::JoinError;
 }
 
 #[cfg(feature = "shuttle")]
@@ -154,6 +154,7 @@ pub mod executor {
     }
 
     /// allow using [`IpaRuntime`] as Hyper executor
+    #[cfg(feature = "web-app")]
     impl<Fut> hyper::rt::Executor<Fut> for IpaRuntime
     where
         Fut: Future + Send + 'static,
@@ -206,6 +207,17 @@ pub(crate) mod executor {
     pub struct IpaRuntime;
     #[pin_project::pin_project]
     pub struct IpaJoinHandle<T>(#[pin] JoinHandle<T>);
+
+    #[cfg(feature = "web-app")]
+    impl<Fut> hyper::rt::Executor<Fut> for IpaRuntime
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        fn execute(&self, fut: Fut) {
+            drop(self.spawn(fut));
+        }
+    }
 
     impl IpaRuntime {
         #[must_use]

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -508,8 +508,12 @@ pub(crate) mod tests {
             certificate: None,
             hpke_config: None,
         };
-        let client =
-            MpcHelperClient::new(&ClientConfig::default(), peer_config, ClientIdentity::None);
+        let client = MpcHelperClient::new(
+            IpaRuntime::current(),
+            &ClientConfig::default(),
+            peer_config,
+            ClientIdentity::None,
+        );
 
         // The server's self-signed test cert is not in the system truststore, and we didn't supply
         // it in the client config, so the connection should fail with a certificate error.

--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -73,7 +73,7 @@ impl Error {
     ///
     /// # Panics
     /// If the response is not a failure (4xx/5xx status)
-    pub async fn from_failed_resp(resp: ResponseFromEndpoint<'_>) -> Self {
+    pub async fn from_failed_resp(resp: ResponseFromEndpoint) -> Self {
         let status = resp.status();
         assert!(status.is_client_error() || status.is_server_error()); // must be failure
         let (endpoint, body) = resp.into_parts();

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -34,8 +34,6 @@ use hyper::{body::Incoming, header::HeaderName, Request};
 use metrics::increment_counter;
 use rustls::{server::WebPkiClientVerifier, RootCertStore};
 use rustls_pki_types::CertificateDer;
-#[cfg(all(feature = "shuttle", test))]
-use shuttle::future as tokio;
 use tokio_rustls::server::TlsStream;
 use tower::{layer::layer_fn, Service};
 use tower_http::trace::TraceLayer;

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -15,14 +15,13 @@ use std::{
 
 use once_cell::sync::Lazy;
 use rustls_pki_types::CertificateDer;
-use tokio::task::JoinHandle;
 
 use crate::{
     config::{
         ClientConfig, HpkeClientConfig, HpkeServerConfig, NetworkConfig, PeerConfig, ServerConfig,
         TlsConfig,
     },
-    executor::IpaRuntime,
+    executor::{IpaJoinHandle, IpaRuntime},
     helpers::{HandlerBox, HelperIdentity, RequestHandler},
     hpke::{Deserializable as _, IpaPublicKey},
     net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHelperServer},
@@ -302,7 +301,9 @@ impl TestServerBuilder {
             clients,
             handler,
         );
-        let (addr, handle) = server.start_on(Some(server_socket), self.metrics).await;
+        let (addr, handle) = server
+            .start_on(&IpaRuntime::current(), Some(server_socket), self.metrics)
+            .await;
         // Get the config for HelperIdentity::ONE
         let h1_peer_config = network_config.peers.into_iter().next().unwrap();
         // At some point it might be appropriate to return two clients here -- the first being

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -201,7 +201,7 @@ impl TestConfigBuilder {
 
 pub struct TestServer {
     pub addr: SocketAddr,
-    pub handle: JoinHandle<()>,
+    pub handle: IpaJoinHandle<()>,
     pub transport: Arc<HttpTransport>,
     pub server: MpcHelperServer,
     pub client: MpcHelperClient,
@@ -291,7 +291,11 @@ impl TestServerBuilder {
         else {
             panic!("TestConfig should have allocated ports");
         };
-        let clients = MpcHelperClient::from_conf(&network_config, &identity.clone_with_key());
+        let clients = MpcHelperClient::from_conf(
+            &IpaRuntime::current(),
+            &network_config,
+            &identity.clone_with_key(),
+        );
         let handler = self.handler.as_ref().map(HandlerBox::owning_ref);
         let (transport, server) = HttpTransport::new(
             IpaRuntime::current(),
@@ -309,7 +313,12 @@ impl TestServerBuilder {
         // At some point it might be appropriate to return two clients here -- the first being
         // another helper and the second being a report collector. For now we use the same client
         // for both types of calls.
-        let client = MpcHelperClient::new(&network_config.client, h1_peer_config, identity);
+        let client = MpcHelperClient::new(
+            IpaRuntime::current(),
+            &network_config.client,
+            h1_peer_config,
+            identity,
+        );
         TestServer {
             addr,
             handle,

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -22,6 +22,7 @@ use crate::{
         ClientConfig, HpkeClientConfig, HpkeServerConfig, NetworkConfig, PeerConfig, ServerConfig,
         TlsConfig,
     },
+    executor::IpaRuntime,
     helpers::{HandlerBox, HelperIdentity, RequestHandler},
     hpke::{Deserializable as _, IpaPublicKey},
     net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHelperServer},
@@ -294,6 +295,7 @@ impl TestServerBuilder {
         let clients = MpcHelperClient::from_conf(&network_config, &identity.clone_with_key());
         let handler = self.handler.as_ref().map(HandlerBox::owning_ref);
         let (transport, server) = HttpTransport::new(
+            IpaRuntime::current(),
             HelperIdentity::ONE,
             server_config,
             network_config.clone(),

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -393,7 +393,11 @@ mod tests {
                         get_test_identity(id)
                     };
                     let (setup, handler) = AppSetup::new(AppConfig::default());
-                    let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), network_config, &identity);
+                    let clients = MpcHelperClient::from_conf(
+                        &IpaRuntime::current(),
+                        network_config,
+                        &identity,
+                    );
                     let (transport, server) = HttpTransport::new(
                         IpaRuntime::current(),
                         id,
@@ -402,7 +406,9 @@ mod tests {
                         clients,
                         Some(handler),
                     );
-                    server.start_on(&IpaRuntime::current(), Some(socket), ()).await;
+                    server
+                        .start_on(&IpaRuntime::current(), Some(socket), ())
+                        .await;
 
                     setup.connect(transport, HttpShardTransport)
                 },
@@ -415,7 +421,11 @@ mod tests {
     }
 
     async fn test_three_helpers(mut conf: TestConfig) {
-        let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), &conf.network, &ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(
+            &IpaRuntime::current(),
+            &conf.network,
+            &ClientIdentity::None,
+        );
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,
@@ -430,7 +440,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn happy_case_twice() {
         let mut conf = TestConfigBuilder::with_open_ports().build();
-        let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), &conf.network, &ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(
+            &IpaRuntime::current(),
+            &conf.network,
+            &ClientIdentity::None,
+        );
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -393,7 +393,7 @@ mod tests {
                         get_test_identity(id)
                     };
                     let (setup, handler) = AppSetup::new(AppConfig::default());
-                    let clients = MpcHelperClient::from_conf(network_config, &identity);
+                    let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), network_config, &identity);
                     let (transport, server) = HttpTransport::new(
                         IpaRuntime::current(),
                         id,
@@ -402,7 +402,7 @@ mod tests {
                         clients,
                         Some(handler),
                     );
-                    server.start_on(Some(socket), ()).await;
+                    server.start_on(&IpaRuntime::current(), Some(socket), ()).await;
 
                     setup.connect(transport, HttpShardTransport)
                 },
@@ -415,7 +415,7 @@ mod tests {
     }
 
     async fn test_three_helpers(mut conf: TestConfig) {
-        let clients = MpcHelperClient::from_conf(&conf.network, &ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), &conf.network, &ClientIdentity::None);
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,
@@ -430,7 +430,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn happy_case_twice() {
         let mut conf = TestConfigBuilder::with_open_ports().build();
-        let clients = MpcHelperClient::from_conf(&conf.network, &ClientIdentity::None);
+        let clients = MpcHelperClient::from_conf(&IpaRuntime::current(), &conf.network, &ClientIdentity::None);
         let _helpers = make_helpers(
             conf.sockets.take().unwrap(),
             conf.servers,


### PR DESCRIPTION
This attempts to mitigate panics we're seeing in PRF where computing proofs + PRF values stalls all available CPUs for long time and that prevents HTTP heartbeats and causes receive timeouts on all helpers. We create two dedicated runtimes to avoid scheduling conflicts.

This shouldn't impact our existing backpressure mechanisms as application receivers are still responsible for not polling the H2 streams if they are full