### PR TITLE
Remove use of MAC-upgraded contexts with Boolean

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -79,11 +79,6 @@ where
 {
 }
 
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>>
-    for AdditiveShare<Boolean>
-{
-}
-
 impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>>
     for AdditiveShare<Boolean>
 {
@@ -95,13 +90,8 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>>
 }
 
 // Used for aggregation tests
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 8>
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>, 8>
     for AdditiveShare<Boolean, 8>
-{
-}
-
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, PRF_CHUNK>
-    for AdditiveShare<Boolean, PRF_CHUNK>
 {
 }
 
@@ -112,11 +102,6 @@ impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>,
 
 impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedMaliciousContext<'a, B>, PRF_CHUNK>
     for AdditiveShare<Boolean, PRF_CHUNK>
-{
-}
-
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, AGG_CHUNK>
-    for AdditiveShare<Boolean, AGG_CHUNK>
 {
 }
 
@@ -147,12 +132,7 @@ const_assert_eq!(
     "Implementation for N = 16 required for num_breakdowns"
 );
 
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 32>
-    for AdditiveShare<Boolean, 32>
-{
-}
-
-impl<'a, B: ShardBinding> BooleanProtocols<UpgradedSemiHonestContext<'a, B, Boolean>, 3>
+impl<'a, B: ShardBinding> BooleanProtocols<DZKPUpgradedSemiHonestContext<'a, B>, 3>
     for AdditiveShare<Boolean, 3>
 {
 }

