### PR TITLE
Add eval_first to LagrangeTable

### DIFF
--- a/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
@@ -106,6 +106,12 @@ where
             .map(|row| dot_product(row, y_coordinates))
     }
 
+    /// Evaluates only the first row of the `LagrangeTable`
+    pub fn eval_first(&self, y_coordinates: &[F; N]) -> F {
+        // Unwrap is safe because the table is not empty
+        dot_product(self.table.first().unwrap(), y_coordinates)
+    }
+
     /// helper function to compute a single row of `LagrangeTable`
     ///
     /// ## Panics

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -171,9 +171,9 @@ impl<F: PrimeField, const L: usize, const P: usize, const M: usize> ProofGenerat
                 let (u_chunk, v_chunk) = polynomial.borrow();
                 (
                     // new u value
-                    lagrange_table_r.eval(u_chunk)[0],
+                    lagrange_table_r.eval_first(u_chunk),
                     // new v value
-                    lagrange_table_r.eval(v_chunk)[0],
+                    lagrange_table_r.eval_first(v_chunk),
                 )
             })
             .collect::<UVValues<F, N>>()

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -82,7 +82,7 @@ pub fn interpolate_at_r<F: PrimeField, const P: usize>(
     lagrange_denominator: &CanonicalLagrangeDenominator<F, P>,
 ) -> F {
     let lagrange_table_g = LagrangeTable::<F, P, 1>::new(lagrange_denominator, r);
-    lagrange_table_g.eval(zkp)[0]
+    lagrange_table_g.eval_first(zkp)
 }
 
 /// This function computes the sum of the first L elements of the zero-knowledge proof
@@ -105,7 +105,7 @@ where
 {
     u_or_v
         .chunk_array::<L>()
-        .map(|x| lagrange_table.eval(&x)[0])
+        .map(|x| lagrange_table.eval_first(&x))
 }
 
 /// This function recursively compresses the `u_or_v` values.
@@ -159,7 +159,7 @@ where
     last_array[1..last_u_or_v_values.len()].copy_from_slice(&last_u_or_v_values[1..]);
 
     // compute and output p_or_q
-    tables.last().unwrap().eval(&last_array)[0]
+    tables.last().unwrap().eval_first(&last_array)
 }
 
 #[cfg(all(test, unit_test))]


### PR DESCRIPTION
I noticed an instance where we were calculating a bunch of dot products but only needed the first ones so I just added an easy function to address that. Hopefully saves a few cycles.

Before: https://draft-mpc.vercel.app/query/view/finer-couch2024-11-13T2343
After: https://draft-mpc.vercel.app/query/view/weary-rough2024-11-13T2313