### PR TITLE
Reshard by oprf

### DIFF
--- a/ipa-core/src/protocol/hybrid/mod.rs
+++ b/ipa-core/src/protocol/hybrid/mod.rs
@@ -1,16 +1,18 @@
 pub(crate) mod oprf;
 pub(crate) mod step;
 
+use oprf::PRFIndistinguishableHybridReport;
+
 use crate::{
     error::Error,
     ff::{
         boolean::Boolean, boolean_array::BooleanArray, curve_points::RP25519,
-        ec_prime_field::Fp25519, U128Conversions,
+        ec_prime_field::Fp25519, Serializable, U128Conversions,
     },
     helpers::query::DpMechanism,
     protocol::{
         basics::{BooleanProtocols, Reveal},
-        context::{DZKPUpgraded, MacUpgraded, ShardedContext, UpgradableContext},
+        context::{reshard_iter, DZKPUpgraded, MacUpgraded, ShardedContext, UpgradableContext},
         hybrid::{
             oprf::{compute_prf_for_inputs, BreakdownKey, CONV_CHUNK, PRF_CHUNK},
             step::HybridStep as Step,
@@ -67,6 +69,7 @@ where
         PrfSharing<MacUpgraded<C, Fp25519>, PRF_CHUNK, Field = Fp25519> + FromPrss,
     Replicated<RP25519, PRF_CHUNK>:
         Reveal<MacUpgraded<C, Fp25519>, Output = <RP25519 as Vectorizable<PRF_CHUNK>>::Array>,
+    PRFIndistinguishableHybridReport<BK, V>: Serializable,
 {
     if input_rows.is_empty() {
         return Ok(vec![Replicated::ZERO; B]);
@@ -83,7 +86,14 @@ where
     // TODO shuffle input rows
     let shuffled_input_rows = padded_input_rows;
 
-    let _prf_input_rows = compute_prf_for_inputs(ctx.clone(), &shuffled_input_rows).await?;
+    let prf_input_rows_stream = compute_prf_for_inputs(ctx.clone(), &shuffled_input_rows).await?;
+
+    let _sharded_prf_rows = reshard_iter(
+        ctx.narrow(&Step::ReshardByPrf),
+        prf_input_rows_stream,
+        |ctx, _, report| report.shard_picker(ctx.shard_count()),
+    )
+    .await?;
 
     unimplemented!("protocol::hybrid::hybrid_protocol is not fully implemented")
 }

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -12,4 +12,5 @@ pub(crate) enum HybridStep {
     PrfKeyGen,
     #[step(child = crate::protocol::context::step::MaliciousProtocolStep)]
     EvalPrf,
+    ReshardByPrf,
 }

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -90,6 +90,14 @@ impl TryFrom<usize> for ShardIndex {
     }
 }
 
+impl TryFrom<u64> for ShardIndex {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        u32::try_from(value).map(Self)
+    }
+}
+
 impl TryFrom<u128> for ShardIndex {
     type Error = TryFromIntError;
 


### PR DESCRIPTION
This is currently a draft, as it's stacked on top of #1413. For review, you'll want to make sure to just look at the commits after `4db9c544`.

This implements `Serializable` for `PRFIndistinguishableHybridReport<BA8, BA3>`. Offline @akoshelev and I discussed this, and instead of dealing with the complicated trait bounds to implement `Serializable` generically for and `BK, V`, we'd only implement it for the types we actually use. If at some point we decide to use this for a large set of replicated types for breakdown keys and values, we can look into other approaches to implement this more efficiently, like a macro.