### PR TITLE
Migrate IPA code to new metrics engine

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -52,7 +52,7 @@ web-app = [
     "http-body",
     "http-body-util",
 ]
-test-fixture = ["weak-field"]
+test-fixture = ["weak-field", "ipa-metrics-tracing", "ipa-metrics/partitions"]
 # Include observability instruments that detect lack of progress inside MPC. If there is a bug that leads to helper
 # miscommunication, this feature helps to detect it. Turning it on has some cost.
 # If "shuttle" feature is enabled, turning this on has no effect.
@@ -86,6 +86,8 @@ ipa-prf = []
 relaxed-dp = []
 
 [dependencies]
+ipa-metrics = { path = "../ipa-metrics", features = [] }
+ipa-metrics-tracing = { optional = true, path = "../ipa-metrics-tracing" }
 ipa-step = { version = "*", path = "../ipa-step" }
 ipa-step-derive = { version = "*", path = "../ipa-step-derive" }
 
@@ -128,9 +130,6 @@ hyper-util = { version = "0.1.3", optional = true, features = ["http2"] }
 http-body-util = { version = "0.1.1", optional = true }
 http-body = { version = "1", optional = true }
 iai = { version = "0.1.1", optional = true }
-metrics = "0.21.0"
-metrics-tracing-context = "0.14.0"
-metrics-util = { version = "0.15.0" }
 once_cell = "1.18"
 pin-project = "1.0"
 rand = "0.8"
@@ -175,6 +174,8 @@ permutation = "0.4.1"
 proptest = "1.4"
 rustls = { version = "0.23" }
 tempfile = "3"
+ipa-metrics-tracing = { path = "../ipa-metrics-tracing" }
+ipa-metrics = { path = "../ipa-metrics", features = ["partitions"] }
 
 
 [lib]

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -86,7 +86,7 @@ ipa-prf = []
 relaxed-dp = []
 
 [dependencies]
-ipa-metrics = { path = "../ipa-metrics", features = [] }
+ipa-metrics = { path = "../ipa-metrics" }
 ipa-metrics-tracing = { optional = true, path = "../ipa-metrics-tracing" }
 ipa-step = { version = "*", path = "../ipa-step" }
 ipa-step-derive = { version = "*", path = "../ipa-step-derive" }

--- a/ipa-core/src/cli/metric_collector.rs
+++ b/ipa-core/src/cli/metric_collector.rs
@@ -1,48 +1,56 @@
-use std::{io::stderr, thread};
+use std::{io, thread, thread::JoinHandle};
 
-use metrics_tracing_context::TracingContextLayer;
-use metrics_util::{
-    debugging::{DebuggingRecorder, Snapshotter},
-    layers::Layer,
+use ipa_metrics::{
+    MetricChannelType, MetricsCollectorController, MetricsCurrentThreadContext, MetricsProducer,
 };
+use tokio::runtime::Builder;
 
-use crate::telemetry::stats::Metrics;
-
-/// Collects metrics using `DebuggingRecorder` and dumps them to `stderr` when dropped.
+/// Holds a reference to metrics controller and producer
 pub struct CollectorHandle {
-    snapshotter: Snapshotter,
+    thread_handle: JoinHandle<()>,
+    /// This will be used once we start consuming metrics
+    _controller: MetricsCollectorController,
+    producer: MetricsProducer,
 }
 
 ///
 /// Initializes this collector by installing `DebuggingRecorder` to keep track of metrics
 /// emitted from different parts of the app.
 ///
-/// ## Panics
-/// Panics if metric recorder has already been set
-#[must_use]
-pub fn install_collector() -> CollectorHandle {
-    let recorder = DebuggingRecorder::new();
-    let snapshotter = recorder.snapshotter();
+/// ## Errors
+/// If it fails to start a new thread
+pub fn install_collector() -> io::Result<CollectorHandle> {
+    let (producer, controller, handle) =
+        ipa_metrics::install_new_thread(MetricChannelType::Unbounded)?;
+    tracing::info!("Metrics engine is enabled");
 
-    // use span fields as dimensions for metric
-    let recorder = TracingContextLayer::all().layer(recorder);
-    metrics::set_boxed_recorder(Box::new(recorder))
-        .expect("Metric recorder has been installed already");
-
-    // register metrics
-    crate::telemetry::metrics::register();
-    tracing::info!("Metrics enabled");
-
-    CollectorHandle { snapshotter }
+    Ok(CollectorHandle {
+        thread_handle: handle,
+        _controller: controller,
+        producer,
+    })
 }
 
 impl Drop for CollectorHandle {
     fn drop(&mut self) {
-        if !thread::panicking() {
-            let stats = Metrics::from_snapshot(self.snapshotter.snapshot());
-            stats
-                .print(&mut stderr())
-                .expect("Failed to dump metrics to stderr");
-        }
+        if !thread::panicking() && !self.thread_handle.is_finished() {
+            tracing::warn!("Metrics thread is still running");
+        };
+    }
+}
+
+impl CollectorHandle {
+    pub fn tokio_bind<'a>(&self, target: &'a mut Builder) -> &'a mut Builder {
+        let flush_fn = || MetricsCurrentThreadContext::flush();
+
+        target
+            .on_thread_start({
+                let producer = self.producer.clone();
+                move || {
+                    producer.install();
+                }
+            })
+            .on_thread_stop(flush_fn)
+            .on_thread_park(flush_fn)
     }
 }

