### PR TITLE
Make disable-metrics feature turn off global recorder

### DIFF
--- a/ipa-core/src/cli/metric_collector.rs
+++ b/ipa-core/src/cli/metric_collector.rs
@@ -31,6 +31,7 @@ pub fn install_collector() -> CollectorHandle {
 
     // register metrics
     crate::telemetry::metrics::register();
+    tracing::info!("Metrics enabled");
 
     CollectorHandle { snapshotter }
 }


### PR DESCRIPTION
It turns out we've been running with metrics overhead the whole time. I tested a run locally with `disable-metrics` feature and to my surprise I still saw the telemetry emitted from helper binary.

Upon investigating, I came across our `Verbosity` struct that was installing the collector unconditionally. I changed that and tested that metrics are no longer emitted