### PR TITLE
Renaming MpcHelperClient to IpaHttpClient<Helper>

### DIFF
--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -18,7 +18,7 @@ use ipa_core::{
     error::BoxError,
     executor::IpaRuntime,
     helpers::HelperIdentity,
-    net::{ClientIdentity, MpcHelperClient, MpcHttpTransport, ShardHttpTransport},
+    net::{ClientIdentity, IpaHttpClient, MpcHttpTransport, ShardHttpTransport},
     sharding::ShardIndex,
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
@@ -167,7 +167,7 @@ async fn server(args: ServerArgs, logging_handle: LoggingHandle) -> Result<(), B
     // ---
 
     let http_runtime = new_http_runtime(&logging_handle);
-    let clients = MpcHelperClient::from_conf(
+    let clients = IpaHttpClient::from_conf(
         &IpaRuntime::from_tokio_runtime(&http_runtime),
         &network_config,
         &identity,

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -333,7 +333,7 @@ async fn ipa(
     args: &Args,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
-    helper_clients: &[MpcHelperClient; 3],
+    helper_clients: &[MpcHelperClient<Helper>; 3],
     encrypted_inputs: &EncryptedInputs,
 ) -> Result<(), Box<dyn Error>> {
     let query_type = get_query_type(security_model, ipa_query_config);
@@ -383,7 +383,7 @@ async fn ipa_test(
     network: &NetworkConfig<Helper>,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
-    helper_clients: &[MpcHelperClient; 3],
+    helper_clients: &[MpcHelperClient<Helper>; 3],
 ) -> Result<(), Box<dyn Error>> {
     let input = InputSource::from(&args.input);
     let query_type = get_query_type(security_model, ipa_query_config);

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -22,7 +22,7 @@ use ipa_core::{
     config::{KeyRegistries, NetworkConfig},
     ff::{boolean_array::BA32, FieldType},
     helpers::query::{DpMechanism, IpaQueryConfig, QueryConfig, QuerySize, QueryType},
-    net::{Helper, MpcHelperClient},
+    net::{Helper, IpaHttpClient},
     report::{EncryptedOprfReportStreams, DEFAULT_KEY_ID},
     test_fixture::{
         ipa::{ipa_in_the_clear, CappingOrder, IpaSecurityModel, TestRawDataRecord},
@@ -333,7 +333,7 @@ async fn ipa(
     args: &Args,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
-    helper_clients: &[MpcHelperClient<Helper>; 3],
+    helper_clients: &[IpaHttpClient<Helper>; 3],
     encrypted_inputs: &EncryptedInputs,
 ) -> Result<(), Box<dyn Error>> {
     let query_type = get_query_type(security_model, ipa_query_config);
@@ -383,7 +383,7 @@ async fn ipa_test(
     network: &NetworkConfig<Helper>,
     security_model: IpaSecurityModel,
     ipa_query_config: IpaQueryConfig,
-    helper_clients: &[MpcHelperClient<Helper>; 3],
+    helper_clients: &[IpaHttpClient<Helper>; 3],
 ) -> Result<(), Box<dyn Error>> {
     let input = InputSource::from(&args.input);
     let query_type = get_query_type(security_model, ipa_query_config);

--- a/ipa-core/src/bin/test_mpc.rs
+++ b/ipa-core/src/bin/test_mpc.rs
@@ -13,7 +13,7 @@ use ipa_core::{
         QueryConfig,
         QueryType::{TestAddInPrimeField, TestMultiply},
     },
-    net::MpcHelperClient,
+    net::{Helper, MpcHelperClient},
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
 };
 
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-async fn multiply_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient; 3])
+async fn multiply_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3])
 where
     F: Field + U128Conversions + IntoShares<AdditiveShare<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
@@ -130,14 +130,14 @@ where
     validate(&expected, &actual);
 }
 
-async fn multiply(args: &Args, helper_clients: &[MpcHelperClient; 3]) {
+async fn multiply(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3]) {
     match args.input.field {
         FieldType::Fp31 => multiply_in_field::<Fp31>(args, helper_clients).await,
         FieldType::Fp32BitPrime => multiply_in_field::<Fp32BitPrime>(args, helper_clients).await,
     };
 }
 
-async fn add_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient; 3])
+async fn add_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3])
 where
     F: Field + U128Conversions + IntoShares<AdditiveShare<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
