### PR TITLE
Use Shuffleable traits for all shuffle routines

### DIFF
--- a/ipa-core/src/error.rs
+++ b/ipa-core/src/error.rs
@@ -63,8 +63,6 @@ pub enum Error {
     ShardInfraError(#[from] crate::helpers::Error<ShardIndex>),
     #[error("Value truncation error: {0}")]
     FieldValueTruncation(String),
-    #[error("The field element size is too small: {0}")]
-    FieldConversion(String),
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParameter(BoxError),
     #[error("invalid report: {0}")]

--- a/ipa-core/src/protocol/ipa_prf/shuffle/sharded.rs
+++ b/ipa-core/src/protocol/ipa_prf/shuffle/sharded.rs
@@ -280,7 +280,7 @@ pub trait MaliciousShuffleable: Shuffleable<Share = Self::MaliciousShare> {
 
     fn to_gf32bit(
         &self,
-    ) -> Result<impl Iterator<Item = AdditiveShare<Gf32Bit>>, crate::error::Error> {
+    ) -> Result<impl Iterator<Item = AdditiveShare<Gf32Bit>> + Send, crate::error::Error> {
         let left_shares: Vec<Gf32Bit> = self.left().try_into()?;
         let right_shares: Vec<Gf32Bit> = self.right().try_into()?;
         Ok(left_shares


### PR DESCRIPTION
This uses the `Shuffleable` trait (originally added for the semi-honest sharded shuffle) in the base shuffle and malicious shuffle code. Doing so simplifies the trait bounds on many of the shuffle routines.

The bounds on `ShuffleShare` here are similar to but different from `BooleanArray`. I avoid assuming `Copy`, which probably doesn't matter much for the things we shuffle currently, but makes the implementation more extensible to shuffling larger things.

There are also a few other changes. Most notably, I adopt the one-side PRSS generation that was added #1187. I also eliminate some `clone`s and make some other small adjustments / simplifications.