### PR TITLE
Sharded Prepare Query API

### DIFF
--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -72,11 +72,11 @@ pub use transport::{
     config as in_memory_config, InMemoryMpcNetwork, InMemoryShardNetwork, InMemoryTransport,
 };
 pub use transport::{
-    make_owned_handler, query, routing, ApiError, BodyStream, BytesStream, HandlerBox, HandlerRef,
-    HelperResponse, Identity as TransportIdentity, LengthDelimitedStream, LogErrors, NoQueryId,
-    NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords, RecordsStream, RequestHandler,
-    RouteParams, SingleRecordStream, StepBinding, StreamCollection, StreamKey, Transport,
-    WrappedBoxBodyStream,
+    make_owned_handler, query, routing, ApiError, BodyStream, BroadcastError, BytesStream,
+    HandlerBox, HandlerRef, HelperResponse, Identity as TransportIdentity, LengthDelimitedStream,
+    LogErrors, NoQueryId, NoResourceIdentifier, NoStep, QueryIdBinding, ReceiveRecords,
+    RecordsStream, RequestHandler, RouteParams, SingleRecordStream, StepBinding, StreamCollection,
+    StreamKey, Transport, WrappedBoxBodyStream,
 };
 use typenum::{Const, ToUInt, Unsigned, U8};
 use x25519_dalek::PublicKey;

--- a/ipa-core/src/helpers/transport/handler.rs
+++ b/ipa-core/src/helpers/transport/handler.rs
@@ -201,12 +201,6 @@ where
         }
     }
 
-    impl<I, F> Drop for Handler<I, F> {
-        fn drop(&mut self) {
-            println!("droping handler");
-        }
-    }
-
     Arc::new(Handler {
         inner: handler,
         phantom: PhantomData,

--- a/ipa-core/src/helpers/transport/handler.rs
+++ b/ipa-core/src/helpers/transport/handler.rs
@@ -201,6 +201,12 @@ where
         }
     }
 
