### PR TITLE
compiling version of aggregate_reports

### DIFF
--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use futures::{stream, FutureExt, StreamExt, TryStreamExt};
+use futures::{stream, StreamExt, TryStreamExt};
 
 use crate::{
     error::Error,
@@ -9,7 +9,7 @@ use crate::{
     protocol::{
         boolean::step::EightBitStep,
         context::{
-            dzkp_validator::{DZKPValidator, TARGET_PROOF_SIZE},
+            dzkp_validator::{validated_seq_join, DZKPValidator, TARGET_PROOF_SIZE},
             Context, DZKPUpgraded, MaliciousProtocolSteps, ShardedContext, UpgradableContext,
         },
         hybrid::step::{AggregateReportsStep, HybridStep},
@@ -132,11 +132,8 @@ where
             }
         });
 
-    dzkp_validator
-        .validated_seq_join(agg_work)
+    validated_seq_join(dzkp_validator, agg_work)
         .try_collect()
-        // "Implementation of Send is not general enough" famous issue
-        .boxed()
         .await
 }
 

--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -1,0 +1,217 @@
+use std::collections::HashMap;
+
+use crate::{
+    error::Error,
+    ff::{boolean::Boolean, boolean_array::BooleanArray, ArrayAccess},
+    helpers::TotalRecords,
+    protocol::{
+        boolean::step::{EightBitStep, ThirtyTwoBitStep},
+        context::{
+            dzkp_validator::{DZKPValidator, TARGET_PROOF_SIZE},
+            Context, DZKPUpgraded, MaliciousProtocolSteps, UpgradableContext,
+        },
+        hybrid::step::HybridStep,
+        ipa_prf::boolean_ops::addition_sequential::integer_add,
+        BooleanProtocols, RecordId,
+    },
+    report::hybrid::{AggregateableHybridReport, PrfHybridReport},
+    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SharedValue},
+};
+
+pub async fn aggregate_reports<BK, V, C>(
+    ctx: C,
+    reports: Vec<PrfHybridReport<BK, V>>,
+) -> Result<Vec<AggregateableHybridReport<BK, V>>, Error>
+where
+    C: UpgradableContext,
+    BK: SharedValue + BooleanArray,
+    V: SharedValue + BooleanArray,
+    Replicated<Boolean>: BooleanProtocols<DZKPUpgraded<C>>,
+{
+    let mut reports_by_matchkey = HashMap::new();
+    reports_by_matchkey.reserve(reports.len() / 2);
+
+    for report in reports {
+        reports_by_matchkey
+            .entry(report.match_key)
+            .or_insert_with(Vec::new)
+            .push(report);
+    }
+
+    // an honest client and report collector will only submit
+    // one report with a breakdown key and one report with a value.
+    // if there are less, it's unattributed. if more, something went wrong.
+    // we remove these (instead of erroring/panicing).
+    let report_pairs: Vec<[AggregateableHybridReport<BK, V>; 2]> = reports_by_matchkey
+        .into_iter()
+        .filter_map(|(_, value)| {
+            if value.len() == 2 {
+                Some([value[0].clone().into(), value[1].clone().into()])
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut agg_reports = Vec::new();
+
+    let chunk_size = TARGET_PROOF_SIZE;
+
+    let dzkp_validator = ctx.clone().dzkp_validator(
+        MaliciousProtocolSteps {
+            protocol: &HybridStep::GroupBySum,
+            validate: &HybridStep::GroupBySumValidate,
+        },
+        std::cmp::min(ctx.active_work().get(), chunk_size.next_power_of_two()),
+    );
+
+    let ctx = dzkp_validator
+        .context()
+        .set_total_records(TotalRecords::specified(2 * report_pairs.len())?);
+
+    for (i, reports) in report_pairs.into_iter().enumerate() {
+        let record_id_bk = RecordId::FIRST + 2 * i;
+        let record_id_v = RecordId::FIRST + 2 * i + 1;
+        let (breakdown_key, _) = integer_add::<_, EightBitStep, 1>(
+            ctx.clone(),
+            record_id_bk,
+            &reports[0].breakdown_key.to_bits(),
+            &reports[1].breakdown_key.to_bits(),
+        )
+        .await?;
+        let (value, _) = integer_add::<_, ThirtyTwoBitStep, 1>(
+            ctx.clone(),
+            record_id_v,
+            &reports[0].value.to_bits(),
+            &reports[1].value.to_bits(),
+        )
+        .await?;
+
+        agg_reports.push(AggregateableHybridReport::<BK, V> {
+            match_key: (),
+            breakdown_key: breakdown_key.collect_bits(),
+            value: value.collect_bits(),
+        });
+    }
+
+    Ok(agg_reports)
+}
+
+#[cfg(all(test, unit_test, feature = "in-memory-infra"))]
+pub mod test {
+    use super::aggregate_reports;
+    use crate::{
+        ff::boolean_array::{BA3, BA8},
+        report::hybrid::{
+            AggregateableHybridReport, IndistinguishableHybridReport, PrfHybridReport,
+        },
+        test_executor::run,
+        test_fixture::{hybrid::TestHybridRecord, Runner, TestWorld, TestWorldConfig, WithShards},
+    };
+
+    #[test]
+    fn aggregate_reports_test() {
+        run(|| async {
+            let records = vec![
+                TestHybridRecord::TestImpression {
+                    match_key: 12345,
+                    breakdown_key: 2,
+                },
+                TestHybridRecord::TestImpression {
+                    match_key: 23456,
+                    breakdown_key: 4,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 23456,
+                    value: 1,
+                }, // attributed
+                TestHybridRecord::TestImpression {
+                    match_key: 34567,
+                    breakdown_key: 1,
+                },
+                TestHybridRecord::TestImpression {
+                    match_key: 45678,
+                    breakdown_key: 3,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 45678,
+                    value: 2,
+                }, // attributed
+                TestHybridRecord::TestImpression {
+                    match_key: 56789,
+                    breakdown_key: 5,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 67890,
+                    value: 3,
+                }, // NOT attributed
+                TestHybridRecord::TestImpression {
+                    match_key: 78901,
+                    breakdown_key: 2,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 78901,
+                    value: 4,
+                }, // attributed twice
+                TestHybridRecord::TestConversion {
+                    match_key: 78901,
+                    value: 5,
+                }, // attributed twice
+                TestHybridRecord::TestImpression {
+                    match_key: 89012,
+                    breakdown_key: 4,
+                },
+                TestHybridRecord::TestConversion {
+                    match_key: 89012,
+                    value: 6,
+                }, // attributed
+                TestHybridRecord::TestConversion {
+                    match_key: 90123,
+                    value: 7,
+                }, // NOT attributed
+            ];
+
+            // at this point, all unattributed values end up in index 0
+            // we will zero them out later.
+            // let expected = vec![
+            //     22, 0, 43, // 14 + 8, 12 + 31
+            //     13, 33, // 25 + 8
+            //     0,
+            // ];
+
+            let world = TestWorld::<WithShards<2>>::with_shards(TestWorldConfig::default());
+
+            let results: Vec<[Vec<AggregateableHybridReport<BA8, BA3>>; 3]> = world
+                .malicious(records.clone().into_iter(), |ctx, input| {
+                    let og_records = records.clone();
+                    async move {
+                        let indistinguishable_reports: Vec<
+                            IndistinguishableHybridReport<BA8, BA3>,
+                        > = input.iter().map(|r| r.clone().into()).collect::<Vec<_>>();
+
+                        let prf_reports: Vec<PrfHybridReport<BA8, BA3>> = indistinguishable_reports
+                            .iter()
+                            .zip(og_records.iter())
+                            .map(|(indist_report, test_report)| {
+                                let match_key = match test_report {
+                                    TestHybridRecord::TestConversion { match_key, .. } => match_key,
+                                    TestHybridRecord::TestImpression { match_key, .. } => match_key,
+                                };
+                                PrfHybridReport {
+                                    match_key: *match_key,
+                                    value: indist_report.value.clone(),
+                                    breakdown_key: indist_report.breakdown_key.clone(),
+                                }
+                            })
+                            .collect::<Vec<_>>();
+
+                        aggregate_reports(ctx.clone(), prf_reports).await.unwrap()
+                    }
+                })
+                .await;
+
+            println!("{:?}", results);
+            panic!();
+        })
+    }
+}

--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -65,9 +65,13 @@ where
 /// This would put the sum of conversion values into `breakdown_key` 0. As this is undetectable,
 /// this makes `breakdown_key = 0` *unreliable*.
 ///
+/// Note: Possible Perf opportunity by removing the `collect()`.
+/// See [#1443](https://github.com/private-attribution/ipa/issues/1443).
+///
 /// *Note*: In order to add the pairs, the vector of pairs must be in the same order across all
 /// three helpers. A standard `HashMap` uses system randomness for insertion placement, so we
 /// use a `BTreeMap` to maintain consistent ordering across the helpers.
+///
 fn group_report_pairs_ordered<BK, V>(
     reports: Vec<PrfHybridReport<BK, V>>,
 ) -> Vec<[AggregateableHybridReport<BK, V>; 2]>

--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -94,6 +94,8 @@ where
 /// This protocol is used to aggregate `PRFHybridReports` and returns `AggregateableHybridReports`.
 /// It groups all the reports by the PRF of the `match_key`, finds all reports from `match_keys`
 /// with that provided exactly 2 reports, then adds those 2 reports.
+/// TODO (Performance opportunity): These additions are not currently vectorized.
+/// We are currently deferring that work until the protocol is complete.
 pub async fn aggregate_reports<BK, V, C>(
     ctx: C,
     reports: Vec<PrfHybridReport<BK, V>>,

--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -10,8 +10,7 @@ use crate::{
         boolean::step::EightBitStep,
         context::{
             dzkp_validator::{DZKPValidator, TARGET_PROOF_SIZE},
-            Context, DZKPContext, DZKPUpgraded, MaliciousProtocolSteps, ShardedContext,
-            UpgradableContext,
+            Context, DZKPUpgraded, MaliciousProtocolSteps, ShardedContext, UpgradableContext,
         },
         hybrid::step::{AggregateReportsStep, HybridStep},
         ipa_prf::boolean_ops::addition_sequential::integer_add,
@@ -19,7 +18,6 @@ use crate::{
     },
     report::hybrid::{AggregateableHybridReport, PrfHybridReport},
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, SharedValue},
-    seq_join::{assert_send, seq_join, SeqJoin},
 };
 
 /// This protocol is used to aggregate `PRFHybridReports` and returns `AggregateableHybridReports`.
@@ -71,7 +69,8 @@ where
         .filter_map(|(_, v)| if v.1 == 2 { Some(v.0) } else { None })
         .collect::<Vec<_>>();
 
-    let chunk_size = TARGET_PROOF_SIZE;
+    let chunk_size: usize = TARGET_PROOF_SIZE / (BK::BITS as usize + V::BITS as usize);
+
     let ctx = ctx.set_total_records(TotalRecords::specified(report_pairs.len())?);
 
     let dzkp_validator = ctx.dzkp_validator(
@@ -79,7 +78,7 @@ where
             protocol: &HybridStep::GroupBySum,
             validate: &HybridStep::GroupBySumValidate,
         },
-        usize::MAX,
+        chunk_size.next_power_of_two(),
     );
 
     let agg_ctx = dzkp_validator.context();

--- a/ipa-core/src/protocol/hybrid/mod.rs
+++ b/ipa-core/src/protocol/hybrid/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod agg;
 pub(crate) mod oprf;
 pub(crate) mod step;
 
@@ -9,9 +10,10 @@ use crate::{
     },
     helpers::query::DpMechanism,
     protocol::{
-        basics::{BooleanProtocols, Reveal},
+        basics::Reveal,
         context::{DZKPUpgraded, MacUpgraded, ShardedContext, UpgradableContext},
         hybrid::{
+            agg::aggregate_reports,
             oprf::{compute_prf_and_reshard, BreakdownKey, CONV_CHUNK, PRF_CHUNK},
             step::HybridStep as Step,
         },
@@ -21,6 +23,7 @@ use crate::{
             shuffle::Shuffle,
         },
         prss::FromPrss,
+        BooleanProtocols,
     },
     report::hybrid::{IndistinguishableHybridReport, PrfHybridReport},
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Vectorizable},
@@ -68,6 +71,7 @@ where
     Replicated<RP25519, PRF_CHUNK>:
         Reveal<MacUpgraded<C, Fp25519>, Output = <RP25519 as Vectorizable<PRF_CHUNK>>::Array>,
     PrfHybridReport<BK, V>: Serializable,
+    Replicated<Boolean>: BooleanProtocols<DZKPUpgraded<C>>,
 {
     if input_rows.is_empty() {
         return Ok(vec![Replicated::ZERO; B]);
@@ -84,7 +88,9 @@ where
     // TODO shuffle input rows
     let shuffled_input_rows = padded_input_rows;
 
-    let _sharded_reports = compute_prf_and_reshard(ctx.clone(), shuffled_input_rows).await?;
+    let sharded_reports = compute_prf_and_reshard(ctx.clone(), shuffled_input_rows).await?;
+
+    let _aggregated_reports = aggregate_reports::<BK, V, C>(ctx.clone(), sharded_reports);
 
     unimplemented!("protocol::hybrid::hybrid_protocol is not fully implemented")
 }

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -17,3 +17,9 @@ pub(crate) enum HybridStep {
     #[step(child = crate::protocol::context::step::DzkpValidationProtocolStep)]
     GroupBySumValidate,
 }
+
+#[derive(CompactStep)]
+pub(crate) enum AggregateReportsStep {
+    #[step(child = crate::protocol::boolean::step::EightBitStep)]
+    Add,
+}

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -13,6 +13,7 @@ pub(crate) enum HybridStep {
     #[step(child = crate::protocol::context::step::MaliciousProtocolStep)]
     EvalPrf,
     ReshardByPrf,
+    #[step(child = AggregateReportsStep)]
     GroupBySum,
     #[step(child = crate::protocol::context::step::DzkpValidationProtocolStep)]
     GroupBySumValidate,

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -13,4 +13,7 @@ pub(crate) enum HybridStep {
     #[step(child = crate::protocol::context::step::MaliciousProtocolStep)]
     EvalPrf,
     ReshardByPrf,
+    GroupBySum,
+    #[step(child = crate::protocol::context::step::DzkpValidationProtocolStep)]
+    GroupBySumValidate,
 }

--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -21,5 +21,7 @@ pub(crate) enum HybridStep {
 #[derive(CompactStep)]
 pub(crate) enum AggregateReportsStep {
     #[step(child = crate::protocol::boolean::step::EightBitStep)]
-    Add,
+    AddBK,
+    #[step(child = crate::protocol::boolean::step::EightBitStep)]
+    AddV,
 }

--- a/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/oprf_padding/mod.rs
@@ -194,7 +194,8 @@ where
         total_number_of_fake_rows: u32,
     ) {
         padding_input_rows.extend(
-            repeat(IndistinguishableHybridReport::ZERO).take(total_number_of_fake_rows as usize),
+            repeat(IndistinguishableHybridReport::<BK, V>::ZERO)
+                .take(total_number_of_fake_rows as usize),
         );
     }
 }

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -72,6 +72,7 @@ where
         PrfSharing<MacUpgraded<C, Fp25519>, PRF_CHUNK, Field = Fp25519> + FromPrss,
     Replicated<RP25519, PRF_CHUNK>:
         Reveal<MacUpgraded<C, Fp25519>, Output = <RP25519 as Vectorizable<PRF_CHUNK>>::Array>,
+    Replicated<Boolean>: BooleanProtocols<DZKPUpgraded<C>>,
 {
     #[tracing::instrument("hybrid_query", skip_all, fields(sz=%query_size))]
     pub async fn execute(

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -680,6 +680,18 @@ pub type PrfHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, u64>;
 /// that OPRF value is no longer required.
 pub type AggregateableHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, ()>;
 
+impl<BK, V> AggregateableHybridReport<BK, V>
+where
+    BK: SharedValue,
+    V: SharedValue,
+{
+    pub const ZERO: Self = Self {
+        match_key: (),
+        value: Replicated::<V>::ZERO,
+        breakdown_key: Replicated::<BK>::ZERO,
+    };
+}
+
 /// When aggregating reports, we need to lift the value from `V` to `HV`.
 impl<BK, V, HV> From<PrfHybridReport<BK, V>> for AggregateableHybridReport<BK, HV>
 where

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -680,18 +680,6 @@ pub type PrfHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, u64>;
 /// that OPRF value is no longer required.
 pub type AggregateableHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, ()>;
 
-impl<BK, V> AggregateableHybridReport<BK, V>
-where
-    BK: SharedValue,
-    V: SharedValue,
-{
-    pub const ZERO: Self = Self {
-        match_key: (),
-        value: Replicated::<V>::ZERO,
-        breakdown_key: Replicated::<BK>::ZERO,
-    };
-}
-
 /// When aggregating reports, we need to lift the value from `V` to `HV`.
 impl<BK, V, HV> From<PrfHybridReport<BK, V>> for AggregateableHybridReport<BK, HV>
 where

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -48,7 +48,7 @@ use crate::{
         open_in_place, seal_in_place, CryptError, EncapsulationSize, PrivateKeyRegistry,
         PublicKeyRegistry, TagSize,
     },
-    protocol::ipa_prf::{shuffle::Shuffleable, boolean_ops::expand_shared_array_in_place},
+    protocol::ipa_prf::{boolean_ops::expand_shared_array_in_place, shuffle::Shuffleable},
     report::hybrid_info::{HybridConversionInfo, HybridImpressionInfo, HybridInfo},
     secret_sharing::{
         replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},


### PR DESCRIPTION
This is a draft of implementing `aggregate_reports`, which adds the expected two shares from each match key (dropping any matchkeys without exactly 2 reports.)

The test is incomplete, and it stalls. Presumably this has to do with the malicious validation. Any feedback or pointers to other code that does something similar would be helpful. I was looking at [this implementation](https://github.com/private-attribution/ipa/blob/main/ipa-core/src/protocol/ipa_prf/prf_sharding/mod.rs#L501-L548), and admittedly some of the comments there suggest there may be a better way to do this.

Additionally, this doesn't yet utilize vectorization. (cc @andyleiserson). Any feedback or pointers in that direction would also be greatly appreciated.