### PR TITLE
Hybrid oprf pt2

### DIFF
--- a/ipa-core/src/protocol/hybrid/mod.rs
+++ b/ipa-core/src/protocol/hybrid/mod.rs
@@ -1,44 +1,30 @@
 pub(crate) mod oprf;
 pub(crate) mod step;
 
-use step::HybridStep as Step;
-
 use crate::{
     error::Error,
     ff::{
-        boolean_array::{BooleanArray, BA5, BA8},
-        U128Conversions,
+        boolean::Boolean, boolean_array::BooleanArray, curve_points::RP25519,
+        ec_prime_field::Fp25519, U128Conversions,
     },
     helpers::query::DpMechanism,
     protocol::{
-        context::{ShardedContext, UpgradableContext},
+        basics::{BooleanProtocols, Reveal},
+        context::{DZKPUpgraded, MacUpgraded, ShardedContext, UpgradableContext},
+        hybrid::{
+            oprf::{compute_prf_for_inputs, BreakdownKey, CONV_CHUNK, PRF_CHUNK},
+            step::HybridStep as Step,
+        },
         ipa_prf::{
             oprf_padding::{apply_dp_padding, PaddingParameters},
+            prf_eval::PrfSharing,
             shuffle::Shuffle,
         },
+        prss::FromPrss,
     },
     report::hybrid::IndistinguishableHybridReport,
-    secret_sharing::replicated::semi_honest::AdditiveShare as Replicated,
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Vectorizable},
 };
-// In theory, we could support (runtime-configured breakdown count) ≤ (compile-time breakdown count)
-// ≤ 2^|bk|, with all three values distinct, but at present, there is no runtime configuration and
-// the latter two must be equal. The implementation of `move_single_value_to_bucket` does support a
-// runtime-specified count via the `breakdown_count` parameter, and implements a runtime check of
-// its value.
-//
-// It would usually be more appropriate to make `MAX_BREAKDOWNS` an associated constant rather than
-// a const parameter. However, we want to use it to enforce a correct pairing of the `BK` type
-// parameter and the `B` const parameter, and specifying a constraint like
-// `BreakdownKey<MAX_BREAKDOWNS = B>` on an associated constant is not currently supported. (Nor is
-// supplying an associated constant `<BK as BreakdownKey>::MAX_BREAKDOWNS` as the value of a const
-// parameter.) Structured the way we have it, it probably doesn't make sense to use the
-// `BreakdownKey` trait in places where the `B` const parameter is not already available.
-//
-// These could be imported from src/protocl/ipa_prf/mod.rs
-// however we've copy/pasted them here with the intention of deleting that file [TODO]
-pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>: BooleanArray + U128Conversions {}
-impl BreakdownKey<32> for BA5 {}
-impl BreakdownKey<256> for BA8 {}
 
 /// The Hybrid Protocol
 ///
@@ -76,18 +62,28 @@ where
     BK: BreakdownKey<B>,
     V: BooleanArray + U128Conversions,
     HV: BooleanArray + U128Conversions,
