### PR TITLE
[Sharding 2] ConnectionFlavor-aware Server and Config

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -22,7 +22,7 @@ use ipa_core::{
     config::{KeyRegistries, NetworkConfig},
     ff::{boolean_array::BA32, FieldType},
     helpers::query::{DpMechanism, IpaQueryConfig, QueryConfig, QuerySize, QueryType},
-    net::MpcHelperClient,
+    net::{Helper, MpcHelperClient},
     report::{EncryptedOprfReportStreams, DEFAULT_KEY_ID},
     test_fixture::{
         ipa::{ipa_in_the_clear, CappingOrder, IpaSecurityModel, TestRawDataRecord},
@@ -380,7 +380,7 @@ async fn ipa(
 
 async fn ipa_test(
     args: &Args,
-    network: &NetworkConfig,
+    network: &NetworkConfig<Helper>,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
     helper_clients: &[MpcHelperClient; 3],

--- a/ipa-core/src/cli/clientconf.rs
+++ b/ipa-core/src/cli/clientconf.rs
@@ -186,7 +186,7 @@ fn assert_network_config(config_toml: &Map<String, Value>, config_str: &str) {
     else {
         panic!("peers section in toml config is not a table");
     };
-    for (i, peer_config_actual) in nw_config.peers.iter().enumerate() {
+    for (i, peer_config_actual) in nw_config.peers().iter().enumerate() {
         assert_peer_config(&peer_config_expected[i], peer_config_actual);
     }
 }

--- a/ipa-core/src/cli/crypto/encrypt.rs
+++ b/ipa-core/src/cli/crypto/encrypt.rs
@@ -244,7 +244,7 @@ this is not toml!
     }
 
     #[test]
-    #[should_panic = "invalid length 2, expected an array of length 3"]
+    #[should_panic = "Expected a Vec of length 3 but it was 2"]
     fn encrypt_incomplete_network_file() {
         let input_file = sample_data::write_csv(sample_data::test_ipa_data().take(10)).unwrap();
 

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     executor::IpaRuntime,
     ff::boolean_array::{BA20, BA3, BA8},
     helpers::query::DpMechanism,
-    net::{ClientIdentity, MpcHelperClient},
+    net::{ClientIdentity, Helper, MpcHelperClient},
     protocol::{dp::NoiseParams, ipa_prf::oprf_padding::insecure::OPRFPaddingDp},
 };
 
@@ -194,19 +194,19 @@ pub async fn make_clients(
     network_path: Option<&Path>,
     scheme: Scheme,
     wait: usize,
-) -> ([MpcHelperClient; 3], NetworkConfig) {
+) -> ([MpcHelperClient; 3], NetworkConfig<Helper>) {
     let mut wait = wait;
     let network = if let Some(path) = network_path {
         NetworkConfig::from_toml_str(&fs::read_to_string(path).unwrap()).unwrap()
     } else {
-        NetworkConfig {
-            peers: [
+        NetworkConfig::<Helper>::new_ring(
+            vec![
                 PeerConfig::new("localhost:3000".parse().unwrap(), None),
                 PeerConfig::new("localhost:3001".parse().unwrap(), None),
                 PeerConfig::new("localhost:3002".parse().unwrap(), None),
             ],
-            client: ClientConfig::default(),
-        }
+            ClientConfig::default(),
+        )
     };
     let network = network.override_scheme(&scheme);
 

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -1,13 +1,13 @@
 use std::{
-    array,
     borrow::{Borrow, Cow},
+    collections::HashMap,
     fmt::{Debug, Formatter},
-    iter::Zip,
+    iter::zip,
     path::PathBuf,
-    slice,
     time::Duration,
 };
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use hyper::{http::uri::Scheme, Uri};
 use hyper_util::client::legacy::Builder;
 use rustls_pemfile::Item;
@@ -22,6 +22,8 @@ use crate::{
         Deserializable as _, IpaPrivateKey, IpaPublicKey, KeyRegistry, PrivateKeyOnly,
         PublicKeyOnly, Serializable as _,
     },
+    net::{ConnectionFlavor, Helper, Shard},
+    sharding::ShardIndex,
 };
 
 pub type OwnedCertificate = CertificateDer<'static>;
@@ -37,23 +39,123 @@ pub enum Error {
     IOError(#[from] std::io::Error),
 }
 
-/// Configuration information describing a helper network.
+/// Configuration describing either 3 peers in a Ring or N shard peers. In a non-sharded case a
+/// single [`NetworkConfig`] represents the entire network. In a sharded case, each host should
+/// have one Ring and one Sharded configuration to know how to reach its peers.
 ///
 /// The most important thing this contains is discovery information for each of the participating
-/// helpers.
+/// peers.
 #[derive(Clone, Debug, Deserialize)]
-pub struct NetworkConfig {
-    /// Information about each helper participating in the network. The order that helpers are
-    /// listed here determines their assigned helper identities in the network. Note that while the
-    /// helper identities are stable, roles are assigned per query.
-    pub peers: [PeerConfig; 3],
+pub struct NetworkConfig<R: ConnectionFlavor = Helper> {
+    peers: Vec<PeerConfig>,
 
     /// HTTP client configuration.
     #[serde(default)]
     pub client: ClientConfig,
+
+    /// The identities of the index-matching peers. Separating this from [`Self::peers`](field) so
+    /// that parsing is easy to implement.
+    #[serde(skip)]
+    identities: Vec<R::Identity>,
 }
 
-impl NetworkConfig {
+impl<R: ConnectionFlavor> NetworkConfig<R> {
+    /// # Panics
+    /// If `PathAndQuery::from_str("")` fails
+    #[must_use]
+    pub fn override_scheme(self, scheme: &Scheme) -> Self {
+        Self {
+            peers: self
+                .peers
+                .into_iter()
+                .map(|mut peer| {
+                    let mut parts = peer.url.into_parts();
+                    parts.scheme = Some(scheme.clone());
+                    // `http::uri::Uri::from_parts()` requires that a URI have a path if it has a
+                    // scheme. If the URI does not have a scheme, it is not required to have a path.
+                    if parts.path_and_query.is_none() {
+                        parts.path_and_query = Some("".parse().unwrap());
+                    }
+                    peer.url = Uri::try_from(parts).unwrap();
+                    peer
+                })
+                .collect(),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn vec_peers(&self) -> Vec<PeerConfig> {
+        self.peers.clone()
+    }
+
+    #[must_use]
+    pub fn get_peer(&self, i: usize) -> Option<&PeerConfig> {
+        self.peers.get(i)
+    }
+
+    pub fn peers_iter(&self) -> std::slice::Iter<'_, PeerConfig> {
+        self.peers.iter()
+    }
+
+    /// We currently require an exact match with the peer cert (i.e. we don't support verifying
+    /// the certificate against a truststore and identifying the peer by the certificate
+    /// subject). This could be changed if the need arises.
+    #[must_use]
+    pub fn identify_cert(&self, cert: Option<&CertificateDer>) -> Option<R::Identity> {
+        let cert = cert?;
+        for (id, p) in zip(self.identities.iter(), self.peers.iter()) {
+            if p.certificate.as_ref() == Some(cert) {
+                return Some(*id);
+            }
+        }
+        // It might be nice to log something here. We could log the certificate base64?
+        tracing::error!(
+            "A client certificate was presented that does not match a known helper. Certificate: {}",
+            BASE64.encode(cert),
+        );
+        None
+    }
+}
+
+impl NetworkConfig<Shard> {
+    #[must_use]
+    pub fn new_shards(peers: Vec<PeerConfig>, client: ClientConfig) -> Self {
+        let mut identities = Vec::with_capacity(peers.len());
+        for (i, _p) in zip(0u32.., peers.iter()) {
+            identities.push(ShardIndex(i));
+        }
+        Self {
+            peers,
+            client,
+            identities,
+        }
+    }
+
+    #[must_use]
+    pub fn peers_map(&self) -> HashMap<ShardIndex, &PeerConfig> {
+        let mut indexed_peers = HashMap::new();
+        for (ix, p) in zip(self.identities.iter(), self.peers.iter()) {
+            indexed_peers.insert(*ix, p);
+        }
+        indexed_peers
+    }
+}
+
+impl NetworkConfig<Helper> {
+    /// Creates a new ring configuration.
+    /// # Panics
+    /// If the vector doesn't contain exactly 3 items.
+    #[must_use]
+    pub fn new_ring(ring: Vec<PeerConfig>, client: ClientConfig) -> Self {
+        assert_eq!(3, ring.len());
+        Self {
+            peers: ring,
+            client,
+            identities: HelperIdentity::make_three().to_vec(),
+        }
+    }
+
     /// Reads config from string. Expects config to be toml format.
     /// To read file, use `fs::read_to_string`
     ///
@@ -62,49 +164,25 @@ impl NetworkConfig {
     pub fn from_toml_str(input: &str) -> Result<Self, Error> {
         use config::{Config, File, FileFormat};
 
-        let conf: Self = Config::builder()
+        let mut conf: Self = Config::builder()
             .add_source(File::from_str(input, FileFormat::Toml))
             .build()?
             .try_deserialize()?;
 
+        conf.identities = HelperIdentity::make_three().to_vec();
+
         Ok(conf)
     }
 
-    pub fn new(peers: [PeerConfig; 3], client: ClientConfig) -> Self {
-        Self { peers, client }
-    }
-
-    pub fn peers(&self) -> &[PeerConfig; 3] {
-        &self.peers
-    }
-
-    // Can maybe be replaced with array::zip when stable?
-    pub fn enumerate_peers(
-        &self,
-    ) -> Zip<array::IntoIter<HelperIdentity, 3>, slice::Iter<PeerConfig>> {
-        HelperIdentity::make_three()
-            .into_iter()
-            .zip(self.peers.iter())
-    }
-
+    /// Clones the internal configs and returns them as an array.
     /// # Panics
-    /// If `PathAndQuery::from_str("")` fails
+    /// If the internal vector isn't of size 3.
     #[must_use]
-    pub fn override_scheme(self, scheme: &Scheme) -> NetworkConfig {
-        NetworkConfig {
-            peers: self.peers.map(|mut peer| {
-                let mut parts = peer.url.into_parts();
-                parts.scheme = Some(scheme.clone());
-                // `http::uri::Uri::from_parts()` requires that a URI have a path if it has a
-                // scheme. If the URI does not have a scheme, it is not required to have a path.
-                if parts.path_and_query.is_none() {
-                    parts.path_and_query = Some("".parse().unwrap());
-                }
-                peer.url = Uri::try_from(parts).unwrap();
-                peer
-            }),
-            ..self
-        }
+    pub fn peers(&self) -> [PeerConfig; 3] {
+        self.peers
+            .clone()
+            .try_into()
+            .unwrap_or_else(|v: Vec<_>| panic!("Expected a Vec of length 3 but it was {}", v.len()))
     }
 }
 
@@ -422,10 +500,11 @@ impl KeyRegistries {
     /// If network file is improperly formatted
     pub fn init_from(
         &mut self,
-        network: &NetworkConfig,
+        network: &NetworkConfig<Helper>,
     ) -> Option<[&KeyRegistry<PublicKeyOnly>; 3]> {
         // Get the configs, if all three peers have one
-        let configs = network.peers().iter().try_fold(Vec::new(), |acc, peer| {
+        let peers = network.peers();
+        let configs = peers.iter().try_fold(Vec::new(), |acc, peer| {
             if let (mut vec, Some(hpke_config)) = (acc, peer.hpke_config.as_ref()) {
                 vec.push(hpke_config);
                 Some(vec)

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -384,7 +384,7 @@ impl MpcHelperClient<Helper> {
     #[allow(clippy::missing_panics_doc)]
     pub fn from_conf(
         runtime: &IpaRuntime,
-        conf: &NetworkConfig,
+        conf: &NetworkConfig<Helper>,
         identity: &ClientIdentity<Helper>,
     ) -> [Self; 3] {
         conf.peers().each_ref().map(|peer_conf| {

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -31,8 +31,7 @@ pub use transport::{HttpShardTransport, HttpTransport};
 const APPLICATION_JSON: &str = "application/json";
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
 static HTTP_HELPER_ID_HEADER: HeaderName = HeaderName::from_static("x-unverified-helper-identity");
-pub static HTTP_SHARD_INDEX_HEADER: HeaderName =
-    HeaderName::from_static("x-unverified-shard-index");
+static HTTP_SHARD_INDEX_HEADER: HeaderName = HeaderName::from_static("x-unverified-shard-index");
 
 /// This has the same meaning as const defined in h2 crate, but we don't import it directly.
 /// According to the [`spec`] it cannot exceed 2^31 - 1.

--- a/ipa-core/src/net/server/handlers/mod.rs
+++ b/ipa-core/src/net/server/handlers/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     sync::Arc,
 };
 
-pub fn router(transport: Arc<HttpTransport>) -> Router {
+pub fn ring_router(transport: Arc<HttpTransport>) -> Router {
     echo::router().nest(
         http_serde::query::BASE_AXUM_PATH,
         Router::new()

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -18,6 +18,7 @@ use hyper::{Request, StatusCode};
 use tower::{layer::layer_fn, Service};
 
 use crate::{
+    helpers::HelperIdentity,
     net::{server::ClientIdentity, HttpTransport},
     sync::Arc,
 };
@@ -88,7 +89,7 @@ impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
     }
 
     fn call(&mut self, req: Request<B>) -> Self::Future {
-        match req.extensions().get() {
+        match req.extensions().get::<ClientIdentity<HelperIdentity>>() {
             Some(ClientIdentity(_)) => self.inner.call(req).left_future(),
             None => ready(Ok((
                 StatusCode::UNAUTHORIZED,

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -2,7 +2,7 @@ use axum::{extract::Path, response::IntoResponse, routing::post, Extension, Json
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{query::PrepareQuery, BodyStream, Transport},
+    helpers::{query::PrepareQuery, BodyStream, HelperIdentity, Transport},
     net::{
         http_serde::{
             self,
@@ -20,7 +20,7 @@ use crate::{
 /// processing of that query.
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
-    _: Extension<ClientIdentity>, // require that client is an authenticated helper
+    _: Extension<ClientIdentity<HelperIdentity>>, // require that client is an authenticated helper
     Path(query_id): Path<QueryId>,
     QueryConfigQueryParams(config): QueryConfigQueryParams,
     Json(RequestBody { roles }): Json<RequestBody>,
@@ -100,7 +100,7 @@ mod tests {
     // since we tested `QueryType` with `create`, skip it here
     // More lenient version of Request, specifically so to test failure scenarios
     struct OverrideReq {
-        client_id: Option<ClientIdentity>,
+        client_id: Option<ClientIdentity<HelperIdentity>>,
         query_id: String,
         field_type: String,
         size: Option<i32>,

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -1,7 +1,7 @@
 use axum::{extract::Path, routing::post, Extension, Router};
 
 use crate::{
-    helpers::{BodyStream, Transport},
+    helpers::{BodyStream, HelperIdentity, Transport},
     net::{
         http_serde,
         server::{ClientIdentity, Error},
@@ -15,7 +15,7 @@ use crate::{
 #[tracing::instrument(level = "trace", "step", skip_all, fields(from = ?**from, gate = ?gate))]
 async fn handler(
     transport: Extension<Arc<HttpTransport>>,
-    from: Extension<ClientIdentity>,
+    from: Extension<ClientIdentity<HelperIdentity>>,
     Path((query_id, gate)): Path<(QueryId, Gate)>,
     body: BodyStream,
 ) -> Result<(), Error> {
@@ -76,7 +76,7 @@ mod tests {
     }
 
     struct OverrideReq {
-        client_id: Option<ClientIdentity>,
+        client_id: Option<ClientIdentity<HelperIdentity>>,
         query_id: String,
         gate: Gate,
         payload: Vec<u8>,

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -4,6 +4,7 @@ mod handlers;
 use std::{
     borrow::Cow,
     io,
+    marker::PhantomData,
     net::{Ipv4Addr, SocketAddr, TcpListener},
     ops::Deref,
     task::{Context, Poll},
@@ -26,7 +27,6 @@ use axum_server::{
     tls_rustls::{RustlsAcceptor, RustlsConfig},
     Handle, Server,
 };
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use futures::{
     future::{ready, BoxFuture, Either, Ready},
     FutureExt,
@@ -34,21 +34,21 @@ use futures::{
 use hyper::{body::Incoming, Request};
 use metrics::increment_counter;
 use rustls::{server::WebPkiClientVerifier, RootCertStore};
-use rustls_pki_types::CertificateDer;
 use tokio_rustls::server::TlsStream;
 use tower::{layer::layer_fn, Service};
 use tower_http::trace::TraceLayer;
 use tracing::{error, Span};
 
-use super::HTTP_HELPER_ID_HEADER;
 use crate::{
-    config::{NetworkConfig, OwnedCertificate, OwnedPrivateKey, ServerConfig, TlsConfig},
+    config::{
+        NetworkConfig, OwnedCertificate, OwnedPrivateKey, PeerConfig, ServerConfig, TlsConfig,
+    },
     error::BoxError,
     executor::{IpaJoinHandle, IpaRuntime},
-    helpers::{HelperIdentity, TransportIdentity},
+    helpers::TransportIdentity,
     net::{
-        parse_certificate_and_private_key_bytes, server::config::HttpServerConfig, Error,
-        HttpTransport, CRYPTO_PROVIDER,
+        parse_certificate_and_private_key_bytes, server::config::HttpServerConfig,
+        ConnectionFlavor, Error, Helper, HttpTransport, CRYPTO_PROVIDER,
     },
     sync::Arc,
     telemetry::metrics::{web::RequestProtocolVersion, REQUESTS_RECEIVED},
@@ -76,34 +76,38 @@ impl TracingSpanMaker for () {
 
 /// IPA helper web service
 ///
-/// `MpcHelperServer` handles requests from both peer helpers and external clients.
-pub struct MpcHelperServer {
-    transport: Arc<HttpTransport>,
+/// `MpcHelperServer` handles requests from peer helpers, shards within the same helper and
+/// external clients.
+///
+/// The Transport Restriction generic is used to make the server aware whether it should offer a
+/// HTTP API for shards or for other Helpers. External clients can reach out to both APIs to push
+/// the input data among other things.
+pub struct MpcHelperServer<F: ConnectionFlavor = Helper> {
     config: ServerConfig,
-    network_config: NetworkConfig,
+    network_config: NetworkConfig<F>,
+    router: Router,
 }
 
-impl MpcHelperServer {
-    pub fn new(
+impl MpcHelperServer<Helper> {
+    pub fn new_ring(
         transport: Arc<HttpTransport>,
         config: ServerConfig,
-        network_config: NetworkConfig,
+        network_config: NetworkConfig<Helper>,
     ) -> Self {
+        let router = handlers::ring_router(transport);
         MpcHelperServer {
-            transport,
             config,
             network_config,
+            router,
         }
     }
+}
 
-    fn router(&self) -> Router {
-        handlers::router(Arc::clone(&self.transport))
-    }
-
+impl<F: ConnectionFlavor> MpcHelperServer<F> {
     #[cfg(all(test, unit_test))]
     async fn handle_req(&self, req: hyper::Request<axum::body::Body>) -> axum::response::Response {
         use tower::ServiceExt;
-        self.router().oneshot(req).await.unwrap()
+        self.router.clone().oneshot(req).await.unwrap()
     }
 
     /// Starts the MPC helper service.
@@ -133,7 +137,7 @@ impl MpcHelperServer {
         #[cfg(not(test))]
         const BIND_ADDRESS: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 
-        let svc = self.router().layer(
+        let svc = self.router.clone().layer(
             TraceLayer::new_for_http()
                 .make_span_with(move |_request: &hyper::Request<_>| tracing.make_span())
                 .on_request(|request: &hyper::Request<_>, _: &Span| {
@@ -146,7 +150,7 @@ impl MpcHelperServer {
         let task_handle = match (self.config.disable_https, listener) {
             (true, Some(listener)) => {
                 let svc = svc
-                    .layer(layer_fn(SetClientIdentityFromHeader::new))
+                    .layer(layer_fn(SetClientIdentityFromHeader::<_, F>::new))
                     .into_make_service();
                 spawn_server(
                     runtime,
@@ -159,12 +163,12 @@ impl MpcHelperServer {
             (true, None) => {
                 let addr = SocketAddr::new(BIND_ADDRESS.into(), self.config.port.unwrap_or(0));
                 let svc = svc
-                    .layer(layer_fn(SetClientIdentityFromHeader::new))
+                    .layer(layer_fn(SetClientIdentityFromHeader::<_, F>::new))
                     .into_make_service();
                 spawn_server(runtime, axum_server::bind(addr), handle.clone(), svc).await
             }
             (false, Some(listener)) => {
-                let rustls_config = rustls_config(&self.config, &self.network_config)
+                let rustls_config = rustls_config(&self.config, self.network_config.vec_peers())
                     .await
                     .expect("invalid TLS configuration");
                 spawn_server(
@@ -179,7 +183,7 @@ impl MpcHelperServer {
             }
             (false, None) => {
                 let addr = SocketAddr::new(BIND_ADDRESS.into(), self.config.port.unwrap_or(0));
-                let rustls_config = rustls_config(&self.config, &self.network_config)
+                let rustls_config = rustls_config(&self.config, self.network_config.vec_peers())
                     .await
                     .expect("invalid TLS configuration");
                 spawn_server(
@@ -276,16 +280,12 @@ async fn certificate_and_key(
 /// If there is a problem with the TLS configuration.
 async fn rustls_config(
     config: &ServerConfig,
-    network: &NetworkConfig,
+    certs: Vec<PeerConfig>,
 ) -> Result<RustlsConfig, BoxError> {
     let (cert, key) = certificate_and_key(config).await?;
 
     let mut trusted_certs = RootCertStore::empty();
-    for cert in network
-        .peers()
-        .iter()
-        .filter_map(|peer| peer.certificate.clone())
-    {
+    for cert in certs.into_iter().filter_map(|peer| peer.certificate) {
         // Note that this uses `webpki::TrustAnchor::try_from_cert_der`, which *does not* validate
         // the certificate. That is not required for security, but might be desirable to flag
         // configuration errors.
@@ -315,73 +315,54 @@ async fn rustls_config(
 // at some inconvenience (e.g. `MaybeExtensionExt`), we avoid using `Option` within the extension,
 // to avoid possible confusion about how many times the return from `req.extensions().get()` must be
 // unwrapped to ensure valid authentication.
-#[derive(Clone, Copy, Debug)]
-struct ClientIdentity(pub HelperIdentity);
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ClientIdentity<I: TransportIdentity>(pub I);
 
-impl Deref for ClientIdentity {
-    type Target = HelperIdentity;
+impl<I: TransportIdentity> Deref for ClientIdentity<I> {
+    type Target = I;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl TryFrom<HeaderValue> for ClientIdentity {
+impl<I: TransportIdentity> TryFrom<HeaderValue> for ClientIdentity<I> {
     type Error = Error;
 
     fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
         let header_str = value.to_str()?;
-        HelperIdentity::from_str(header_str)
+        I::from_str(header_str)
             .map_err(|e| Error::InvalidHeader(Box::new(e)))
             .map(ClientIdentity)
     }
 }
 
 /// `Accept`or that sets an axum `Extension` indiciating the authenticated remote helper identity.
+/// Validating the certificate is something that happens earlier at connection time, this just
+/// provide identity to the inner server handlers.
 #[derive(Clone)]
-struct ClientCertRecognizingAcceptor {
+struct ClientCertRecognizingAcceptor<F: ConnectionFlavor> {
     inner: RustlsAcceptor,
-    network_config: Arc<NetworkConfig>,
+    network_config: Arc<NetworkConfig<F>>,
 }
 
-impl ClientCertRecognizingAcceptor {
-    fn new(inner: RustlsAcceptor, network_config: NetworkConfig) -> Self {
+impl<F: ConnectionFlavor> ClientCertRecognizingAcceptor<F> {
+    fn new(inner: RustlsAcceptor, network_config: NetworkConfig<F>) -> Self {
         Self {
             inner,
             network_config: Arc::new(network_config),
         }
     }
-
-    // This can't be a method (at least not that takes `&self`) because it needs to go in a 'static future.
-    fn identify_client(
-        network_config: &NetworkConfig,
-        cert_option: Option<&CertificateDer>,
-    ) -> Option<ClientIdentity> {
-        let cert = cert_option?;
-        // We currently require an exact match with the peer cert (i.e. we don't support verifying
-        // the certificate against a truststore and identifying the peer by the certificate
-        // subject). This could be changed if the need arises.
-        for (id, peer) in network_config.enumerate_peers() {
-            if peer.certificate.as_ref() == Some(cert) {
-                return Some(ClientIdentity(id));
-            }
-        }
-        // It might be nice to log something here. We could log the certificate base64?
-        error!(
-            "A client certificate was presented that does not match a known helper. Certificate: {}",
-            BASE64.encode(cert),
-        );
-        None
-    }
 }
 
-impl<I, S> Accept<I, S> for ClientCertRecognizingAcceptor
+impl<I, S, F> Accept<I, S> for ClientCertRecognizingAcceptor<F>
 where
     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     S: Send + 'static,
+    F: ConnectionFlavor,
 {
     type Stream = TlsStream<I>;
-    type Service = SetClientIdentityFromCertificate<S>;
+    type Service = SetClientIdentityFromCertificate<S, F>;
     type Future = BoxFuture<'static, io::Result<(Self::Stream, Self::Service)>>;
 
     fn accept(&self, stream: I, service: S) -> Self::Future {
@@ -390,7 +371,7 @@ where
 
         Box::pin(async move {
             let (stream, service) = acceptor.accept(stream, service).await.map_err(|err| {
-                error!("[ClientCertRecognizingAcceptor] connection error: {err}");
+                error!("[ClientCertRecognizingAcceptor] Internal acceptor error: {err}");
                 err
             })?;
 
@@ -401,27 +382,33 @@ where
             //    certificate here, because the certificate must have passed full verification at
             //    connection time. But it's possible the certificate subject is not something we
             //    recognize as a helper.
-            let id = Self::identify_client(
-                &network_config,
-                stream
-                    .get_ref()
-                    .1
-                    .peer_certificates()
-                    .and_then(<[_]>::first),
-            );
-            let service = SetClientIdentityFromCertificate { inner: service, id };
+            let opt_cert = stream
+                .get_ref()
+                .1
+                .peer_certificates()
+                .and_then(<[_]>::first);
+            let option_id: Option<F::Identity> = network_config.identify_cert(opt_cert);
+            let client_id = option_id.map(ClientIdentity);
+            let service = SetClientIdentityFromCertificate {
+                inner: service,
+                id: client_id,
+            };
             Ok((stream, service))
         })
     }
 }
 
 #[derive(Clone)]
-struct SetClientIdentityFromCertificate<S> {
+struct SetClientIdentityFromCertificate<S, F: ConnectionFlavor> {
     inner: S,
-    id: Option<ClientIdentity>,
+    id: Option<ClientIdentity<F::Identity>>,
 }
 
-impl<B, S: Service<Request<B>>> Service<Request<B>> for SetClientIdentityFromCertificate<S> {
+impl<B, F, S> Service<Request<B>> for SetClientIdentityFromCertificate<S, F>
+where
+    S: Service<Request<B>>,
+    F: ConnectionFlavor,
+{
     type Response = S::Response;
     type Error = S::Error;
     type Future = S::Future;
@@ -444,18 +431,24 @@ impl<B, S: Service<Request<B>>> Service<Request<B>> for SetClientIdentityFromCer
 /// Since this allows a client to claim any identity, it is completely
 /// insecure. It must only be used in contexts where that is acceptable.
 #[derive(Clone)]
-struct SetClientIdentityFromHeader<S> {
+struct SetClientIdentityFromHeader<S, F: ConnectionFlavor> {
     inner: S,
+    _restriction: PhantomData<F>,
 }
 
-impl<S> SetClientIdentityFromHeader<S> {
+impl<S, F: ConnectionFlavor> SetClientIdentityFromHeader<S, F> {
     fn new(inner: S) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            _restriction: PhantomData,
+        }
     }
 }
 
-impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
-    for SetClientIdentityFromHeader<S>
+impl<B, S, F> Service<Request<B>> for SetClientIdentityFromHeader<S, F>
+where
+    S: Service<Request<B>, Response = Response>,
+    F: ConnectionFlavor,
 {
     type Response = Response;
     type Error = S::Error;
@@ -467,15 +460,36 @@ impl<B, S: Service<Request<B>, Response = Response>> Service<Request<B>>
     }
 
     fn call(&mut self, mut req: Request<B>) -> Self::Future {
-        if let Some(header_value) = req.headers().get(&HTTP_HELPER_ID_HEADER) {
-            let id_result = ClientIdentity::try_from(header_value.clone())
-                .map_err(|e| Error::InvalidHeader(format!("{HTTP_HELPER_ID_HEADER}: {e}").into()));
+        if let Some(header_value) = req.headers().get(F::identity_header()) {
+            let id_result = ClientIdentity::<F::Identity>::try_from(header_value.clone());
             match id_result {
                 Ok(id) => req.extensions_mut().insert(id),
                 Err(err) => return ready(Ok(err.into_response())).right_future(),
             };
         }
         self.inner.call(req).left_future()
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use axum::http::HeaderValue;
+
+    use crate::{helpers::HelperIdentity, net::server::ClientIdentity};
+
+    #[test]
+    fn identify_from_header_happy_case() {
+        let h = HeaderValue::from_static("A");
+        let id = ClientIdentity::<HelperIdentity>::try_from(h);
+        assert_eq!(id.unwrap(), ClientIdentity(HelperIdentity::ONE));
+    }
+
+    #[test]
+    #[should_panic = "The string H1 is an invalid Helper Identity"]
+    fn identify_from_header_wrong_header() {
+        let h = HeaderValue::from_static("H1");
+        let id = ClientIdentity::<HelperIdentity>::try_from(h);
+        id.unwrap();
     }
 }
 
@@ -499,6 +513,7 @@ mod e2e_tests {
         client::danger::{ServerCertVerified, ServerCertVerifier},
         pki_types::ServerName,
     };
+    use rustls_pki_types::CertificateDer;
     use tracing::Level;
 
     use super::*;

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -24,7 +24,7 @@ use crate::{
     executor::{IpaJoinHandle, IpaRuntime},
     helpers::{HandlerBox, HelperIdentity, RequestHandler},
     hpke::{Deserializable as _, IpaPublicKey},
-    net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHelperServer},
+    net::{ClientIdentity, Helper, HttpTransport, MpcHelperClient, MpcHelperServer},
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
 };
@@ -33,7 +33,7 @@ pub const DEFAULT_TEST_PORTS: [u16; 3] = [3000, 3001, 3002];
 
 pub struct TestConfig {
     pub disable_https: bool,
-    pub network: NetworkConfig,
+    pub network: NetworkConfig<Helper>,
     pub servers: [ServerConfig; 3],
     pub sockets: Option<[TcpListener; 3]>,
 }
@@ -174,16 +174,13 @@ impl TestConfigBuilder {
                     ))
                 },
             })
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
-        let network = NetworkConfig {
+            .collect::<Vec<_>>();
+        let network = NetworkConfig::<Helper>::new_ring(
             peers,
-            client: self
-                .use_http1
+            self.use_http1
                 .then(ClientConfig::use_http1)
                 .unwrap_or_default(),
-        };
+        );
         let servers = if self.disable_https {
             ports.map(|ports| server_config_insecure_http(ports, !self.disable_matchkey_encryption))
         } else {
@@ -203,7 +200,7 @@ pub struct TestServer {
     pub addr: SocketAddr,
     pub handle: IpaJoinHandle<()>,
     pub transport: Arc<HttpTransport>,
-    pub server: MpcHelperServer,
+    pub server: MpcHelperServer<Helper>,
     pub client: MpcHelperClient,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use futures::{Stream, TryFutureExt};
 use pin_project::{pin_project, pinned_drop};
 
-use super::client::resp_ok;
+use super::{client::resp_ok, Helper};
 use crate::{
     config::{NetworkConfig, ServerConfig},
     executor::IpaRuntime,
@@ -68,12 +68,13 @@ impl HttpTransport {
         runtime: IpaRuntime,
         identity: HelperIdentity,
         server_config: ServerConfig,
-        network_config: NetworkConfig,
+        network_config: NetworkConfig<Helper>,
         clients: [MpcHelperClient; 3],
         handler: Option<HandlerRef>,
-    ) -> (Arc<Self>, MpcHelperServer) {
+    ) -> (Arc<Self>, MpcHelperServer<Helper>) {
         let transport = Self::new_internal(runtime, identity, clients, handler);
-        let server = MpcHelperServer::new(Arc::clone(&transport), server_config, network_config);
+        let server =
+            MpcHelperServer::new_ring(Arc::clone(&transport), server_config, network_config);
         (transport, server)
     }
 
@@ -378,7 +379,7 @@ mod tests {
     async fn make_helpers(
         sockets: [TcpListener; 3],
         server_config: [ServerConfig; 3],
-        network_config: &NetworkConfig,
+        network_config: &NetworkConfig<Helper>,
         disable_https: bool,
     ) -> [HelperApp; 3] {
         join_all(


### PR DESCRIPTION
This is the second of a series of pull requests (PR) to enable sharding on IPA. See [1](https://github.com/private-attribution/ipa/pull/1348).

This change doesn't meaningfully change any tests or the operation of IPA. This is just adding abstractions that are going to be useful later.

**Configs** now contain a Vec of PeerConfigs and Identities so that we can re-use Config for Ring and Shard communication. In spite of its internal representation, `Config<Helper>` provides a familiar interface with arrays (except in cases where Vec was simpler). Didn't felt the need to add more Config tests since it's exercised by `TestConfigBuilder` in many places. In an upcoming PR (Sharding 3) the new API is going to be further utilized.

Also, just moved the `identify_cert` function from the Server into the Config. This allows the Server to just depend on the respective Sharded or Ring Config to find the appropriate certificate depending on the case.

I made these changes before we moved `ConnectionFlavor` (CF) deeper into the `net` module (as part of PR #1348). I'm leaving `NetworkConfig` using CF here to show how it "looks like". If we want to avoid depending on CF, I will switch to use `TransportIdentity`. But maybe we want to pull CF back out into the `sharding` module.

**Server** was generalized to be able to work on Sharded and Ring cases. For the most part this only meant separating the client identification layer. Also, Server, unlike Client, doesn't change its API depending on the TransportRestriction. Instead we will initialize a different Axum router when creating. In here I'm creating the `ring_router`.
