### PR TITLE
[Sharding 3] ConnectionFlavor-aware HttpTransport

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     io::BufReader,
     net::TcpListener,
@@ -17,7 +18,8 @@ use ipa_core::{
     error::BoxError,
     executor::IpaRuntime,
     helpers::HelperIdentity,
-    net::{ClientIdentity, HttpShardTransport, HttpTransport, MpcHelperClient},
+    net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHttpTransport, ShardHttpTransport},
+    sharding::ShardIndex,
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tokio::runtime::Runtime;
@@ -158,13 +160,19 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
     let network_config_path = args.network.as_deref().unwrap();
     let network_config = NetworkConfig::from_toml_str(&fs::read_to_string(network_config_path)?)?
         .override_scheme(&scheme);
+
+    // TODO: Following is just temporary until Shard Transport is actually used.
+    let shard_clients_config = network_config.client.clone();
+    let shard_server_config = server_config.clone();
+    // ---
+
     let http_runtime = new_http_runtime();
     let clients = MpcHelperClient::from_conf(
         &IpaRuntime::from_tokio_runtime(&http_runtime),
         &network_config,
         &identity,
     );
-    let (transport, server) = HttpTransport::new(
+    let (transport, server) = MpcHttpTransport::new(
         IpaRuntime::from_tokio_runtime(&http_runtime),
         my_identity,
         server_config,
@@ -173,7 +181,19 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         Some(handler),
     );
 
-    let _app = setup.connect(transport.clone(), HttpShardTransport);
+    // TODO: Following is just temporary until Shard Transport is actually used.
+    let shard_network_config = NetworkConfig::new_shards(vec![], shard_clients_config);
+    let (shard_transport, _shard_server) = ShardHttpTransport::new(
+        IpaRuntime::from_tokio_runtime(&http_runtime),
+        ShardIndex::FIRST,
+        shard_server_config,
+        shard_network_config,
+        HashMap::new(),
+        None,
+    );
+    // ---
+
+    let _app = setup.connect(transport.clone(), shard_transport.clone());
 
     let listener = args.server_socket_fd
         .map(|fd| {

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -18,7 +18,7 @@ use ipa_core::{
     error::BoxError,
     executor::IpaRuntime,
     helpers::HelperIdentity,
-    net::{ClientIdentity, HttpTransport, MpcHelperClient, MpcHttpTransport, ShardHttpTransport},
+    net::{ClientIdentity, MpcHelperClient, MpcHttpTransport, ShardHttpTransport},
     sharding::ShardIndex,
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs,
     io::BufReader,
     net::TcpListener,
@@ -177,7 +176,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         my_identity,
         server_config,
         network_config,
-        clients,
+        &clients,
         Some(handler),
     );
 
@@ -188,7 +187,7 @@ async fn server(args: ServerArgs) -> Result<(), BoxError> {
         ShardIndex::FIRST,
         shard_server_config,
         shard_network_config,
-        HashMap::new(),
+        vec![],
         None,
     );
     // ---

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -45,9 +45,9 @@ pub type MpcTransportImpl = TransportImpl<crate::helpers::HelperIdentity>;
 pub type ShardTransportImpl = TransportImpl<ShardIndex>;
 
 #[cfg(feature = "real-world-infra")]
-pub type MpcTransportImpl = crate::sync::Arc<crate::net::HttpTransport>;
+pub type MpcTransportImpl = crate::net::MpcHttpTransport;
 #[cfg(feature = "real-world-infra")]
-pub type ShardTransportImpl = crate::net::HttpShardTransport;
+pub type ShardTransportImpl = crate::net::ShardHttpTransport;
 
 pub type MpcTransportError = <MpcTransportImpl as Transport>::Error;
 

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -50,6 +50,9 @@ pub trait Identity:
     /// # Errors
     /// If there where any problems parsing the identity.
     fn from_str(s: &str) -> Result<Self, crate::error::Error>;
+
+    /// Returns a 0-based index suitable to index Vec or other containers.
+    fn as_index(&self) -> usize;
 }
 
 impl Identity for ShardIndex {
@@ -63,6 +66,10 @@ impl Identity for ShardIndex {
                 crate::error::Error::InvalidId(format!("The string {s} is an invalid Shard Index"))
             })
             .map(ShardIndex::from)
+    }
+
+    fn as_index(&self) -> usize {
+        usize::from(*self)
     }
 }
 impl Identity for HelperIdentity {
@@ -85,6 +92,10 @@ impl Identity for HelperIdentity {
             ))),
         }
     }
