### PR TITLE
Reshard Hybrid reports according to PRF values

### DIFF
--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{Debug, Display, Formatter},
     num::TryFromIntError,
-    ops::{Index, IndexMut},
+    ops::{Index, IndexMut, Rem},
     sync::Arc,
 };
 
@@ -103,6 +103,19 @@ impl TryFrom<u128> for ShardIndex {
 
     fn try_from(value: u128) -> Result<Self, Self::Error> {
         u32::try_from(value).map(Self)
+    }
+}
+
+/// It is common to compute the shard index based on some integer value modulo
+/// total shard count
+impl Rem<ShardIndex> for u64 {
+    type Output = ShardIndex;
+
+    fn rem(self, rhs: ShardIndex) -> Self::Output {
+        // mod u32 always fits in u32
+        // branching may hurt performance here, so a cast is preferred
+        #[allow(clippy::cast_possible_truncation)]
+        ShardIndex((self % u64::from(rhs.0)) as u32)
     }
 }
 


### PR DESCRIPTION
Doing it along with computing PRF values helps with latency as reports get out as soon as OPRF is computed and we don't need to wait until the end.

Note that this requires malicious security with abort to be implemented across shards - if one shard detects malicious behavior, all shards must abort

I also noticed that we use semi-honest execution which is wrong as we need malicious, but I couldn't fix it as part of this PR - there were trait bounds errors that require more attention