--- a/ipa-core/src/cli/mod.rs
+++ b/ipa-core/src/cli/mod.rs
@@ -23,4 +23,4 @@ pub use metric_collector::{install_collector, CollectorHandle};
 pub use paths::PathExt as CliPaths;
 #[cfg(feature = "web-app")]
 pub use test_setup::{test_setup, TestSetupArgs};
-pub use verbosity::Verbosity;
+pub use verbosity::{LoggingHandle, Verbosity};

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -62,6 +62,7 @@ pub use gateway::{
     MpcTransportError, MpcTransportImpl, RoleResolvingTransport, ShardTransportImpl,
 };
 pub use gateway_exports::{Gateway, MpcReceivingEnd, SendingEnd, ShardReceivingEnd};
+use ipa_metrics::LabelValue;
 pub use prss_protocol::negotiate as negotiate_prss;
 #[cfg(feature = "web-app")]
 pub use transport::WrappedAxumBodyStream;
@@ -174,6 +175,22 @@ impl From<i32> for HelperIdentity {
             .ok()
             .and_then(|id| HelperIdentity::try_from(id).ok())
             .unwrap()
+    }
+}
+
+impl Display for HelperIdentity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl LabelValue for HelperIdentity {
+    fn hash(&self) -> u64 {
+        u64::from(self.id)
+    }
+
+    fn boxed(&self) -> Box<dyn LabelValue> {
+        Box::new(*self)
     }
 }
 
@@ -399,6 +416,22 @@ impl<T> Index<Role> for Vec<T> {
 impl<T> IndexMut<Role> for Vec<T> {
     fn index_mut(&mut self, index: Role) -> &mut Self::Output {
         self.as_mut_slice().index_mut(index)
+    }
+}
+
+impl Display for Role {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_static_str())
+    }
+}
+
+impl LabelValue for Role {
+    fn hash(&self) -> u64 {
+        u64::from(*self as u32)
+    }
+
+    fn boxed(&self) -> Box<dyn LabelValue> {
+        Box::new(*self)
     }
 }
 

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -713,6 +713,23 @@ mod tests {
         }
     }
 
+    mod helper_identity_tests {
+        use ipa_metrics::LabelValue;
+
+        use crate::helpers::HelperIdentity;
+
+        #[test]
+        fn label_value() {
+            for (id, hash) in [
+                (HelperIdentity::ONE, 1),
+                (HelperIdentity::TWO, 2),
+                (HelperIdentity::THREE, 3),
+            ] {
+                assert_eq!(id.boxed().hash(), hash);
+            }
+        }
+    }
+
     mod role_assignment_tests {
         use crate::{
             ff::Fp31,

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -25,6 +25,7 @@ pub use handler::{
 };
 #[cfg(feature = "in-memory-infra")]
 pub use in_memory::{config, InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport};
+use ipa_metrics::LabelValue;
 pub use receive::{LogErrors, ReceiveRecords};
 #[cfg(feature = "web-app")]
 pub use stream::WrappedAxumBodyStream;
@@ -41,7 +42,7 @@ use crate::{
 /// An identity of a peer that can be communicated with using [`Transport`]. There are currently two
 /// types of peers - helpers and shards.
 pub trait Identity:
-    Copy + Clone + Debug + PartialEq + Eq + PartialOrd + Ord + Hash + Send + Sync + 'static
+    Copy + Clone + Debug + PartialEq + Eq + PartialOrd + Ord + Hash + Send + Sync + LabelValue + 'static
 {
     fn as_str(&self) -> Cow<'static, str>;
 

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -161,7 +161,7 @@ impl<F: ConnectionFlavor> MpcHelperServer<F> {
             TraceLayer::new_for_http()
                 .make_span_with(move |_request: &hyper::Request<_>| tracing.make_span())
                 .on_request(|request: &hyper::Request<_>, _: &Span| {
-                    counter!(RequestProtocolVersion::from(request.version()), 1);
+                    counter!(RequestProtocolVersion::from(request.version()).as_str(), 1);
                     counter!(REQUESTS_RECEIVED, 1);
                 }),
         );
@@ -733,15 +733,15 @@ mod e2e_tests {
 
         assert_eq!(
             Some(1),
-            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_11))
+            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_11).as_str())
         );
         assert_eq!(
             Some(1),
-            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_2))
+            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_2).as_str())
         );
         assert_eq!(
             None,
-            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_3))
+            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_3).as_str())
         );
     }
 
