### PR TITLE
Implement protocol to create cross-shard coordinated randomness

### DIFF
--- a/ipa-core/src/helpers/buffers/unordered_receiver.rs
+++ b/ipa-core/src/helpers/buffers/unordered_receiver.rs
@@ -19,7 +19,7 @@ use crate::{
 
 #[derive(Debug, thiserror::Error)]
 #[error("Expected to receive {0:?} but hit end of stream")]
-pub struct EndOfStreamError(RecordId);
+pub struct EndOfStreamError(pub RecordId);
 
 #[derive(Debug, thiserror::Error)]
 #[error("Error deserializing {0:?} record: {1}")]

--- a/ipa-core/src/helpers/cross_shard_prss.rs
+++ b/ipa-core/src/helpers/cross_shard_prss.rs
@@ -1,0 +1,107 @@
+use futures::{stream::FuturesUnordered, TryStreamExt};
+
+use crate::{
+    helpers::{buffers::EndOfStreamError, ChannelId, Error, Gateway, TotalRecords},
+    protocol::{
+        prss::{Endpoint as PrssEndpoint, Seed, SeededEndpointSetup, SharedRandomness},
+        Gate, RecordId,
+    },
+    sharding::ShardConfiguration,
+};
+
+/// This routine sets up cross-shard coordinated randomness. Each
+/// shard has access to the same PRSS instance as all others on the same helper.
+/// The PRSS instance is seeded by the leader shard, and seed is distributed
+/// to other instances. As with regular PRSS, there are two random generators:
+/// one is shared with helper on the left and another one with the right helper.
+///
+/// ## Errors
+/// If shard communication channels fail
+#[allow(dead_code)] // until this is used in real sharded protocol
+async fn gen_and_distribute<R: SharedRandomness, C: ShardConfiguration>(
+    gateway: &Gateway,
+    gate: &Gate,
+    prss: R,
+    shard_config: C,
+) -> Result<PrssEndpoint, crate::error::Error> {
+    let endpoint = if shard_config.is_leader() {
+        // Generate seeds
+        let setup: SeededEndpointSetup = prss.generate(RecordId::FIRST);
+
+        // Distribute them across all shards
+        shard_config
+            .peer_shards()
+            .map(|shard| {
+                let channel = ChannelId::new(shard, gate.clone());
+                let sender = gateway.get_shard_sender(&channel, TotalRecords::ONE);
+                let (l_seed, r_seed) = (setup.left_seed().clone(), setup.right_seed().clone());
+                async move { sender.send(RecordId::FIRST, (l_seed, r_seed)).await }
+            })
+            .collect::<FuturesUnordered<_>>()
+            .try_collect::<()>()
+            .await?;
+
+        // finish the setup
+        setup.setup()
+    } else {
+        // Receive seeds from the leader.
+        let channel_id = ChannelId::new(shard_config.leader(), gate.clone());
+        let (l_seed, r_seed): (_, Seed) = gateway
+            .get_shard_receiver(&channel_id)
+            .try_next()
+            .await?
+            .ok_or_else(|| Error::EndOfStream {
+                channel_id,
+                inner: EndOfStreamError(RecordId::FIRST),
+            })?;
+
+        SeededEndpointSetup::from_seeds(l_seed, r_seed).setup()
+    };
+
+    Ok(endpoint)
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use crate::{
+        ff::boolean_array::BA64,
+        helpers::cross_shard_prss::gen_and_distribute,
+        protocol::{context::Context, prss::SharedRandomness, Gate, RecordId},
+        secret_sharing::{replicated::semi_honest::AdditiveShare, SharedValue},
+        sharding::ShardConfiguration,
+        test_executor::run,
+        test_fixture::{Reconstruct, Runner, TestWorld, TestWorldConfig, WithShards},
+    };
+
+    #[test]
+    fn shard_setup() {
+        run(|| async {
+            let world: TestWorld<WithShards<4>> =
+                TestWorld::with_shards(TestWorldConfig::default());
+            let values = world
+                .semi_honest(std::iter::empty::<BA64>(), |ctx, _| {
+                    let world = &world;
+                    async move {
+                        let gateway = world.gateway(ctx.role(), ctx.shard_id());
+                        let shard_prss =
+                            gen_and_distribute(gateway, &Gate::default(), ctx.prss(), ctx.clone())
+                                .await
+                                .unwrap();
+
+                        let share: AdditiveShare<BA64> = shard_prss
+                            .indexed(&Gate::default())
+                            .generate(RecordId::FIRST);
+                        share
+                    }
+                })
+                .await;
+
+            let mut v = BA64::ZERO; // assumes the number of shards is even
+            for shares in values {
+                v += shares.reconstruct();
+            }
+
+            assert_eq!(BA64::ZERO, v);
+        });
+    }
+}

--- a/ipa-core/src/helpers/mod.rs
+++ b/ipa-core/src/helpers/mod.rs
@@ -13,6 +13,7 @@ use std::{
 use generic_array::GenericArray;
 
 mod buffers;
+mod cross_shard_prss;
 mod error;
 mod futures;
 mod gateway;

--- a/ipa-core/src/protocol/prss/crypto.rs
+++ b/ipa-core/src/protocol/prss/crypto.rs
@@ -271,8 +271,8 @@ impl KeyExchange {
     pub fn key_exchange(self, pk: &PublicKey) -> GeneratorFactory {
         debug_assert_ne!(pk, &self.public_key(), "self key exchange detected");
         let secret = self.sk.diffie_hellman(pk);
-        let kdf = Hkdf::<Sha256>::new(None, secret.as_bytes());
-        GeneratorFactory { kdf }
+
+        GeneratorFactory::from_secret(secret.as_bytes())
     }
 }
 
@@ -283,6 +283,13 @@ pub struct GeneratorFactory {
 }
 
 impl GeneratorFactory {
+    /// Create a factory from provided secret. This is not public,
+    /// as it is only intended use is within the PRSS module.
+    pub(super) fn from_secret(secret: &[u8; 32]) -> Self {
+        let kdf = Hkdf::<Sha256>::new(None, secret);
+        GeneratorFactory { kdf }
+    }
+
     /// Create a new generator using the provided context string.
     #[allow(clippy::missing_panics_doc)] // Panic should be impossible.
     #[must_use]

--- a/ipa-core/src/protocol/prss/mod.rs
+++ b/ipa-core/src/protocol/prss/mod.rs
@@ -1,4 +1,6 @@
 mod crypto;
+mod seed;
+
 use std::{collections::HashMap, fmt::Debug, marker::PhantomData, ops::AddAssign};
 
 pub use crypto::{
@@ -7,6 +9,7 @@ pub use crypto::{
 };
 use generic_array::{sequence::GenericSequence, ArrayLength, GenericArray};
 pub(super) use internal::PrssIndex128;
+pub use seed::{Seed, SeededEndpointSetup};
 use x25519_dalek::PublicKey;
 
 use crate::{

--- a/ipa-core/src/protocol/prss/seed.rs
+++ b/ipa-core/src/protocol/prss/seed.rs
@@ -1,0 +1,184 @@
+use std::{collections::HashMap, convert::Infallible, sync::Mutex};
+
+use generic_array::GenericArray;
+use typenum::{Unsigned, U2, U32, U64};
+
+use crate::{
+    ff::Serializable,
+    protocol::prss::{
+        Endpoint, EndpointInner, FromPrss, FromRandom, GeneratorFactory, PrssIndex,
+        SharedRandomness,
+    },
+};
+
+/// Constructing a seed is only allowed through PRSS.
+/// Serialization/Deserialization mechanisms are provided
+/// to allow for setup of cross-shard PRSS.
+/// This type must never be sent across helper boundaries.
+#[derive(Clone, Debug)]
+pub struct Seed {
+    entropy: [u8; 32],
+}
+
+impl Serializable for Seed {
+    type Size = U32;
+    type DeserializationError = Infallible;
+
+    fn serialize(&self, buf: &mut GenericArray<u8, Self::Size>) {
+        buf.copy_from_slice(&self.entropy);
+    }
+
+    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Result<Self, Self::DeserializationError> {
+        Ok(Self {
+            entropy: (*buf).into(),
+        })
+    }
+}
+
+impl Serializable for (Seed, Seed) {
+    type Size = U64;
+    type DeserializationError = Infallible;
+
+    fn serialize(&self, buf: &mut GenericArray<u8, Self::Size>) {
+        let (left, right) = buf.split_at_mut(<Seed as Serializable>::Size::USIZE);
+        self.0.serialize(GenericArray::from_mut_slice(left));
+        self.1.serialize(GenericArray::from_mut_slice(right));
+    }
+
+    fn deserialize(buf: &GenericArray<u8, Self::Size>) -> Result<Self, Self::DeserializationError> {
+        let left = Seed::deserialize(GenericArray::from_slice(
+            &buf[..<Seed as Serializable>::Size::USIZE],
+        ))?;
+        let right = Seed::deserialize(GenericArray::from_slice(
+            &buf[<Seed as Serializable>::Size::USIZE..],
+        ))?;
+
+        Ok((left, right))
+    }
+}
+
+impl FromRandom for Seed {
+    type SourceLength = U2;
+
+    fn from_random(src: GenericArray<u128, Self::SourceLength>) -> Self {
+        let low = src[0];
+        let high = src[1];
+        let mut entropy = [0u8; 32];
+        entropy[..16].copy_from_slice(&low.to_le_bytes());
+        entropy[16..].copy_from_slice(&high.to_le_bytes());
+
+        Seed { entropy }
+    }
+}
+
+impl From<Seed> for GeneratorFactory {
+    fn from(value: Seed) -> Self {
+        Self::from_secret(&value.entropy)
+    }
+}
+
+/// This allows setting up cross-shard coordinated randomness, by sampling
+/// a shared seed from PRSS and later distributing it across all shards.
+pub struct SeededEndpointSetup {
+    left: Seed,
+    right: Seed,
+}
+
+impl FromPrss for SeededEndpointSetup {
+    fn from_prss_with<P: SharedRandomness + ?Sized, I: Into<PrssIndex>>(
+        prss: &P,
+        index: I,
+        _params: (),
+    ) -> Self {
+        let (l, r): (Seed, _) = prss.generate(index.into());
+
+        Self { left: l, right: r }
+    }
+}
+
+impl SeededEndpointSetup {
+    /// Prepare this setup from pregenerated seeds.
+    #[must_use]
+    pub fn from_seeds(left: Seed, right: Seed) -> Self {
+        Self { left, right }
+    }
+
+    #[must_use]
+    pub fn left_seed(&self) -> &Seed {
+        &self.left
+    }
+
+    #[must_use]
+    pub fn right_seed(&self) -> &Seed {
+        &self.right
+    }
+
+    /// Finish the setup and generate a working [`Endpoint`]
+    #[must_use]
+    pub fn setup(self) -> Endpoint {
+        let fl = GeneratorFactory::from(self.left);
+        let fr = GeneratorFactory::from(self.right);
+
+        Endpoint {
+            inner: Mutex::new(EndpointInner {
+                left: fl,
+                right: fr,
+                items: HashMap::new(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{rngs::StdRng, thread_rng};
+    use rand_core::{CryptoRngCore, SeedableRng};
+
+    use crate::{
+        protocol::{
+            prss::{Endpoint, SeededEndpointSetup, SharedRandomness},
+            Gate, RecordId,
+        },
+        test_fixture::make_participants,
+        utils::array::zip3,
+    };
+
+    fn setup_new<R: CryptoRngCore>(mut rng: R) -> [SeededEndpointSetup; 3] {
+        let participants = make_participants(&mut rng);
+
+        participants
+            .each_ref()
+            .map(|p| p.indexed(&Gate::default()).generate(RecordId::FIRST))
+    }
+
+    fn random_value(endpoint: &Endpoint) -> (u128, u128) {
+        endpoint.indexed(&Gate::default()).generate(RecordId::FIRST)
+    }
+
+    #[test]
+    fn setup() {
+        let r1 = setup_new(&mut thread_rng());
+
+        assert_eq!(r1[0].right.entropy, r1[1].left.entropy);
+        assert_eq!(r1[1].right.entropy, r1[2].left.entropy);
+        assert_eq!(r1[2].right.entropy, r1[0].left.entropy);
+
+        // also make sure seeds are unique
+        let r2 = setup_new(&mut thread_rng());
+
+        zip3(r1, r2).map(|(r1, r2)| {
+            assert_ne!(r1.right.entropy, r2.right.entropy);
+            assert_ne!(r1.left.entropy, r2.left.entropy);
+        });
+    }
+
+    #[test]
+    fn same_seed_same_randomness() {
+        let r1 = setup_new(&mut StdRng::seed_from_u64(42)).map(SeededEndpointSetup::setup);
+        let r2 = setup_new(&mut StdRng::seed_from_u64(42)).map(SeededEndpointSetup::setup);
+
+        assert_eq!(random_value(&r1[0]), random_value(&r2[0]));
+        assert_eq!(random_value(&r1[1]), random_value(&r2[1]));
+        assert_eq!(random_value(&r1[2]), random_value(&r2[2]));
+    }
+}

--- a/ipa-core/src/protocol/prss/seed.rs
+++ b/ipa-core/src/protocol/prss/seed.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::Infallible, sync::Mutex};
+use std::{collections::HashMap, convert::Infallible};
 
 use generic_array::GenericArray;
 use typenum::{Unsigned, U2, U32, U64};
@@ -9,6 +9,7 @@ use crate::{
         Endpoint, EndpointInner, FromPrss, FromRandom, GeneratorFactory, PrssIndex,
         SharedRandomness,
     },
+    sync::Mutex,
 };
 
 /// Constructing a seed is only allowed through PRSS.
@@ -129,7 +130,7 @@ impl SeededEndpointSetup {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 mod tests {
     use rand::{rngs::StdRng, thread_rng};
     use rand_core::{CryptoRngCore, SeedableRng};

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -179,6 +179,16 @@ pub trait ShardConfiguration {
 
         max.iter().filter(move |&v| v != this)
     }
+
+    /// Returns `true` if this shard is considered leader.
+    fn is_leader(&self) -> bool {
+        self.shard_id() == ShardIndex::FIRST
+    }
+
+    /// Returns the index of leader shard.
+    fn leader(&self) -> ShardIndex {
+        ShardIndex::FIRST
+    }
 }
 
 pub trait ShardBinding: Debug + Send + Sync + Clone + 'static {

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -207,6 +207,15 @@ impl<const SHARDS: usize, D: Distribute> TestWorld<WithShards<SHARDS, D>> {
             .unwrap()
     }
 
+    /// Returns a reference to the gateway for the specific shard on
+    /// the given helper.
+    /// # Panics
+    /// If there are fewer shards than the shard index provided
+    #[must_use]
+    pub fn gateway(&self, role: Role, shard_index: ShardIndex) -> &Gateway {
+        &self.shards[usize::from(shard_index)].gateways[role]
+    }
+
     /// Creates protocol contexts for 3 helpers across all shards
     ///
     /// # Panics


### PR DESCRIPTION
This protocol will generate random seeds using PRSS and then distribute those seeds to all shards. Every shard will initialize cross-shard PRSS from those seeds. Follows up on #1410.