@@ -159,13 +159,13 @@ where
     validate(&vec![expected], &vec![actual]);
 }
 
-async fn add(args: &Args, helper_clients: &[MpcHelperClient; 3]) {
+async fn add(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3]) {
     match args.input.field {
         FieldType::Fp31 => add_in_field::<Fp31>(args, helper_clients).await,
         FieldType::Fp32BitPrime => add_in_field::<Fp32BitPrime>(args, helper_clients).await,
     };
 }
 
-async fn sharded_shuffle(_args: &Args, _helper_clients: &[MpcHelperClient; 3]) {
+async fn sharded_shuffle(_args: &Args, _helper_clients: &[MpcHelperClient<Helper>; 3]) {
     unimplemented!()
 }

--- a/ipa-core/src/bin/test_mpc.rs
+++ b/ipa-core/src/bin/test_mpc.rs
@@ -13,7 +13,7 @@ use ipa_core::{
         QueryConfig,
         QueryType::{TestAddInPrimeField, TestMultiply},
     },
-    net::{Helper, MpcHelperClient},
+    net::{Helper, IpaHttpClient},
     secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
 };
 
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-async fn multiply_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3])
+async fn multiply_in_field<F>(args: &Args, helper_clients: &[IpaHttpClient<Helper>; 3])
 where
     F: Field + U128Conversions + IntoShares<AdditiveShare<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
@@ -130,14 +130,14 @@ where
     validate(&expected, &actual);
 }
 
-async fn multiply(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3]) {
+async fn multiply(args: &Args, helper_clients: &[IpaHttpClient<Helper>; 3]) {
     match args.input.field {
         FieldType::Fp31 => multiply_in_field::<Fp31>(args, helper_clients).await,
         FieldType::Fp32BitPrime => multiply_in_field::<Fp32BitPrime>(args, helper_clients).await,
     };
 }
 
-async fn add_in_field<F>(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3])
+async fn add_in_field<F>(args: &Args, helper_clients: &[IpaHttpClient<Helper>; 3])
 where
     F: Field + U128Conversions + IntoShares<AdditiveShare<F>>,
     <F as Serializable>::Size: Add<<F as Serializable>::Size>,
@@ -159,13 +159,13 @@ where
     validate(&vec![expected], &vec![actual]);
 }
 