+    Replicated<Boolean, CONV_CHUNK>: BooleanProtocols<DZKPUpgraded<C>, CONV_CHUNK>,
+    Replicated<Fp25519, PRF_CHUNK>:
+        PrfSharing<MacUpgraded<C, Fp25519>, PRF_CHUNK, Field = Fp25519> + FromPrss,
+    Replicated<RP25519, PRF_CHUNK>:
+        Reveal<MacUpgraded<C, Fp25519>, Output = <RP25519 as Vectorizable<PRF_CHUNK>>::Array>,
 {
     if input_rows.is_empty() {
         return Ok(vec![Replicated::ZERO; B]);
     }
 
     // Apply DP padding for OPRF
-    let _padded_input_rows = apply_dp_padding::<_, IndistinguishableHybridReport<BK, V>, B>(
+    let padded_input_rows = apply_dp_padding::<_, IndistinguishableHybridReport<BK, V>, B>(
         ctx.narrow(&Step::PaddingDp),
         input_rows,
         &dp_padding_params,
     )
     .await?;
+
+    // TODO shuffle input rows
+    let shuffled_input_rows = padded_input_rows;
+
+    let _prf_input_rows = compute_prf_for_inputs(ctx.clone(), &shuffled_input_rows).await?;
 
     unimplemented!("protocol::hybrid::hybrid_protocol is not fully implemented")
 }

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -258,21 +258,6 @@ mod test {
                     .try_into()
                     .expect("Expected exactly 3 elements");
 
-            // #[allow(clippy::large_futures)]
-            // let results = chunked_reports
-            //     .into_iter()
-            //     .zip(contexts)
-            //     .map(|(reports_by_helper, helper_ctxs)| {
-            //         reports_by_helper
-            //             .into_iter()
-            //             .zip(helper_ctxs)
-            //             .map(|(reports, ctx)| async move {
-            //                 compute_prf_for_inputs(ctx, &reports).await.unwrap()
-            //             })
-            //             .collect::<Vec<_>>()
-            //     })
-            //     .collect::<Vec<_>>();
-
             let mut results = Vec::new();
             for (reports_by_helper, helper_ctxs) in chunked_reports.into_iter().zip(contexts) {
                 for (reports, ctx) in reports_by_helper.into_iter().zip(helper_ctxs) {

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -20,23 +20,23 @@ use crate::{
         basics::{BooleanProtocols, Reveal},
         context::{
             dzkp_validator::DZKPValidator, DZKPUpgraded, MacUpgraded, MaliciousProtocolSteps,
-            UpgradableContext, Validator,
+            ShardedContext, UpgradableContext, Validator,
         },
+        hybrid::step::HybridStep,
         ipa_prf::{
             boolean_ops::convert_to_fp25519,
             prf_eval::{eval_dy_prf, gen_prf_key, PrfSharing},
-            prf_sharding::PrfShardedIpaInputRow,
-            step::IpaPrfStep,
-            OPRFIPAInputRow,
         },
         prss::FromPrss,
         RecordId,
     },
+    report::hybrid::IndistinguishableHybridReport,
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
-        Vectorizable,
+        replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, SharedValue,
+        TransposeFrom, Vectorizable,
     },
     seq_join::seq_join,
+    sharding::ShardIndex,
 };
 
 // In theory, we could support (runtime-configured breakdown count) ≤ (compile-time breakdown count)
@@ -52,7 +52,10 @@ use crate::{
 // supplying an associated constant `<BK as BreakdownKey>::MAX_BREAKDOWNS` as the value of a const
 // parameter.) Structured the way we have it, it probably doesn't make sense to use the
 // `BreakdownKey` trait in places where the `B` const parameter is not already available.
-#[allow(dead_code)]
+
+// These could be imported from src/protocl/ipa_prf/mod.rs
+// however we've copy/pasted them here with the intention of deleting that file [TODO]
+
 pub trait BreakdownKey<const MAX_BREAKDOWNS: usize>: BooleanArray + U128Conversions {}
 impl BreakdownKey<32> for BA5 {}
 impl BreakdownKey<256> for BA8 {}
@@ -74,17 +77,23 @@ pub const PRF_CHUNK: usize = 16;
 // multiplications per batch
 const CONV_PROOF_CHUNK: usize = 256;
 
-#[allow(dead_code)]
+#[derive(Default, Debug)]
+#[allow(dead_code)] // needed to mute warning until used in future PRs
+pub struct PRFIndistinguishableHybridReport<BK: SharedValue, V: SharedValue> {
+    prf_of_match_key: u64,
+    value: Replicated<V>,
+    breakdown_key: Replicated<BK>,
+}
+
 #[tracing::instrument(name = "compute_prf_for_inputs", skip_all)]
-async fn compute_prf_for_inputs<C, BK, TV, TS>(
+pub async fn compute_prf_for_inputs<C, BK, V>(
     ctx: C,
-    input_rows: &[OPRFIPAInputRow<BK, TV, TS>],
-) -> Result<Vec<PrfShardedIpaInputRow<BK, TV, TS>>, Error>
+    input_rows: &[IndistinguishableHybridReport<BK, V>],
+) -> Result<Vec<PRFIndistinguishableHybridReport<BK, V>>, Error>
 where
-    C: UpgradableContext,
+    C: UpgradableContext + ShardedContext,
     BK: BooleanArray,
-    TV: BooleanArray,
-    TS: BooleanArray,
+    V: BooleanArray,
     Replicated<Boolean, CONV_CHUNK>: BooleanProtocols<DZKPUpgraded<C>, CONV_CHUNK>,
     Replicated<Fp25519, PRF_CHUNK>:
         PrfSharing<MacUpgraded<C, Fp25519>, PRF_CHUNK, Field = Fp25519> + FromPrss,
@@ -98,8 +107,8 @@ where
 
     let validator = convert_ctx.dzkp_validator(
         MaliciousProtocolSteps {
-            protocol: &IpaPrfStep::ConvertFp25519,
-            validate: &IpaPrfStep::ConvertFp25519Validate,
+            protocol: &HybridStep::ConvertFp25519,
+            validate: &HybridStep::ConvertFp25519Validate,
         },
         CONV_PROOF_CHUNK,
     );
@@ -122,9 +131,31 @@ where
     .try_collect::<Vec<_>>()
     .await?;
 
-    let prf_key = gen_prf_key(&ctx.narrow(&IpaPrfStep::PrfKeyGen));
+    // In order to compute the same PRF value for the same match key
+    // all shards must have the same prf_key. This has the leader
+    // generate a key, and give it to all the followers.
+    let prf_key_ctx = ctx.set_total_records(TotalRecords::ONE);
+    let prf_key = if ctx.shard_id() == ShardIndex::FIRST {
+        let leader_prf_key = gen_prf_key(&ctx.narrow(&HybridStep::PrfKeyGen));
+
+        for shard in ctx.shard_count().iter().skip(1) {
+            prf_key_ctx
+                .clone()
+                .shard_send_channel::<Replicated<Fp25519>>(shard)
+                .send(RecordId::FIRST, leader_prf_key.clone())
+                .await?;
+        }
+        Ok(leader_prf_key)
+    } else {
+        let mut receiver = prf_key_ctx
+            .shard_recv_channel::<Replicated<Fp25519>>(ShardIndex::FIRST)
+            .take(1);
+        receiver.next().await.unwrap()
+    }
+    .unwrap();
+
     let validator = ctx
-        .narrow(&IpaPrfStep::EvalPrf)
+        .narrow(&HybridStep::EvalPrf)
         .set_total_records(eval_records)
         .validator::<Fp25519>();
     let eval_ctx = validator.context();
@@ -144,22 +175,148 @@ where
 
     Ok(zip(input_rows, prf_of_match_keys.into_iter().flatten())
         .map(|(input, prf_of_match_key)| {
-            let OPRFIPAInputRow {
+            let IndistinguishableHybridReport {
                 match_key: _,
-                is_trigger,
+                value,
                 breakdown_key,
-                trigger_value,
-                timestamp,
             } = &input;
 
-            PrfShardedIpaInputRow {
+            PRFIndistinguishableHybridReport {
                 prf_of_match_key,
-                is_trigger_bit: is_trigger.clone(),
+                value: value.clone(),
                 breakdown_key: breakdown_key.clone(),
-                trigger_value: trigger_value.clone(),
-                timestamp: timestamp.clone(),
-                sort_key: Replicated::ZERO,
             }
         })
         .collect())
+}
+
+#[cfg(all(test, unit_test, feature = "in-memory-infra"))]
+mod test {
+    use ipa_step::StepNarrow;
+
+    use crate::{
+        ff::boolean_array::{BA3, BA8},
+        protocol::{hybrid::oprf::compute_prf_for_inputs, step::ProtocolStep, Gate},
+        report::hybrid::{HybridReport, IndistinguishableHybridReport},
+        secret_sharing::IntoShares,
+        test_executor::run,
+        test_fixture::{
+            hybrid::TestHybridRecord, RoundRobinInputDistribution, TestWorld, TestWorldConfig,
+            WithShards,
+        },
+    };
+
+    #[test]
+    fn hybrid_oprf() {
+        run(|| async {
+            const SHARDS: usize = 2;
+            let world: TestWorld<WithShards<SHARDS, RoundRobinInputDistribution>> =
+                TestWorld::with_shards(TestWorldConfig {
+                    initial_gate: Some(Gate::default().narrow(&ProtocolStep::Hybrid)),
+                    ..Default::default()
+                });
+
+            let contexts = world.contexts();
+
+            let records = [
+                TestHybridRecord::TestImpression {
+                    match_key: 12345,
+                    breakdown_key: 2,
+                },
+                TestHybridRecord::TestImpression {
+                    match_key: 68362,
+                    breakdown_key: 1,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 12345,
+                    value: 5,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 68362,
+                    value: 2,
+                },
+                TestHybridRecord::TestImpression {
+                    match_key: 68362,
+                    breakdown_key: 1,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 68362,
+                    value: 7,
+                },
+            ];
+            let indices_to_compare = [(0, 2), (1, 3), (1, 4), (1, 5)];
+
+            let shares: [Vec<HybridReport<BA8, BA3>>; 3] = records.iter().cloned().share();
+
+            let indistinguishable_reports: [Vec<IndistinguishableHybridReport<BA8, BA3>>; 3] =
+                shares
+                    .iter()
+                    .map(|s| s.iter().map(|r| r.clone().into()).collect::<Vec<_>>())
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("Expected exactly 3 elements");
+
+            let chunked_reports: [Vec<Vec<IndistinguishableHybridReport<BA8, BA3>>>; 3] =
+                indistinguishable_reports
+                    .iter()
+                    .map(|vec| {
+                        let mid = vec.len() / SHARDS;
+                        vec.chunks(mid)
+                            .map(<[IndistinguishableHybridReport<BA8, BA3>]>::to_vec)
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("Expected exactly 3 elements");
+
+            // #[allow(clippy::large_futures)]
+            // let results = chunked_reports
+            //     .into_iter()
+            //     .zip(contexts)
+            //     .map(|(reports_by_helper, helper_ctxs)| {
+            //         reports_by_helper
+            //             .into_iter()
+            //             .zip(helper_ctxs)
+            //             .map(|(reports, ctx)| async move {
+            //                 compute_prf_for_inputs(ctx, &reports).await.unwrap()
+            //             })
+            //             .collect::<Vec<_>>()
+            //     })
+            //     .collect::<Vec<_>>();
+
+            let mut results = Vec::new();
+            for (reports_by_helper, helper_ctxs) in chunked_reports.into_iter().zip(contexts) {
+                for (reports, ctx) in reports_by_helper.into_iter().zip(helper_ctxs) {
+                    let result = async move { compute_prf_for_inputs(ctx, &reports).await };
+                    results.push(result);
+                }
+            }
+
+            #[allow(clippy::large_futures)]
+            let results = futures::future::try_join_all(results).await.unwrap();
+
+            let results = results
+                .chunks(SHARDS)
+                .map(|chunk| chunk.iter().flatten().collect::<Vec<_>>())
+                .collect::<Vec<_>>();
+
+            let prfs = results
+                .iter()
+                .map(|helper_results| {
+                    helper_results
+                        .iter()
+                        .map(|r| r.prf_of_match_key)
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+
+            // check to make sure each helper has the same PRF values
+            assert!(prfs.iter().all(|x| *x == prfs[0]));
+
+            // check to make sure the reports with the same match keys have the same prf values
+            for (i, j) in indices_to_compare {
+                assert_eq!(prfs[0][i], prfs[0][j]);
+            }
+        });
+    }
 }

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -5,4 +5,11 @@ pub(crate) enum HybridStep {
     ReshardByTag,
     #[step(child = crate::protocol::ipa_prf::oprf_padding::step::PaddingDpStep, name="padding_dp")]
     PaddingDp,
+    #[step(child = crate::protocol::ipa_prf::boolean_ops::step::Fp25519ConversionStep)]
+    ConvertFp25519,
+    #[step(child = crate::protocol::context::step::DzkpValidationProtocolStep)]
+    ConvertFp25519Validate,
+    PrfKeyGen,
+    #[step(child = crate::protocol::context::step::MaliciousProtocolStep)]
+    EvalPrf,
 }

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -19,7 +19,7 @@ use crate::{
         replicated::{malicious, semi_honest::AdditiveShare},
         FieldSimd, Vectorizable,
     },
-    sharding::NotSharded,
+    sharding::{NotSharded, Sharded},
 };
 
 /// This trait defines the requirements to the sharing types and the underlying fields
@@ -43,6 +43,19 @@ where
     RP25519: Vectorizable<N>,
     AdditiveShare<Fp25519, N>:
         BasicProtocols<UpgradedSemiHonestContext<'a, NotSharded, Fp25519>, Fp25519, N> + FromPrss,
+{
+    type Field = Fp25519;
+    type UpgradedSharing = AdditiveShare<Fp25519, N>;
+}
+
+/// Allow semi-honest shares to be used for PRF generation with shards
+impl<'a, const N: usize> PrfSharing<UpgradedSemiHonestContext<'a, Sharded, Fp25519>, N>
+    for AdditiveShare<Fp25519, N>
+where
+    Fp25519: FieldSimd<N>,
+    RP25519: Vectorizable<N>,
+    AdditiveShare<Fp25519, N>:
+        BasicProtocols<UpgradedSemiHonestContext<'a, Sharded, Fp25519>, Fp25519, N> + FromPrss,
 {
     type Field = Fp25519;
     type UpgradedSharing = AdditiveShare<Fp25519, N>;

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -673,7 +673,7 @@ where
 /// and `HybridImpressionReport`s so that they can be made indistingushable.
 /// Note: these need to be shuffled (and secret shares need to be rerandomized)
 /// to provide any formal indistinguishability.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct IndistinguishableHybridReport<BK, V>
 where
     BK: SharedValue,


### PR DESCRIPTION
This is stacked on top of #1412, so to look at the just the diff, make sure to ignore the `d1199d1` commit in the diff viewer.

This updates the OPRF function to work with hybrid reports, as well as negotiating a key exchange across shards. Note that that will be replaced by the functionality in #1410 once merged.

It also adds a direct test for this function, which was lacking before.