### PR TITLE
upgrade hybrid tests to use malicious context

### DIFF
--- a/ipa-core/src/protocol/basics/mod.rs
+++ b/ipa-core/src/protocol/basics/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     protocol::{
         context::{
             Context, DZKPUpgradedMaliciousContext, DZKPUpgradedSemiHonestContext,
-            UpgradedMaliciousContext, UpgradedSemiHonestContext,
+            ShardedUpgradedMaliciousContext, UpgradedMaliciousContext, UpgradedSemiHonestContext,
         },
         ipa_prf::{AGG_CHUNK, PRF_CHUNK},
         prss::FromPrss,
@@ -59,6 +59,14 @@ impl<'a, B: ShardBinding>
 }
 
 impl<'a, const N: usize> BasicProtocols<UpgradedMaliciousContext<'a, Fp25519>, Fp25519, N>
+    for malicious::AdditiveShare<Fp25519, N>
+where
+    Fp25519: FieldSimd<N>,
+    AdditiveShare<Fp25519, N>: FromPrss,
+{
+}
+
+impl<'a, const N: usize> BasicProtocols<ShardedUpgradedMaliciousContext<'a, Fp25519>, Fp25519, N>
     for malicious::AdditiveShare<Fp25519, N>
 where
     Fp25519: FieldSimd<N>,

--- a/ipa-core/src/protocol/context/mod.rs
+++ b/ipa-core/src/protocol/context/mod.rs
@@ -28,6 +28,7 @@ pub type ShardedSemiHonestContext<'a> = semi_honest::Context<'a, Sharded>;
 pub type MaliciousContext<'a, B = NotSharded> = malicious::Context<'a, B>;
 pub type ShardedMaliciousContext<'a> = malicious::Context<'a, Sharded>;
 pub type UpgradedMaliciousContext<'a, F, B = NotSharded> = malicious::Upgraded<'a, F, B>;
