### PR TITLE
[Sharding 1] TransportRestriction and Client

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -127,7 +127,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
                 }),
             )
         }
-        (None, None) => (ClientIdentity::Helper(my_identity), None),
+        (None, None) => (ClientIdentity::Header(my_identity), None),
         _ => panic!("should have been rejected by clap"),
     };
 

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -181,6 +181,10 @@ impl HelperIdentity {
     pub const TWO: Self = Self { id: 2 };
     pub const THREE: Self = Self { id: 3 };
 
+    pub const ONE_STR: &'static str = "A";
+    pub const TWO_STR: &'static str = "B";
+    pub const THREE_STR: &'static str = "C";
+
     /// Given a helper identity, return an array of the identities of the other two helpers.
     // The order that helpers are returned here is not intended to be meaningful, however,
     // it is currently used directly to determine the assignment of roles in

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -520,6 +520,7 @@ pub(crate) mod tests {
             hpke_config: None,
         };
         let client = MpcHelperClient::new(
+            IpaRuntime::current(),
             &ClientConfig::default(),
             peer_config,
             ClientIdentity::<Ring>::None,
@@ -691,7 +692,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        MpcHelperClient::<IntraHelper>::resp_ok(resp).await.unwrap();
+        MpcHelperClient::<Ring>::resp_ok(resp).await.unwrap();
 
         let mut stream = Arc::clone(&transport)
             .receive(HelperIdentity::ONE, (QueryId, expected_step.clone()))

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -50,7 +50,7 @@ static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
 /// This simple trait is used to make aware on what transport dimnsion one is running. Structs like
 /// [`MpcHelperClient<F>`] use it to know whether they are talking to other servers as Shards
 /// inside a Helper or as a Helper talking to another Helper in a Ring. This trait can be used to
-///  limit the functions exposed by a struct impl depending on the context that it's being used.
+/// limit the functions exposed by a struct impl, depending on the context that it's being used.
 /// Continuing the previous example, the functions a [`MpcHelperClient<F>`] provides are dependent
 /// on whether it's communicating with another Shard or another Helper.
 ///
@@ -62,6 +62,7 @@ pub trait ConnectionFlavor: Debug + Send + Sync + Clone + 'static {
     /// The meaningful identity used in this transport dimension.
     type Identity: TransportIdentity;
 
+    /// The header to be used to identify a HTTP request
     fn identity_header() -> HeaderName;
 }
 

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -1,14 +1,19 @@
 use std::{
+    fmt::Debug,
     io::{self, BufRead},
     sync::Arc,
 };
 
-use axum::http::HeaderName;
+use hyper::header::HeaderName;
 use once_cell::sync::Lazy;
 use rustls::crypto::CryptoProvider;
 use rustls_pki_types::CertificateDer;
 
-use crate::config::{OwnedCertificate, OwnedPrivateKey};
+use crate::{
+    config::{OwnedCertificate, OwnedPrivateKey},
+    helpers::{HelperIdentity, TransportIdentity},
+    sharding::ShardIndex,
+};
 
 mod client;
 mod error;
@@ -23,10 +28,9 @@ pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpShardTransport, HttpTransport};
 
-pub const APPLICATION_JSON: &str = "application/json";
-pub const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
-pub static HTTP_CLIENT_ID_HEADER: HeaderName =
-    HeaderName::from_static("x-unverified-client-identity");
+const APPLICATION_JSON: &str = "application/json";
+const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+static HTTP_HELPER_ID_HEADER: HeaderName = HeaderName::from_static("x-unverified-helper-identity");
 pub static HTTP_SHARD_INDEX_HEADER: HeaderName =
     HeaderName::from_static("x-unverified-shard-index");
 
@@ -42,6 +46,50 @@ pub(crate) const MAX_HTTP2_CONCURRENT_STREAMS: u32 = 5000;
 /// Provides access to IPAs Crypto Provider (AWS Libcrypto).
 static CRYPTO_PROVIDER: Lazy<Arc<CryptoProvider>> =
     Lazy::new(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()));
+
+/// This simple trait is used to make aware on what transport dimnsion one is running. Structs like
+/// [`MpcHelperClient<F>`] use it to know whether they are talking to other servers as Shards
+/// inside a Helper or as a Helper talking to another Helper in a Ring. This trait can be used to
+///  limit the functions exposed by a struct impl depending on the context that it's being used.
+/// Continuing the previous example, the functions a [`MpcHelperClient<F>`] provides are dependent
+/// on whether it's communicating with another Shard or another Helper.
+///
+/// This trait is a safety restriction so that structs or traits only expose an API that's
+/// meaningful for their specific context. When used as a generic bound, it also spreads through
+/// the types making it harder to be misused or combining incompatible types, e.g. Using a
+/// [`ShardIndex`] with a [`Shard`].
+pub trait ConnectionFlavor: Debug + Send + Sync + Clone + 'static {
+    /// The meaningful identity used in this transport dimension.
+    type Identity: TransportIdentity;
+
+    fn identity_header() -> HeaderName;
+}
+
+/// Shard-to-shard communication marker.
+/// This marker is used to restrict communication inside a single Helper, with other shards.
+#[derive(Debug, Copy, Clone)]
+pub struct Shard;
+
+/// Helper-to-helper communication marker.
+/// This marker is used to restrict communication between Helpers. This communication usually has
+/// more restrictions. 3 Hosts with the same sharding index are conencted in a Ring.
+#[derive(Debug, Copy, Clone)]
+pub struct Helper;
+
+impl ConnectionFlavor for Shard {
+    type Identity = ShardIndex;
+
+    fn identity_header() -> HeaderName {
+        HTTP_SHARD_INDEX_HEADER.clone()
+    }
+}
+impl ConnectionFlavor for Helper {
+    type Identity = HelperIdentity;
+
+    fn identity_header() -> HeaderName {
+        HTTP_HELPER_ID_HEADER.clone()
+    }
+}
 
 /// Reads certificates and a private key from the corresponding readers
 ///

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use axum::http::HeaderName;
 use once_cell::sync::Lazy;
 use rustls::crypto::CryptoProvider;
 use rustls_pki_types::CertificateDer;
