### PR TITLE
Optimized modulo operator for `Fp61BitPrime`

### DIFF
--- a/ipa-core/src/ff/prime_field.rs
+++ b/ipa-core/src/ff/prime_field.rs
@@ -570,10 +570,25 @@ mod fp61bit {
             }
 
             #[test]
+            fn sub(a: Fp61BitPrime, b: Fp61BitPrime) {
+                let c = a - b;
+                assert!(c.0 < Fp61BitPrime::PRIME);
+                assert_eq!(c.0, (Fp61BitPrime::PRIME + a.0 - b.0) % Fp61BitPrime::PRIME);
+            }
+
+            #[test]
             fn mul(a: Fp61BitPrime, b: Fp61BitPrime) {
                 let c = a * b;
                 assert!(c.0 < Fp61BitPrime::PRIME);
                 assert_eq!(c.0, u64::try_from((u128::from(a.0) * u128::from(b.0)) % u128::from(Fp61BitPrime::PRIME)).unwrap());
+            }
+
+            #[test]
+            fn neg(a: Fp61BitPrime) {
+                let c = -a;
+                assert!(c.0 < Fp61BitPrime::PRIME);
+                assert_eq!(0, c + a);
+                assert_eq!(Fp61BitPrime::PRIME, c.0 + a.0);
             }
 
             #[test]


### PR DESCRIPTION
Zero-knowledge proofs use multiplication on this field extensively. For every bit of multiplication output, we perform [~10 multiplications](https://github.com/private-attribution/ipa/blob/cf25c69f7c641ed70de62c6536c0293e1e6b2db5/ipa-core/src/protocol/context/dzkp_field.rs#L122) in `Fp61BitPrime`. That's around $86 \times 10^9$ modulo reduction operations per 35 million MPC multiplications.

My preliminary testing shows ~30% improvement in local runs, will do some Draft runs to confirm