### PR TITLE
[Bugfix] Add debug_assertions requirement to rejects_the_same_index

### DIFF
--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -340,7 +340,7 @@ impl UsedSet {
     pub fn new(key: Vec<u8>) -> Self {
         use std::collections::HashSet;
 
-        use crate::sync::{Arc, Mutex};
+        use crate::sync::Mutex;
 
         Self {
             key: String::from_utf8(key).unwrap_or_else(|e| {
@@ -371,6 +371,7 @@ mod tests {
     )]
     fn rejects_the_same_index() {
         use rand::thread_rng;
+
         use crate::protocol::prss::KeyExchange;
         let other_gen = KeyExchange::new(&mut thread_rng());
         let gen = KeyExchange::new(&mut thread_rng())

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -340,7 +340,7 @@ impl UsedSet {
     pub fn new(key: Vec<u8>) -> Self {
         use std::collections::HashSet;
 
-        use crate::sync::Mutex;
+        use crate::sync::{Arc, Mutex};
 
         Self {
             key: String::from_utf8(key).unwrap_or_else(|e| {
@@ -364,15 +364,14 @@ impl UsedSet {
 
 #[cfg(all(test, unit_test))]
 mod tests {
-    use rand::thread_rng;
-
-    use crate::protocol::prss::KeyExchange;
-
     #[test]
+    #[cfg(debug_assertions)]
     #[should_panic(
         expected = "Generated randomness for index '0:0' twice using the same key 'foo'"
     )]
     fn rejects_the_same_index() {
+        use rand::thread_rng;
+        use crate::protocol::prss::KeyExchange;
         let other_gen = KeyExchange::new(&mut thread_rng());
         let gen = KeyExchange::new(&mut thread_rng())
             .key_exchange(&other_gen.public_key())


### PR DESCRIPTION
I noticed that rejects_the_same_index fails when running `cargo test -r`. The reason is that it tests UsedSet, which is only enabled when using cfg(debug_assertions). So I added that requirement to the test