+pub type ShardedUpgradedMaliciousContext<'a, F, B = Sharded> = malicious::Upgraded<'a, F, B>;
 
 #[cfg(all(feature = "in-memory-infra", any(test, feature = "test-fixture")))]
 pub(crate) use malicious::TEST_DZKP_STEPS;

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -21,7 +21,8 @@ use crate::{
         context::{
             dzkp_validator::{DZKPValidator, TARGET_PROOF_SIZE},
             reshard_try_stream, DZKPUpgraded, MacUpgraded, MaliciousProtocolSteps, ShardedContext,
-            UpgradableContext, Validator,
+            ShardedUpgradedMaliciousContext, UpgradableContext, UpgradedMaliciousContext,
+            Validator,
         },
         hybrid::step::HybridStep,
         ipa_prf::{
@@ -29,12 +30,12 @@ use crate::{
             prf_eval::{eval_dy_prf, PrfSharing},
         },
         prss::{FromPrss, SharedRandomness},
-        RecordId,
+        BasicProtocols, RecordId,
     },
     report::hybrid::{IndistinguishableHybridReport, PrfHybridReport},
     secret_sharing::{
-        replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
-        Vectorizable,
+        replicated::{malicious, semi_honest::AdditiveShare as Replicated},
+        BitDecomposed, FieldSimd, TransposeFrom, Vectorizable,
     },
     seq_join::seq_join,
     utils::non_zero_prev_power_of_two,
@@ -79,6 +80,20 @@ pub const PRF_CHUNK: usize = 16;
 /// of zero when `TARGET_PROOF_SIZE` is smaller for tests.
 fn conv_proof_chunk() -> usize {
     non_zero_prev_power_of_two(max(2, TARGET_PROOF_SIZE / CONV_CHUNK / 512))
+}
+
+/// Allow MAC-malicious shares to be used for PRF generation with shards
+impl<'a, const N: usize> PrfSharing<ShardedUpgradedMaliciousContext<'a, Fp25519>, N>
+    for Replicated<Fp25519, N>
+where
+    Fp25519: FieldSimd<N>,
+    RP25519: Vectorizable<N>,
+    malicious::AdditiveShare<Fp25519, N>:
+        BasicProtocols<UpgradedMaliciousContext<'a, Fp25519>, Fp25519, N>,
+    Replicated<Fp25519, N>: FromPrss,
+{
+    type Field = Fp25519;
+    type UpgradedSharing = malicious::AdditiveShare<Fp25519, N>;
 }
 
 /// This computes the Dodis-Yampolsky PRF value on every match key from input,
@@ -235,7 +250,7 @@ mod test {
 
             // TODO: we need to use malicious circuits here
             let reports_per_shard = world
-                .semi_honest(records.clone().into_iter(), |ctx, reports| async move {
+                .malicious(records.clone().into_iter(), |ctx, reports| async move {
                     let ind_reports = reports
                         .into_iter()
                         .map(IndistinguishableHybridReport::from)

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -248,7 +248,6 @@ mod test {
                 },
             ];
 
-            // TODO: we need to use malicious circuits here
             let reports_per_shard = world
                 .malicious(records.clone().into_iter(), |ctx, reports| async move {
                     let ind_reports = reports

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -276,7 +276,7 @@ mod tests {
     #[should_panic(
         expected = "not implemented: protocol::hybrid::hybrid_protocol is not fully implemented"
     )]
-    fn encrypted_hybrid_reports() {
+    fn encrypted_hybrid_reports_happy() {
         // While this test currently checks for an unimplemented panic it is
         // designed to test for a correct result for a complete implementation.
         run(|| async {
@@ -293,7 +293,7 @@ mod tests {
             } = build_buffers_from_records(&records, SHARDS, &hybrid_info);
 
             let world = TestWorld::<WithShards<SHARDS>>::with_shards(TestWorldConfig::default());
-            let contexts = world.contexts();
+            let contexts = world.malicious_contexts();
 
             #[allow(clippy::large_futures)]
             let results = flatten3v(buffers.into_iter().zip(contexts).map(
@@ -384,7 +384,7 @@ mod tests {
 
         let world: TestWorld<WithShards<SHARDS, RoundRobinInputDistribution>> =
             TestWorld::with_shards(TestWorldConfig::default());
-        let contexts = world.contexts();
+        let contexts = world.malicious_contexts();
 
         #[allow(clippy::large_futures)]
         let results = flatten3v(buffers.into_iter().zip(contexts).map(
@@ -437,7 +437,7 @@ mod tests {
 
         let world: TestWorld<WithShards<SHARDS, RoundRobinInputDistribution>> =
             TestWorld::with_shards(TestWorldConfig::default());
-        let contexts = world.contexts();
+        let contexts = world.malicious_contexts();
 
         #[allow(clippy::large_futures)]
         let results = flatten3v(buffers.into_iter().zip(contexts).map(

--- a/ipa-core/src/query/runner/reshard_tag.rs
+++ b/ipa-core/src/query/runner/reshard_tag.rs
@@ -100,7 +100,7 @@ mod tests {
             let world: TestWorld<WithShards<2>> =
                 TestWorld::with_shards(TestWorldConfig::default());
             world
-                .semi_honest(
+                .malicious(
                     vec![BA8::truncate_from(1u128), BA8::truncate_from(2u128)].into_iter(),
                     |ctx, input| async move {
                         let shard_id = ctx.shard_id();
@@ -130,7 +130,7 @@ mod tests {
             let world: TestWorld<WithShards<2>> =
                 TestWorld::with_shards(TestWorldConfig::default());
             world
-                .semi_honest(
+                .malicious(
                     vec![BA8::truncate_from(1u128), BA8::truncate_from(2u128)].into_iter(),
                     |ctx, input| async move {
                         reshard_aad(

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -240,9 +240,10 @@ impl<const SHARDS: usize, D: Distribute> TestWorld<WithShards<SHARDS, D>> {
     /// Panics if world has more or less than 3 gateways/participants
     #[must_use]
     pub fn malicious_contexts(&self) -> [Vec<ShardedMaliciousContext<'_>>; 3] {
+        let gate = &self.next_gate();
         self.shards()
             .iter()
-            .map(|shard| shard.malicious_contexts(&self.next_gate()))
+            .map(|shard| shard.malicious_contexts(gate))
             .fold([Vec::new(), Vec::new(), Vec::new()], |mut acc, contexts| {
                 // Distribute contexts into the respective vectors.
                 for (vec, context) in acc.iter_mut().zip(contexts.iter()) {


### PR DESCRIPTION
This upgrades our tests to use malicious context, and implements a couple necessary traits.

~Unfortunately, two tests are stalling (at least when run locally) after this change. I'm not sure what about this change would cause a stall, especially since it's not all the tests. @akoshelev could you take a look?~

~Stalling tests:~