+
+    fn as_index(&self) -> usize {
+        usize::from(self.id) - 1
+    }
 }
 
 /// Role is an identifier of helper peer, only valid within a given query. For every query, there
@@ -102,6 +113,14 @@ impl Identity for Role {
             _ => Err(crate::error::Error::InvalidId(format!(
                 "The string {s} is an invalid Role"
             ))),
+        }
+    }
+
+    fn as_index(&self) -> usize {
+        match self {
+            Self::H1 => 0,
+            Self::H2 => 1,
+            Self::H3 => 2,
         }
     }
 }

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -691,7 +691,7 @@ pub(crate) mod tests {
 
         resp_ok(resp).await.unwrap();
 
-        let mut stream = Arc::clone(&transport)
+        let mut stream = transport
             .receive(HelperIdentity::ONE, (QueryId, expected_step.clone()))
             .into_bytes_stream();
 

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -26,7 +26,7 @@ mod transport;
 pub use client::{ClientIdentity, MpcHelperClient};
 pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
-pub use transport::{HttpShardTransport, HttpTransport};
+pub use transport::{HttpTransport, MpcHttpTransport, ShardHttpTransport};
 
 const APPLICATION_JSON: &str = "application/json";
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";

--- a/ipa-core/src/net/server/handlers/mod.rs
+++ b/ipa-core/src/net/server/handlers/mod.rs
@@ -3,16 +3,13 @@ mod query;
 
 use axum::Router;
 
-use crate::{
-    net::{http_serde, HttpTransport},
-    sync::Arc,
-};
+use crate::net::{http_serde, transport::MpcHttpTransport};
 
-pub fn mpc_router(transport: Arc<HttpTransport>) -> Router {
+pub fn mpc_router(transport: MpcHttpTransport) -> Router {
     echo::router().nest(
         http_serde::query::BASE_AXUM_PATH,
         Router::new()
-            .merge(query::query_router(Arc::clone(&transport)))
+            .merge(query::query_router(transport.clone()))
             .merge(query::h2h_router(transport)),
     )
 }

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -19,8 +19,7 @@ use tower::{layer::layer_fn, Service};
 
 use crate::{
     helpers::HelperIdentity,
-    net::{server::ClientIdentity, HttpTransport},
-    sync::Arc,
+    net::{server::ClientIdentity, transport::MpcHttpTransport},
 };
 
 /// Construct router for IPA query web service
@@ -28,12 +27,12 @@ use crate::{
 /// In principle, this web service could be backed by either an HTTP-interconnected helper network or
 /// an in-memory helper network. These are the APIs used by external callers (report collectors) to
 /// examine attribution results.
-pub fn query_router(transport: Arc<HttpTransport>) -> Router {
+pub fn query_router(transport: MpcHttpTransport) -> Router {
     Router::new()
-        .merge(create::router(Arc::clone(&transport)))
-        .merge(input::router(Arc::clone(&transport)))
-        .merge(status::router(Arc::clone(&transport)))
-        .merge(kill::router(Arc::clone(&transport)))
+        .merge(create::router(transport.clone()))
+        .merge(input::router(transport.clone()))
+        .merge(status::router(transport.clone()))
+        .merge(kill::router(transport.clone()))
         .merge(results::router(transport))
 }
 
@@ -44,9 +43,9 @@ pub fn query_router(transport: Arc<HttpTransport>) -> Router {
 /// particular query, to coordinate servicing that query.
 //
 // It might make sense to split the query and h2h handlers into two modules.
-pub fn h2h_router(transport: Arc<HttpTransport>) -> Router {
+pub fn h2h_router(transport: MpcHttpTransport) -> Router {
     Router::new()
-        .merge(prepare::router(Arc::clone(&transport)))
+        .merge(prepare::router(transport.clone()))
         .merge(step::router(transport))
         .layer(layer_fn(HelperAuthentication::new))
 }

--- a/ipa-core/src/net/server/handlers/query/prepare.rs
+++ b/ipa-core/src/net/server/handlers/query/prepare.rs
@@ -2,24 +2,24 @@ use axum::{extract::Path, response::IntoResponse, routing::post, Extension, Json
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{query::PrepareQuery, BodyStream, HelperIdentity, Transport},
+    helpers::{query::PrepareQuery, BodyStream, HelperIdentity},
     net::{
         http_serde::{
             self,
             query::{prepare::RequestBody, QueryConfigQueryParams},
         },
         server::ClientIdentity,
-        Error, HttpTransport,
+        transport::MpcHttpTransport,
+        Error,
     },
     protocol::QueryId,
     query::PrepareQueryError,
-    sync::Arc,
 };
 
 /// Called by whichever peer helper is the leader for an individual query, to initiatialize
 /// processing of that query.
 async fn handler(
-    transport: Extension<Arc<HttpTransport>>,
+    transport: Extension<MpcHttpTransport>,
     _: Extension<ClientIdentity<HelperIdentity>>, // require that client is an authenticated helper
     Path(query_id): Path<QueryId>,
     QueryConfigQueryParams(config): QueryConfigQueryParams,
@@ -30,7 +30,6 @@ async fn handler(
         config,
         roles,
     };
-    let transport = Transport::clone_ref(&*transport);
     let _ = transport
         .dispatch(data, BodyStream::empty())
         .await
@@ -45,7 +44,7 @@ impl IntoResponse for PrepareQueryError {
     }
 }
 
-pub fn router(transport: Arc<HttpTransport>) -> Router {
+pub fn router(transport: MpcHttpTransport) -> Router {
     Router::new()
         .route(http_serde::query::prepare::AXUM_PATH, post(handler))
         .layer(Extension(transport))

--- a/ipa-core/src/net/server/handlers/query/results.rs
+++ b/ipa-core/src/net/server/handlers/query/results.rs
@@ -2,31 +2,29 @@ use axum::{extract::Path, routing::get, Extension, Router};
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{BodyStream, Transport},
+    helpers::BodyStream,
     net::{
         http_serde::{self, query::results::Request},
         server::Error,
-        HttpTransport,
+        transport::MpcHttpTransport,
     },
     protocol::QueryId,
-    sync::Arc,
 };
 
 /// Handles the completion of the query by blocking the sender until query is completed.
 async fn handler(
-    transport: Extension<Arc<HttpTransport>>,
+    transport: Extension<MpcHttpTransport>,
     Path(query_id): Path<QueryId>,
 ) -> Result<Vec<u8>, Error> {
     let req = Request { query_id };
     // TODO: we may be able to stream the response
-    let transport = Transport::clone_ref(&*transport);
     match transport.dispatch(req, BodyStream::empty()).await {
         Ok(resp) => Ok(resp.into_body()),
         Err(e) => Err(Error::application(StatusCode::INTERNAL_SERVER_ERROR, e)),
     }
 }
 
-pub fn router(transport: Arc<HttpTransport>) -> Router {
+pub fn router(transport: MpcHttpTransport) -> Router {
     Router::new()
         .route(http_serde::query::results::AXUM_PATH, get(handler))
         .layer(Extension(transport))

--- a/ipa-core/src/net/server/handlers/query/status.rs
+++ b/ipa-core/src/net/server/handlers/query/status.rs
@@ -2,29 +2,27 @@ use axum::{extract::Path, routing::get, Extension, Json, Router};
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{BodyStream, Transport},
+    helpers::BodyStream,
     net::{
         http_serde::query::status::{self, Request},
         server::Error,
-        HttpTransport,
+        transport::MpcHttpTransport,
     },
     protocol::QueryId,
-    sync::Arc,
 };
 
 async fn handler(
-    transport: Extension<Arc<HttpTransport>>,
+    transport: Extension<MpcHttpTransport>,
     Path(query_id): Path<QueryId>,
 ) -> Result<Json<status::ResponseBody>, Error> {
     let req = Request { query_id };
-    let transport = Transport::clone_ref(&*transport);
     match transport.dispatch(req, BodyStream::empty()).await {
         Ok(state) => Ok(Json(status::ResponseBody::from(state))),
         Err(e) => Err(Error::application(StatusCode::INTERNAL_SERVER_ERROR, e)),
     }
 }
 
-pub fn router(transport: Arc<HttpTransport>) -> Router {
+pub fn router(transport: MpcHttpTransport) -> Router {
     Router::new()
         .route(status::AXUM_PATH, get(handler))
         .layer(Extension(transport))

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -16,6 +16,7 @@ use std::{
 use once_cell::sync::Lazy;
 use rustls_pki_types::CertificateDer;
 
+use super::transport::MpcHttpTransport;
 use crate::{
     config::{
         ClientConfig, HpkeClientConfig, HpkeServerConfig, NetworkConfig, PeerConfig, ServerConfig,
@@ -24,7 +25,7 @@ use crate::{
     executor::{IpaJoinHandle, IpaRuntime},
     helpers::{HandlerBox, HelperIdentity, RequestHandler},
     hpke::{Deserializable as _, IpaPublicKey},
-    net::{ClientIdentity, Helper, HttpTransport, MpcHelperClient, MpcHelperServer},
+    net::{ClientIdentity, Helper, MpcHelperClient, MpcHelperServer},
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
 };
@@ -199,7 +200,7 @@ impl TestConfigBuilder {
 pub struct TestServer {
     pub addr: SocketAddr,
     pub handle: IpaJoinHandle<()>,
-    pub transport: Arc<HttpTransport>,
+    pub transport: MpcHttpTransport,
     pub server: MpcHelperServer<Helper>,
     pub client: MpcHelperClient,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
@@ -295,7 +296,7 @@ impl TestServerBuilder {
         );
         let handler = self.handler.as_ref().map(HandlerBox::owning_ref);
         let client = clients[0].clone();
-        let (transport, server) = HttpTransport::new(
+        let (transport, server) = MpcHttpTransport::new(
             IpaRuntime::current(),
             HelperIdentity::ONE,
             server_config,

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -301,7 +301,7 @@ impl TestServerBuilder {
             HelperIdentity::ONE,
             server_config,
             network_config.clone(),
-            clients,
+            &clients,
             handler,
         );
         let (addr, handle) = server

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -45,7 +45,6 @@ pub struct MpcHttpTransport {
 /// A stub for HTTP transport implementation, suitable for serving shard-to-shard traffic
 #[derive(Clone)]
 pub struct ShardHttpTransport {
-    #[allow(dead_code)]
     inner_transport: Arc<HttpTransport<Shard>>,
 }
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Borrow,
+    collections::HashMap,
     future::Future,
     pin::Pin,
     task::{Context, Poll},
@@ -9,7 +10,7 @@ use async_trait::async_trait;
 use futures::{Stream, TryFutureExt};
 use pin_project::{pin_project, pinned_drop};
 
-use super::{client::resp_ok, Helper};
+use super::{client::resp_ok, ConnectionFlavor, Helper, Shard};
 use crate::{
     config::{NetworkConfig, ServerConfig},
     executor::IpaRuntime,
@@ -26,21 +27,27 @@ use crate::{
     sync::Arc,
 };
 
-/// HTTP transport for IPA helper service.
-/// TODO: rename to MPC
-pub struct HttpTransport {
+/// Shared implementation used by [`MpcHttpTransport`] and [`ShardHttpTransport`]
+pub struct HttpTransport<F: ConnectionFlavor> {
     http_runtime: IpaRuntime,
-    identity: HelperIdentity,
-    clients: [MpcHelperClient; 3],
-    // TODO(615): supporting multiple queries likely require a hashmap here. It will be ok if we
-    // only allow one query at a time.
-    record_streams: StreamCollection<HelperIdentity, BodyStream>,
-    handler: Option<HandlerRef>,
+    identity: F::Identity,
+    clients: HashMap<F::Identity, MpcHelperClient<F>>,
+    record_streams: StreamCollection<F::Identity, BodyStream>,
+    handler: Option<HandlerRef<F::Identity>>,
 }
 
-/// A stub for HTTP transport implementation, suitable for serviing inter-shard traffic
-#[derive(Clone, Default)]
-pub struct HttpShardTransport;
+/// HTTP transport for helper to helper traffic.
+#[derive(Clone)]
+pub struct MpcHttpTransport {
+    inner_transport: Arc<HttpTransport<Helper>>,
+}
+
+/// A stub for HTTP transport implementation, suitable for serving shard-to-shard traffic
+#[derive(Clone)]
+pub struct ShardHttpTransport {
+    #[allow(dead_code)]
+    inner_transport: Arc<HttpTransport<Shard>>,
+}
 
 impl RouteParams<RouteId, NoQueryId, NoStep> for QueryConfig {
     type Params = String;
@@ -62,35 +69,64 @@ impl RouteParams<RouteId, NoQueryId, NoStep> for QueryConfig {
     }
 }
 
-impl HttpTransport {
-    #[must_use]
-    pub fn new(
-        runtime: IpaRuntime,
-        identity: HelperIdentity,
-        server_config: ServerConfig,
-        network_config: NetworkConfig<Helper>,
-        clients: [MpcHelperClient; 3],
-        handler: Option<HandlerRef>,
-    ) -> (Arc<Self>, MpcHelperServer<Helper>) {
-        let transport = Self::new_internal(runtime, identity, clients, handler);
-        let server =
-            MpcHelperServer::new_mpc(Arc::clone(&transport), server_config, network_config);
-        (transport, server)
+impl<F: ConnectionFlavor> HttpTransport<F> {
+    async fn send<
+        D: Stream<Item = Vec<u8>> + Send + 'static,
+        Q: QueryIdBinding,
+        S: StepBinding,
+        R: RouteParams<RouteId, Q, S>,
+    >(
+        &self,
+        dest: F::Identity,
+        route: R,
+        data: D,
+    ) -> Result<(), Error>
+    where
+        Option<QueryId>: From<Q>,
+        Option<Gate>: From<S>,
+    {
+        let route_id = route.resource_identifier();
+        match route_id {
+            RouteId::Records => {
+                // TODO(600): These fallible extractions aren't really necessary.
+                let query_id = <Option<QueryId>>::from(route.query_id())
+                    .expect("query_id required when sending records");
+                let step =
+                    <Option<Gate>>::from(route.gate()).expect("step required when sending records");
+                let resp_future = self.clients[&dest].step(query_id, &step, data)?;
+                // Use a dedicated HTTP runtime to poll this future for several reasons:
+                // - avoid blocking this task, if the current runtime is overloaded
+                // - use the runtime that enables IO (current runtime may not).
+                self.http_runtime
+                    .spawn(resp_future.map_err(Into::into).and_then(resp_ok))
+                    .await?;
+                Ok(())
+            }
+            RouteId::PrepareQuery => {
+                let req = serde_json::from_str(route.extra().borrow()).unwrap();
+                self.clients[&dest].prepare_query(req).await
+            }
+            evt @ (RouteId::QueryInput
+            | RouteId::ReceiveQuery
+            | RouteId::QueryStatus
+            | RouteId::CompleteQuery
+            | RouteId::KillQuery) => {
+                unimplemented!(
+                    "attempting to send client-specific request {evt:?} to another helper"
+                )
+            }
+        }
     }
 
-    fn new_internal(
-        runtime: IpaRuntime,
-        identity: HelperIdentity,
-        clients: [MpcHelperClient; 3],
-        handler: Option<HandlerRef>,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            http_runtime: runtime,
-            identity,
-            clients,
-            handler,
-            record_streams: StreamCollection::default(),
-        })
+    fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
+        &self,
+        from: F::Identity,
+        route: &R,
+    ) -> ReceiveRecords<F::Identity, BodyStream> {
+        ReceiveRecords::new(
+            (route.query_id(), from, route.gate()),
+            self.record_streams.clone(),
+        )
     }
 
     /// Dispatches the given request to the [`RequestHandler`] connected to this transport.
@@ -114,13 +150,13 @@ impl HttpTransport {
         /// This implementation is a poor man's safety net and only works because we run
         /// one query at a time and don't use query identifiers.
         #[pin_project(PinnedDrop)]
-        struct ClearOnDrop<F: Future> {
-            transport: Arc<HttpTransport>,
+        struct ClearOnDrop<CF: ConnectionFlavor, F: Future> {
+            transport: Arc<HttpTransport<CF>>,
             #[pin]
             inner: F,
         }
 
-        impl<F: Future> Future for ClearOnDrop<F> {
+        impl<CF: ConnectionFlavor, F: Future> Future for ClearOnDrop<CF, F> {
             type Output = F::Output;
 
             fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -129,7 +165,7 @@ impl HttpTransport {
         }
 
         #[pinned_drop]
-        impl<F: Future> PinnedDrop for ClearOnDrop<F> {
+        impl<CF: ConnectionFlavor, F: Future> PinnedDrop for ClearOnDrop<CF, F> {
             fn drop(self: Pin<&mut Self>) {
                 self.transport.record_streams.clear();
             }
@@ -152,30 +188,88 @@ impl HttpTransport {
             r.await
         }
     }
+}
 
-    /// Connect an inbound stream of MPC record data.
+impl MpcHttpTransport {
+    #[must_use]
+    pub fn new(
+        http_runtime: IpaRuntime,
+        identity: HelperIdentity,
+        server_config: ServerConfig,
+        network_config: NetworkConfig<Helper>,
+        clients: [MpcHelperClient; 3],
+        handler: Option<HandlerRef<HelperIdentity>>,
+    ) -> (Self, MpcHelperServer<Helper>) {
+        let transport = Self::new_internal(http_runtime, identity, clients, handler);
+        let server = MpcHelperServer::new_mpc(&transport, server_config, network_config);
+        (transport, server)
+    }
+
+    fn new_internal(
+        http_runtime: IpaRuntime,
+        identity: HelperIdentity,
+        clients: [MpcHelperClient; 3],
+        handler: Option<HandlerRef<HelperIdentity>>,
+    ) -> Self {
+        let mut id_clients = HashMap::new();
+        let [c1, c2, c3] = clients;
+        id_clients.insert(HelperIdentity::ONE, c1);
+        id_clients.insert(HelperIdentity::TWO, c2);
+        id_clients.insert(HelperIdentity::THREE, c3);
+        Self {
+            inner_transport: Arc::new(HttpTransport {
+                http_runtime,
+                identity,
+                clients: id_clients,
+                handler,
+                record_streams: StreamCollection::default(),
+            }),
+        }
+    }
+
+    /// Connect an inbound stream of record data.
     ///
     /// This is called by peer helpers via the HTTP server.
     pub fn receive_stream(
-        self: Arc<Self>,
+        &self,
         query_id: QueryId,
         gate: Gate,
         from: HelperIdentity,
         stream: BodyStream,
     ) {
-        self.record_streams
+        self.inner_transport
+            .record_streams
             .add_stream((query_id, from, gate), stream);
+    }
+
+    /// Dispatches the given request to the [`RequestHandler`] connected to this transport.
+    ///
+    /// ## Errors
+    /// Returns an error, if handler rejects the request for any reason.
+    ///
+    /// ## Panics
+    /// This will panic if request handler hasn't been previously set for this transport.
+    pub async fn dispatch<Q: QueryIdBinding, R: RouteParams<RouteId, Q, NoStep>>(
+        &self,
+        req: R,
+        body: BodyStream,
+    ) -> Result<HelperResponse, ApiError>
+    where
+        Option<QueryId>: From<Q>,
+    {
+        let t = Arc::clone(&self.inner_transport);
+        t.dispatch(req, body).await
     }
 }
 
 #[async_trait]
-impl Transport for Arc<HttpTransport> {
+impl Transport for MpcHttpTransport {
     type Identity = HelperIdentity;
-    type RecordsStream = ReceiveRecords<HelperIdentity, BodyStream>;
+    type RecordsStream = ReceiveRecords<Self::Identity, BodyStream>;
     type Error = Error;
 
-    fn identity(&self) -> HelperIdentity {
-        self.identity
+    fn identity(&self) -> Self::Identity {
+        self.inner_transport.identity
     }
 
     async fn send<
@@ -185,7 +279,7 @@ impl Transport for Arc<HttpTransport> {
         R: RouteParams<RouteId, Q, S>,
     >(
         &self,
-        dest: HelperIdentity,
+        dest: Self::Identity,
         route: R,
         data: D,
     ) -> Result<(), Error>
@@ -193,67 +287,70 @@ impl Transport for Arc<HttpTransport> {
         Option<QueryId>: From<Q>,
         Option<Gate>: From<S>,
     {
-        let route_id = route.resource_identifier();
-        match route_id {
-            RouteId::Records => {
-                // TODO(600): These fallible extractions aren't really necessary.
-                let query_id = <Option<QueryId>>::from(route.query_id())
-                    .expect("query_id required when sending records");
-                let step =
-                    <Option<Gate>>::from(route.gate()).expect("step required when sending records");
-                let resp_future = self.clients[dest].step(query_id, &step, data)?;
-
-                // Use a dedicated HTTP runtime to poll this future for several reasons:
-                // - avoid blocking this task, if the current runtime is overloaded
-                // - use the runtime that enables IO (current runtime may not).
-                self.http_runtime
-                    .spawn(resp_future.map_err(Into::into).and_then(resp_ok))
-                    .await?;
-                Ok(())
-            }
-            RouteId::PrepareQuery => {
-                let req = serde_json::from_str(route.extra().borrow()).unwrap();
-                self.clients[dest].prepare_query(req).await
-            }
-            evt @ (RouteId::QueryInput
-            | RouteId::ReceiveQuery
-            | RouteId::QueryStatus
-            | RouteId::CompleteQuery
-            | RouteId::KillQuery) => {
-                unimplemented!(
-                    "attempting to send client-specific request {evt:?} to another helper"
-                )
-            }
-        }
+        self.inner_transport.send(dest, route, data).await
     }
 
     fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
         &self,
-        from: HelperIdentity,
+        from: Self::Identity,
         route: R,
     ) -> Self::RecordsStream {
-        ReceiveRecords::new(
-            (route.query_id(), from, route.gate()),
-            self.record_streams.clone(),
-        )
+        self.inner_transport.receive(from, &route)
+    }
+}
+
+impl ShardHttpTransport {
+    #[must_use]
+    pub fn new(
+        http_runtime: IpaRuntime,
+        identity: ShardIndex,
+        server_config: ServerConfig,
+        network_config: NetworkConfig<Shard>,
+        clients: HashMap<ShardIndex, MpcHelperClient<Shard>>,
+        handler: Option<HandlerRef<ShardIndex>>,
+    ) -> (Self, MpcHelperServer<Shard>) {
+        let transport = Self::new_internal(http_runtime, identity, clients, handler);
+        let server = MpcHelperServer::new_shards(&transport, server_config, network_config);
+        (transport, server)
+    }
+
+    fn new_internal(
+        http_runtime: IpaRuntime,
+        identity: ShardIndex,
+        clients: HashMap<ShardIndex, MpcHelperClient<Shard>>,
+        handler: Option<HandlerRef<ShardIndex>>,
+    ) -> Self {
+        let mut base_clients = HashMap::new();
+        for (ix, client) in clients {
+            base_clients.insert(ix, client);
+        }
+        Self {
+            inner_transport: Arc::new(HttpTransport {
+                http_runtime,
+                identity,
+                clients: base_clients,
+                handler,
+                record_streams: StreamCollection::default(),
+            }),
+        }
     }
 }
 
 #[async_trait]
-impl Transport for HttpShardTransport {
+impl Transport for ShardHttpTransport {
     type Identity = ShardIndex;
     type RecordsStream = ReceiveRecords<ShardIndex, BodyStream>;
-    type Error = ();
+    type Error = Error;
 
     fn identity(&self) -> Self::Identity {
-        unimplemented!()
+        self.inner_transport.identity
     }
 
     async fn send<D, Q, S, R>(
         &self,
-        _dest: Self::Identity,
-        _route: R,
-        _data: D,
+        dest: Self::Identity,
+        route: R,
+        data: D,
     ) -> Result<(), Self::Error>
     where
         Option<QueryId>: From<Q>,
@@ -263,15 +360,15 @@ impl Transport for HttpShardTransport {
         R: RouteParams<RouteId, Q, S>,
         D: Stream<Item = Vec<u8>> + Send + 'static,
     {
-        unimplemented!()
+        self.inner_transport.send(dest, route, data).await
     }
 
     fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
         &self,
-        _from: Self::Identity,
-        _route: R,
+        from: Self::Identity,
+        route: R,
     ) -> Self::RecordsStream {
-        unimplemented!()
+        self.inner_transport.receive(from, &route)
     }
 }
 
@@ -319,18 +416,18 @@ mod tests {
             .build()
             .await;
 
-        transport.record_streams.add_stream(
+        transport.inner_transport.record_streams.add_stream(
             (QueryId, HelperIdentity::ONE, Gate::default()),
             BodyStream::empty(),
         );
-        assert_eq!(1, transport.record_streams.len());
+        assert_eq!(1, transport.inner_transport.record_streams.len());
 
         Transport::clone_ref(&transport)
             .dispatch((RouteId::KillQuery, QueryId), BodyStream::empty())
             .await
             .unwrap();
 
-        assert!(transport.record_streams.is_empty());
+        assert!(transport.inner_transport.record_streams.is_empty());
     }
 
     #[tokio::test]
@@ -344,10 +441,10 @@ mod tests {
         let body = BodyStream::from_bytes_stream(ReceiverStream::new(rx));
 
         // Register the stream with the transport (normally called by step data HTTP API handler)
-        Arc::clone(&transport).receive_stream(QueryId, STEP.clone(), HelperIdentity::TWO, body);
+        transport.receive_stream(QueryId, STEP.clone(), HelperIdentity::TWO, body);
 
         // Request step data reception (normally called by protocol)
-        let mut stream = Arc::clone(&transport)
+        let mut stream = transport
             .receive(HelperIdentity::TWO, (QueryId, STEP.clone()))
             .into_bytes_stream();
 
@@ -396,19 +493,34 @@ mod tests {
                         network_config,
                         &identity,
                     );
-                    let (transport, server) = HttpTransport::new(
+                    let (transport, server) = MpcHttpTransport::new(
                         IpaRuntime::current(),
                         id,
-                        server_config,
+                        server_config.clone(),
                         network_config.clone(),
                         clients,
                         Some(handler),
                     );
+                    // TODO: Following is just temporary until Shard Transport is actually used.
+                    let shard_clients_config = network_config.client.clone();
+                    let shard_server_config = server_config;
+                    let shard_network_config =
+                        NetworkConfig::new_shards(vec![], shard_clients_config);
+                    let (shard_transport, _shard_server) = ShardHttpTransport::new(
+                        IpaRuntime::current(),
+                        ShardIndex::FIRST,
+                        shard_server_config,
+                        shard_network_config,
+                        HashMap::new(),
+                        None,
+                    );
+                    // ---
+
                     server
                         .start_on(&IpaRuntime::current(), Some(socket), ())
                         .await;
 
-                    setup.connect(transport, HttpShardTransport)
+                    setup.connect(transport, shard_transport)
                 },
             ),
         )


### PR DESCRIPTION
This is the third of a series of pull requests (PR) to enable sharding on IPA. See #1360 

This change doesn't meaningfully change any tests or the operation of IPA. This is just adding abstractions that are going to be useful later.

Biggest changes are concentrated in `net/transport.rs`. 

`HttpTransport` has now 2 "sub-classes"; Mpc and Shard, each implemented as a composition. E.g.
```
#[derive(Clone)]
pub struct MpcHttpTransport {
    inner_transport: Arc<HttpTransport<Helper>>,
}
```
Having `MpcHttpTransport` own the inner Arc simplified the interactions with these HttpTransports since they know how to clone themselves. Shard and MPC HTTP Transports are very similar, hence most of the functionality has been factored inside `HttpTransport`.

`bin/helper.rs` and `net/test.rs` have a few temporary changes required for the code to compile. These will go away as I continue pushing the changes required for sharding.
