### PR TITLE
Include `Add<&Self>` in `SharedValue`

### DIFF
--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -108,12 +108,20 @@ impl rand::distributions::Distribution<Boolean> for rand::distributions::Standar
     }
 }
 
-impl std::ops::Add for Boolean {
+impl std::ops::Add<&Boolean> for Boolean {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
-    fn add(self, rhs: Self) -> Self::Output {
+    fn add(self, rhs: &Self) -> Self::Output {
         Self(self.0 ^ rhs.0)
+    }
+}
+
+impl std::ops::Add for Boolean {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        std::ops::Add::add(self, &rhs)
     }
 }
 
@@ -132,12 +140,20 @@ impl std::ops::Neg for Boolean {
     }
 }
 
-impl std::ops::Sub for Boolean {
+impl std::ops::Sub<&Self> for Boolean {
     type Output = Self;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: &Self) -> Self::Output {
+        std::ops::Add::add(self, rhs)
+    }
+}
+
+impl std::ops::Sub for Boolean {
+    type Output = Self;
+
     fn sub(self, rhs: Self) -> Self::Output {
-        self + rhs
+        std::ops::Sub::sub(self, &rhs)
     }
 }
 

--- a/ipa-core/src/ff/curve_points.rs
+++ b/ipa-core/src/ff/curve_points.rs
@@ -78,11 +78,19 @@ impl Serializable for RP25519 {
 ///## Panics
 /// Panics when decompressing invalid curve point. This can happen when deserialize curve point
 /// from bit array that does not have a valid representation on the curve
+impl std::ops::Add<&Self> for RP25519 {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self::Output {
+        Self((self.0.decompress().unwrap() + rhs.0.decompress().unwrap()).compress())
+    }
+}
+
 impl std::ops::Add for RP25519 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        Self((self.0.decompress().unwrap() + rhs.0.decompress().unwrap()).compress())
+        std::ops::Add::add(self, &rhs)
     }
 }
 
@@ -107,11 +115,19 @@ impl std::ops::Neg for RP25519 {
 ///## Panics
 /// Panics when decompressing invalid curve point. This can happen when deserialize curve point
 /// from bit array that does not have a valid representation on the curve
+impl std::ops::Sub<&Self> for RP25519 {
+    type Output = Self;
+
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Self((self.0.decompress().unwrap() - rhs.0.decompress().unwrap()).compress())
+    }
+}
+
 impl std::ops::Sub for RP25519 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Self((self.0.decompress().unwrap() - rhs.0.decompress().unwrap()).compress())
+        std::ops::Sub::sub(self, &rhs)
     }
 }
 

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -84,11 +84,19 @@ impl rand::distributions::Distribution<Fp25519> for rand::distributions::Standar
     }
 }
 
+impl std::ops::Add<&Self> for Fp25519 {
+    type Output = Self;
+
+    fn add(self, rhs: &Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
 impl std::ops::Add for Fp25519 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0 + rhs.0)
+        std::ops::Add::add(self, &rhs)
     }
 }
 
@@ -107,11 +115,19 @@ impl std::ops::Neg for Fp25519 {
     }
 }
 
+impl std::ops::Sub<&Self> for Fp25519 {
+    type Output = Self;
+
+    fn sub(self, rhs: &Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
 impl std::ops::Sub for Fp25519 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0 - rhs.0)
+        std::ops::Sub::sub(self, &rhs)
     }
 }
 

--- a/ipa-core/src/ff/galois_field.rs
+++ b/ipa-core/src/ff/galois_field.rs
@@ -287,10 +287,17 @@ macro_rules! bit_array_impl {
                 }
             }
 
+            impl std::ops::Sub<&$name> for $name {
+                type Output = Self;
+                fn sub(self, rhs: &Self) -> Self::Output {
+                    std::ops::Add::add(self, rhs)
+                }
+            }
+
             impl std::ops::Sub for $name {
                 type Output = Self;
                 fn sub(self, rhs: Self) -> Self::Output {
-                    self + rhs
+                    std::ops::Sub::sub(self, &rhs)
                 }
             }
 