+    impl<I, F> Drop for Handler<I, F> {
+        fn drop(&mut self) {
+            println!("droping handler");
+        }
+    }
+
     Arc::new(Handler {
         inner: handler,
         phantom: PhantomData,

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -84,7 +84,6 @@ impl InMemoryShardNetwork {
                 .map(|i| {
                     Setup::with_config(
                         i,
-                        shard_count.iter().collect(),
                         config_builder.with_sharding(Some(Sharded {
                             shard_id: i,
                             shard_count,

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -84,6 +84,7 @@ impl InMemoryShardNetwork {
                 .map(|i| {
                     Setup::with_config(
                         i,
+                        shard_count.iter().collect(),
                         config_builder.with_sharding(Some(Sharded {
                             shard_id: i,
                             shard_count,

--- a/ipa-core/src/helpers/transport/in_memory/sharding.rs
+++ b/ipa-core/src/helpers/transport/in_memory/sharding.rs
@@ -2,7 +2,7 @@ use crate::{
     helpers::{
         in_memory_config::{passthrough, DynStreamInterceptor},
         transport::in_memory::transport::{InMemoryTransport, Setup, TransportConfigBuilder},
-        HelperIdentity,
+        HandlerBox, HelperIdentity, RequestHandler,
     },
     sharding::{ShardIndex, Sharded},
     sync::{Arc, Weak},
@@ -78,6 +78,7 @@ impl InMemoryShardNetwork {
         let mut handlers = Vec::with_capacity(3 * usize::from(shard_count));
         let shard_network: [_; 3] = HelperIdentity::make_three().map(|h| {
             let config_builder = TransportConfigBuilder::for_helper(h);
+
             let mut shard_connections = shard_count
                 .iter()
                 .map(|i| {

--- a/ipa-core/src/helpers/transport/in_memory/transport.rs
+++ b/ipa-core/src/helpers/transport/in_memory/transport.rs
@@ -277,7 +277,7 @@ impl Debug for InMemoryStream {
 }
 
 pub struct Setup<I> {
-    identity: I,
+    pub identity: I,
     tx: ConnectionTx<I>,
     rx: ConnectionRx<I>,
     connections: HashMap<I, ConnectionTx<I>>,

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -292,7 +292,7 @@ impl RouteParams<RouteId, QueryId, NoStep> for (RouteId, QueryId) {
 #[derive(thiserror::Error, Debug)]
 #[error("One or more peers rejected the request: {failures:?}")]
 pub struct BroadcastError<I: TransportIdentity, E: Debug> {
-    failures: Vec<(I, E)>,
+    pub failures: Vec<(I, E)>,
 }
 
 impl<I: TransportIdentity, E: Debug> From<Vec<(I, E)>> for BroadcastError<I, E> {

--- a/ipa-core/src/helpers/transport/mod.rs
+++ b/ipa-core/src/helpers/transport/mod.rs
@@ -341,8 +341,7 @@ pub trait Transport: Clone + Send + Sync + 'static {
 
     /// Broadcasts a message to all peers, excluding this instance, collecting all failures and
     /// successes. This method waits for all responses and returns only when all peers responded.
-    /// The routes and data will be cloned.
-    async fn broadcast<Q, S, R, D>(
+    async fn broadcast<Q, S, R>(
         &self,
         route: R,
     ) -> Result<(), BroadcastError<Self::Identity, Self::Error>>

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -3,7 +3,10 @@ use std::{
     fmt::{Debug, Formatter},
 };
 
-use futures::{future::try_join, stream};
+use futures::{
+    future::try_join,
+    stream,
+};
 use serde::Serialize;
 
 use crate::{
@@ -12,7 +15,7 @@ use crate::{
     helpers::{
         query::{PrepareQuery, QueryConfig, QueryInput},
         Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment,
-        ShardTransportImpl, Transport,
+        ShardTransportError, ShardTransportImpl, ShardedTransport, Transport,
     },
     hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
@@ -21,6 +24,7 @@ use crate::{
         state::{QueryState, QueryStatus, RemoveQuery, RunningQueries, StateError},
         CompletionHandle, ProtocolResult,
     },
+    sharding::ShardIndex,
     sync::Arc,
     utils::NonZeroU32PowerOfTwo,
 };
@@ -66,6 +70,8 @@ pub enum NewQueryError {
     State(#[from] StateError),
     #[error(transparent)]
     MpcTransport(#[from] MpcTransportError),
+    #[error(transparent)]
+    ShardTransport(#[from] ShardTransportError),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -79,6 +85,8 @@ pub enum PrepareQueryError {
         #[from]
         source: StateError,
     },
+    #[error(transparent)]
+    ShardTransport(#[from] ShardTransportError),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -141,7 +149,7 @@ impl Processor {
     /// * Requests Infra and Network layer to create resources for this query
     /// * sends `prepare` request that describes the query configuration
     ///     (query id, query type, field type, roles -> endpoints or reverse)
-    ///         to followers and waits for the confirmation
+    ///         to helpers and its shards and waits for the confirmation
     /// * records newly created query id internally and sets query state to awaiting data
     /// * returns query configuration
     ///
@@ -151,6 +159,7 @@ impl Processor {
     pub async fn new_query(
         &self,
         transport: MpcTransportImpl,
+        shard_transport: ShardTransportImpl,
         req: QueryConfig,
     ) -> Result<PrepareQuery, NewQueryError> {
         let query_id = QueryId;
@@ -169,14 +178,15 @@ impl Processor {
             config: req,
             roles: roles.clone(),
         };
-
-        // Inform other parties about new query. If any of them rejects it, this join will fail
+        // Inform other helpers about new query. If any of them rejects it, this join will fail
         try_join(
             transport.send(left, prepare_request.clone(), stream::empty()),
             transport.send(right, prepare_request.clone(), stream::empty()),
         )
         .await
         .map_err(NewQueryError::MpcTransport)?;
+
+        shard_transport.broadcast(req.clone(), stream::empty()).await?;
 
         handle.set_state(QueryState::AwaitingInputs(query_id, req, roles))?;
 
@@ -185,23 +195,51 @@ impl Processor {
     }
 
     /// On prepare, each follower:
-    /// * ensures that it is not the leader on this query
+    /// * ensures that it is not the leader helper on this query
     /// * query is not registered yet
-    /// * creates gateway and network
     /// * registers query
     ///
     /// ## Errors
     /// if query is already running or this helper cannot be a follower in it
-    pub fn prepare(
+    pub async fn prepare_helper(
         &self,
-        transport: &MpcTransportImpl,
+        mpc_transport: MpcTransportImpl,
+        shard_transport: ShardTransportImpl,
         req: PrepareQuery,
     ) -> Result<(), PrepareQueryError> {
-        let my_role = req.roles.role(transport.identity());
+        let my_role = req.roles.role(mpc_transport.identity());
+        let shard_index = shard_transport.identity();
 
         if my_role == Role::H1 {
             return Err(PrepareQueryError::WrongTarget);
         }
+        if shard_index != ShardIndex::FIRST {
+            return Err(PrepareQueryError::WrongTarget);
+        }
+        let handle = self.queries.handle(req.query_id);
+        if handle.status().is_some() {
+            return Err(PrepareQueryError::AlreadyRunning);
+        }
+
+        shard_transport.broadcast(req.clone(), stream::empty()).await?;
+
+        handle.set_state(QueryState::AwaitingInputs(
+            req.query_id,
+            req.config,
+            req.roles,
+        ))?;
+
+        Ok(())
+    }
+
+    /// On prepare, each shard:
+    /// * ensures that it is not the leader on this query
+    /// * query is not registered yet
+    /// * registers query
+    ///
+    /// ## Errors
+    /// if query is already running or this helper cannot be a follower in it
+    pub fn prepare_shard(&self, req: PrepareQuery) -> Result<(), PrepareQueryError> {
         let handle = self.queries.handle(req.query_id);
         if handle.status().is_some() {
             return Err(PrepareQueryError::AlreadyRunning);
@@ -216,7 +254,7 @@ impl Processor {
         Ok(())
     }
 
-    /// Receive inputs for the specified query. That triggers query processing
+    /// Receive inputs for the specified query and creates gateway and network
     ///
     /// ## Errors
     /// if query is not registered on this helper.
@@ -381,15 +419,16 @@ mod tests {
             make_owned_handler,
             query::{PrepareQuery, QueryConfig, QueryType::TestMultiply},
             ApiError, HandlerBox, HelperIdentity, HelperResponse, InMemoryMpcNetwork,
-            RequestHandler, RoleAssignment, Transport,
+            InMemoryShardNetwork, RequestHandler, RoleAssignment, Transport,
         },
         protocol::QueryId,
         query::{
             processor::Processor, state::StateError, NewQueryError, PrepareQueryError, QueryStatus,
         },
+        sharding::ShardIndex,
     };
 
-    fn prepare_query_handler<F, Fut>(cb: F) -> Arc<dyn RequestHandler<HelperIdentity>>
+    fn prepare_helper_query_handler<F, Fut>(cb: F) -> Arc<dyn RequestHandler<HelperIdentity>>
     where
         F: Fn(PrepareQuery) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<HelperResponse, ApiError>> + Send + Sync + 'static,
@@ -400,8 +439,23 @@ mod tests {
         })
     }
 
-    fn respond_ok() -> Arc<dyn RequestHandler<HelperIdentity>> {
-        prepare_query_handler(move |_| async move { Ok(HelperResponse::ok()) })
+    fn helper_respond_ok() -> Arc<dyn RequestHandler<HelperIdentity>> {
+        prepare_helper_query_handler(move |_| async move { Ok(HelperResponse::ok()) })
+    }
+
+    fn prepare_shard_query_handler<F, Fut>(cb: F) -> Arc<dyn RequestHandler<ShardIndex>>
+    where
+        F: Fn(PrepareQuery) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<HelperResponse, ApiError>> + Send + Sync + 'static,
+    {
+        make_owned_handler(move |req, _| {
+            let prepare_query = req.into().unwrap();
+            cb(prepare_query)
+        })
+    }
+
+    fn shard_respond_ok(_si: ShardIndex) -> Arc<dyn RequestHandler<ShardIndex>> {
+        prepare_shard_query_handler(move |_| async move { Ok(HelperResponse::ok()) })
     }
 
     fn test_multiply_config() -> QueryConfig {
@@ -413,20 +467,25 @@ mod tests {
         let barrier = Arc::new(Barrier::new(3));
         let h2_barrier = Arc::clone(&barrier);
         let h3_barrier = Arc::clone(&barrier);
-        let h2 = prepare_query_handler(move |_| {
+        let h2 = prepare_helper_query_handler(move |_| {
             let barrier = Arc::clone(&h2_barrier);
             async move {
                 barrier.wait().await;
                 Ok(HelperResponse::ok())
             }
         });
-        let h3 = prepare_query_handler(move |_| {
+        let h3 = prepare_helper_query_handler(move |_| {
             let barrier = Arc::clone(&h3_barrier);
             async move {
                 barrier.wait().await;
                 Ok(HelperResponse::ok())
             }
         });
+        let (shard_network, _s_handlers) =
+            InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+        let id = HelperIdentity::ONE;
+        let si0 = ShardIndex::FIRST;
+        let s0 = shard_network.transport(id, si0);
         let network = InMemoryMpcNetwork::new([
             None,
             Some(HandlerBox::owning_ref(&h2)),
@@ -436,7 +495,7 @@ mod tests {
         let p0 = Processor::default();
         let request = test_multiply_config();
 
-        let qc_future = p0.new_query(t0, request);
+        let qc_future = p0.new_query(t0, s0, request);
         pin_mut!(qc_future);
 
         // poll future once to trigger query status change
@@ -465,28 +524,38 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_duplicate_query_id() {
-        let handlers =
-            array::from_fn(|_| prepare_query_handler(|_| async { Ok(HelperResponse::ok()) }));
+        let handlers = array::from_fn(|_| {
+            prepare_helper_query_handler(|_| async { Ok(HelperResponse::ok()) })
+        });
         let network =
             InMemoryMpcNetwork::new(handlers.each_ref().map(HandlerBox::owning_ref).map(Some));
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
+        let (shard_network, _s_handlers) =
+            InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+        let id = HelperIdentity::ONE;
+        let si0 = ShardIndex::FIRST;
+        let s0 = shard_network.transport(id, si0);
 
         let _qc = p0
-            .new_query(Transport::clone_ref(&t0), request)
+            .new_query(
+                Transport::clone_ref(&t0),
+                Transport::clone_ref(&s0),
+                request,
+            )
             .await
             .unwrap();
         assert!(matches!(
-            p0.new_query(t0, request).await,
+            p0.new_query(t0, s0, request).await,
             Err(NewQueryError::State(StateError::AlreadyRunning)),
         ));
     }
 
     #[tokio::test]
     async fn prepare_error() {
-        let h2 = respond_ok();
-        let h3 = prepare_query_handler(|_| async move {
+        let h2 = helper_respond_ok();
+        let h3 = prepare_helper_query_handler(|_| async move {
             Err(ApiError::QueryPrepare(PrepareQueryError::WrongTarget))
         });
         let network = InMemoryMpcNetwork::new([
@@ -497,17 +566,22 @@ mod tests {
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
+        let (shard_network, _s_handlers) =
+            InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+        let id = HelperIdentity::ONE;
+        let si0 = ShardIndex::FIRST;
+        let s0 = shard_network.transport(id, si0);
 
         assert!(matches!(
-            p0.new_query(t0, request).await.unwrap_err(),
+            p0.new_query(t0, s0, request).await.unwrap_err(),
             NewQueryError::MpcTransport(_)
         ));
     }
 
     #[tokio::test]
     async fn can_recover_from_prepare_error() {
-        let h2 = respond_ok();
-        let h3 = prepare_query_handler(|_| async move {
+        let h2 = helper_respond_ok();
+        let h3 = prepare_helper_query_handler(|_| async move {
             Err(ApiError::QueryPrepare(PrepareQueryError::WrongTarget))
         });
         let network = InMemoryMpcNetwork::new([
@@ -515,13 +589,20 @@ mod tests {
             Some(HandlerBox::owning_ref(&h2)),
             Some(HandlerBox::owning_ref(&h3)),
         ]);
+        let (shard_network, _s_handlers) =
+            InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+        let id = HelperIdentity::ONE;
+        let si0 = ShardIndex::FIRST;
+        let s0 = shard_network.transport(id, si0);
         let [t0, _, _] = network.transports();
         let p0 = Processor::default();
         let request = test_multiply_config();
-        p0.new_query(t0.clone_ref(), request).await.unwrap_err();
+        p0.new_query(t0.clone_ref(), s0.clone_ref(), request)
+            .await
+            .unwrap_err();
 
         assert!(matches!(
-            p0.new_query(t0, request).await.unwrap_err(),
+            p0.new_query(t0, s0, request).await.unwrap_err(),
             NewQueryError::MpcTransport(_)
         ));
     }
@@ -545,12 +626,17 @@ mod tests {
             let req = prepare_query(identities);
             let transport = network.transport(identities[1]);
             let processor = Processor::default();
+            let (shard_network, _s_handlers) =
+                InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+            let id = HelperIdentity::ONE;
+            let si0 = ShardIndex::FIRST;
+            let s0 = shard_network.transport(id, si0);
 
             assert!(matches!(
                 processor.query_status(QueryId).unwrap_err(),
                 QueryStatusError::NoSuchQuery(_)
             ));
-            processor.prepare(&transport, req).unwrap();
+            processor.prepare_helper(transport, s0, req).await.unwrap();
             assert_eq!(
                 QueryStatus::AwaitingInputs,
                 processor.query_status(QueryId).unwrap()
@@ -564,9 +650,14 @@ mod tests {
             let req = prepare_query(identities);
             let transport = network.transport(identities[0]);
             let processor = Processor::default();
+            let (shard_network, _s_handlers) =
+                InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+            let id = HelperIdentity::ONE;
+            let si0 = ShardIndex::FIRST;
+            let s0 = shard_network.transport(id, si0);
 
             assert!(matches!(
-                processor.prepare(&transport, req),
+                processor.prepare_helper(transport, s0, req).await,
                 Err(PrepareQueryError::WrongTarget)
             ));
         }
@@ -578,9 +669,17 @@ mod tests {
             let req = prepare_query(identities);
             let transport = network.transport(identities[1]);
             let processor = Processor::default();
-            processor.prepare(&transport, req.clone()).unwrap();
+            let (shard_network, _s_handlers) =
+                InMemoryShardNetwork::with_shards_and_handlers(2, shard_respond_ok);
+            let id = HelperIdentity::ONE;
+            let si0 = ShardIndex::FIRST;
+            let s0 = shard_network.transport(id, si0);
+            processor
+                .prepare_helper(transport.clone_ref(), s0.clone_ref(), req.clone())
+                .await
+                .unwrap();
             assert!(matches!(
-                processor.prepare(&transport, req),
+                processor.prepare_helper(transport, s0, req).await,
                 Err(PrepareQueryError::AlreadyRunning)
             ));
         }
@@ -597,14 +696,15 @@ mod tests {
                     QueryConfig,
                     QueryType::{TestAddInPrimeField, TestMultiply},
                 },
-                HandlerBox, HelperIdentity, InMemoryMpcNetwork, Transport,
+                HandlerBox, HelperIdentity, InMemoryMpcNetwork, InMemoryShardNetwork, Transport,
             },
             protocol::QueryId,
             query::{
-                processor::{tests::respond_ok, Processor},
+                processor::{tests::helper_respond_ok, Processor},
                 state::{QueryState, RunningQuery},
                 QueryKillStatus,
             },
+            sharding::ShardIndex,
             test_executor::run,
         };
 
@@ -622,8 +722,8 @@ mod tests {
         #[test]
         fn existing_query() {
             run(|| async move {
-                let h2 = respond_ok();
-                let h3 = respond_ok();
+                let h2 = helper_respond_ok();
+                let h3 = helper_respond_ok();
                 let network = InMemoryMpcNetwork::new([
                     None,
                     Some(HandlerBox::owning_ref(&h2)),
@@ -632,9 +732,15 @@ mod tests {
                 let identities = HelperIdentity::make_three();
                 let processor = Processor::default();
                 let transport = network.transport(identities[0]);
+                let (shard_network, _s_handlers) =
+                    InMemoryShardNetwork::with_shards_and_handlers(2, super::shard_respond_ok);
+                let id = HelperIdentity::ONE;
+                let si0 = ShardIndex::FIRST;
+                let s0 = shard_network.transport(id, si0);
                 processor
                     .new_query(
                         Transport::clone_ref(&transport),
+                        Transport::clone_ref(&s0),
                         QueryConfig::new(TestMultiply, FieldType::Fp31, 1).unwrap(),
                     )
                     .await
@@ -646,6 +752,7 @@ mod tests {
                 processor
                     .new_query(
                         transport,
+                        s0,
                         QueryConfig::new(TestAddInPrimeField, FieldType::Fp32BitPrime, 1).unwrap(),
                     )
                     .await


### PR DESCRIPTION
Added `processor::prepare_helper` and `processor::prepare_shard` to Processor and corresponding tests to validate the correct behavior. Had to add functionality in `InMemoryShardNetwork` to be able to set custom Handlers. Since the amount of testing code in `processor` was getting out of hand I created a few structs to help streamlining them.

Following is a description of the overall approach we want to take for Sharded APIs. 

## Sharding Query Workflow

![Prepare Query Diagram](https://github.com/user-attachments/assets/3cd9fae8-0974-4162-a1ab-3d7f753ee787)

Query APIs (Create Query, Query Status, etc), the Report Collector (RC) will reach out to the Leader Shards **only**. The diagram above shows how Shard 1-0 receives a Create Query from RC (`processor::new_query`). He validates its own state and then forwards the calls to the other leaders; Shard 2-0 and Shard 3-0, using the `processor::prepare_helper` (blue arrows in the diagram). So far this is the same operating mode as now, but in a sharded environment, each leader will subsequently call all his shard's `processor::prepare_shard` (red arrows in diagram). If all shards in the network are Ok, then an Ok is sent back to RC by the Leader. To the RC, this is a synchronous HTTP call.

The following doesn't involve this PR but is helpful to understand how PrepareQuery fits with the rest of the APIs. 

Similarly, while the query is running, RC will call Query Status on all leaders; Shard 1-0, Shard 2-0 and Shard 3-0, which each returns a unified response for its Helper (same as Prepare Query). Query Results works in the same way, aggregating all responses for a Helper.

The only odd case is Query Input, in which the RC will individually push the input to each Shard in all helpers. This unwanted exposure of Shards can be mitigated by implementing a pull model for inputs, but will be left as future work.