### PR TITLE
Prepare HTTP Endoint

### DIFF
--- a/ipa-core/src/net/server/handlers/mod.rs
+++ b/ipa-core/src/net/server/handlers/mod.rs
@@ -3,7 +3,7 @@ mod query;
 
 use axum::Router;
 
-use crate::net::{http_serde, transport::MpcHttpTransport};
+use crate::net::{http_serde, transport::MpcHttpTransport, ShardHttpTransport};
 
 pub fn mpc_router(transport: MpcHttpTransport) -> Router {
     echo::router().nest(
@@ -11,5 +11,12 @@ pub fn mpc_router(transport: MpcHttpTransport) -> Router {
         Router::new()
             .merge(query::query_router(transport.clone()))
             .merge(query::h2h_router(transport)),
+    )
+}
+
+pub fn shard_router(transport: ShardHttpTransport) -> Router {
+    echo::router().nest(
+        http_serde::query::BASE_AXUM_PATH,
+        Router::new().merge(query::s2s_router(transport)),
     )
 }

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -52,6 +52,7 @@ pub fn h2h_router(transport: MpcHttpTransport) -> Router {
         .layer(layer_fn(HelperAuthentication::<_, Helper>::new))
 }
 
+/// Construct router for shard-to-shard communications similar to [`h2h_router`].
 pub fn s2s_router(transport: ShardHttpTransport) -> Router {
     Router::new()
         .merge(prepare::router(transport.inner_transport))

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -157,7 +157,7 @@ pub mod test_helpers {
 
     pub async fn assert_fails_with_handler(
         req: hyper::Request<Body>,
-        handler: Arc<dyn RequestHandler<HelperIdentity>>,
+        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
         expected_status: StatusCode,
     ) {
         let test_server = TestServer::builder()
@@ -170,7 +170,7 @@ pub mod test_helpers {
 
     pub async fn assert_success_with(
         req: hyper::Request<Body>,
-        handler: Arc<dyn RequestHandler<HelperIdentity>>,
+        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
     ) -> bytes::Bytes {
         let test_server = TestServer::builder()
             .with_request_handler(handler)

--- a/ipa-core/src/net/server/mod.rs
+++ b/ipa-core/src/net/server/mod.rs
@@ -111,14 +111,15 @@ impl IpaHttpServer<Helper> {
 impl IpaHttpServer<Shard> {
     #[must_use]
     pub fn new_shards(
-        _transport: &ShardHttpTransport,
+        transport: &ShardHttpTransport,
         config: ServerConfig,
         network_config: NetworkConfig<Shard>,
     ) -> Self {
+        let router = handlers::shard_router(transport.clone());
         IpaHttpServer {
             config,
             network_config,
-            router: Router::new(),
+            router,
         }
     }
 }

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -38,13 +38,14 @@ pub struct HttpTransport<F: ConnectionFlavor> {
 /// HTTP transport for helper to helper traffic.
 #[derive(Clone)]
 pub struct MpcHttpTransport {
-    inner_transport: Arc<HttpTransport<Helper>>,
+    pub(super) inner_transport: Arc<HttpTransport<Helper>>,
 }
 
 /// A stub for HTTP transport implementation, suitable for serving shard-to-shard traffic
 #[derive(Clone)]
 pub struct ShardHttpTransport {
-    inner_transport: Arc<HttpTransport<Shard>>,
+    pub(super) inner_transport: Arc<HttpTransport<Shard>>,
+    pub(super) shard_config: Sharded,
 }
 
 impl RouteParams<RouteId, NoQueryId, NoStep> for QueryConfig {

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -45,7 +45,6 @@ pub struct MpcHttpTransport {
 #[derive(Clone)]
 pub struct ShardHttpTransport {
     pub(super) inner_transport: Arc<HttpTransport<Shard>>,
-    pub(super) shard_config: Sharded,
 }
 
 impl RouteParams<RouteId, NoQueryId, NoStep> for QueryConfig {


### PR DESCRIPTION
Adding the HTTP endpoint for the prepare query API. Modified it so that the same code can be used for either shard/helper communication (both just forward the input to their respective transports).