### PR TITLE
Exclude all packages from sanitizers except ipa_core

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Add Rust sources
         run: rustup component add rust-src
       - name: Run tests with sanitizer
-        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test -Z build-std --target $TARGET --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate ${{ matrix.features }}"
+        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test -Z build-std -p ipa-core --target $TARGET --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate ${{ matrix.features }}"
 
   miri:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are getting errors in our CI like these, so everything is blocked now: https://github.com/private-attribution/ipa/actions/runs/11243388038/job/31259140713

Thanks to @andyleiserson who pointed that out that we could actually exclude packages that are failing because we only use unsafe features in ipa-core. He also figured that this failure may be related to this https://github.com/lu-zero/cargo-c/issues/398#issuecomment-2349191336 which means that the fix may be coming soon

I checked the fix in my repo and it appears to be working: https://github.com/akoshelev/raw-ipa/actions/runs/11246313348/job/31267934735