@@ -768,7 +768,7 @@ mod e2e_tests {
 
         assert_eq!(
             Some(1),
-            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_2))
+            handle.get_counter_value(RequestProtocolVersion::from(Version::HTTP_2).as_str())
         );
     }
 }

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -744,6 +744,8 @@ mod tests {
 
         let input_size = input.len();
         let snapshot = world.metrics_snapshot();
+        // this will print all metrics if test fails
+        snapshot.print(&mut std::io::stdout()).unwrap();
 
         // for semi-honest protocols, amplification factor per helper is 1.
         // that is, for every communication, there is exactly one send and receive of the same data

--- a/ipa-core/src/protocol/mod.rs
+++ b/ipa-core/src/protocol/mod.rs
@@ -24,6 +24,17 @@ pub type Gate = step::ProtocolGate;
 #[cfg(descriptive_gate)]
 pub type Gate = ipa_step::descriptive::Descriptive;
 
+#[cfg(compact_gate)]
+impl ipa_metrics::LabelValue for step::ProtocolGate {
+    fn hash(&self) -> u64 {
+        u64::from(self.index())
+    }
+
+    fn boxed(&self) -> Box<dyn ipa_metrics::LabelValue> {
+        Box::new(self.clone())
+    }
+}
+
 /// Unique identifier of the MPC query requested by report collectors
 /// TODO(615): Generating this unique id may be tricky as it may involve communication between helpers and
 /// them collaborating on constructing this unique id. These details haven't been flushed out yet,

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -4,6 +4,8 @@ use std::{
     ops::{Index, IndexMut},
 };
 
+use ipa_metrics::LabelValue;
+
 /// A unique zero-based index of the helper shard.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShardIndex(pub u32);
@@ -81,6 +83,16 @@ impl<T> Index<ShardIndex> for Vec<T> {
 impl<T> IndexMut<ShardIndex> for Vec<T> {
     fn index_mut(&mut self, index: ShardIndex) -> &mut Self::Output {
         self.as_mut_slice().index_mut(usize::from(index))
+    }
+}
+
+impl LabelValue for ShardIndex {
+    fn hash(&self) -> u64 {
+        u64::from(self.0)
+    }
+
+    fn boxed(&self) -> Box<dyn LabelValue> {
+        Box::new(*self)
     }
 }
 

--- a/ipa-core/src/telemetry/mod.rs
+++ b/ipa-core/src/telemetry/mod.rs
@@ -9,7 +9,6 @@ pub mod labels {
 }
 
 pub mod metrics {
-    use metrics::{describe_counter, Unit};
 
     pub const REQUESTS_RECEIVED: &str = "requests.received";
     pub const RECORDS_SENT: &str = "records.sent";
@@ -22,7 +21,6 @@ pub mod metrics {
     #[cfg(feature = "web-app")]
     pub mod web {
         use axum::http::Version;
-        use metrics::KeyName;
 
         /// Metric that records the version of HTTP protocol used for a particular request.
         pub struct RequestProtocolVersion(Version);
@@ -33,84 +31,20 @@ pub mod metrics {
             }
         }
 
-        impl From<RequestProtocolVersion> for KeyName {
+        impl From<RequestProtocolVersion> for &'static str {
             fn from(v: RequestProtocolVersion) -> Self {
                 const HTTP11: &str = "request.protocol.HTTP/1.1";
                 const HTTP2: &str = "request.protocol.HTTP/2";
                 const HTTP3: &str = "request.protocol.HTTP/3";
                 const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
 
-                KeyName::from_const_str(match v.0 {
+                match v.0 {
                     Version::HTTP_11 => HTTP11,
                     Version::HTTP_2 => HTTP2,
                     Version::HTTP_3 => HTTP3,
                     _ => UNKNOWN,
-                })
+                }
             }
         }
-    }
-
-    /// Registers metrics used in the system with the metrics recorder.
-    ///
-    /// ## Panics
-    /// Panic if there is no recorder installed
-    pub fn register() {
-        describe_counter!(
-            REQUESTS_RECEIVED,
-            Unit::Count,
-            "Total number of requests received by the web server"
-        );
-
-        #[cfg(feature = "web-app")]
-        {
-            use axum::http::Version;
-            describe_counter!(
-                web::RequestProtocolVersion::from(Version::HTTP_11),
-                Unit::Count,
-                "Total number of HTTP/1.1 requests received"
-            );
-
-            describe_counter!(
-                web::RequestProtocolVersion::from(Version::HTTP_2),
-                Unit::Count,
-                "Total number of HTTP/2 requests received"
-            );
-        }
-
-        describe_counter!(
-            RECORDS_SENT,
-            Unit::Count,
-            "Number of unique records sent from the infrastructure layer to the network"
-        );
-
-        describe_counter!(
-            BYTES_SENT,
-            Unit::Count,
-            "Bytes sent from the infrastructure layer to the network"
-        );
-
-        describe_counter!(
-            INDEXED_PRSS_GENERATED,
-            Unit::Count,
-            "Number of times shared randomness is requested by the protocols"
-        );
-
-        describe_counter!(
-            SEQUENTIAL_PRSS_GENERATED,
-            Unit::Count,
-            "Number of times PRSS is used as CPRNG to generate a random value"
-        );
-
-        describe_counter!(
-            STEP_NARROWED,
-            Unit::Count,
-            "Number of times the step is narrowed"
-        );
-
-        describe_counter!(
-            DZKP_BATCH_INCREMENTS,
-            Unit::Count,
-            "Number of DZKP Batch updates, i.e. verifications"
-        );
     }
 }

--- a/ipa-core/src/telemetry/mod.rs
+++ b/ipa-core/src/telemetry/mod.rs
@@ -31,14 +31,15 @@ pub mod metrics {
             }
         }
 
-        impl From<RequestProtocolVersion> for &'static str {
-            fn from(v: RequestProtocolVersion) -> Self {
+        impl RequestProtocolVersion {
+            #[must_use]
+            pub fn as_str(&self) -> &'static str {
                 const HTTP11: &str = "request.protocol.HTTP/1.1";
                 const HTTP2: &str = "request.protocol.HTTP/2";
                 const HTTP3: &str = "request.protocol.HTTP/3";
                 const UNKNOWN: &str = "request.protocol.HTTP/UNKNOWN";
 
-                match v.0 {
+                match self.0 {
                     Version::HTTP_11 => HTTP11,
                     Version::HTTP_2 => HTTP2,
                     Version::HTTP_3 => HTTP3,

--- a/ipa-core/src/telemetry/stats.rs
+++ b/ipa-core/src/telemetry/stats.rs
@@ -1,13 +1,12 @@
 use std::{
-    collections::{hash_map::Iter, HashMap},
+    collections::{
+        hash_map::{Entry, Iter},
+        HashMap,
+    },
     fmt::Debug,
 };
 
-use metrics::{KeyName, Label, SharedString};
-use metrics_util::{
-    debugging::{DebugValue, Snapshot},
-    CompositeKey, MetricKind,
-};
+use ipa_metrics::{MetricPartition, MetricsStore};
 
 use crate::{helpers::Role, protocol::Gate, telemetry::labels};
 
@@ -15,7 +14,7 @@ use crate::{helpers::Role, protocol::Gate, telemetry::labels};
 #[derive(Debug, Default)]
 pub struct CounterDetails {
     pub total_value: u64,
-    pub dimensions: HashMap<SharedString, HashMap<SharedString, u64>>,
+    pub dimensions: HashMap<&'static str, HashMap<String, u64>>,
 }
 
 /// Container for metrics, their descriptions and values they've accumulated.
@@ -32,35 +31,43 @@ pub struct CounterDetails {
 /// or POST requests.
 ///
 /// X1 and X2 cannot be greater than X, but these values may overlap, i.e. X1 + X2 >= X
+#[derive(Default)]
 pub struct Metrics {
-    pub counters: HashMap<KeyName, CounterDetails>,
-    pub metric_description: HashMap<KeyName, SharedString>,
+    pub counters: HashMap<&'static str, CounterDetails>,
+}
+
+pub struct CompositeKey {
+    pub key: &'static str,
+    pub labels: Vec<Label>,
+}
+
+#[derive(Clone)]
+pub struct Label {
+    pub name: &'static str,
+    pub value: String,
 }
 
 impl CounterDetails {
-    pub fn add(&mut self, key: &CompositeKey, val: &DebugValue) {
-        let DebugValue::Counter(val) = val else {
-            unreachable!()
-        };
-        for label in key.key().labels() {
-            let (label_key, label_val) = label.clone().into_parts();
-            let dimension_values = self.dimensions.entry(label_key).or_default();
+    pub fn add(&mut self, key: &CompositeKey, val: u64) {
+        for label in &key.labels {
+            let Label { name, value } = label.clone();
+            let dimension_values = self.dimensions.entry(name).or_default();
 
-            *dimension_values.entry(label_val).or_insert(0) += val;
+            *dimension_values.entry(value).or_insert(0) += val;
         }
 
         self.total_value += val;
     }
 
     #[must_use]
-    pub fn iter(&self) -> Iter<'_, SharedString, HashMap<SharedString, u64>> {
+    pub fn iter(&self) -> Iter<'_, &'static str, HashMap<String, u64>> {
         self.dimensions.iter()
     }
 }
 
 impl<'a> IntoIterator for &'a CounterDetails {
     type Item = <Self::IntoIter as Iterator>::Item;
-    type IntoIter = Iter<'a, SharedString, HashMap<SharedString, u64>>;
+    type IntoIter = Iter<'a, &'static str, HashMap<String, u64>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -68,45 +75,45 @@ impl<'a> IntoIterator for &'a CounterDetails {
 }
 
 impl Metrics {
-    pub fn from_snapshot(snapshot: Snapshot) -> Self {
-        const ALWAYS_TRUE: fn(&[Label]) -> bool = |_| true;
-        Self::with_filter(snapshot, ALWAYS_TRUE)
-    }
-
-    /// Consumes the provided snapshot and filters out metrics that don't satisfy `filter_fn`
-    /// conditions.
+    /// Builds a new metric snapshot for the specified partition.
+    ///
+    /// ## Panics
+    /// If partition does not exist in the metrics store.
     #[must_use]
-    pub fn with_filter<F: Fn(&[Label]) -> bool>(snapshot: Snapshot, filter_fn: F) -> Self {
-        let mut this = Metrics {
-            counters: HashMap::new(),
-            metric_description: HashMap::new(),
-        };
-
-        let snapshot = snapshot.into_vec();
-        for (ckey, _, descr, val) in snapshot {
-            let (key_name, labels) = ckey.key().clone().into_parts();
-            if !filter_fn(labels.as_slice()) {
-                continue;
+    pub fn from_partition(metrics_store: &MetricsStore, partition: MetricPartition) -> Self {
+        let v = metrics_store.with_partition(partition, |store| {
+            let mut this = Self::default();
+            for (counter, value) in store.counters() {
+                let composite_key = CompositeKey {
+                    key: counter.key,
+                    labels: counter
+                        .labels()
+                        .map(|l| Label {
+                            name: l.name,
+                            value: l.val.to_string(),
+                        })
+                        .collect::<Vec<_>>(),
+                };
+                match this.counters.entry(composite_key.key) {
+                    Entry::Occupied(mut entry) => entry.get_mut().add(&composite_key, value),
+                    Entry::Vacant(entry) => {
+                        let mut counter_details = CounterDetails::default();
+                        counter_details.add(&composite_key, value);
+                        entry.insert(counter_details);
+                    }
+                }
             }
-            let entry = this.counters.entry(key_name.clone()).or_default();
 
-            if let Some(descr) = descr {
-                this.metric_description.insert(key_name, descr);
-            }
+            this
+        });
 
-            match ckey.kind() {
-                MetricKind::Counter => entry.add(&ckey, &val),
-                MetricKind::Gauge | MetricKind::Histogram => unimplemented!(),
-            }
-        }
-
-        this
+        v.unwrap_or_else(|| panic!("Partition {partition} does not exist"))
     }
 
     #[must_use]
     pub fn get_counter(&self, name: &'static str) -> u64 {
         self.counters
-            .get::<KeyName>(&name.into())
+            .get(name)
             .map_or(0, |details| details.total_value)
     }
 
@@ -119,7 +126,7 @@ impl Metrics {
     pub fn assert_metric(&self, name: &'static str) -> MetricAssertion {
         let details = self
             .counters
-            .get::<KeyName>(&name.into())
+            .get(name)
             .unwrap_or_else(|| panic!("{name} metric does not exist in the snapshot"));
         MetricAssertion {
             name,
@@ -133,7 +140,7 @@ impl Metrics {
     /// returns an IO error if it fails to write to the provided writer.
     pub fn print(&self, w: &mut impl std::io::Write) -> Result<(), std::io::Error> {
         let mut metrics_table = comfy_table::Table::new();
-        metrics_table.set_header(vec!["metric", "description", "value", "dimensions"]);
+        metrics_table.set_header(vec!["metric", "value", "dimensions"]);
 
         for (key_name, counter_stats) in &self.counters {
             let mut dim_cell_content = String::new();
@@ -145,10 +152,7 @@ impl Metrics {
             }
 
             metrics_table.add_row(vec![
-                key_name.as_str(),
-                self.metric_description
-                    .get(key_name)
-                    .unwrap_or(&SharedString::from("")),
+                key_name,
                 counter_stats.total_value.to_string().as_str(),
                 dim_cell_content.as_str(),
             ]);
@@ -207,7 +211,7 @@ impl<'a> MetricAssertion<'a> {
         self.clone()
     }
 
-    fn get_dimension(&self, name: &'static str) -> &HashMap<SharedString, u64> {
+    fn get_dimension(&self, name: &'static str) -> &HashMap<String, u64> {
         self.snapshot.dimensions.get(name).unwrap_or_else(|| {
             panic!(
                 "No metric '{}' recorded per dimension '{name:?}'",

--- a/ipa-core/src/telemetry/step_stats.rs
+++ b/ipa-core/src/telemetry/step_stats.rs
@@ -30,7 +30,7 @@ impl CsvExporter for Metrics {
         for (counter_name, details) in &self.counters {
             if let Some(steps) = details.dimensions.get(labels::STEP) {
                 for (step, val) in steps {
-                    steps_stats.offer(step, counter_name.as_str(), *val);
+                    steps_stats.offer(step, counter_name, *val);
                 }
             }
         }

--- a/ipa-core/src/test_fixture/logging.rs
+++ b/ipa-core/src/test_fixture/logging.rs
@@ -19,7 +19,6 @@ pub fn setup() {
         {
             use std::str::FromStr;
 
-            use metrics_tracing_context::MetricsLayer;
             use tracing::Level;
             use tracing_subscriber::{
                 filter::Directive, fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
@@ -43,7 +42,7 @@ pub fn setup() {
                         .from_env_lossy(),
                 )
                 .with(fmt_layer)
-                .with(MetricsLayer::new())
+                .with(ipa_metrics_tracing::MetricsPartitioningLayer)
                 .init();
         }
     });

--- a/ipa-step/Cargo.toml
+++ b/ipa-step/Cargo.toml
@@ -10,6 +10,8 @@ name = []
 string-step = []
 
 [dependencies]
+ipa-metrics = { path = "../ipa-metrics" }
+
 prettyplease = { version = "0.2", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "1.0.36", optional = true }

--- a/ipa-step/src/descriptive.rs
+++ b/ipa-step/src/descriptive.rs
@@ -1,5 +1,9 @@
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    fmt::{Debug, Display, Formatter},
+    hash::{Hash, Hasher},
+};
 
+use ipa_metrics::{label_hasher, LabelValue};
 use serde::Deserialize;
 
 use crate::{Gate, Step, StepNarrow};
@@ -90,5 +94,18 @@ impl<S: Step + ?Sized> StepNarrow<S> for Descriptive {
         let id = format!("{}/{}", self.id, step.as_ref());
 
         Self { id }
+    }
+}
+
+impl LabelValue for Descriptive {
+    fn hash(&self) -> u64 {
+        let mut hasher = label_hasher();
+        Hash::hash(self, &mut hasher);
+
+        hasher.finish()
+    }
+
+    fn boxed(&self) -> Box<dyn LabelValue> {
+        Box::new(self.clone())
     }
 }


### PR DESCRIPTION
This is the final PR to upgrade IPA to use new metric engine. This change removes the old metric dependency and updates the code to use new metrics.

This approach was tested in #1278 and the only difference here is that we don't consume metrics yet. #1353 will take care of it