@@ -24,6 +25,10 @@ pub use transport::{HttpShardTransport, HttpTransport};
 
 pub const APPLICATION_JSON: &str = "application/json";
 pub const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+pub static HTTP_CLIENT_ID_HEADER: HeaderName =
+    HeaderName::from_static("x-unverified-client-identity");
+pub static HTTP_SHARD_INDEX_HEADER: HeaderName =
+    HeaderName::from_static("x-unverified-shard-index");
 
 /// This has the same meaning as const defined in h2 crate, but we don't import it directly.
 /// According to the [`spec`] it cannot exceed 2^31 - 1.

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     net::{client::MpcHelperClient, error::Error, MpcHelperServer},
     protocol::{Gate, QueryId},
-    sharding::ShardIndex,
+    sharding::{Ring, ShardIndex},
     sync::Arc,
 };
 
@@ -208,7 +208,7 @@ impl Transport for Arc<HttpTransport> {
                     .spawn(
                         resp_future
                             .map_err(Into::into)
-                            .and_then(MpcHelperClient::resp_ok),
+                            .and_then(MpcHelperClient::<Ring>::resp_ok),
                     )
                     .await?;
                 Ok(())

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -388,7 +388,7 @@ mod tests {
             zip(HelperIdentity::make_three(), zip(sockets, server_config)).map(
                 |(id, (socket, server_config))| async move {
                     let identity = if disable_https {
-                        ClientIdentity::Helper(id)
+                        ClientIdentity::Header(id)
                     } else {
                         get_test_identity(id)
                     };

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use futures::{Stream, TryFutureExt};
 use pin_project::{pin_project, pinned_drop};
 
+use super::client::resp_ok;
 use crate::{
     config::{NetworkConfig, ServerConfig},
     executor::IpaRuntime,
@@ -21,7 +22,7 @@ use crate::{
     },
     net::{client::MpcHelperClient, error::Error, MpcHelperServer},
     protocol::{Gate, QueryId},
-    sharding::{Ring, ShardIndex},
+    sharding::ShardIndex,
     sync::Arc,
 };
 
@@ -205,11 +206,7 @@ impl Transport for Arc<HttpTransport> {
                 // - avoid blocking this task, if the current runtime is overloaded
                 // - use the runtime that enables IO (current runtime may not).
                 self.http_runtime
-                    .spawn(
-                        resp_future
-                            .map_err(Into::into)
-                            .and_then(MpcHelperClient::<Ring>::resp_ok),
-                    )
+                    .spawn(resp_future.map_err(Into::into).and_then(resp_ok))
                     .await?;
                 Ok(())
             }

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -3,46 +3,8 @@ use std::{
     num::TryFromIntError,
 };
 
-use serde::{Deserialize, Serialize};
-
-use crate::helpers::{HelperIdentity, TransportIdentity};
-
-/// This simple trait is used to make aware on what transport dimnsion one is running. Structs like
-/// [`crate::net::client::MpcHelperClient<R>`] use it to know whether they are talking to other
-/// servers as Shards inside a Helper or as a Helper talking to another Helper in a Ring. This
-/// trait can be used to limit the functions exposed by a struct impl depending on the context that
-/// it's being used. Continuing the previous example, the functions a
-/// [`crate::net::client::MpcHelperClient<R>`] provides are dependent on whether it's communicating
-/// with another Shard or another Helper.
-///
-/// This trait is a safety restriction so that structs or traits only expose an API that's
-/// meaningful for their specific context. When used as a generic bound, it also spreads through
-/// the types making it harder to be misused or combining incompatible types, e.g. Using a
-/// [`ShardIndex`] with a [`Ring`].
-pub trait TransportRestriction: Debug + Send + Sync + Clone + 'static {
-    /// The meaningful identity used in this transport dimension.
-    type Identity: TransportIdentity;
-}
-
-/// This marker is used to restrict communication inside a single Helper, with other shards.
-#[derive(Debug, Copy, Clone)]
-pub struct Sharding;
-
-/// This marker is used to restrict communication inter Helpers. This communication usually has
-/// more restrictions. 3 Hosts with the same sharding index are conencted in a Ring.
-#[derive(Debug, Copy, Clone)]
-pub struct Ring;
-
-impl TransportRestriction for Sharding {
-    type Identity = ShardIndex;
-}
-impl TransportRestriction for Ring {
-    type Identity = HelperIdentity;
-}
-
 /// A unique zero-based index of the helper shard.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-#[serde(from = "u32")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShardIndex(pub u32);
 
 impl From<ShardIndex> for u32 {


### PR DESCRIPTION
This is the first of a series of pull requests (PR) to enable sharding on IPA.

This change doesn't meaningfully change any tests or the operation of IPA. This is just adding abstractions that are going to be useful later.

The key introduction of this PR is the `TransportRestriction` trait. Please take a read at the included docs for more details. To make more sense of the intended usage of this new trait, I'm modifying `MpcHelperClient` to make use of it, but without altering it's API, yet. I understand the scope of this example is limited, hence I can answer questions about its future use if needed.

Renamed `ClientIdentity::Helper` to `ClientIdentity::Header` since I'm planning to use the same mechanism for Shard to Shard identity resolution.