### PR TITLE
[Bugfix] Add cfg(debug_assertions) to rejects_large_chunks test

### DIFF
--- a/ipa-core/src/helpers/transport/stream/mod.rs
+++ b/ipa-core/src/helpers/transport/stream/mod.rs
@@ -179,6 +179,7 @@ mod tests {
         });
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "Chunk size 1048577 is greater than maximum allowed 1048576 bytes")]
     fn rejects_large_chunks() {


### PR DESCRIPTION
The rejects_large_chunks relies on a panic being initiated by a `debug_assert`, so we should either make it a regular `assert` or limit the test to debug mode