### PR TITLE
Prepare Query API Plumbing

### DIFF
--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -13,6 +13,7 @@ use crate::{
     hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
     query::{NewQueryError, QueryProcessor, QueryStatus},
+    sharding::ShardIndex,
     sync::Arc,
     utils::NonZeroU32PowerOfTwo,
 };
@@ -46,7 +47,8 @@ impl AppConfig {
 
 pub struct Setup {
     query_processor: QueryProcessor,
-    handler: HandlerRef,
+    mpc_handler: HandlerRef<HelperIdentity>,
+    shard_handler: HandlerRef<ShardIndex>,
 }
 
 /// The API layer to interact with a helper.
@@ -67,21 +69,25 @@ struct Inner {
 
 impl Setup {
     #[must_use]
-    pub fn new(config: AppConfig) -> (Self, HandlerRef) {
+    pub fn new(config: AppConfig) -> (Self, HandlerRef<HelperIdentity>, HandlerRef<ShardIndex>) {
         let key_registry = config.key_registry.unwrap_or_else(KeyRegistry::empty);
         let query_processor = QueryProcessor::new(key_registry, config.active_work, config.runtime);
-        let handler = HandlerBox::empty();
+        let mpc_handler = HandlerBox::empty();
+        let shard_handler = HandlerBox::empty();
         let this = Self {
             query_processor,
-            handler: handler.clone(),
+            mpc_handler: mpc_handler.clone(),
+            shard_handler: shard_handler.clone(),
         };
 
         // TODO: weak reference to query processor to prevent mem leak
-        (this, handler)
+        (this, mpc_handler, shard_handler)
     }
 
     #[must_use]
-    pub fn with_key_registry(key_registry: KeyRegistry<PrivateKeyOnly>) -> (Self, HandlerRef) {
+    pub fn with_key_registry(
+        key_registry: KeyRegistry<PrivateKeyOnly>,
+    ) -> (Self, HandlerRef<HelperIdentity>, HandlerRef<ShardIndex>) {
         Self::new(AppConfig::default().with_key_registry(key_registry))
     }
 
@@ -96,9 +102,10 @@ impl Setup {
             mpc_transport,
             shard_transport,
         });
-        self.handler.set_handler(
-            Arc::downgrade(&app) as Weak<dyn RequestHandler<Identity = HelperIdentity>>
-        );
+        self.mpc_handler
+            .set_handler(Arc::downgrade(&app) as Weak<dyn RequestHandler<HelperIdentity>>);
+        self.shard_handler
+            .set_handler(Arc::downgrade(&app) as Weak<dyn RequestHandler<ShardIndex>>);
 
         // Handler must be kept inside the app instance. When app is dropped, handler, transport and
         // query processor are destroyed.
@@ -160,12 +167,34 @@ impl HelperApp {
 }
 
 #[async_trait]
-impl RequestHandler for Inner {
-    type Identity = HelperIdentity;
-
+impl RequestHandler<ShardIndex> for Inner {
     async fn handle(
         &self,
-        req: Addr<Self::Identity>,
+        req: Addr<ShardIndex>,
+        _data: BodyStream,
+    ) -> Result<HelperResponse, ApiError> {
+        let qp = &self.query_processor;
+
+        Ok(match req.route {
+            RouteId::PrepareQuery => {
+                let req = req.into::<PrepareQuery>()?;
+                HelperResponse::from(qp.prepare_shard(req)?)
+            }
+            r => {
+                return Err(ApiError::BadRequest(
+                    format!("{r:?} request must not be handled by shard query processing flow")
+                        .into(),
+                ))
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl RequestHandler<HelperIdentity> for Inner {
+    async fn handle(
+        &self,
+        req: Addr<HelperIdentity>,
         data: BodyStream,
     ) -> Result<HelperResponse, ApiError> {
         fn ext_query_id(req: &Addr<HelperIdentity>) -> Result<QueryId, ApiError> {
@@ -179,7 +208,8 @@ impl RequestHandler for Inner {
         Ok(match req.route {
             r @ RouteId::Records => {
                 return Err(ApiError::BadRequest(
-                    format!("{r:?} request must not be handled by query processing flow").into(),
+                    format!("{r:?} request must not be handled by MPC query processing flow")
+                        .into(),
                 ))
             }
             RouteId::ReceiveQuery => {

--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -170,23 +170,10 @@ impl HelperApp {
 impl RequestHandler<ShardIndex> for Inner {
     async fn handle(
         &self,
-        req: Addr<ShardIndex>,
+        _req: Addr<ShardIndex>,
         _data: BodyStream,
     ) -> Result<HelperResponse, ApiError> {
-        let qp = &self.query_processor;
-
-        Ok(match req.route {
-            RouteId::PrepareQuery => {
-                let req = req.into::<PrepareQuery>()?;
-                HelperResponse::from(qp.prepare_shard(req)?)
-            }
-            r => {
-                return Err(ApiError::BadRequest(
-                    format!("{r:?} request must not be handled by shard query processing flow")
-                        .into(),
-                ))
-            }
-        })
+        Ok(HelperResponse::ok())
     }
 }
 

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -19,7 +19,7 @@ use ipa_core::{
     executor::IpaRuntime,
     helpers::HelperIdentity,
     net::{ClientIdentity, IpaHttpClient, MpcHttpTransport, ShardHttpTransport},
-    sharding::ShardIndex,
+    sharding::{ShardIndex, Sharded},
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tokio::runtime::Runtime;
@@ -143,7 +143,7 @@ async fn server(args: ServerArgs, logging_handle: LoggingHandle) -> Result<(), B
         .with_active_work(args.active_work)
         .with_runtime(IpaRuntime::from_tokio_runtime(&query_runtime));
 
-    let (setup, handler) = AppSetup::new(app_config);
+    let (setup, handler, shard_handler) = AppSetup::new(app_config);
 
     let server_config = ServerConfig {
         port: args.port,
@@ -185,11 +185,14 @@ async fn server(args: ServerArgs, logging_handle: LoggingHandle) -> Result<(), B
     let shard_network_config = NetworkConfig::new_shards(vec![], shard_clients_config);
     let (shard_transport, _shard_server) = ShardHttpTransport::new(
         IpaRuntime::from_tokio_runtime(&http_runtime),
-        ShardIndex::FIRST,
+        Sharded {
+            shard_id: ShardIndex::FIRST,
+            shard_count: ShardIndex::from(1),
+        },
         shard_server_config,
         shard_network_config,
         vec![],
-        None,
+        Some(shard_handler),
     );
     // ---
 

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -185,10 +185,7 @@ async fn server(args: ServerArgs, logging_handle: LoggingHandle) -> Result<(), B
     let shard_network_config = NetworkConfig::new_shards(vec![], shard_clients_config);
     let (shard_transport, _shard_server) = ShardHttpTransport::new(
         IpaRuntime::from_tokio_runtime(&http_runtime),
-        Sharded {
-            shard_id: ShardIndex::FIRST,
-            shard_count: ShardIndex::from(1),
-        },
+        Sharded::new(0, 1),
         shard_server_config,
         shard_network_config,
         vec![],

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -19,7 +19,7 @@ use ipa_core::{
     executor::IpaRuntime,
     helpers::HelperIdentity,
     net::{ClientIdentity, IpaHttpClient, MpcHttpTransport, ShardHttpTransport},
-    sharding::{ShardIndex, Sharded},
+    sharding::Sharded,
     AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tokio::runtime::Runtime;

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -119,7 +119,7 @@ impl<F: ConnectionFlavor> NetworkConfig<F> {
 
 impl NetworkConfig<Shard> {
     /// # Panics
-    /// In the unlikely event a usize cannot be turned into a u32
+    /// In the unexpected case there are more than max usize shards.
     #[must_use]
     pub fn new_shards(peers: Vec<PeerConfig>, client: ClientConfig) -> Self {
         let identities = (0u32..peers.len().try_into().unwrap())
@@ -133,10 +133,10 @@ impl NetworkConfig<Shard> {
     }
 
     /// # Panics
-    /// In the unlikely event a usize cannot be turned into a u32
+    /// In the unexpected case there are more than max usize shards.
     #[must_use]
     pub fn shard_count(&self) -> ShardIndex {
-        ShardIndex::from(u32::try_from(self.peers.len()).unwrap())
+        ShardIndex::try_from(self.peers.len()).unwrap()
     }
 }
 

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -131,6 +131,13 @@ impl NetworkConfig<Shard> {
             identities,
         }
     }
+
+    /// # Panics
+    /// In the unlikely event a usize cannot be turned into a u32
+    #[must_use]
+    pub fn shard_count(&self) -> ShardIndex {
+        ShardIndex::from(u32::try_from(self.peers.len()).unwrap())
+    }
 }
 
 impl NetworkConfig<Helper> {

--- a/ipa-core/src/helpers/gateway/mod.rs
+++ b/ipa-core/src/helpers/gateway/mod.rs
@@ -50,6 +50,7 @@ pub type MpcTransportImpl = crate::net::MpcHttpTransport;
 pub type ShardTransportImpl = crate::net::ShardHttpTransport;
 
 pub type MpcTransportError = <MpcTransportImpl as Transport>::Error;
+pub type ShardTransportError = <ShardTransportImpl as Transport>::Error;
 
 /// Gateway into IPA Network infrastructure. It allows helpers send and receive messages.
 pub struct Gateway {

--- a/ipa-core/src/helpers/gateway/transport.rs
+++ b/ipa-core/src/helpers/gateway/transport.rs
@@ -4,7 +4,7 @@ use futures::Stream;
 use crate::{
     helpers::{
         transport::routing::RouteId, MpcTransportImpl, NoResourceIdentifier, QueryIdBinding, Role,
-        RoleAssignment, RouteParams, StepBinding, Transport,
+        RoleAssignment, RouteParams, ShardedTransport, StepBinding, Transport,
     },
     protocol::{Gate, QueryId},
     sharding::ShardIndex,
@@ -25,7 +25,10 @@ pub struct RoleResolvingTransport {
 }
 
 /// Set of transports used inside [`super::Gateway`].
-pub(super) struct Transports<M: Transport<Identity = Role>, S: Transport<Identity = ShardIndex>> {
+pub(super) struct Transports<
+    M: Transport<Identity = Role>,
+    S: ShardedTransport<Identity = ShardIndex>,
+> {
     pub mpc: M,
     pub shard: S,
 }

--- a/ipa-core/src/helpers/gateway/transport.rs
+++ b/ipa-core/src/helpers/gateway/transport.rs
@@ -4,7 +4,7 @@ use futures::Stream;
 use crate::{
     helpers::{
         transport::routing::RouteId, MpcTransportImpl, NoResourceIdentifier, QueryIdBinding, Role,
-        RoleAssignment, RouteParams, ShardedTransport, StepBinding, Transport,
+        RoleAssignment, RouteParams, StepBinding, Transport,
     },
     protocol::{Gate, QueryId},
     sharding::ShardIndex,
@@ -25,10 +25,7 @@ pub struct RoleResolvingTransport {
 }
 
 /// Set of transports used inside [`super::Gateway`].
-pub(super) struct Transports<
-    M: Transport<Identity = Role>,
-    S: ShardedTransport<Identity = ShardIndex>,
-> {
+pub(super) struct Transports<M: Transport<Identity = Role>, S: Transport<Identity = ShardIndex>> {
     pub mpc: M,
     pub shard: S,
 }
@@ -42,6 +39,10 @@ impl Transport for RoleResolvingTransport {
     fn identity(&self) -> Role {
         let helper_identity = self.inner.identity();
         self.roles.role(helper_identity)
+    }
+
+    fn all_identities(&self) -> impl Iterator<Item = Role> {
+        Role::all().iter().copied()
     }
 
     async fn send<

--- a/ipa-core/src/helpers/gateway/transport.rs
+++ b/ipa-core/src/helpers/gateway/transport.rs
@@ -41,8 +41,9 @@ impl Transport for RoleResolvingTransport {
         self.roles.role(helper_identity)
     }
 
-    fn all_identities(&self) -> impl Iterator<Item = Role> {
-        Role::all().iter().copied()
+    fn peers(&self) -> impl Iterator<Item = Role> {
+        let this = self.identity();
+        Role::all().iter().filter(move |&v| v != &this).copied()
     }
 
     async fn send<

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -59,7 +59,8 @@ pub use gateway::GatewayConfig;
 // TODO: this type should only be available within infra. Right now several infra modules
 // are exposed at the root level. That makes it impossible to have a proper hierarchy here.
 pub use gateway::{
-    MpcTransportError, MpcTransportImpl, RoleResolvingTransport, ShardTransportImpl,
+    MpcTransportError, MpcTransportImpl, RoleResolvingTransport, ShardTransportError,
+    ShardTransportImpl,
 };
 pub use gateway_exports::{Gateway, MpcReceivingEnd, SendingEnd, ShardReceivingEnd};
 use ipa_metrics::LabelValue;
@@ -74,8 +75,8 @@ pub use transport::{
     make_owned_handler, query, routing, ApiError, BodyStream, BytesStream, HandlerBox, HandlerRef,
     HelperResponse, Identity as TransportIdentity, LengthDelimitedStream, LogErrors, NoQueryId,
     NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords, RecordsStream, RequestHandler,
-    RouteParams, SingleRecordStream, StepBinding, StreamCollection, StreamKey, Transport,
-    WrappedBoxBodyStream,
+    RouteParams, ShardedTransport, SingleRecordStream, StepBinding, StreamCollection, StreamKey,
+    Transport, WrappedBoxBodyStream,
 };
 use typenum::{Const, ToUInt, Unsigned, U8};
 use x25519_dalek::PublicKey;

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -75,8 +75,8 @@ pub use transport::{
     make_owned_handler, query, routing, ApiError, BodyStream, BytesStream, HandlerBox, HandlerRef,
     HelperResponse, Identity as TransportIdentity, LengthDelimitedStream, LogErrors, NoQueryId,
     NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords, RecordsStream, RequestHandler,
-    RouteParams, ShardedTransport, SingleRecordStream, StepBinding, StreamCollection, StreamKey,
-    Transport, WrappedBoxBodyStream,
+    RouteParams, SingleRecordStream, StepBinding, StreamCollection, StreamKey, Transport,
+    WrappedBoxBodyStream,
 };
 use typenum::{Const, ToUInt, Unsigned, U8};
 use x25519_dalek::PublicKey;

--- a/ipa-core/src/helpers/transport/in_memory/config.rs
+++ b/ipa-core/src/helpers/transport/in_memory/config.rs
@@ -1,7 +1,7 @@
 use crate::{
     helpers::{HelperIdentity, Role, RoleAssignment},
     protocol::Gate,
-    sharding::{ShardContext, ShardIndex},
+    sharding::{ShardIndex, Sharded},
     sync::Arc,
 };
 
@@ -90,7 +90,7 @@ pub enum InspectContext {
     MpcMessage {
         /// The shard of this instance.
         /// This is `None` for non-sharded helpers.
-        shard: ShardContext,
+        shard: Option<Sharded>,
         /// Helper sending this stream.
         source: HelperIdentity,
         /// Helper that will receive this stream.
@@ -161,7 +161,7 @@ impl<F: Fn(&MaliciousHelperContext, &mut Vec<u8>) + Send + Sync> MaliciousHelper
 pub struct MaliciousHelperContext {
     /// The shard of this instance.
     /// This is `None` for non-sharded helpers.
-    pub shard: ShardContext,
+    pub shard: Option<Sharded>,
     /// Helper that will receive this stream.
     pub dest: Role,
     /// Circuit gate this stream is tied to.

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -56,11 +56,7 @@ impl InMemoryMpcNetwork {
             let mut config_builder = TransportConfigBuilder::for_helper(i);
             config_builder.with_interceptor(interceptor);
 
-            Setup::with_config(
-                i,
-                HelperIdentity::make_three().to_vec(),
-                config_builder.with_sharding(shard_context),
-            )
+            Setup::with_config(i, config_builder.with_sharding(shard_context))
         });
 
         first.connect(&mut second);

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -56,7 +56,11 @@ impl InMemoryMpcNetwork {
             let mut config_builder = TransportConfigBuilder::for_helper(i);
             config_builder.with_interceptor(interceptor);
 
-            Setup::with_config(i, config_builder.with_sharding(shard_context))
+            Setup::with_config(
+                i,
+                HelperIdentity::make_three().to_vec(),
+                config_builder.with_sharding(shard_context),
+            )
         });
 
         first.connect(&mut second);

--- a/ipa-core/src/helpers/transport/in_memory/mod.rs
+++ b/ipa-core/src/helpers/transport/in_memory/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         in_memory_config::DynStreamInterceptor, transport::in_memory::config::passthrough,
         HandlerRef, HelperIdentity,
     },
-    sharding::ShardContext,
+    sharding::Sharded,
     sync::{Arc, Weak},
 };
 
@@ -50,7 +50,7 @@ impl InMemoryMpcNetwork {
     pub fn with_stream_interceptor(
         handlers: [Option<HandlerRef>; 3],
         interceptor: &DynStreamInterceptor,
-        shard_context: ShardContext,
+        shard_context: Option<Sharded>,
     ) -> Self {
         let [mut first, mut second, mut third]: [_; 3] = HelperIdentity::make_three().map(|i| {
             let mut config_builder = TransportConfigBuilder::for_helper(i);

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -40,6 +40,7 @@ impl InMemoryShardNetwork {
                 .map(|i| {
                     Setup::with_config(
                         i,
+                        shard_count.iter().collect(),
                         config_builder.with_sharding(Some(Sharded {
                             shard_id: i,
                             shard_count,

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -2,7 +2,7 @@ use crate::{
     helpers::{
         in_memory_config::{passthrough, DynStreamInterceptor},
         transport::in_memory::transport::{InMemoryTransport, Setup, TransportConfigBuilder},
-        HandlerBox, HelperIdentity, RequestHandler,
+        HelperIdentity,
     },
     sharding::{ShardIndex, Sharded},
     sync::{Arc, Weak},

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -40,7 +40,6 @@ impl InMemoryShardNetwork {
                 .map(|i| {
                     Setup::with_config(
                         i,
-                        shard_count.iter().collect(),
                         config_builder.with_sharding(Some(Sharded {
                             shard_id: i,
                             shard_count,

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -28,7 +28,7 @@ use crate::{
         Transport, TransportIdentity,
     },
     protocol::{Gate, QueryId},
-    sharding::{ShardIndex, Sharded},
+    sharding::Sharded,
     sync::{Arc, Weak},
 };
 
@@ -58,13 +58,6 @@ pub enum Error<I> {
     DeserializationFailed {
         #[from]
         inner: serde_json::Error,
-    },
-
-    #[error("Broacast to shard {dest:?} failed: {inner:?}")]
-    Broadcast {
-        dest: ShardIndex,
-        #[source]
-        inner: BoxError,
     },
 }
 

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -274,7 +274,7 @@ impl Debug for InMemoryStream {
 }
 
 pub struct Setup<I> {
-    pub identity: I,
+    identity: I,
     tx: ConnectionTx<I>,
     rx: ConnectionRx<I>,
     connections: HashMap<I, ConnectionTx<I>>,

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -162,15 +162,13 @@ impl<I: TransportIdentity> Transport for Weak<InMemoryTransport<I>> {
     }
 
     fn peers(&self) -> impl Iterator<Item = I> {
-        let this = self.identity();
-        let all: Vec<I> = self
-            .upgrade()
+        self.upgrade()
             .unwrap()
             .connections
             .keys()
             .copied()
-            .collect();
-        all.into_iter().filter(move |&id| id != this)
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 
     async fn send<

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -577,7 +577,7 @@ pub(crate) mod tests {
         ClientOut: Eq + Debug,
         ClientFut: Future<Output = ClientOut>,
         ClientF: Fn(IpaHttpClient<Helper>) -> ClientFut,
-        HandlerF: Fn() -> Arc<dyn RequestHandler<Identity = HelperIdentity>>,
+        HandlerF: Fn() -> Arc<dyn RequestHandler<HelperIdentity>>,
     {
         let mut results = Vec::with_capacity(4);
         for (use_https, use_http1) in zip([true, false], [true, false]) {

--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -3,7 +3,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 
-use crate::{error::BoxError, net::client::ResponseFromEndpoint, protocol::QueryId};
+use crate::{
+    error::BoxError, net::client::ResponseFromEndpoint, protocol::QueryId, sharding::ShardIndex,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -130,6 +132,14 @@ impl From<axum::extract::rejection::PathRejection> for Error {
     fn from(err: axum::extract::rejection::PathRejection) -> Self {
         Self::BadPathString(err.into())
     }
+}
+
+/// Wrapper for net Errors used to distinghish them when they happen in a sharded transport.
+#[derive(thiserror::Error, Debug)]
+#[error("Error in shard {shard_index}: {source}")]
+pub struct ShardError {
+    pub shard_index: ShardIndex,
+    pub source: Error,
 }
 
 impl IntoResponse for Error {

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -158,7 +158,7 @@ pub mod test_helpers {
 
     pub async fn assert_fails_with_handler(
         req: hyper::Request<Body>,
-        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
+        handler: Arc<dyn RequestHandler<HelperIdentity>>,
         expected_status: StatusCode,
     ) {
         let test_server = TestServer::builder()
@@ -171,7 +171,7 @@ pub mod test_helpers {
 
     pub async fn assert_success_with(
         req: hyper::Request<Body>,
-        handler: Arc<dyn RequestHandler<Identity = HelperIdentity>>,
+        handler: Arc<dyn RequestHandler<HelperIdentity>>,
     ) -> bytes::Bytes {
         let test_server = TestServer::builder()
             .with_request_handler(handler)

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -259,8 +259,11 @@ impl Transport for MpcHttpTransport {
         self.inner_transport.identity
     }
 
-    fn all_identities(&self) -> impl Iterator<Item = Self::Identity> {
-        HelperIdentity::make_three().into_iter()
+    fn peers(&self) -> impl Iterator<Item = Self::Identity> {
+        let this = self.identity();
+        HelperIdentity::make_three()
+            .into_iter()
+            .filter(move |&id| id != this)
     }
 
     async fn send<
@@ -326,8 +329,12 @@ impl Transport for ShardHttpTransport {
         self.inner_transport.identity
     }
 
-    fn all_identities(&self) -> impl Iterator<Item = Self::Identity> {
-        self.shard_config.shard_count.iter()
+    fn peers(&self) -> impl Iterator<Item = Self::Identity> {
+        let this = self.identity();
+        self.shard_config
+            .shard_count
+            .iter()
+            .filter(move |&v| v != this)
     }
 
     async fn send<D, Q, S, R>(

--- a/ipa-core/src/protocol/ipa_prf/shuffle/malicious.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/malicious.rs
@@ -573,7 +573,6 @@ mod tests {
         },
         protocol::ipa_prf::shuffle::base::shuffle_protocol,
         secret_sharing::SharedValue,
-        sharding::ShardContext,
         test_executor::{run, run_random},
         test_fixture::{
             RandomInputDistribution, Reconstruct, Runner, TestWorld, TestWorldConfig, WithShards,
@@ -861,14 +860,14 @@ mod tests {
     #[allow(clippy::ptr_arg)] // to match StreamInterceptor trait
     fn interceptor_h1_to_h2(
         ctx: &MaliciousHelperContext,
-        target_shard: ShardContext,
+        target_shard: Option<ShardIndex>,
         data: &mut Vec<u8>,
     ) {
         // H1 runs an additive attack against H2 by
         // changing x2
         if ctx.gate.as_ref().contains("transfer_x_y")
             && ctx.dest == Role::H2
-            && ctx.shard == target_shard
+            && ctx.shard.map(|s| s.shard_id) == target_shard
         {
             data[0] ^= 1u8;
         }
@@ -877,14 +876,14 @@ mod tests {
     #[allow(clippy::ptr_arg)] // to match StreamInterceptor trait
     fn interceptor_h2_to_h3(
         ctx: &MaliciousHelperContext,
-        target_shard: ShardContext,
+        target_shard: Option<ShardIndex>,
         data: &mut Vec<u8>,
     ) {
         // H2 runs an additive attack against H3 by
         // changing y1
         if ctx.gate.as_ref().contains("transfer_x_y")
             && ctx.dest == Role::H3
-            && ctx.shard == target_shard
+            && ctx.shard.map(|s| s.shard_id) == target_shard
         {
             data[0] ^= 1u8;
         }
@@ -893,14 +892,14 @@ mod tests {
     #[allow(clippy::ptr_arg)] // to match StreamInterceptor trait
     fn interceptor_h3_to_h2(
         ctx: &MaliciousHelperContext,
-        target_shard: ShardContext,
+        target_shard: Option<ShardIndex>,
         data: &mut Vec<u8>,
     ) {
         // H3 runs an additive attack against H2 by
         // changing c_hat_2
         if ctx.gate.as_ref().contains("transfer_c")
             && ctx.dest == Role::H2
-            && ctx.shard == target_shard
+            && ctx.shard.map(|s| s.shard_id) == target_shard
         {
             data[0] ^= 1u8;
         }

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -389,7 +389,7 @@ mod tests {
         },
     };
 
-    fn prepare_query_handler<F, Fut>(cb: F) -> Arc<dyn RequestHandler<Identity = HelperIdentity>>
+    fn prepare_query_handler<F, Fut>(cb: F) -> Arc<dyn RequestHandler<HelperIdentity>>
     where
         F: Fn(PrepareQuery) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<HelperResponse, ApiError>> + Send + Sync + 'static,
@@ -400,7 +400,7 @@ mod tests {
         })
     }
 
-    fn respond_ok() -> Arc<dyn RequestHandler<Identity = HelperIdentity>> {
+    fn respond_ok() -> Arc<dyn RequestHandler<HelperIdentity>> {
         prepare_query_handler(move |_| async move { Ok(HelperResponse::ok()) })
     }
 

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -131,6 +131,7 @@ pub struct Sharded {
 }
 
 impl Sharded {
+    #[must_use]
     pub fn new(id: u32, count: u32) -> Self {
         Self {
             shard_id: ShardIndex::from(id),

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -130,6 +130,15 @@ pub struct Sharded {
     pub shard_count: ShardIndex,
 }
 
+impl Sharded {
+    pub fn new(id: u32, count: u32) -> Self {
+        Self {
+            shard_id: ShardIndex::from(id),
+            shard_count: ShardIndex::from(count),
+        }
+    }
+}
+
 impl ShardConfiguration for Sharded {
     fn shard_id(&self) -> ShardIndex {
         self.shard_id
@@ -168,6 +177,9 @@ pub trait ShardConfiguration {
 }
 
 pub trait ShardBinding: Debug + Send + Sync + Clone + 'static {
+    /// Returns the runtime sharding configuration if this is a [`Sharded`] or [`None`] otherwise.
+    /// It is used by the stream interceptor to avoid type parameter proliferation. It should not
+    /// be used by protocols.
     fn shard_config(&self) -> Option<Sharded>;
 }
 

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -167,26 +167,22 @@ pub trait ShardConfiguration {
     }
 }
 
-/// This is a runtime version of `ShardBinding`. It is used by the stream interceptor to
-/// avoid type parameter proliferation. It should not be used by protocols.
-pub type ShardContext = Option<ShardIndex>;
-
 pub trait ShardBinding: Debug + Send + Sync + Clone + 'static {
-    fn context(&self) -> ShardContext;
+    fn shard_config(&self) -> Option<Sharded>;
 }
 
 #[derive(Debug, Copy, Clone)]
 pub struct NotSharded;
 
 impl ShardBinding for NotSharded {
-    fn context(&self) -> ShardContext {
+    fn shard_config(&self) -> Option<Sharded> {
         None
     }
 }
 
 impl ShardBinding for Sharded {
-    fn context(&self) -> ShardContext {
-        Some(self.shard_id)
+    fn shard_config(&self) -> Option<Sharded> {
+        Some(*self)
     }
 }
 

--- a/ipa-core/src/test_fixture/app.rs
+++ b/ipa-core/src/test_fixture/app.rs
@@ -55,14 +55,14 @@ pub struct TestApp {
     shard_network: InMemoryShardNetwork,
 }
 
-fn unzip_tuple_array<T, U>(input: [(T, U); 3]) -> ([T; 3], [U; 3]) {
+fn unzip_tuple_array<T, U, V>(input: [(T, U, V); 3]) -> ([T; 3], [U; 3], [V; 3]) {
     let [v0, v1, v2] = input;
-    ([v0.0, v1.0, v2.0], [v0.1, v1.1, v2.1])
+    ([v0.0, v1.0, v2.0], [v0.1, v1.1, v2.1], [v0.2, v1.2, v2.2])
 }
 
 impl Default for TestApp {
     fn default() -> Self {
-        let (setup, handlers) =
+        let (setup, handlers, _shard_handlers) =
             unzip_tuple_array(array::from_fn(|_| AppSetup::new(AppConfig::default())));
 
         let mpc_network = InMemoryMpcNetwork::new(handlers.map(Some));

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -1097,7 +1097,6 @@ mod tests {
                 Role::H1,
                 config.role_assignment(),
                 |ctx: &MaliciousHelperContext, data: &mut Vec<u8>| {
-                    assert!(ctx.shard.is_some());
                     if ctx.shard.unwrap().shard_id == TARGET_SHARD
                         && ctx.gate.as_ref().contains(STEP)
                     {

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -328,12 +328,12 @@ impl<S: ShardingScheme> TestWorld<S> {
 
         let shards = shard_count
             .iter()
-            .map(|shard| {
+            .map(|shard_id| {
                 ShardWorld::new(
-                    S::bind_shard(shard),
+                    S::bind_shard(shard_id),
                     config,
                     &mut rng,
-                    shard_network.shard_transports(shard),
+                    shard_network.shard_transports(shard_id),
                 )
             })
             .collect::<Vec<_>>()
@@ -795,10 +795,11 @@ impl<B: ShardBinding> ShardWorld<B> {
         transports: [InMemoryTransport<ShardIndex>; 3],
     ) -> Self {
         let participants = make_participants(rng);
+
         let network = InMemoryMpcNetwork::with_stream_interceptor(
             InMemoryMpcNetwork::noop_handlers(),
             &config.stream_interceptor,
-            shard_info.context(),
+            shard_info.shard_config(),
         );
 
         let mut gateways = zip3_ref(&network.transports(), &transports).map(|(mpc, shard)| {
@@ -1097,7 +1098,9 @@ mod tests {
                 config.role_assignment(),
                 |ctx: &MaliciousHelperContext, data: &mut Vec<u8>| {
                     assert!(ctx.shard.is_some());
-                    if ctx.shard == Some(TARGET_SHARD) && ctx.gate.as_ref().contains(STEP) {
+                    if ctx.shard.unwrap().shard_id == TARGET_SHARD
+                        && ctx.gate.as_ref().contains(STEP)
+                    {
                         corrupt_byte(&mut data[0]);
                     }
                 },


### PR DESCRIPTION
A few changes required to make Prepare Query API work for the sharded scenario:

1. HandlerRef was generalized to support both `<ShardIndex>` and `<HelperIdentity>`
2. `app::Setup` returns also a `HandlerRef<ShardIndex>` to give to the ShardHttpTransport.
3. Added `ShardTransports` trait. This one provides an additional function to retrieve my shard configuration (`Sharded`). I need shard transports to know how many shards are in total. I will use this functionality in the Prepare Query API (query processor) so that the leader shard can send messages to all other shards. Note there's no Context at this stage, these are the preliminary steps of the query.
4. Created a simple `net::errors::ShardError`. This one only wraps the general net Error with shard information. This is needed by the processor to be able to distinguish errors that happen in the MPC transport vs the ones in the shard transport. Also provides more context information for the error itself.
5. Related to 3; So that TestWorlds can create In-Memory Shard Transport I had to expand `ShardContext = Option<ShardIndex>` to also contain the total count of shards. For simplicity I ended up using `Option<ShardIndex>`. The name ShardContext was overly generic so I removed it.