### PR TITLE
Renaming MpcHelperServer to IpaHttpServer<Helper>

### DIFF
--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -25,7 +25,7 @@ mod transport;
 
 pub use client::{ClientIdentity, IpaHttpClient};
 pub use error::Error;
-pub use server::{MpcHelperServer, TracingSpanMaker};
+pub use server::{IpaHttpServer, TracingSpanMaker};
 pub use transport::{HttpTransport, MpcHttpTransport, ShardHttpTransport};
 
 const APPLICATION_JSON: &str = "application/json";

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -86,13 +86,13 @@ impl TracingSpanMaker for () {
 /// The Transport Restriction generic is used to make the server aware whether it should offer a
 /// HTTP API for shards or for other Helpers. External clients can reach out to both APIs to push
 /// the input data among other things.
-pub struct MpcHelperServer<F: ConnectionFlavor = Helper> {
+pub struct IpaHttpServer<F: ConnectionFlavor> {
     config: ServerConfig,
     network_config: NetworkConfig<F>,
     router: Router,
 }
 
-impl MpcHelperServer<Helper> {
+impl IpaHttpServer<Helper> {
     #[must_use]
     pub fn new_mpc(
         transport: &MpcHttpTransport,
@@ -100,7 +100,7 @@ impl MpcHelperServer<Helper> {
         network_config: NetworkConfig<Helper>,
     ) -> Self {
         let router = handlers::mpc_router(transport.clone());
-        MpcHelperServer {
+        IpaHttpServer {
             config,
             network_config,
             router,
@@ -108,14 +108,14 @@ impl MpcHelperServer<Helper> {
     }
 }
 
-impl MpcHelperServer<Shard> {
+impl IpaHttpServer<Shard> {
     #[must_use]
     pub fn new_shards(
         _transport: &ShardHttpTransport,
         config: ServerConfig,
         network_config: NetworkConfig<Shard>,
     ) -> Self {
-        MpcHelperServer {
+        IpaHttpServer {
             config,
             network_config,
             router: Router::new(),
@@ -123,7 +123,7 @@ impl MpcHelperServer<Shard> {
     }
 }
 
-impl<F: ConnectionFlavor> MpcHelperServer<F> {
+impl<F: ConnectionFlavor> IpaHttpServer<F> {
     #[cfg(all(test, unit_test))]
     async fn handle_req(&self, req: hyper::Request<axum::body::Body>) -> axum::response::Response {
         use tower::ServiceExt;

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -26,7 +26,7 @@ use crate::{
     executor::{IpaJoinHandle, IpaRuntime},
     helpers::{HandlerBox, HelperIdentity, RequestHandler, TransportIdentity},
     hpke::{Deserializable as _, IpaPublicKey},
-    net::{ClientIdentity, Helper, IpaHttpClient, MpcHelperServer},
+    net::{ClientIdentity, Helper, IpaHttpClient, IpaHttpServer},
     sharding::{ShardIndex, ShardedHelperIdentity},
     sync::Arc,
     test_fixture::metrics::MetricsHandle,
@@ -393,7 +393,7 @@ pub struct TestServer {
     pub addr: SocketAddr,
     pub handle: IpaJoinHandle<()>,
     pub transport: MpcHttpTransport,
-    pub server: MpcHelperServer<Helper>,
+    pub server: IpaHttpServer<Helper>,
     pub client: IpaHttpClient<Helper>,
     pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -20,7 +20,7 @@ use crate::{
         NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords, RequestHandler, RouteParams,
         StepBinding, StreamCollection, Transport, TransportIdentity,
     },
-    net::{client::IpaHttpClient, error::Error, MpcHelperServer},
+    net::{client::IpaHttpClient, error::Error, IpaHttpServer},
     protocol::{Gate, QueryId},
     sharding::ShardIndex,
     sync::Arc,
@@ -198,7 +198,7 @@ impl MpcHttpTransport {
         network_config: NetworkConfig<Helper>,
         clients: &[IpaHttpClient<Helper>; 3],
         handler: Option<HandlerRef<HelperIdentity>>,
-    ) -> (Self, MpcHelperServer<Helper>) {
+    ) -> (Self, IpaHttpServer<Helper>) {
         let transport = Self {
             inner_transport: Arc::new(HttpTransport {
                 http_runtime,
@@ -209,7 +209,7 @@ impl MpcHttpTransport {
             }),
         };
 
-        let server = MpcHelperServer::new_mpc(&transport, server_config, network_config);
+        let server = IpaHttpServer::new_mpc(&transport, server_config, network_config);
         (transport, server)
     }
 
@@ -294,7 +294,7 @@ impl ShardHttpTransport {
         network_config: NetworkConfig<Shard>,
         clients: Vec<IpaHttpClient<Shard>>,
         handler: Option<HandlerRef<ShardIndex>>,
-    ) -> (Self, MpcHelperServer<Shard>) {
+    ) -> (Self, IpaHttpServer<Shard>) {
         let transport = Self {
             inner_transport: Arc::new(HttpTransport {
                 http_runtime,
@@ -305,7 +305,7 @@ impl ShardHttpTransport {
             }),
         };
 
-        let server = MpcHelperServer::new_shards(&transport, server_config, network_config);
+        let server = IpaHttpServer::new_shards(&transport, server_config, network_config);
         (transport, server)
     }
 }


### PR DESCRIPTION
Two things happened in here:
(Server)

1. Removed the default `Helper` for `ConnectionFlavor` in the Http Server. Now you have to be explicit.
2. Renamed `MpcHelperServer` to `IpaHttpServer` since it can handle both Mpc and Shard communication.