### PR TITLE
Adding testing infrastructure to support sharded tests

### DIFF
--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -46,20 +46,8 @@ pub const DEFAULT_TEST_PORTS: Ports = Ports {
     shards: [6000, 6001, 6002],
 };
 
-/// A network with two shards per helper.
-pub const TWO_SHARDS: [Ports; 2] = [
-    Ports {
-        ring: [3000, 3001, 3002],
-        shards: [6000, 6001, 6002],
-    },
-    Ports {
-        ring: [3010, 3011, 3012],
-        shards: [6010, 6011, 6012],
-    },
-];
-
 /// A network with 4 shards per helper.
-pub const FOUR_SHARDS: [Ports; 4] = [
+const FOUR_SHARDS: [Ports; 4] = [
     Ports {
         ring: [10000, 10001, 10002],
         shards: [10005, 10006, 10007],
@@ -447,16 +435,6 @@ impl TestConfigBuilder {
     }
 
     #[must_use]
-    pub fn four_shards(self) -> Self {
-        self.with_ports_by_ring(FOUR_SHARDS.to_vec())
-    }
-
-    #[must_use]
-    pub fn two_shards(self) -> Self {
-        self.with_ports_by_ring(TWO_SHARDS.to_vec())
-    }
-
-    #[must_use]
     pub fn with_shard_count(mut self, value: u32) -> Self {
         self.shard_count = value;
         self
@@ -838,7 +816,7 @@ mod tests {
         // Providing ports and no https certs to keep this test fast
         let conf = TestConfigBuilder::default()
             .with_disable_https_option(true)
-            .four_shards()
+            .with_ports_by_ring(FOUR_SHARDS.to_vec())
             .build();
 
         assert!(conf.disable_https);

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -464,7 +464,7 @@ pub struct TestServer {
     pub transport: MpcHttpTransport,
     pub server: IpaHttpServer<Helper>,
     pub client: IpaHttpClient<Helper>,
-    pub request_handler: Option<Arc<dyn RequestHandler<HelperIdentity>>>,
+    pub request_handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
 }
 
 impl TestServer {
@@ -485,7 +485,7 @@ impl TestServer {
 
 #[derive(Default)]
 pub struct TestServerBuilder {
-    handler: Option<Arc<dyn RequestHandler<HelperIdentity>>>,
+    handler: Option<Arc<dyn RequestHandler<Identity = HelperIdentity>>>,
     metrics: Option<MetricsHandle>,
     disable_https: bool,
     use_http1: bool,
@@ -496,7 +496,7 @@ impl TestServerBuilder {
     #[must_use]
     pub fn with_request_handler(
         mut self,
-        handler: Arc<dyn RequestHandler<HelperIdentity>>,
+        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
     ) -> Self {
         self.handler = Some(handler);
         self

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -46,26 +46,6 @@ pub const DEFAULT_TEST_PORTS: Ports = Ports {
     shards: [6000, 6001, 6002],
 };
 
-/// A network with 4 shards per helper.
-const FOUR_SHARDS: [Ports; 4] = [
-    Ports {
-        ring: [10000, 10001, 10002],
-        shards: [10005, 10006, 10007],
-    },
-    Ports {
-        ring: [10010, 10011, 10012],
-        shards: [10015, 10016, 10017],
-    },
-    Ports {
-        ring: [10020, 10021, 10022],
-        shards: [10025, 10026, 10027],
-    },
-    Ports {
-        ring: [10030, 10031, 10032],
-        shards: [10035, 10036, 10037],
-    },
-];
-
 /// Configuration of a server that can be reached via socket or port.
 pub struct AddressableTestServer {
     /// The identity of this server in the network.
@@ -797,11 +777,31 @@ mod tests {
         config::NetworkConfig,
         helpers::HelperIdentity,
         net::{
-            test::{Ports, FOUR_SHARDS, TEST_CERTS, TEST_KEYS},
+            test::{Ports, TEST_CERTS, TEST_KEYS},
             ConnectionFlavor,
         },
         sharding::{ShardIndex, ShardedHelperIdentity},
     };
+
+    /// A network with 4 shards per helper.
+    const FOUR_SHARDS: [Ports; 4] = [
+        Ports {
+            ring: [10000, 10001, 10002],
+            shards: [10005, 10006, 10007],
+        },
+        Ports {
+            ring: [10010, 10011, 10012],
+            shards: [10015, 10016, 10017],
+        },
+        Ports {
+            ring: [10020, 10021, 10022],
+            shards: [10025, 10026, 10027],
+        },
+        Ports {
+            ring: [10030, 10031, 10032],
+            shards: [10035, 10036, 10037],
+        },
+    ];
 
     fn assert_eq_configs<F: ConnectionFlavor>(nc1: &NetworkConfig<F>, nc2: &NetworkConfig<F>) {
         let urls1: Vec<_> = nc1.vec_peers().into_iter().map(|p| p.url).collect();

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -371,10 +371,9 @@ mod tests {
         },
         net::{
             client::ClientIdentity,
-            test::{ClientIdentities, TestConfig, TestConfigBuilder, TestServer},
+            test::{ClientIdentities, TestApp, TestConfig, TestConfigBuilder, TestServer},
         },
         secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
-        sharding::ShardedHelperIdentity,
         test_fixture::Reconstruct,
         AppConfig, AppSetup, HelperApp,
     };
@@ -448,70 +447,72 @@ mod tests {
         );
     }
 
-    // TODO(651): write a test for an error while reading the body (after error handling is finalized)
-    async fn make_helpers(mut conf: TestConfig) -> [HelperApp; 3] {
-        let leaders_ring = conf.rings.pop().unwrap();
-        join_all(zip(HelperIdentity::make_three(), leaders_ring.servers).map(
-            |(id, mut addr_server)| {
-                let (setup, mpc_handler) = AppSetup::new(AppConfig::default());
-                let sid = ShardedHelperIdentity::new(id, ShardIndex::FIRST);
-                let identities = ClientIdentities::new(conf.disable_https, sid);
+    async fn start_app(mut test_app: TestApp, disable_https: bool) -> HelperApp {
+        let (setup, mpc_handler, shard_handler) = AppSetup::new(AppConfig::default());
+        let sid = test_app.mpc_server.id;
+        let identities = ClientIdentities::new(disable_https, sid);
 
-                // Ring config
-                let clients = IpaHttpClient::from_conf(
-                    &IpaRuntime::current(),
-                    &leaders_ring.network,
-                    &identities.helper,
-                );
-                let (transport, server) = MpcHttpTransport::new(
-                    IpaRuntime::current(),
-                    id,
-                    addr_server.config.clone(),
-                    leaders_ring.network.clone(),
-                    &clients,
-                    Some(mpc_handler),
-                );
+        // Ring config
+        let clients = IpaHttpClient::from_conf(
+            &IpaRuntime::current(),
+            &test_app.mpc_network_config,
+            &identities.helper,
+        );
+        let (transport, server) = MpcHttpTransport::new(
+            IpaRuntime::current(),
+            sid.helper_identity,
+            test_app.mpc_server.config,
+            test_app.mpc_network_config,
+            &clients,
+            Some(mpc_handler),
+        );
 
-                // Shard Config
-                let helper_shards = conf.get_shards_for_helper(id);
-                let addr_shard = helper_shards.get_first_shard();
-                let shard_network_config = helper_shards.network.clone();
-                let shard_clients = IpaHttpClient::<Shard>::shards_from_conf(
-                    &IpaRuntime::current(),
-                    &shard_network_config,
-                    &identities.shard,
-                );
-                let (shard_transport, shard_server) = ShardHttpTransport::new(
-                    IpaRuntime::current(),
-                    sid.shard_index,
-                    addr_shard.config.clone(),
-                    shard_network_config,
-                    shard_clients,
-                    None, // This will come online once we go into Query Workflow
-                );
-
-                let helper_shards = conf.get_shards_for_helper_mut(id);
-                let addr_shard = helper_shards.get_first_shard_mut();
-                let ring_socket = addr_server.socket.take();
-                let sharding_socket = addr_shard.socket.take();
-
-                async move {
-                    join(
-                        server.start_on(&IpaRuntime::current(), ring_socket, ()),
-                        shard_server.start_on(&IpaRuntime::current(), sharding_socket, ()),
-                    )
-                    .await;
-                    setup.connect(transport, shard_transport)
-                }
+        // Shard Config
+        let shard_clients = IpaHttpClient::<Shard>::shards_from_conf(
+            &IpaRuntime::current(),
+            &test_app.shard_network_config,
+            &identities.shard,
+        );
+        let (shard_transport, shard_server) = ShardHttpTransport::new(
+            IpaRuntime::current(),
+            Sharded {
+                shard_id: sid.shard_index,
+                shard_count: test_app.shard_network_config.shard_count(),
             },
-        ))
-        .await
-        .try_into()
-        .ok()
-        .unwrap()
+            test_app.shard_server.config,
+            test_app.shard_network_config,
+            shard_clients,
+            Some(shard_handler),
+        );
+
+        join(
+            server.start_on(
+                &IpaRuntime::current(),
+                test_app.mpc_server.socket.take(),
+                (),
+            ),
+            shard_server.start_on(
+                &IpaRuntime::current(),
+                test_app.shard_server.socket.take(),
+                (),
+            ),
+        )
+        .await;
+        setup.connect(transport, shard_transport)
     }
 
-    async fn test_three_helpers(conf: TestConfig) {
+    // TODO(651): write a test for an error while reading the body (after error handling is finalized)
+    async fn make_helpers(conf: TestConfig) -> Vec<HelperApp> {
+        let disable_https = conf.disable_https;
+        join_all(
+            conf.into_apps()
+                .into_iter()
+                .map(|a| start_app(a, disable_https)),
+        )
+        .await
+    }
+
+    async fn test_make_helpers(conf: TestConfig) {
         let clients = IpaHttpClient::from_conf(
             &IpaRuntime::current(),
             &conf.leaders_ring().network,
@@ -582,12 +583,27 @@ mod tests {
         let conf = TestConfigBuilder::default()
             .with_disable_https_option(true)
             .build();
-        test_three_helpers(conf).await;
+        test_make_helpers(conf).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn three_helpers_https() {
         let conf = TestConfigBuilder::default().build();
-        test_three_helpers(conf).await;
+        test_make_helpers(conf).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn two_shards_https() {
+        let conf = TestConfigBuilder::default().two_shards().build();
+        test_make_helpers(conf).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn four_shards_http() {
+        let conf = TestConfigBuilder::default()
+            .with_shard_count(4)
+            .with_disable_https_option(true)
+            .build();
+        test_make_helpers(conf).await;
     }
 }

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -536,12 +536,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn two_shards_https() {
-        let conf = TestConfigBuilder::default().two_shards().build();
-        test_make_helpers(conf).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn four_shards_http() {
         let conf = TestConfigBuilder::default()
             .with_shard_count(4)

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -348,7 +348,7 @@ impl Transport for ShardHttpTransport {
 
 #[cfg(all(test, web_test, descriptive_gate))]
 mod tests {
-    use std::{iter::zip, task::Poll};
+    use std::task::Poll;
 
     use bytes::Bytes;
     use futures::stream::{poll_immediate, StreamExt};


### PR DESCRIPTION
Now we can start a sharded infrastructure for tests. I'm using the following changes to test the upcoming Query Workflow. I'm front-loading the tests that I will later use to make sure everything keeps working on every PR.

Created the `TestApp` struct which is used to create `HelperApp` by HTTP tests. HTTP Transport tests uses this new struct to spin up the hosts.  

One of the certificates I had uploaded before was wrong so I'm updating it now.

I plan to breakdown `tests.rs` in a later PR, once the changes I have in the backlog are merged.