### PR TITLE
Hybrid padding

### DIFF
--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -3,4 +3,6 @@ use ipa_step_derive::CompactStep;
 #[derive(CompactStep)]
 pub(crate) enum HybridStep {
     ReshardByTag,
+    #[step(child = crate::protocol::ipa_prf::oprf_padding::step::PaddingDpStep, name="padding_dp")]
+    PaddingDp,
 }

--- a/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
@@ -166,11 +166,11 @@ where
                                 Direction::Left => AdditiveShare::new(BA64::ZERO, dummy_mk),
                                 Direction::Right => AdditiveShare::new(dummy_mk, BA64::ZERO),
                             };
-                            let row = IndistinguishableHybridReport::new(
-                                match_key_shares,
-                                AdditiveShare::ZERO,
-                                AdditiveShare::ZERO,
-                            );
+                            let row = IndistinguishableHybridReport {
+                                match_key: match_key_shares,
+                                value: AdditiveShare::ZERO,
+                                breakdown_key: AdditiveShare::ZERO,
+                            };
                             padding_input_rows.extend(std::iter::once(row));
                         }
                     }
@@ -185,11 +185,11 @@ where
         total_number_of_fake_rows: u32,
     ) {
         for _ in 0..total_number_of_fake_rows as usize {
-            let row = IndistinguishableHybridReport::new(
-                AdditiveShare::ZERO,
-                AdditiveShare::ZERO,
-                AdditiveShare::ZERO,
-            );
+            let row = IndistinguishableHybridReport {
+                match_key: AdditiveShare::ZERO,
+                value: AdditiveShare::ZERO,
+                breakdown_key: AdditiveShare::ZERO,
+            };
 
             padding_input_rows.extend(std::iter::once(row));
         }

--- a/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
@@ -138,6 +138,12 @@ where
     BK: BooleanArray + U128Conversions,
     V: BooleanArray,
 {
+    /// Given an extendable collection of `IndistinguishableHybridReport`s,
+    /// this function will pad the collection with dummy reports. The reports
+    /// have a random `match_key` and zeros for `breakdown_key` and `value`.
+    /// Dummies need to be added at every possible cardinality of `match_key`s,
+    /// e.g., we add sets of dummies with the same `match_key` at each possible cardinality.
+    /// The number of sets at each cardinality is random, and determined by `padding_params`.
     fn add_padding_items<VC: Extend<Self>, const B: usize>(
         direction_to_excluded_helper: Direction,
         padding_input_rows: &mut VC,
@@ -181,6 +187,8 @@ where
         Ok(total_number_of_fake_rows)
     }
 
+    /// Given an extendable collection of `IndistinguishableHybridReport`s,
+    /// this function ads `total_number_of_fake_rows` of Reports with zeros in all fields.
     fn add_zero_shares<VC: Extend<Self>>(
         padding_input_rows: &mut VC,
         total_number_of_fake_rows: u32,

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -353,28 +353,9 @@ where
     BK: SharedValue,
     V: SharedValue,
 {
-    match_key: Replicated<BA64>,
-    value: Replicated<V>,
-    breakdown_key: Replicated<BK>,
-}
-
-impl<BK, V> IndistinguishableHybridReport<BK, V>
-where
-    BK: SharedValue,
-    V: SharedValue,
-{
-    #[must_use]
-    pub fn new(
-        match_key: Replicated<BA64>,
-        value: Replicated<V>,
-        breakdown_key: Replicated<BK>,
-    ) -> Self {
-        Self {
-            match_key,
-            value,
-            breakdown_key,
-        }
-    }
+    pub match_key: Replicated<BA64>,
+    pub value: Replicated<V>,
+    pub breakdown_key: Replicated<BK>,
 }
 
 impl<BK, V> From<HybridReport<BK, V>> for IndistinguishableHybridReport<BK, V>

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -358,6 +358,32 @@ where
     pub breakdown_key: Replicated<BK>,
 }
 
+impl<BK, V> IndistinguishableHybridReport<BK, V>
+where
+    BK: SharedValue,
+    V: SharedValue,
+{
+    pub const ZERO: Self = Self {
+        match_key: Replicated::<BA64>::ZERO,
+        value: Replicated::<V>::ZERO,
+        breakdown_key: Replicated::<BK>::ZERO,
+    };
+}
+
+impl<BK, V> From<Replicated<BA64>> for IndistinguishableHybridReport<BK, V>
+where
+    BK: SharedValue,
+    V: SharedValue,
+{
+    fn from(match_key: Replicated<BA64>) -> Self {
+        Self {
+            match_key,
+            value: Replicated::<V>::ZERO,
+            breakdown_key: Replicated::<BK>::ZERO,
+        }
+    }
+}
+
 impl<BK, V> From<HybridReport<BK, V>> for IndistinguishableHybridReport<BK, V>
 where
     BK: SharedValue,

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -358,6 +358,25 @@ where
     breakdown_key: Replicated<BK>,
 }
 
+impl<BK, V> IndistinguishableHybridReport<BK, V>
+where
+    BK: SharedValue,
+    V: SharedValue,
+{
+    #[must_use]
+    pub fn new(
+        match_key: Replicated<BA64>,
+        value: Replicated<V>,
+        breakdown_key: Replicated<BK>,
+    ) -> Self {
+        Self {
+            match_key,
+            value,
+            breakdown_key,
+        }
+    }
+}
+
 impl<BK, V> From<HybridReport<BK, V>> for IndistinguishableHybridReport<BK, V>
 where
     BK: SharedValue,

--- a/ipa-core/src/secret_sharing/replicated/mod.rs
+++ b/ipa-core/src/secret_sharing/replicated/mod.rs
@@ -2,11 +2,19 @@ pub mod malicious;
 pub mod semi_honest;
 
 use super::{SecretSharing, SharedValue};
+use crate::helpers::Direction;
 
 pub trait ReplicatedSecretSharing<V: SharedValue>: SecretSharing<V> {
     fn new(a: V, b: V) -> Self;
     fn left(&self) -> V;
     fn right(&self) -> V;
+
+    fn new_excluding_direction(v: V, direction: Direction) -> Self {
+        match direction {
+            Direction::Left => Self::new(V::ZERO, v),
+            Direction::Right => Self::new(v, V::ZERO),
+        }
+    }
 
     fn map<F: Fn(V) -> T, R: ReplicatedSecretSharing<T>, T: SharedValue>(&self, f: F) -> R {
         R::new(f(self.left()), f(self.right()))

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -27,17 +27,21 @@ where
     V: BooleanArray + U128Conversions + IntoShares<Replicated<V>>,
 {
     fn reconstruct(&self) -> TestIndistinguishableHybridReport {
-        let [s0, s1, s2] = self;
-
-        let match_key = [&s0.match_key, &s1.match_key, &s2.match_key]
+        let match_key = self
+            .each_ref()
+            .map(|v| v.match_key.clone())
             .reconstruct()
             .as_u128();
-
-        let breakdown_key = [&s0.breakdown_key, &s1.breakdown_key, &s2.breakdown_key]
+        let breakdown_key = self
+            .each_ref()
+            .map(|v| v.breakdown_key.clone())
             .reconstruct()
             .as_u128();
-
-        let value = [&s0.value, &s1.value, &s2.value].reconstruct().as_u128();
+        let value = self
+            .each_ref()
+            .map(|v| v.value.clone())
+            .reconstruct()
+            .as_u128();
 
         TestIndistinguishableHybridReport {
             match_key: match_key.try_into().unwrap(),

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -1,9 +1,50 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::{
+    ff::{boolean_array::BooleanArray, U128Conversions},
+    report::hybrid::IndistinguishableHybridReport,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
+    test_fixture::sharing::Reconstruct,
+};
+
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq)]
 pub enum TestHybridRecord {
     TestImpression { match_key: u64, breakdown_key: u32 },
     TestConversion { match_key: u64, value: u32 },
+}
+
+#[derive(PartialEq, Eq)]
+pub struct TestIndistinguishableHybridReport {
+    pub match_key: u64,
+    pub value: u32,
+    pub breakdown_key: u32,
+}
+
+impl<BK, V> Reconstruct<TestIndistinguishableHybridReport>
+    for [&IndistinguishableHybridReport<BK, V>; 3]
+where
+    BK: BooleanArray + U128Conversions + IntoShares<Replicated<BK>>,
+    V: BooleanArray + U128Conversions + IntoShares<Replicated<V>>,
+{
+    fn reconstruct(&self) -> TestIndistinguishableHybridReport {
+        let [s0, s1, s2] = self;
+
+        let match_key = [&s0.match_key, &s1.match_key, &s2.match_key]
+            .reconstruct()
+            .as_u128();
+
+        let breakdown_key = [&s0.breakdown_key, &s1.breakdown_key, &s2.breakdown_key]
+            .reconstruct()
+            .as_u128();
+
+        let value = [&s0.value, &s1.value, &s2.value].reconstruct().as_u128();
+
+        TestIndistinguishableHybridReport {
+            match_key: match_key.try_into().unwrap(),
+            breakdown_key: breakdown_key.try_into().unwrap(),
+            value: value.try_into().unwrap(),
+        }
+    }
 }
 
 struct HashmapEntry {


### PR DESCRIPTION
This implements the `Paddable` trait for `IndistinguishableHybridReport` so that it can work with `apply_dp_padding`. It also implements `TestIndistinguishableHybridReport` and `Reconstruct` to support the tests.

Note that this is fairly repetitive to the OPRF implementation. If we wanted to keep that around, we'd want to make this more generic, but given our intention is to delete that, it's copied and modified to work directly with  `IndistinguishableHybridReport`.