-async fn add(args: &Args, helper_clients: &[MpcHelperClient<Helper>; 3]) {
+async fn add(args: &Args, helper_clients: &[IpaHttpClient<Helper>; 3]) {
     match args.input.field {
         FieldType::Fp31 => add_in_field::<Fp31>(args, helper_clients).await,
         FieldType::Fp32BitPrime => add_in_field::<Fp32BitPrime>(args, helper_clients).await,
     };
 }
 
-async fn sharded_shuffle(_args: &Args, _helper_clients: &[MpcHelperClient<Helper>; 3]) {
+async fn sharded_shuffle(_args: &Args, _helper_clients: &[IpaHttpClient<Helper>; 3]) {
     unimplemented!()
 }

--- a/ipa-core/src/cli/playbook/add.rs
+++ b/ipa-core/src/cli/playbook/add.rs
@@ -9,7 +9,7 @@ use typenum::Unsigned;
 use crate::{
     ff::{Field, Serializable},
     helpers::{query::QueryInput, BodyStream},
-    net::MpcHelperClient,
+    net::{Helper, MpcHelperClient},
     protocol::QueryId,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::Reconstruct,
@@ -19,7 +19,7 @@ use crate::{
 #[allow(clippy::missing_panics_doc, clippy::disallowed_methods)]
 pub async fn secure_add<F>(
     input: impl Iterator<Item = F>,
-    clients: &[MpcHelperClient; 3],
+    clients: &[MpcHelperClient<Helper>; 3],
     query_id: QueryId,
 ) -> F
 where

--- a/ipa-core/src/cli/playbook/add.rs
+++ b/ipa-core/src/cli/playbook/add.rs
@@ -9,7 +9,7 @@ use typenum::Unsigned;
 use crate::{
     ff::{Field, Serializable},
     helpers::{query::QueryInput, BodyStream},
-    net::{Helper, MpcHelperClient},
+    net::{Helper, IpaHttpClient},
     protocol::QueryId,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::Reconstruct,
@@ -19,7 +19,7 @@ use crate::{
 #[allow(clippy::missing_panics_doc, clippy::disallowed_methods)]
 pub async fn secure_add<F>(
     input: impl Iterator<Item = F>,
-    clients: &[MpcHelperClient<Helper>; 3],
+    clients: &[IpaHttpClient<Helper>; 3],
     query_id: QueryId,
 ) -> F
 where

--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -23,7 +23,7 @@ use crate::{
         BodyStream,
     },
     hpke::PublicKeyRegistry,
-    net::{Helper, MpcHelperClient},
+    net::{Helper, IpaHttpClient},
     protocol::{ipa_prf::OPRFIPAInputRow, QueryId},
     query::QueryStatus,
     report::{KeyIdentifier, OprfReport},
@@ -37,7 +37,7 @@ use crate::{
 /// If report encryption fails
 pub async fn playbook_oprf_ipa<HV, KR>(
     records: Vec<TestRawDataRecord>,
-    clients: &[MpcHelperClient<Helper>; 3],
+    clients: &[IpaHttpClient<Helper>; 3],
     query_id: QueryId,
     query_config: IpaQueryConfig,
     encryption: Option<(KeyIdentifier, [&KR; 3])>,
@@ -101,7 +101,7 @@ where
 pub async fn run_query_and_validate<HV>(
     inputs: [BodyStream; 3],
     query_size: usize,
-    clients: &[MpcHelperClient<Helper>; 3],
+    clients: &[IpaHttpClient<Helper>; 3],
     query_id: QueryId,
     query_config: IpaQueryConfig,
 ) -> IpaQueryResult

--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -23,7 +23,7 @@ use crate::{
         BodyStream,
     },
     hpke::PublicKeyRegistry,
-    net::MpcHelperClient,
+    net::{Helper, MpcHelperClient},
     protocol::{ipa_prf::OPRFIPAInputRow, QueryId},
     query::QueryStatus,
     report::{KeyIdentifier, OprfReport},
@@ -37,7 +37,7 @@ use crate::{
 /// If report encryption fails
 pub async fn playbook_oprf_ipa<HV, KR>(
     records: Vec<TestRawDataRecord>,
-    clients: &[MpcHelperClient; 3],
+    clients: &[MpcHelperClient<Helper>; 3],
     query_id: QueryId,
     query_config: IpaQueryConfig,
     encryption: Option<(KeyIdentifier, [&KR; 3])>,
@@ -101,7 +101,7 @@ where
 pub async fn run_query_and_validate<HV>(
     inputs: [BodyStream; 3],
     query_size: usize,
-    clients: &[MpcHelperClient; 3],
+    clients: &[MpcHelperClient<Helper>; 3],
     query_id: QueryId,
     query_config: IpaQueryConfig,
 ) -> IpaQueryResult

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -194,7 +194,7 @@ pub async fn make_clients(
     network_path: Option<&Path>,
     scheme: Scheme,
     wait: usize,
-) -> ([MpcHelperClient; 3], NetworkConfig<Helper>) {
+) -> ([MpcHelperClient<Helper>; 3], NetworkConfig<Helper>) {
     let mut wait = wait;
     let network = if let Some(path) = network_path {
         NetworkConfig::from_toml_str(&fs::read_to_string(path).unwrap()).unwrap()
@@ -222,7 +222,7 @@ pub async fn make_clients(
     (clients, network)
 }
 
-async fn clients_ready(clients: &[MpcHelperClient; 3]) -> bool {
+async fn clients_ready(clients: &[MpcHelperClient<Helper>; 3]) -> bool {
     clients[0].echo("").await.is_ok()
         && clients[1].echo("").await.is_ok()
         && clients[2].echo("").await.is_ok()

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     executor::IpaRuntime,
     ff::boolean_array::{BA20, BA3, BA8},
     helpers::query::DpMechanism,
-    net::{ClientIdentity, Helper, MpcHelperClient},
+    net::{ClientIdentity, Helper, IpaHttpClient},
     protocol::{dp::NoiseParams, ipa_prf::oprf_padding::insecure::OPRFPaddingDp},
 };
 
@@ -194,7 +194,7 @@ pub async fn make_clients(
     network_path: Option<&Path>,
     scheme: Scheme,
     wait: usize,
-) -> ([MpcHelperClient<Helper>; 3], NetworkConfig<Helper>) {
+) -> ([IpaHttpClient<Helper>; 3], NetworkConfig<Helper>) {
     let mut wait = wait;
     let network = if let Some(path) = network_path {
         NetworkConfig::from_toml_str(&fs::read_to_string(path).unwrap()).unwrap()
@@ -213,7 +213,7 @@ pub async fn make_clients(
     // Note: This closure is only called when the selected action uses clients.
 
     let clients =
-        MpcHelperClient::from_conf(&IpaRuntime::current(), &network, &ClientIdentity::None);
+        IpaHttpClient::from_conf(&IpaRuntime::current(), &network, &ClientIdentity::None);
     while wait > 0 && !clients_ready(&clients).await {
         tracing::debug!("waiting for servers to come up");
         sleep(Duration::from_secs(1)).await;
@@ -222,7 +222,7 @@ pub async fn make_clients(
     (clients, network)
 }
 
-async fn clients_ready(clients: &[MpcHelperClient<Helper>; 3]) -> bool {
+async fn clients_ready(clients: &[IpaHttpClient<Helper>; 3]) -> bool {
     clients[0].echo("").await.is_ok()
         && clients[1].echo("").await.is_ok()
         && clients[2].echo("").await.is_ok()

--- a/ipa-core/src/cli/playbook/mod.rs
+++ b/ipa-core/src/cli/playbook/mod.rs
@@ -212,8 +212,7 @@ pub async fn make_clients(
 
     // Note: This closure is only called when the selected action uses clients.
 
-    let clients =
-        IpaHttpClient::from_conf(&IpaRuntime::current(), &network, &ClientIdentity::None);
+    let clients = IpaHttpClient::from_conf(&IpaRuntime::current(), &network, &ClientIdentity::None);
     while wait > 0 && !clients_ready(&clients).await {
         tracing::debug!("waiting for servers to come up");
         sleep(Duration::from_secs(1)).await;

--- a/ipa-core/src/cli/playbook/multiply.rs
+++ b/ipa-core/src/cli/playbook/multiply.rs
@@ -9,7 +9,7 @@ use typenum::Unsigned;
 use crate::{
     ff::{Field, Serializable},
     helpers::{query::QueryInput, BodyStream},
-    net::MpcHelperClient,
+    net::{Helper, MpcHelperClient},
     protocol::QueryId,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::Reconstruct,
@@ -21,7 +21,7 @@ use crate::{
 pub async fn secure_mul<F>(
     // I couldn't make `share` work with `&[(F, F)]`
     input: Vec<(F, F)>,
-    clients: &[MpcHelperClient; 3],
+    clients: &[MpcHelperClient<Helper>; 3],
     query_id: QueryId,
 ) -> Vec<F>
 where

--- a/ipa-core/src/cli/playbook/multiply.rs
+++ b/ipa-core/src/cli/playbook/multiply.rs
@@ -9,7 +9,7 @@ use typenum::Unsigned;
 use crate::{
     ff::{Field, Serializable},
     helpers::{query::QueryInput, BodyStream},
-    net::{Helper, MpcHelperClient},
+    net::{Helper, IpaHttpClient},
     protocol::QueryId,
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::Reconstruct,
@@ -21,7 +21,7 @@ use crate::{
 pub async fn secure_mul<F>(
     // I couldn't make `share` work with `&[(F, F)]`
     input: Vec<(F, F)>,
-    clients: &[MpcHelperClient<Helper>; 3],
+    clients: &[IpaHttpClient<Helper>; 3],
     query_id: QueryId,
 ) -> Vec<F>
 where

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -175,7 +175,7 @@ async fn response_to_bytes(resp: ResponseFromEndpoint) -> Result<Bytes, Error> {
 /// TODO: It probably isn't necessary to always use `[MpcHelperClient; 3]`. Instead, a single
 ///       client can be configured to talk to all three helpers.
 #[derive(Debug, Clone)]
-pub struct MpcHelperClient<F: ConnectionFlavor> {
+pub struct IpaHttpClient<F: ConnectionFlavor> {
     client: Client<HttpsConnector<HttpConnector>, Body>,
     scheme: uri::Scheme,
     authority: uri::Authority,
@@ -183,7 +183,7 @@ pub struct MpcHelperClient<F: ConnectionFlavor> {
     _restriction: PhantomData<F>,
 }
 
-impl<F: ConnectionFlavor> MpcHelperClient<F> {
+impl<F: ConnectionFlavor> IpaHttpClient<F> {
     /// Create a new client with the given configuration
     ///
     /// `identity`, if present, configures whether and how the client will authenticate to the server
@@ -371,7 +371,7 @@ impl<F: ConnectionFlavor> MpcHelperClient<F> {
     }
 }
 
-impl MpcHelperClient<Helper> {
+impl IpaHttpClient<Helper> {
     /// Create a set of clients for the MPC helpers in the supplied helper network configuration.
     ///
     /// This function returns a set of three clients, which may be used to talk to each of the
@@ -469,7 +469,7 @@ impl MpcHelperClient<Helper> {
     }
 }
 
-impl MpcHelperClient<Shard> {
+impl IpaHttpClient<Shard> {
     /// This is a mirror of [`MpcHelperClient<Helper>::from_config`] but for Shards. This creates
     /// set of Shard clients in the supplied helper network configuration, which can be used to
     /// talk to each of the shards in this helper.
@@ -544,7 +544,7 @@ pub(crate) mod tests {
             certificate: None,
             hpke_config: None,
         };
-        let client = MpcHelperClient::new(
+        let client = IpaHttpClient::new(
             IpaRuntime::current(),
             &ClientConfig::default(),
             peer_config,
@@ -573,7 +573,7 @@ pub(crate) mod tests {
     where
         ClientOut: Eq + Debug,
         ClientFut: Future<Output = ClientOut>,
-        ClientF: Fn(MpcHelperClient<Helper>) -> ClientFut,
+        ClientF: Fn(IpaHttpClient<Helper>) -> ClientFut,
         HandlerF: Fn() -> Arc<dyn RequestHandler<Identity = HelperIdentity>>,
     {
         let mut results = Vec::with_capacity(4);

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -171,7 +171,7 @@ async fn response_to_bytes(resp: ResponseFromEndpoint) -> Result<Bytes, Error> {
 
 /// HTTP Client for calls to IPA hosts. It supports calls from Report Collector to Helper Network,
 /// from one Helper to another Helper and from one Shard to another Shard. Handles authentication.
-/// 
+///
 /// TODO: we need a client that can be used by any system that is not aware of the internals
 ///       of the helper network. That means that create query and send inputs API need to be
 ///       separated from prepare/step data etc.

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -169,6 +169,9 @@ async fn response_to_bytes(resp: ResponseFromEndpoint) -> Result<Bytes, Error> {
     Ok(resp.into_body().collect().await?.to_bytes())
 }
 
+/// HTTP Client for calls to IPA hosts. It supports calls from Report Collector to Helper Network,
+/// from one Helper to another Helper and from one Shard to another Shard. Handles authentication.
+/// 
 /// TODO: we need a client that can be used by any system that is not aware of the internals
 ///       of the helper network. That means that create query and send inputs API need to be
 ///       separated from prepare/step data etc.

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -573,7 +573,7 @@ pub(crate) mod tests {
     where
         ClientOut: Eq + Debug,
         ClientFut: Future<Output = ClientOut>,
-        ClientF: Fn(MpcHelperClient) -> ClientFut,
+        ClientF: Fn(MpcHelperClient<Helper>) -> ClientFut,
         HandlerF: Fn() -> Arc<dyn RequestHandler<Identity = HelperIdentity>>,
     {
         let mut results = Vec::with_capacity(4);

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -175,7 +175,7 @@ async fn response_to_bytes(resp: ResponseFromEndpoint) -> Result<Bytes, Error> {
 /// TODO: It probably isn't necessary to always use `[MpcHelperClient; 3]`. Instead, a single
 ///       client can be configured to talk to all three helpers.
 #[derive(Debug, Clone)]
-pub struct MpcHelperClient<F: ConnectionFlavor = Helper> {
+pub struct MpcHelperClient<F: ConnectionFlavor> {
     client: Client<HttpsConnector<HttpConnector>, Body>,
     scheme: uri::Scheme,
     authority: uri::Authority,

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -23,7 +23,7 @@ mod server;
 pub mod test;
 mod transport;
 
-pub use client::{ClientIdentity, MpcHelperClient};
+pub use client::{ClientIdentity, IpaHttpClient};
 pub use error::Error;
 pub use server::{MpcHelperServer, TracingSpanMaker};
 pub use transport::{HttpTransport, MpcHttpTransport, ShardHttpTransport};

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -26,7 +26,7 @@ use crate::{
     executor::{IpaJoinHandle, IpaRuntime},
     helpers::{HandlerBox, HelperIdentity, RequestHandler, TransportIdentity},
     hpke::{Deserializable as _, IpaPublicKey},
-    net::{ClientIdentity, Helper, MpcHelperClient, MpcHelperServer},
+    net::{ClientIdentity, Helper, IpaHttpClient, MpcHelperServer},
     sharding::{ShardIndex, ShardedHelperIdentity},
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
@@ -394,7 +394,7 @@ pub struct TestServer {
     pub handle: IpaJoinHandle<()>,
     pub transport: MpcHttpTransport,
     pub server: MpcHelperServer<Helper>,
-    pub client: MpcHelperClient<Helper>,
+    pub client: IpaHttpClient<Helper>,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }
 
@@ -471,7 +471,7 @@ impl TestServerBuilder {
             .build();
         let leaders_ring = test_config.rings.pop().unwrap();
         let first_server = leaders_ring.servers.into_iter().next().unwrap();
-        let clients = MpcHelperClient::from_conf(
+        let clients = IpaHttpClient::from_conf(
             &IpaRuntime::current(),
             &leaders_ring.network,
             &identities.helper.clone_with_key(),

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -394,7 +394,7 @@ pub struct TestServer {
     pub handle: IpaJoinHandle<()>,
     pub transport: MpcHttpTransport,
     pub server: MpcHelperServer<Helper>,
-    pub client: MpcHelperClient,
+    pub client: MpcHelperClient<Helper>,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -535,7 +535,7 @@ mod tests {
         test_multiply(&clients).await;
     }
 
-    async fn test_multiply(clients: &[MpcHelperClient; 3]) {
+    async fn test_multiply(clients: &[MpcHelperClient<Helper>; 3]) {
         const SZ: usize = <AdditiveShare<Fp31> as Serializable>::Size::USIZE;
 
         // send a create query command

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -196,7 +196,7 @@ impl MpcHttpTransport {
         identity: HelperIdentity,
         server_config: ServerConfig,
         network_config: NetworkConfig<Helper>,
-        clients: &[MpcHelperClient; 3],
+        clients: &[MpcHelperClient<Helper>; 3],
         handler: Option<HandlerRef<HelperIdentity>>,
     ) -> (Self, MpcHelperServer<Helper>) {
         let transport = Self {


### PR DESCRIPTION
Two things happened in here:
1. Removed the default `Helper` for `ConnectionFlavor` in the Http Client. Now you have to be explicit.
2. Renamed `MpcHelperClient` to `IpaHttpClient` since it can handle both Mpc and Shard  communication.