--- a/ipa-core/src/ff/prime_field.rs
+++ b/ipa-core/src/ff/prime_field.rs
@@ -117,14 +117,22 @@ macro_rules! field_impl {
             const PRIME: Self::PrimeInteger = $prime;
         }
 
-        impl std::ops::Add for $field {
+        impl std::ops::Add<&$field> for $field {
             type Output = Self;
 
-            fn add(self, rhs: Self) -> Self::Output {
+            fn add(self, rhs: &Self) -> Self::Output {
                 let c = u64::from;
                 debug_assert!(c(Self::PRIME) < (u64::MAX >> 1));
                 #[allow(clippy::cast_possible_truncation)]
                 Self(((c(self.0) + c(rhs.0)) % c(Self::PRIME)) as <Self as SharedValue>::Storage)
+            }
+        }
+
+        impl std::ops::Add for $field {
+            type Output = Self;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                std::ops::Add::add(self, &rhs)
             }
         }
 
@@ -143,10 +151,10 @@ macro_rules! field_impl {
             }
         }
 
-        impl std::ops::Sub for $field {
+        impl std::ops::Sub<&$field> for $field {
             type Output = Self;
 
-            fn sub(self, rhs: Self) -> Self::Output {
+            fn sub(self, rhs: &Self) -> Self::Output {
                 let c = u64::from;
                 debug_assert!(c(Self::PRIME) < (u64::MAX >> 1));
                 // TODO(mt) - constant time?
@@ -155,6 +163,14 @@ macro_rules! field_impl {
                     ((c(Self::PRIME) + c(self.0) - c(rhs.0)) % c(Self::PRIME))
                         as <Self as SharedValue>::Storage,
                 )
+            }
+        }
+
+        impl std::ops::Sub for $field {
+            type Output = Self;
+
+            fn sub(self, rhs: Self) -> Self::Output {
+                std::ops::Sub::sub(self, &rhs)
             }
         }
 

--- a/ipa-core/src/protocol/basics/reshare.rs
+++ b/ipa-core/src/protocol/basics/reshare.rs
@@ -74,7 +74,7 @@ impl<C: Context, F: Field> Reshare<C> for Replicated<F> {
                 .await?;
 
             // Sleep until `to_helper.right` sends us their part2 value
-            let part2 = ctx
+            let part2: F = ctx
                 .recv_channel(to_helper.peer(Direction::Right))
                 .receive(record_id)
                 .await?;

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -690,7 +690,7 @@ mod tests {
             ctx.role().peer(Direction::Right),
         );
         let record_id = index.into();
-        let (l, r) = ctx.prss().generate_fields(record_id);
+        let (l, r): (F, F) = ctx.prss().generate_fields(record_id);
 
         let (seq_l, seq_r) = {
             let ctx = ctx.narrow(&format!("seq-prss-{record_id}"));

--- a/ipa-core/src/protocol/context/semi_honest.rs
+++ b/ipa-core/src/protocol/context/semi_honest.rs
@@ -37,6 +37,7 @@ use crate::{
 pub struct Context<'a, B: ShardBinding> {
     inner: Base<'a, B>,
 }
+
 impl ShardConfiguration for Context<'_, Sharded> {
     fn shard_id(&self) -> ShardIndex {
         self.inner.shard_id()

--- a/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/base.rs
@@ -92,7 +92,7 @@ where
     let mut x_2 = x_1.clone();
     add_single_shares_in_place(&mut x_2, z_31);
     x_2.shuffle(&mut rng_perm_l);
-    send_to_peer(&x_2, ctx, &OPRFShuffleStep::TransferX2, Direction::Right).await?;
+    send_to_peer(&x_2, ctx, &OPRFShuffleStep::TransferXY, Direction::Right).await?;
 
     let res = combine_single_shares(a_hat, b_hat).collect::<Vec<_>>();
     // we only need to store x_1 in IntermediateShuffleMessage
@@ -130,12 +130,12 @@ where
 
     let mut x_2: Vec<S> = Vec::with_capacity(batch_size.get());
     future::try_join(
-        send_to_peer(&y_1, ctx, &OPRFShuffleStep::TransferY1, Direction::Right),
+        send_to_peer(&y_1, ctx, &OPRFShuffleStep::TransferXY, Direction::Right),
         receive_from_peer_into(
             &mut x_2,
             batch_size,
             ctx,
-            &OPRFShuffleStep::TransferX2,
+            &OPRFShuffleStep::TransferXY,
             Direction::Left,
         ),
     )
@@ -153,17 +153,12 @@ where
 
     let mut c_hat_2 = repurpose_allocation(x_3);
     future::try_join(
-        send_to_peer(
-            &c_hat_1,
-            ctx,
-            &OPRFShuffleStep::TransferCHat,
-            Direction::Right,
-        ),
+        send_to_peer(&c_hat_1, ctx, &OPRFShuffleStep::TransferC, Direction::Right),
         receive_from_peer_into(
             &mut c_hat_2,
             batch_size,
             ctx,
-            &OPRFShuffleStep::TransferCHat,
+            &OPRFShuffleStep::TransferC,
             Direction::Right,
         ),
     )
@@ -199,7 +194,7 @@ where
         &mut y_1,
         batch_size,
         ctx,
-        &OPRFShuffleStep::TransferY1,
+        &OPRFShuffleStep::TransferXY,
         Direction::Left,
     )
     .await?;
@@ -224,17 +219,12 @@ where
     let c_hat_2: Vec<S> = add_single_shares(y_3.iter(), a_hat.iter()).collect();
     let mut c_hat_1 = repurpose_allocation(y_3);
     future::try_join(
-        send_to_peer(
-            &c_hat_2,
-            ctx,
-            &OPRFShuffleStep::TransferCHat,
-            Direction::Left,
-        ),
+        send_to_peer(&c_hat_2, ctx, &OPRFShuffleStep::TransferC, Direction::Left),
         receive_from_peer_into(
             &mut c_hat_1,
             batch_size,
             ctx,
-            &OPRFShuffleStep::TransferCHat,
+            &OPRFShuffleStep::TransferC,
             Direction::Left,
         ),
     )

--- a/ipa-core/src/protocol/ipa_prf/shuffle/sharded.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/sharded.rs
@@ -369,7 +369,7 @@ where
                 send_channel.send(record_id, c1),
                 recv_channel.receive(record_id),
             )
-            .map_ok(move |((), c2)| S::new(b, c1 + c2))
+            .map_ok(move |((), c2): ((), S::Share)| S::new(b, c1 + c2))
         }))
         .await?;
 