--- a/ipa-core/src/protocol/basics/reveal.rs
+++ b/ipa-core/src/protocol/basics/reveal.rs
@@ -447,7 +447,7 @@ mod tests {
 
         let input = rng.gen::<TestField>();
         let results = world
-            .upgraded_semi_honest::<TestField, _, _, _, _, _>(input, |ctx, share| async move {
+            .dzkp_semi_honest(input, |ctx, share| async move {
                 TestField::from_array(
                     &share
                         .reveal(ctx.set_total_records(1), RecordId::from(0))
@@ -474,7 +474,7 @@ mod tests {
         for &excluded in Role::all() {
             let input = rng.gen::<TestField>();
             let results = world
-                .upgraded_semi_honest::<TestField, _, _, _, _, _>(input, |ctx, share| async move {
+                .dzkp_semi_honest(input, |ctx, share| async move {
                     share
                         .partial_reveal(ctx.set_total_records(1), RecordId::from(0), excluded)
                         .await
@@ -505,7 +505,7 @@ mod tests {
 
         let input = rng.gen::<TestFieldArray>();
         let results = world
-            .upgraded_semi_honest::<TestField, _, _, _, _, _>(
+            .dzkp_semi_honest(
                 input,
                 |ctx, share: AdditiveShare<TestField, 32>| async move {
                     share
@@ -724,17 +724,14 @@ mod tests {
     #[tokio::test]
     async fn reveal_empty_vec() {
         let [res0, res1, res2] = TestWorld::default()
-            .upgraded_semi_honest::<Boolean, _, _, _, _, _>(
-                iter::empty::<Boolean>(),
-                |ctx, share| async move {
-                    reveal(ctx, RecordId::FIRST, &BitDecomposed::new(share))
-                        .await
-                        .unwrap()
-                        .into_iter()
-                        .map(|v| Boolean::from_array(&v))
-                        .collect::<Vec<_>>()
-                },
-            )
+            .dzkp_semi_honest(iter::empty::<Boolean>(), |ctx, share| async move {
+                reveal(ctx, RecordId::FIRST, &BitDecomposed::new(share))
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|v| Boolean::from_array(&v))
+                    .collect::<Vec<_>>()
+            })
             .await;
 
         assert_eq!(res0, vec![]);
@@ -745,14 +742,11 @@ mod tests {
     #[tokio::test]
     async fn reveal_empty_vec_partial() {
         let [res0, res1, res2] = TestWorld::default()
-            .upgraded_semi_honest::<Boolean, _, _, _, _, _>(
-                iter::empty::<Boolean>(),
-                |ctx, share| async move {
-                    partial_reveal(ctx, RecordId::FIRST, Role::H3, &BitDecomposed::new(share))
-                        .await
-                        .unwrap()
-                },
-            )
+            .dzkp_semi_honest(iter::empty::<Boolean>(), |ctx, share| async move {
+                partial_reveal(ctx, RecordId::FIRST, Role::H3, &BitDecomposed::new(share))
+                    .await
+                    .unwrap()
+            })
             .await;
 
         assert_eq!(res0, Some(vec![]));

--- a/ipa-core/src/protocol/dp/mod.rs
+++ b/ipa-core/src/protocol/dp/mod.rs
@@ -829,7 +829,7 @@ mod test {
         let input: BitDecomposed<[Boolean; NUM_BREAKDOWNS as usize]> =
             vectorize_input(16, &input_values);
         let result = world
-            .upgraded_semi_honest(input, |ctx, input| async move {
+            .dzkp_semi_honest(input, |ctx, input| async move {
                 apply_dp_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                     ctx,
                     input,
@@ -871,7 +871,7 @@ mod test {
         }
         let world = TestWorld::default();
         let result: [Vec<Replicated<OutputValue>>; 3] = world
-            .upgraded_semi_honest((), |ctx, ()| async move {
+            .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
                     &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
@@ -906,7 +906,7 @@ mod test {
         let num_bernoulli: u32 = 2000;
         let world = TestWorld::default();
         let result: [Vec<Replicated<OutputValue>>; 3] = world
-            .upgraded_semi_honest((), |ctx, ()| async move {
+            .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
                     &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
@@ -941,7 +941,7 @@ mod test {
         let num_bernoulli: u32 = 1000;
         let world = TestWorld::default();
         let result: [Vec<Replicated<OutputValue>>; 3] = world
-            .upgraded_semi_honest((), |ctx, ()| async move {
+            .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
                     &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,
@@ -982,7 +982,7 @@ mod test {
 
         let num_bernoulli: u32 = 1_000;
         let result: [Vec<Replicated<OutputValue>>; 3] = world
-            .upgraded_semi_honest((), |ctx, ()| async move {
+            .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
                     &gen_binomial_noise::<_, { NUM_BREAKDOWNS as usize }, OutputValue>(
                         ctx,

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -276,7 +276,7 @@ pub mod tests {
                 Ok(input_row(1, &[0, 0, 0, 0, 1, 0, 1, 1])),
             ];
             let result: BitDecomposed<BA8> = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -299,7 +299,7 @@ pub mod tests {
                 Ok(input_row(1, &[0, 0, 1, 1, 0, 0, 0, 0])),
             ];
             let result = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -325,7 +325,7 @@ pub mod tests {
                 Ok(input_row(3, &[0, 0, 0, 1, 3, 1, 2, 0])),
             ];
             let result = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -353,7 +353,7 @@ pub mod tests {
                 Ok(input_row(7, &[0, 0, 0, 1, 0, 2, 2, 1])),
             ];
             let result = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -380,7 +380,7 @@ pub mod tests {
                 Ok(input_row(7, &[0, 0x40, 0x7f, 1, 0, 0, 0, 0])),
             ];
             let result = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -400,7 +400,7 @@ pub mod tests {
     fn aggregate_empty() {
         run(|| async move {
             let result = TestWorld::default()
-                .upgraded_semi_honest((), |ctx, ()| {
+                .dzkp_semi_honest((), |ctx, ()| {
                     aggregate_values::<_, BA8, 8>(ctx, stream::empty().boxed(), 0, None)
                 })
                 .await
@@ -420,7 +420,7 @@ pub mod tests {
                 Err(Error::Internal),
             ];
             let result = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len();
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -440,7 +440,7 @@ pub mod tests {
         run(|| async move {
             let inputs = vec![Ok(input_row(1, &[0, 0, 1, 1, 0, 0, 0, 0]))];
             let _ = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len() + 1;
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -462,7 +462,7 @@ pub mod tests {
                 Ok(input_row(1, &[0, 0, 1, 1, 0, 0, 0, 0])),
             ];
             let _ = TestWorld::default()
-                .upgraded_semi_honest(inputs.into_iter(), |ctx, inputs| {
+                .dzkp_semi_honest(inputs.into_iter(), |ctx, inputs| {
                     let num_rows = inputs.len() - 1;
                     aggregate_values::<_, BA8, 8>(ctx, stream::iter(inputs).boxed(), num_rows, None)
                 })
@@ -544,7 +544,7 @@ pub mod tests {
                     Ok(input_row(tv_bits, &row))
                 });
                 let result: BitDecomposed<PropHistogramValue> = TestWorld::with_seed(seed)
-                    .upgraded_semi_honest(inputs, |ctx, inputs| {
+                    .dzkp_semi_honest(inputs, |ctx, inputs| {
                         let num_rows = inputs.len();
                         aggregate_values::<_, PropHistogramValue, PROP_BUCKETS>(
                             ctx,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/addition_sequential.rs
@@ -192,7 +192,7 @@ mod test {
             let expected_carry = (x + y) >> 64 & 1;
 
             let (result, carry) = world
-                .upgraded_semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
+                .dzkp_semi_honest((x_ba64, y_ba64), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
@@ -233,7 +233,7 @@ mod test {
             let expected = if x + y > z { z - 1 } else { (x + y) % z };
 
             let result = world
-                .upgraded_semi_honest((x_bits, y_bits), |ctx, x_y| async move {
+                .dzkp_semi_honest((x_bits, y_bits), |ctx, x_y| async move {
                     integer_sat_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
@@ -269,7 +269,7 @@ mod test {
             let expected_carry = (x + y) >> 64 & 1;
 
             let (result, carry) = world
-                .upgraded_semi_honest((x_ba64, y_ba32), |ctx, x_y| async move {
+                .dzkp_semi_honest((x_ba64, y_ba32), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,
@@ -290,7 +290,7 @@ mod test {
             let expected = (x + y) % (1 << 32);
             let expected_carry = (x + y) >> 32 & 1;
             let (result, carry) = world
-                .upgraded_semi_honest((y_ba32, x_ba64), |ctx, x_y| async move {
+                .dzkp_semi_honest((y_ba32, x_ba64), |ctx, x_y| async move {
                     integer_add::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         RecordId::FIRST,

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/comparison_and_subtraction_sequential.rs
@@ -293,7 +293,7 @@ mod test {
             let expected = x >= y;
 
             let result = world
-                .upgraded_semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
                     compare_geq::<_, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -309,7 +309,7 @@ mod test {
             assert_eq!(result, <Boolean>::from(expected));
 
             let result2 = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.into_iter(), |ctx, x_y| async move {
                     compare_geq::<_, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -340,7 +340,7 @@ mod test {
             let expected = x > y;
 
             let result = world
-                .upgraded_semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.clone().into_iter(), |ctx, x_y| async move {
                     compare_gt::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -357,7 +357,7 @@ mod test {
 
             // check that x is not greater than itself
             let result2 = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.into_iter(), |ctx, x_y| async move {
                     compare_gt::<_, DefaultBitStep, 1>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -395,7 +395,7 @@ mod test {
             let expected = x_int.iter().map(|x| *x > y_int).collect::<Vec<_>>();
 
             let result = world
-                .upgraded_semi_honest((x.clone().into_iter(), y), |ctx, (x, y)| async move {
+                .dzkp_semi_honest((x.clone().into_iter(), y), |ctx, (x, y)| async move {
                     #[cfg(not(debug_assertions))]
                     let begin = std::time::Instant::now();
                     let ctx = ctx.set_total_records(x.len());
@@ -478,7 +478,7 @@ mod test {
 
             let xa_iter = xa.clone().into_iter();
             let result = world
-                .upgraded_semi_honest((xa_iter, ya.clone()), |ctx, (x, y)| async move {
+                .dzkp_semi_honest((xa_iter, ya.clone()), |ctx, (x, y)| async move {
                     #[cfg(not(debug_assertions))]
                     let begin = std::time::Instant::now();
                     let ctx = ctx.set_total_records(x.len());
@@ -529,7 +529,7 @@ mod test {
             let expected = ((x + z) - y) % z;
 
             let result = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.into_iter(), |ctx, x_y| async move {
                     integer_sub::<_, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -560,7 +560,7 @@ mod test {
             let expected = if y > x { 0u128 } else { x - y };
 
             let result = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, x_y| async move {
+                .dzkp_semi_honest(records.into_iter(), |ctx, x_y| async move {
                     integer_sat_sub::<_, _, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -587,7 +587,7 @@ mod test {
             let expected = 4_u128;
 
             let result = world
-                .upgraded_semi_honest((x, y), |ctx, x_y| async move {
+                .dzkp_semi_honest((x, y), |ctx, x_y| async move {
                     integer_sub::<_, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),
@@ -619,7 +619,7 @@ mod test {
             let expected = ((x + z) - y) % z;
 
             let result = world
-                .upgraded_semi_honest(records, |ctx, x_y| async move {
+                .dzkp_semi_honest(records, |ctx, x_y| async move {
                     integer_sub::<_, DefaultBitStep>(
                         ctx.set_total_records(1),
                         protocol::RecordId(0),

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/multiplication.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/multiplication.rs
@@ -118,7 +118,7 @@ mod test {
             let random_y_values = (0..256).map(|_| rng.gen::<BA8>()).collect::<Vec<_>>();
 
             let result: Vec<BA16> = world
-                .upgraded_semi_honest(
+                .dzkp_semi_honest(
                     all_x_values
                         .clone()
                         .into_iter()

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/sigmoid.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/sigmoid.rs
@@ -206,7 +206,7 @@ mod test {
             let all_x_values = (0..256).map(|i| BA8::truncate_from(u128::try_from(i).unwrap()));
 
             let result: Vec<BA8> = world
-                .upgraded_semi_honest(all_x_values, |ctx, all_x_values| async move {
+                .dzkp_semi_honest(all_x_values, |ctx, all_x_values| async move {
                     let vectorized_inputs = BitDecomposed::transposed_from(&all_x_values).unwrap();
 
                     let result = sigmoid::<_, 256>(

--- a/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_sharding/feature_label_dot_product.rs
@@ -453,7 +453,7 @@ pub mod tests {
             let users_having_n_records = vec![4, 3, 2, 2, 1, 1, 1, 1];
 
             let result = world
-                .upgraded_semi_honest(records.into_iter(), |ctx, input_rows| {
+                .dzkp_semi_honest(records.into_iter(), |ctx, input_rows| {
                     let h = users_having_n_records.as_slice();
                     async move {
                         compute_feature_label_dot_product::<_, BA8, BA16, 32>(ctx, input_rows, h)


### PR DESCRIPTION
This changes a bunch of tests that were upgrading Boolean contexts to MAC-semi-honest to instead use DZKP-semi-honest. An upgrade of some kind became necessary after removing support for MPC primitives from the base context. When that first happened, DZKP upgrades were not ready. Now that DZKP upgrades work, it makes more sense to use them here -- it's unlikely we would want to use MAC security with a Boolean field, because it is significantly more expensive than the DZKPs.

Making this change avoids the need to maintain MAC support for `Boolean`, which was never properly implemented. (When we actually used it, it was with `Gf2`, which is distinct from `Boolean`, for better or worse.)