### PR TITLE
[Sharding 2] TransportRestriction-aware Config and Server

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -127,7 +127,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
                 }),
             )
         }
-        (None, None) => (ClientIdentity::Helper(my_identity), None),
+        (None, None) => (ClientIdentity::Header(my_identity), None),
         _ => panic!("should have been rejected by clap"),
     };
 

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -24,6 +24,7 @@ use ipa_core::{
     helpers::query::{DpMechanism, IpaQueryConfig, QueryConfig, QuerySize, QueryType},
     net::MpcHelperClient,
     report::{EncryptedOprfReportStreams, DEFAULT_KEY_ID},
+    sharding::Ring,
     test_fixture::{
         ipa::{ipa_in_the_clear, CappingOrder, IpaSecurityModel, TestRawDataRecord},
         EventGenerator, EventGeneratorConfig, HybridEventGenerator, HybridGeneratorConfig,
@@ -380,7 +381,7 @@ async fn ipa(
 
 async fn ipa_test(
     args: &Args,
-    network: &NetworkConfig,
+    network: &NetworkConfig<Ring>,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
     helper_clients: &[MpcHelperClient; 3],

--- a/ipa-core/src/cli/clientconf.rs
+++ b/ipa-core/src/cli/clientconf.rs
@@ -186,7 +186,7 @@ fn assert_network_config(config_toml: &Map<String, Value>, config_str: &str) {
     else {
         panic!("peers section in toml config is not a table");
     };
-    for (i, peer_config_actual) in nw_config.peers.iter().enumerate() {
+    for (i, peer_config_actual) in nw_config.peers().iter().enumerate() {
         assert_peer_config(&peer_config_expected[i], peer_config_actual);
     }
 }

--- a/ipa-core/src/cli/crypto/encrypt.rs
+++ b/ipa-core/src/cli/crypto/encrypt.rs
@@ -244,7 +244,7 @@ this is not toml!
     }
 
     #[test]
-    #[should_panic = "invalid length 2, expected an array of length 3"]
+    #[should_panic = "Expected a Vec of length 3 but it was 2"]
     fn encrypt_incomplete_network_file() {
         let input_file = sample_data::write_csv(sample_data::test_ipa_data().take(10)).unwrap();
 

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     helpers::query::DpMechanism,
     net::{ClientIdentity, MpcHelperClient},
     protocol::{dp::NoiseParams, ipa_prf::oprf_padding::insecure::OPRFPaddingDp},
+    sharding::Ring,
 };
 
 pub type BreakdownKey = BA8;
@@ -194,19 +195,19 @@ pub async fn make_clients(
     network_path: Option<&Path>,
     scheme: Scheme,
     wait: usize,
-) -> ([MpcHelperClient; 3], NetworkConfig) {
+) -> ([MpcHelperClient; 3], NetworkConfig<Ring>) {
     let mut wait = wait;
     let network = if let Some(path) = network_path {
         NetworkConfig::from_toml_str(&fs::read_to_string(path).unwrap()).unwrap()
     } else {
-        NetworkConfig {
-            peers: [
+        NetworkConfig::<Ring>::new_ring(
+            vec![
                 PeerConfig::new("localhost:3000".parse().unwrap(), None),
                 PeerConfig::new("localhost:3001".parse().unwrap(), None),
                 PeerConfig::new("localhost:3002".parse().unwrap(), None),
             ],
-            client: ClientConfig::default(),
-        }
+            ClientConfig::default(),
+        )
     };
     let network = network.override_scheme(&scheme);
 

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -59,22 +59,6 @@ pub struct NetworkConfig<R: TransportRestriction = Ring> {
 }
 
 impl<R: TransportRestriction> NetworkConfig<R> {
-    /// Reads config from string. Expects config to be toml format.
-    /// To read file, use `fs::read_to_string`
-    ///
-    /// # Errors
-    /// if `input` is in an invalid format
-    pub fn from_toml_str(input: &str) -> Result<Self, Error> {
-        use config::{Config, File, FileFormat};
-
-        let conf: Self = Config::builder()
-            .add_source(File::from_str(input, FileFormat::Toml))
-            .build()?
-            .try_deserialize()?;
-
-        Ok(conf)
-    }
-
     /// # Panics
     /// If `PathAndQuery::from_str("")` fails
     #[must_use]
@@ -169,6 +153,24 @@ impl NetworkConfig<Ring> {
             client,
             identities: HelperIdentity::make_three().to_vec(),
         }
+    }
+
+    /// Reads config from string. Expects config to be toml format.
+    /// To read file, use `fs::read_to_string`
+    ///
+    /// # Errors
+    /// if `input` is in an invalid format
+    pub fn from_toml_str(input: &str) -> Result<Self, Error> {
+        use config::{Config, File, FileFormat};
+
+        let mut conf: Self = Config::builder()
+            .add_source(File::from_str(input, FileFormat::Toml))
+            .build()?
+            .try_deserialize()?;
+
+        conf.identities = HelperIdentity::make_three().to_vec();
+
+        Ok(conf)
     }
 
     /// Clones the internal configs and returns them as an array.

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -181,7 +181,6 @@ impl NetworkConfig<Ring> {
             .try_into()
             .unwrap_or_else(|v: Vec<_>| panic!("Expected a Vec of length 3 but it was {}", v.len()))
     }
-
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -181,6 +181,10 @@ impl HelperIdentity {
     pub const TWO: Self = Self { id: 2 };
     pub const THREE: Self = Self { id: 3 };
 
+    pub const ONE_STR: &'static str = "A";
+    pub const TWO_STR: &'static str = "B";
+    pub const THREE_STR: &'static str = "C";
+
     /// Given a helper identity, return an array of the identities of the other two helpers.
     // The order that helpers are returned here is not intended to be meaningful, however,
     // it is currently used directly to determine the assignment of roles in

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -385,7 +385,7 @@ impl MpcHelperClient<Ring> {
     #[allow(clippy::missing_panics_doc)]
     pub fn from_conf(
         runtime: &IpaRuntime,
-        conf: &NetworkConfig,
+        conf: &NetworkConfig<Ring>,
         identity: &ClientIdentity<Ring>,
     ) -> [Self; 3] {
         conf.peers().each_ref().map(|peer_conf| {

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -520,6 +520,7 @@ pub(crate) mod tests {
             hpke_config: None,
         };
         let client = MpcHelperClient::new(
+            IpaRuntime::current(),
             &ClientConfig::default(),
             peer_config,
             ClientIdentity::<Ring>::None,
@@ -691,7 +692,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        MpcHelperClient::<IntraHelper>::resp_ok(resp).await.unwrap();
+        MpcHelperClient::<Ring>::resp_ok(resp).await.unwrap();
 
         let mut stream = Arc::clone(&transport)
             .receive(HelperIdentity::ONE, (QueryId, expected_step.clone()))

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use axum::http::HeaderName;
 use once_cell::sync::Lazy;
 use rustls::crypto::CryptoProvider;
 use rustls_pki_types::CertificateDer;
@@ -24,6 +25,10 @@ pub use transport::{HttpShardTransport, HttpTransport};
 
 pub const APPLICATION_JSON: &str = "application/json";
 pub const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
+pub static HTTP_CLIENT_ID_HEADER: HeaderName =
+    HeaderName::from_static("x-unverified-client-identity");
+pub static HTTP_SHARD_INDEX_HEADER: HeaderName =
+    HeaderName::from_static("x-unverified-shard-index");
 
 /// This has the same meaning as const defined in h2 crate, but we don't import it directly.
 /// According to the [`spec`] it cannot exceed 2^31 - 1.

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -18,6 +18,7 @@ use hyper::{Request, StatusCode};
 use tower::{layer::layer_fn, Service};
 
 use crate::{
+    helpers::HelperIdentity,
     net::{server::ClientIdentity, HttpTransport},
     sync::Arc,
 };
@@ -88,7 +89,7 @@ impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        match req.extensions().get() {
+        match req.extensions().get::<ClientIdentity<HelperIdentity>>() {
             Some(ClientIdentity(_)) => self.inner.call(req).left_future(),
             None => ready(Ok((
                 StatusCode::UNAUTHORIZED,

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -2,7 +2,7 @@ use axum::{extract::Path, response::IntoResponse, routing::post, Extension, Json
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{query::PrepareQuery, BodyStream, Transport},
+    helpers::{query::PrepareQuery, BodyStream, HelperIdentity, Transport},
     net::{
         http_serde::{
             self,
@@ -20,7 +20,7 @@ use crate::{
 /// processing of that query.
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
-    _: Extension<ClientIdentity>, // require that client is an authenticated helper
+    _: Extension<ClientIdentity<HelperIdentity>>, // require that client is an authenticated helper
     Path(query_id): Path<QueryId>,
     QueryConfigQueryParams(config): QueryConfigQueryParams,
     Json(RequestBody { roles }): Json<RequestBody>,
@@ -100,7 +100,7 @@ mod tests {
     // since we tested `QueryType` with `create`, skip it here
     // More lenient version of Request, specifically so to test failure scenarios
     struct OverrideReq {
-        client_id: Option<ClientIdentity>,
+        client_id: Option<ClientIdentity<HelperIdentity>>,
         query_id: String,
         field_type: String,
         size: Option<i32>,

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -1,7 +1,7 @@
 use axum::{extract::Path, routing::post, Extension, Router};
 
 use crate::{
-    helpers::{BodyStream, Transport},
+    helpers::{BodyStream, HelperIdentity, Transport},
     net::{
         http_serde,
         server::{ClientIdentity, Error},
@@ -15,7 +15,7 @@ use crate::{
 #[tracing::instrument(level = "trace", "step", skip_all, fields(from = ?**from, gate = ?gate))]
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
-    from: Extension<ClientIdentity>,
+    from: Extension<ClientIdentity<HelperIdentity>>,
     Path((query_id, gate)): Path<(QueryId, Gate)>,
     body: BodyStream,
 ) -> Result<(), Error> {
@@ -76,7 +76,7 @@ mod tests {
     }
 
     struct OverrideReq {
-        client_id: Option<ClientIdentity>,
+        client_id: Option<ClientIdentity<HelperIdentity>>,
         query_id: String,
         gate: Gate,
         payload: Vec<u8>,

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -25,6 +25,7 @@ use crate::{
     helpers::{HandlerBox, HelperIdentity, RequestHandler},
     hpke::{Deserializable as _, IpaPublicKey},
     net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHelperServer},
+    sharding::Ring,
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
 };
@@ -33,7 +34,7 @@ pub const DEFAULT_TEST_PORTS: [u16; 3] = [3000, 3001, 3002];
 
 pub struct TestConfig {
     pub disable_https: bool,
-    pub network: NetworkConfig,
+    pub network: NetworkConfig<Ring>,
     pub servers: [ServerConfig; 3],
     pub sockets: Option<[TcpListener; 3]>,
 }
@@ -174,16 +175,13 @@ impl TestConfigBuilder {
                     ))
                 },
             })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let network = NetworkConfig {
+            .collect::<Vec<_>>();
+        let network = NetworkConfig::<Ring>::new_ring(
             peers,
-            client: self
-                .use_http1
+            self.use_http1
                 .then(ClientConfig::use_http1)
                 .unwrap_or_default(),
-        };
+        );
         let servers = if self.disable_https {
             ports.map(|ports| server_config_insecure_http(ports, !self.disable_matchkey_encryption))
         } else {
@@ -203,7 +201,7 @@ pub struct TestServer {
     pub addr: SocketAddr,
     pub handle: IpaJoinHandle<()>,
     pub transport: Arc<HttpTransport>,
-    pub server: MpcHelperServer,
+    pub server: MpcHelperServer<Ring>,
     pub client: MpcHelperClient,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     net::{client::MpcHelperClient, error::Error, MpcHelperServer},
     protocol::{Gate, QueryId},
-    sharding::ShardIndex,
+    sharding::{Ring, ShardIndex},
     sync::Arc,
 };
 
@@ -208,7 +208,7 @@ impl Transport for Arc<HttpTransport> {
                     .spawn(
                         resp_future
                             .map_err(Into::into)
-                            .and_then(MpcHelperClient::resp_ok),
+                            .and_then(MpcHelperClient::<Ring>::resp_ok),
                     )
                     .await?;
                 Ok(())

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -388,7 +388,7 @@ mod tests {
             zip(HelperIdentity::make_three(), zip(sockets, server_config)).map(
                 |(id, (socket, server_config))| async move {
                     let identity = if disable_https {
-                        ClientIdentity::Helper(id)
+                        ClientIdentity::Header(id)
                     } else {
                         get_test_identity(id)
                     };

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -67,12 +67,13 @@ impl HttpTransport {
         runtime: IpaRuntime,
         identity: HelperIdentity,
         server_config: ServerConfig,
-        network_config: NetworkConfig,
+        network_config: NetworkConfig<Ring>,
         clients: [MpcHelperClient; 3],
         handler: Option<HandlerRef>,
-    ) -> (Arc<Self>, MpcHelperServer) {
+    ) -> (Arc<Self>, MpcHelperServer<Ring>) {
         let transport = Self::new_internal(runtime, identity, clients, handler);
-        let server = MpcHelperServer::new(Arc::clone(&transport), server_config, network_config);
+        let server =
+            MpcHelperServer::new_ring(Arc::clone(&transport), server_config, network_config);
         (transport, server)
     }
 
@@ -381,7 +382,7 @@ mod tests {
     async fn make_helpers(
         sockets: [TcpListener; 3],
         server_config: [ServerConfig; 3],
-        network_config: &NetworkConfig,
+        network_config: &NetworkConfig<Ring>,
         disable_https: bool,
     ) -> [HelperApp; 3] {
         join_all(


### PR DESCRIPTION
This is the second of a series of pull requests (PR) to enable sharding on IPA. See [1](https://github.com/private-attribution/ipa/pull/1348). Until 1 is merged, this PR will show both 1 and 2 changes.

This change doesn't meaningfully change any tests or the operation of IPA. This is just adding abstractions that are going to be useful later.

**Configs** now contain a Vec of PeerConfigs and Identities so that we can re-use Config for Ring and Shard communication. In spite of its internal representation, `Config<Ring>` provides a familiar interface with arrays (except in cases where Vec was simpler). Didn't felt the need to add more Config tests since it's exercised by `TestConfigBuilder` in many places. In an upcoming PR (Sharding 3) the new API is going to be further utilized.
Also, moved the `identify_cert` function from the Server into the Config. This allows the Server to just depend on the respective Sharded or Ring Config to find the appropriate certificate depending on the case.

**Server** was generalized to be able to work on Sharded and Ring cases. For the most part this only meant separating the client identification layer. Also, Server, unlike Client, doesn't change its API depending on the TransportRestriction. Instead we will initialize a different Axum router when creating.