--- a/ipa-core/src/protocol/ipa_prf/shuffle/step.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/step.rs
@@ -1,14 +1,18 @@
 use ipa_step_derive::CompactStep;
 
+// Note: the stream interception tests for malicious shuffles require that the
+// `TransferXY` and `TransferC` steps have the same name in `OPRFShuffleStep` and
+// `ShardedShuffleStep`.
+
 #[derive(CompactStep)]
 pub(crate) enum OPRFShuffleStep {
+    SetupKeys,
     ApplyPermutations,
     GenerateAHat,
     GenerateBHat,
     GenerateZ,
-    TransferCHat,
-    TransferX2,
-    TransferY1,
+    TransferXY, // Transfer of X2 and Y1
+    TransferC,  // Exchange of `C_1` and `C_2`
     GenerateTags,
     #[step(child = crate::protocol::ipa_prf::shuffle::step::VerifyShuffleStep)]
     VerifyShuffle,
@@ -20,4 +24,27 @@ pub(crate) enum VerifyShuffleStep {
     HashesH3toH1,
     HashH2toH1,
     HashH3toH2,
+}
+
+#[derive(CompactStep)]
+pub(crate) enum ShardedShuffleStep {
+    /// Depending on the helper position inside the MPC ring, generate Ã, B̃ or both.
+    PseudoRandomTable,
+    /// Permute the input according to the PRSS shared between H1 and H2.
+    Permute12,
+    /// Permute the input according to the PRSS shared between H2 and H3.
+    Permute23,
+    /// Permute the input according to the PRSS shared between H3 and H1.
+    Permute31,
+    /// Specific to H1 and H2 interaction - H2 informs H1 about |C|.
+    Cardinality,
+    /// H1 sends X2 to H2. H2 sends Y1 to H3.
+    TransferXY,
+    /// H2 and H3 interaction - Exchange `C_1` and `C_2`.
+    TransferC,
+    /// Apply a mask to the given set of shares. Masking values come from PRSS.
+    Mask,
+    /// Local per-shard shuffle, where each shard redistributes shares locally according to samples
+    /// obtained from PRSS. Does not require Shard or MPC communication.
+    LocalShuffle,
 }

--- a/ipa-core/src/protocol/prss/mod.rs
+++ b/ipa-core/src/protocol/prss/mod.rs
@@ -655,8 +655,8 @@ pub mod test {
         let s3 = p3.indexed(&step);
 
         let r1: Fp31 = random(&*s1, IDX1);
-        let r2 = random(&*s2, IDX1);
-        let r3 = random(&*s3, IDX1);
+        let r2: Fp31 = random(&*s2, IDX1);
+        let r3: Fp31 = random(&*s3, IDX1);
         let v1 = r1 + r2 + r3;
 
         // There isn't enough entropy in this field (~5 bits) to be sure that the test will pass.
@@ -664,8 +664,8 @@ pub mod test {
         let mut v2 = Fp31::truncate_from(0_u8);
         for i in IDX2..(IDX2 + 21) {
             let r1: Fp31 = random(&*s1, i);
-            let r2 = random(&*s2, i);
-            let r3 = random(&*s3, i);
+            let r2: Fp31 = random(&*s2, i);
+            let r3: Fp31 = random(&*s3, i);
 
             v2 = r1 + r2 + r3;
             if v1 != v2 {

--- a/ipa-core/src/protocol/step.rs
+++ b/ipa-core/src/protocol/step.rs
@@ -39,6 +39,8 @@ pub enum DeadCodeStep {
     FeatureLabelDotProduct,
     #[step(child = crate::protocol::ipa_prf::boolean_ops::step::MultiplicationStep)]
     Multiplication,
+    #[step(child = crate::protocol::ipa_prf::shuffle::step::ShardedShuffleStep)]
+    ShardedShuffle,
 }
 
 /// Provides a unique per-iteration context in tests.

--- a/ipa-core/src/secret_sharing/mod.rs
+++ b/ipa-core/src/secret_sharing/mod.rs
@@ -36,12 +36,15 @@ use crate::{
 
 /// Operations supported for weak shared values.
 pub trait Additive<Rhs = Self, Output = Self>:
-    AddSub<Rhs, Output> + AddSubAssign<Rhs> + Neg<Output = Output>
+    AddSub<Rhs, Output> + for<'a> AddSub<&'a Rhs, Output> + AddSubAssign<Rhs> + Neg<Output = Output>
 {
 }
 
 impl<T, Rhs, Output> Additive<Rhs, Output> for T where
-    T: AddSub<Rhs, Output> + AddSubAssign<Rhs> + Neg<Output = Output>
+    T: AddSub<Rhs, Output>
+        + for<'a> AddSub<&'a Rhs, Output>
+        + AddSubAssign<Rhs>
+        + Neg<Output = Output>
 {
 }
 


### PR DESCRIPTION
This will be required to eliminate `Add` bounds from the shuffle traits.

This is on top of #1394. 