### PR TITLE
Use lookup tables for first proof Lagrange output

### DIFF
--- a/ipa-core/benches/dzkp_convert_prover.rs
+++ b/ipa-core/benches/dzkp_convert_prover.rs
@@ -1,41 +1,15 @@
 //! Benchmark for the convert_prover function in dzkp_field.rs.
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use ipa_core::{
-    ff::Fp61BitPrime,
-    protocol::context::{dzkp_field::DZKPBaseField, dzkp_validator::MultiplicationInputsBlock},
-};
+use ipa_core::protocol::context::dzkp_validator::MultiplicationInputsBlock;
 use rand::{thread_rng, Rng};
 
 fn convert_prover_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("dzkp_convert_prover");
     group.bench_function("convert", |b| {
         b.iter_batched_ref(
-            || {
-                // Generate input
-                let mut rng = thread_rng();
-
-                MultiplicationInputsBlock {
-                    x_left: rng.gen::<[u8; 32]>().into(),
-                    x_right: rng.gen::<[u8; 32]>().into(),
-                    y_left: rng.gen::<[u8; 32]>().into(),
-                    y_right: rng.gen::<[u8; 32]>().into(),
-                    prss_left: rng.gen::<[u8; 32]>().into(),
-                    prss_right: rng.gen::<[u8; 32]>().into(),
-                    z_right: rng.gen::<[u8; 32]>().into(),
-                }
-            },
-            |input| {
-                let MultiplicationInputsBlock {
-                    x_left,
-                    x_right,
-                    y_left,
-                    y_right,
-                    prss_right,
-                    ..
-                } = input;
-                Fp61BitPrime::convert_prover(x_left, x_right, y_left, y_right, prss_right);
-            },
+            || thread_rng().gen(),
+            |input| input.table_indices_prover(),
             BatchSize::SmallInput,
         )
     });

--- a/ipa-core/benches/dzkp_convert_prover.rs
+++ b/ipa-core/benches/dzkp_convert_prover.rs
@@ -1,4 +1,4 @@
-//! Benchmark for the convert_prover function in dzkp_field.rs.
+//! Benchmark for the table_indices_prover function in dzkp_field.rs.
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ipa_core::protocol::context::dzkp_validator::MultiplicationInputsBlock;
@@ -9,7 +9,7 @@ fn convert_prover_benchmark(c: &mut Criterion) {
     group.bench_function("convert", |b| {
         b.iter_batched_ref(
             || thread_rng().gen(),
-            |input| input.table_indices_prover(),
+            |input: &mut MultiplicationInputsBlock| input.table_indices_prover(),
             BatchSize::SmallInput,
         )
     });

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -1,17 +1,12 @@
-use std::{iter::zip, sync::LazyLock};
+use std::{ops::Index, sync::LazyLock};
 
 use bitvec::field::BitField;
 
 use crate::{
     ff::{Field, Fp61BitPrime, PrimeField},
-    protocol::context::dzkp_validator::{Array256Bit, SegmentEntry},
+    protocol::context::dzkp_validator::{Array256Bit, MultiplicationInputsBlock, SegmentEntry},
     secret_sharing::{FieldSimd, SharedValue, Vectorizable},
 };
-
-// BlockSize is fixed to 32
-pub const BLOCK_SIZE: usize = 32;
-// UVTupleBlock is a block of interleaved U and V values
-pub type UVTupleBlock<F> = ([F; BLOCK_SIZE], [F; BLOCK_SIZE]);
 
 /// Trait for fields compatible with DZKPs
 /// Field needs to support conversion to `SegmentEntry`, i.e. `to_segment_entry` which is required by DZKPs
@@ -25,35 +20,12 @@ pub trait DZKPBaseField: PrimeField {
     const INVERSE_OF_TWO: Self;
     const MINUS_ONE_HALF: Self;
     const MINUS_TWO: Self;
+}
 
-    /// Convert allows to convert individual bits from multiplication gates into dzkp compatible field elements.
-    /// This function is called by the prover.
-    fn convert_prover<'a>(
-        x_left: &'a Array256Bit,
-        x_right: &'a Array256Bit,
-        y_left: &'a Array256Bit,
-        y_right: &'a Array256Bit,
-        prss_right: &'a Array256Bit,
-    ) -> Vec<UVTupleBlock<Self>>;
-
-    /// This is similar to `convert_prover` except that it is called by the verifier to the left of the prover.
-    /// The verifier on the left uses its right shares, since they are consistent with the prover's left shares.
-    /// This produces the 'u' values.
-    fn convert_value_from_right_prover<'a>(
-        x_right: &'a Array256Bit,
-        y_right: &'a Array256Bit,
-        prss_right: &'a Array256Bit,
-        z_right: &'a Array256Bit,
-    ) -> Vec<Self>;
-
-    /// This is similar to `convert_prover` except that it is called by the verifier to the right of the prover.
-    /// The verifier on the right uses its left shares, since they are consistent with the prover's right shares.
-    /// This produces the 'v' values
-    fn convert_value_from_left_prover<'a>(
-        x_left: &'a Array256Bit,
-        y_left: &'a Array256Bit,
-        prss_left: &'a Array256Bit,
-    ) -> Vec<Self>;
+impl DZKPBaseField for Fp61BitPrime {
+    const INVERSE_OF_TWO: Self = Fp61BitPrime::const_truncate(1_152_921_504_606_846_976u64);
+    const MINUS_ONE_HALF: Self = Fp61BitPrime::const_truncate(1_152_921_504_606_846_975u64);
+    const MINUS_TWO: Self = Fp61BitPrime::const_truncate(2_305_843_009_213_693_949u64);
 }
 
 impl<const P: usize> FromIterator<Fp61BitPrime> for [Fp61BitPrime; P] {
@@ -90,7 +62,7 @@ impl<const P: usize> FromIterator<Fp61BitPrime> for Vec<[Fp61BitPrime; P]> {
     }
 }
 
-/// Construct indices for the `convert_values` lookup tables.
+/// Construct indices for the `TABLE_U` and `TABLE_V` lookup tables.
 ///
 /// `b0` has the least significant bit of each index, and `b1` and `b2` the subsequent
 /// bits. This routine rearranges the bits so that there is one table index in each
@@ -102,7 +74,7 @@ impl<const P: usize> FromIterator<Fp61BitPrime> for Vec<[Fp61BitPrime; P]> {
 /// (i%4) == j. The "0s", "1s", "2s", "3s" comments trace the movement from
 /// input to output.
 #[must_use]
-fn convert_values_table_indices(b0: u128, b1: u128, b2: u128) -> [u128; 4] {
+fn bits_to_table_indices(b0: u128, b1: u128, b2: u128) -> [u128; 4] {
     // 0x55 is 0b0101_0101. This mask selects bits having (i%2) == 0.
     const CONST_55: u128 = u128::from_le_bytes([0x55; 16]);
     // 0xaa is 0b1010_1010. This mask selects bits having (i%2) == 1.
@@ -148,10 +120,31 @@ fn convert_values_table_indices(b0: u128, b1: u128, b2: u128) -> [u128; 4] {
     [y0, y1, y2, y3]
 }
 
+pub struct UVTable<F>(pub [[F; 4]; 8]);
+
+impl<F> Index<u8> for UVTable<F> {
+    type Output = [F; 4];
+
+    fn index(&self, index: u8) -> &Self::Output {
+        self.0.index(usize::from(index))
+    }
+}
+
+impl<F> Index<usize> for UVTable<F> {
+    type Output = [F; 4];
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.index(index)
+    }
+}
+
 // Table used for `convert_prover` and `convert_value_from_right_prover`.
 //
-// The conversion to "g" and "h" values is from https://eprint.iacr.org/2023/909.pdf.
-static TABLE_RIGHT: LazyLock<[[Fp61BitPrime; 4]; 8]> = LazyLock::new(|| {
+// This table is for "g" or "u" values. This table is "right" on a verifier when it is
+// processing values for the prover on its right. On a prover, this table is "left".
+//
+// The conversion logic is from https://eprint.iacr.org/2023/909.pdf.
+pub static TABLE_U: LazyLock<UVTable<Fp61BitPrime>> = LazyLock::new(|| {
     let mut result = Vec::with_capacity(8);
     for e in [false, true] {
         for c in [false, true] {
@@ -172,13 +165,16 @@ static TABLE_RIGHT: LazyLock<[[Fp61BitPrime; 4]; 8]> = LazyLock::new(|| {
             }
         }
     }
-    result.try_into().unwrap()
+    UVTable(result.try_into().unwrap())
 });
 
 // Table used for `convert_prover` and `convert_value_from_left_prover`.
 //
-// The conversion to "g" and "h" values is from https://eprint.iacr.org/2023/909.pdf.
-static TABLE_LEFT: LazyLock<[[Fp61BitPrime; 4]; 8]> = LazyLock::new(|| {
+// This table is for "h" or "v" values. This table is "left" on a verifier when it is
+// processing values for the prover on its left. On a prover, this table is "right".
+//
+// The conversion logic is from https://eprint.iacr.org/2023/909.pdf.
+pub static TABLE_V: LazyLock<UVTable<Fp61BitPrime>> = LazyLock::new(|| {
     let mut result = Vec::with_capacity(8);
     for f in [false, true] {
         for d in [false, true] {
@@ -199,31 +195,32 @@ static TABLE_LEFT: LazyLock<[[Fp61BitPrime; 4]; 8]> = LazyLock::new(|| {
             }
         }
     }
-    result.try_into().unwrap()
+    UVTable(result.try_into().unwrap())
 });
 
-/// Lookup-table-based conversion logic used by `convert_prover`,
-/// `convert_value_from_left_prover`, and `convert_value_from_left_prover`.
+/// Lookup-table-based conversion logic used by `table_indices_prover`,
+/// `table_indices_from_right_prover`, and `table_indices_from_left_prover`.
 ///
 /// Inputs `i0`, `i1`, and `i2` each contain the value of one of the "a" through "f"
 /// intermediates for each of 256 multiplies. `table` is the lookup table to use,
-/// which should be either `TABLE_LEFT` or `TABLE_RIGHT`.
+/// which should be either `TABLE_U` or `TABLE_V`.
 ///
 /// We want to interpret the 3-tuple of intermediates at each bit position in `i0`, `i1`
 /// and `i2` as an integer index in the range 0..8 into the table. The
-/// `convert_values_table_indices` helper does this in bulk more efficiently than using
+/// `bits_to_table_indices` helper does this in bulk more efficiently than using
 /// bit-manipulation to handle them one-by-one.
 ///
 /// Preserving the order from inputs to outputs is not necessary for correctness as long
 /// as the same order is used on all three helpers. We preserve the order anyways
 /// to simplify the end-to-end dataflow, even though it makes this routine slightly
 /// more complicated.
-fn convert_values(
+#[allow(clippy::missing_panics_doc)]
+fn intermediates_to_table_indices<'a>(
     i0: &Array256Bit,
     i1: &Array256Bit,
     i2: &Array256Bit,
-    table: &[[Fp61BitPrime; 4]; 8],
-) -> Vec<Fp61BitPrime> {
+    mut out: impl Iterator<Item = &'a mut u8>,
+) {
     // Split inputs to two `u128`s. We do this because `u128` is the largest integer
     // type rust supports. It is possible that using SIMD types here would improve
     // code generation for AVX-256/512.
@@ -238,45 +235,49 @@ fn convert_values(
 
     // Output word `j` in each set contains the table indices for input positions `i`
     // having (i%4) == j.
-    let [mut z00, mut z01, mut z02, mut z03] = convert_values_table_indices(i00, i10, i20);
-    let [mut z10, mut z11, mut z12, mut z13] = convert_values_table_indices(i01, i11, i21);
+    let [mut z00, mut z01, mut z02, mut z03] = bits_to_table_indices(i00, i10, i20);
+    let [mut z10, mut z11, mut z12, mut z13] = bits_to_table_indices(i01, i11, i21);
 
-    let mut result = Vec::with_capacity(1024);
+    #[allow(clippy::cast_possible_truncation)]
     for _ in 0..32 {
         // Take one index in turn from each `z` to preserve the output order.
-        for z in [&mut z00, &mut z01, &mut z02, &mut z03] {
-            result.extend(table[(*z as usize) & 0x7]);
-            *z >>= 4;
-        }
+        *out.next().unwrap() = (z00 as u8) & 0x7;
+        z00 >>= 4;
+        *out.next().unwrap() = (z01 as u8) & 0x7;
+        z01 >>= 4;
+        *out.next().unwrap() = (z02 as u8) & 0x7;
+        z02 >>= 4;
+        *out.next().unwrap() = (z03 as u8) & 0x7;
+        z03 >>= 4;
     }
+    #[allow(clippy::cast_possible_truncation)]
     for _ in 0..32 {
-        for z in [&mut z10, &mut z11, &mut z12, &mut z13] {
-            result.extend(table[(*z as usize) & 0x7]);
-            *z >>= 4;
-        }
+        *out.next().unwrap() = (z10 as u8) & 0x7;
+        z10 >>= 4;
+        *out.next().unwrap() = (z11 as u8) & 0x7;
+        z11 >>= 4;
+        *out.next().unwrap() = (z12 as u8) & 0x7;
+        z12 >>= 4;
+        *out.next().unwrap() = (z13 as u8) & 0x7;
+        z13 >>= 4;
     }
-    debug_assert!(result.len() == 1024);
-
-    result
+    debug_assert!(out.next().is_none());
 }
 
-impl DZKPBaseField for Fp61BitPrime {
-    const INVERSE_OF_TWO: Self = Fp61BitPrime::const_truncate(1_152_921_504_606_846_976u64);
-    const MINUS_ONE_HALF: Self = Fp61BitPrime::const_truncate(1_152_921_504_606_846_975u64);
-    const MINUS_TWO: Self = Fp61BitPrime::const_truncate(2_305_843_009_213_693_949u64);
-
-    // Convert allows to convert individual bits from multiplication gates into dzkp compatible field elements
+impl MultiplicationInputsBlock {
+    /// Repack the intermediates in this block into lookup indices for `TABLE_U` and `TABLE_V`.
+    ///
+    /// This is the convert function called by the prover.
+    //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
-    // This function does not use any optimization.
-    //
-    // Prover and left can compute:
+    // Prover and left compute:
     // g1=-2ac(1-2e),
     // g2=c(1-2e),
     // g3=a(1-2e),
     // g4=-1/2(1-2e),
     //
-    // Prover and right can compute:
+    // Prover and right compute:
     // h1=bd(1-2f),
     // h2=d(1-2f),
     // h3=b(1-2f),
@@ -292,30 +293,27 @@ impl DZKPBaseField for Fp61BitPrime {
     // therefore e = ab⊕cd⊕ f must hold. (alternatively, you can also see this by substituting z_left,
     // i.e. z_left = x_left · y_left ⊕ x_left · y_right ⊕ x_right · y_left ⊕ prss_left ⊕ prss_right
     #[allow(clippy::many_single_char_names)]
-    fn convert_prover<'a>(
-        x_left: &'a Array256Bit,
-        x_right: &'a Array256Bit,
-        y_left: &'a Array256Bit,
-        y_right: &'a Array256Bit,
-        prss_right: &'a Array256Bit,
-    ) -> Vec<UVTupleBlock<Fp61BitPrime>> {
-        let a = x_left;
-        let b = y_right;
-        let c = y_left;
-        let d = x_right;
+    #[must_use]
+    pub fn table_indices_prover(&self) -> Vec<(u8, u8)> {
+        let a = &self.x_left;
+        let b = &self.y_right;
+        let c = &self.y_left;
+        let d = &self.x_right;
         // e = ab ⊕ cd ⊕ f = x_left * y_right ⊕ y_left * x_right ⊕ prss_right
-        let e = (*x_left & y_right) ^ (*y_left & x_right) ^ prss_right;
-        let f = prss_right;
+        let e = (self.x_left & self.y_right) ^ (self.y_left & self.x_right) ^ self.prss_right;
+        let f = &self.prss_right;
 
-        let g = convert_values(a, c, &e, &TABLE_RIGHT);
-        let h = convert_values(b, d, f, &TABLE_LEFT);
-
-        zip(g.chunks_exact(BLOCK_SIZE), h.chunks_exact(BLOCK_SIZE))
-            .map(|(g_chunk, h_chunk)| (g_chunk.try_into().unwrap(), h_chunk.try_into().unwrap()))
-            .collect()
+        let mut output = vec![(0u8, 0u8); 256];
+        intermediates_to_table_indices(a, c, &e, output.iter_mut().map(|tup| &mut tup.0));
+        intermediates_to_table_indices(b, d, f, output.iter_mut().map(|tup| &mut tup.1));
+        output
     }
 
-    // Convert allows to convert individual bits from multiplication gates into dzkp compatible field elements
+    /// Repack the intermediates in this block into lookup indices for `TABLE_U`.
+    ///
+    /// This is the convert function called by the verifier when processing for the
+    /// prover on its right.
+    //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
     // Prover and left can compute:
@@ -328,25 +326,27 @@ impl DZKPBaseField for Fp61BitPrime {
     // (a,c,e) = (x_right, y_right, x_right * y_right ⊕ z_right ⊕ prss_right)
     // here e is defined as in the paper (since the the verifier does not have access to b,d,f,
     // he cannot use the simplified formula for e)
-    fn convert_value_from_right_prover<'a>(
-        x_right: &'a Array256Bit,
-        y_right: &'a Array256Bit,
-        prss_right: &'a Array256Bit,
-        z_right: &'a Array256Bit,
-    ) -> Vec<Self> {
-        let a = x_right;
-        let c = y_right;
+    #[must_use]
+    pub fn table_indices_from_right_prover(&self) -> Vec<u8> {
+        let a = &self.x_right;
+        let c = &self.y_right;
         // e = ac ⊕ zright ⊕ prssright
         // as defined in the paper
-        let e = (*a & *c) ^ prss_right ^ z_right;
+        let e = (self.x_right & self.y_right) ^ self.prss_right ^ self.z_right;
 
-        convert_values(a, c, &e, &TABLE_RIGHT)
+        let mut output = vec![0u8; 256];
+        intermediates_to_table_indices(a, c, &e, output.iter_mut());
+        output
     }
 
-    // Convert allows to convert individual bits from multiplication gates into dzkp compatible field elements
+    /// Repack the intermediates in this block into lookup indices for `TABLE_V`.
+    ///
+    /// This is the convert function called by the verifier when processing for the
+    /// prover on its left.
+    //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
-    // Prover and right can compute:
+    // The prover and the verifier on its left compute:
     // h1=bd(1-2f),
     // h2=d(1-2f),
     // h3=b(1-2f),
@@ -354,31 +354,33 @@ impl DZKPBaseField for Fp61BitPrime {
     //
     // where
     // (b,d,f) = (y_left, x_left, prss_left)
-    fn convert_value_from_left_prover<'a>(
-        x_left: &'a Array256Bit,
-        y_left: &'a Array256Bit,
-        prss_left: &'a Array256Bit,
-    ) -> Vec<Self> {
-        let b = y_left;
-        let d = x_left;
-        let f = prss_left;
+    #[must_use]
+    pub fn table_indices_from_left_prover(&self) -> Vec<u8> {
+        let b = &self.y_left;
+        let d = &self.x_left;
+        let f = &self.prss_left;
 
-        convert_values(b, d, f, &TABLE_LEFT)
+        let mut output = vec![0u8; 256];
+        intermediates_to_table_indices(b, d, f, output.iter_mut());
+        output
     }
 }
 
 #[cfg(all(test, unit_test))]
-mod tests {
-    use bitvec::{array::BitArray, macros::internal::funty::Fundamental, slice::BitSlice};
+pub mod tests {
+
+    use bitvec::{array::BitArray, macros::internal::funty::Fundamental};
     use proptest::proptest;
     use rand::{thread_rng, Rng};
 
     use crate::{
         ff::{Field, Fp61BitPrime, U128Conversions},
-        protocol::context::dzkp_field::{
-            convert_values_table_indices, DZKPBaseField, UVTupleBlock, BLOCK_SIZE,
+        protocol::context::{
+            dzkp_field::{bits_to_table_indices, DZKPBaseField, TABLE_U, TABLE_V},
+            dzkp_validator::MultiplicationInputsBlock,
         },
         secret_sharing::SharedValue,
+        test_executor::run_random,
     };
 
     #[test]
@@ -386,7 +388,7 @@ mod tests {
         let b0 = 0xaa;
         let b1 = 0xcc;
         let b2 = 0xf0;
-        let [z0, z1, z2, z3] = convert_values_table_indices(b0, b1, b2);
+        let [z0, z1, z2, z3] = bits_to_table_indices(b0, b1, b2);
         assert_eq!(z0, 0x40_u128);
         assert_eq!(z1, 0x51_u128);
         assert_eq!(z2, 0x62_u128);
@@ -396,7 +398,7 @@ mod tests {
         let b0 = rng.gen();
         let b1 = rng.gen();
         let b2 = rng.gen();
-        let [z0, z1, z2, z3] = convert_values_table_indices(b0, b1, b2);
+        let [z0, z1, z2, z3] = bits_to_table_indices(b0, b1, b2);
 
         for i in (0..128).step_by(4) {
             fn check(i: u32, j: u32, b0: u128, b1: u128, b2: u128, z: u128) {
@@ -417,85 +419,71 @@ mod tests {
         }
     }
 
-    #[test]
-    fn batch_convert() {
-        let mut rng = thread_rng();
-
-        // bitvecs
-        let mut vec_x_left = Vec::<u8>::new();
-        let mut vec_x_right = Vec::<u8>::new();
-        let mut vec_y_left = Vec::<u8>::new();
-        let mut vec_y_right = Vec::<u8>::new();
-        let mut vec_prss_left = Vec::<u8>::new();
-        let mut vec_prss_right = Vec::<u8>::new();
-        let mut vec_z_right = Vec::<u8>::new();
-
-        // gen 32 random values
-        for _i in 0..32 {
-            let x_left: u8 = rng.gen();
-            let x_right: u8 = rng.gen();
-            let y_left: u8 = rng.gen();
-            let y_right: u8 = rng.gen();
-            let prss_left: u8 = rng.gen();
-            let prss_right: u8 = rng.gen();
-            // we set this up to be equal to z_right for this local test
-            // local here means that only a single party is involved
-            // and we just test this against this single party
-            let z_right: u8 = (x_left & y_left)
-                ^ (x_left & y_right)
-                ^ (x_right & y_left)
-                ^ prss_left
-                ^ prss_right;
-
-            // fill vec
-            vec_x_left.push(x_left);
-            vec_x_right.push(x_right);
-            vec_y_left.push(y_left);
-            vec_y_right.push(y_right);
-            vec_prss_left.push(prss_left);
-            vec_prss_right.push(prss_right);
-            vec_z_right.push(z_right);
+    impl MultiplicationInputsBlock {
+        /// Rotate the "right" values into the "left" values, setting the right values
+        /// to zero. _z_ is not modified. If the input represents a prover's block of
+        /// intermediates, the output represents the intermediates that the verifier on
+        /// the right shares with that prover.
+        #[must_use]
+        pub fn rotate_left(&self) -> Self {
+            Self {
+                x_left: self.x_right,
+                y_left: self.y_right,
+                prss_left: self.prss_right,
+                x_right: [0u8; 32].into(),
+                y_right: [0u8; 32].into(),
+                prss_right: [0u8; 32].into(),
+                z_right: self.z_right,
+            }
         }
 
-        // conv to BitVec
-        let x_left = BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_x_left)).unwrap();
-        let x_right = BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_x_right)).unwrap();
-        let y_left = BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_y_left)).unwrap();
-        let y_right = BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_y_right)).unwrap();
-        let prss_left =
-            BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_prss_left)).unwrap();
-        let prss_right =
-            BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_prss_right)).unwrap();
-        let z_right = BitArray::<[u8; 32]>::try_from(BitSlice::from_slice(&vec_z_right)).unwrap();
-
-        // check consistency of the polynomials
-        assert_convert(
-            Fp61BitPrime::convert_prover(&x_left, &x_right, &y_left, &y_right, &prss_right),
-            // flip intputs right to left since it is checked against itself and not party on the left
-            // z_right is set to match z_left
-            Fp61BitPrime::convert_value_from_right_prover(&x_left, &y_left, &prss_left, &z_right),
-            // flip intputs right to left since it is checked against itself and not party on the left
-            Fp61BitPrime::convert_value_from_left_prover(&x_right, &y_right, &prss_right),
-        );
+        /// Rotate the "left" values into the "right" values, setting the left values to
+        /// zero. _z_ is not modified. If the input represents a prover's block of
+        /// intermediates, the output represents the intermediates that the verifier on
+        /// the left shares with that prover.
+        #[must_use]
+        pub fn rotate_right(&self) -> Self {
+            Self {
+                x_right: self.x_left,
+                y_right: self.y_left,
+                prss_right: self.prss_left,
+                x_left: [0u8; 32].into(),
+                y_left: [0u8; 32].into(),
+                prss_left: [0u8; 32].into(),
+                z_right: self.z_right,
+            }
+        }
     }
+
+    #[test]
+    fn batch_convert() {
+        run_random(|mut rng| async move {
+            // This generates all the intermediates except _z_ randomly, and calculates
+            // _z_ from the others.
+            let block = rng.gen::<MultiplicationInputsBlock>();
+
+            // check consistency of the polynomials
+            assert_convert(
+                block.table_indices_prover(),
+                // flip inputs right to left since it is checked against itself and not party on the left
+                // z_right is set to match z_left
+                block.rotate_right().table_indices_from_right_prover(),
+                // flip inputs right to left since it is checked against itself and not party on the left
+                block.rotate_left().table_indices_from_left_prover(),
+            );
+        });
+    }
+
     fn assert_convert<P, L, R>(prover: P, verifier_left: L, verifier_right: R)
     where
-        P: IntoIterator<Item = UVTupleBlock<Fp61BitPrime>>,
-        L: IntoIterator<Item = Fp61BitPrime>,
-        R: IntoIterator<Item = Fp61BitPrime>,
+        P: IntoIterator<Item = (u8, u8)>,
+        L: IntoIterator<Item = u8>,
+        R: IntoIterator<Item = u8>,
     {
         prover
             .into_iter()
-            .zip(
-                verifier_left
-                    .into_iter()
-                    .collect::<Vec<[Fp61BitPrime; BLOCK_SIZE]>>(),
-            )
-            .zip(
-                verifier_right
-                    .into_iter()
-                    .collect::<Vec<[Fp61BitPrime; BLOCK_SIZE]>>(),
-            )
+            .zip(verifier_left.into_iter().collect::<Vec<_>>())
+            .zip(verifier_right.into_iter().collect::<Vec<_>>())
             .for_each(|((prover, verifier_left), verifier_right)| {
                 assert_eq!(prover.0, verifier_left);
                 assert_eq!(prover.1, verifier_right);
@@ -534,37 +522,15 @@ mod tests {
     }
 
     #[allow(clippy::fn_params_excessive_bools)]
-    fn correctness_prover_values(
+    #[must_use]
+    pub fn reference_convert(
         x_left: bool,
         x_right: bool,
         y_left: bool,
         y_right: bool,
         prss_left: bool,
         prss_right: bool,
-    ) {
-        let mut array_x_left = BitArray::<[u8; 32]>::ZERO;
-        let mut array_x_right = BitArray::<[u8; 32]>::ZERO;
-        let mut array_y_left = BitArray::<[u8; 32]>::ZERO;
-        let mut array_y_right = BitArray::<[u8; 32]>::ZERO;
-        let mut array_prss_left = BitArray::<[u8; 32]>::ZERO;
-        let mut array_prss_right = BitArray::<[u8; 32]>::ZERO;
-
-        // initialize bits
-        array_x_left.set(0, x_left);
-        array_x_right.set(0, x_right);
-        array_y_left.set(0, y_left);
-        array_y_right.set(0, y_right);
-        array_prss_left.set(0, prss_left);
-        array_prss_right.set(0, prss_right);
-
-        let prover = Fp61BitPrime::convert_prover(
-            &array_x_left,
-            &array_x_right,
-            &array_y_left,
-            &array_y_right,
-            &array_prss_right,
-        )[0];
-
+    ) -> ([Fp61BitPrime; 4], [Fp61BitPrime; 4]) {
         // compute expected
         // (a,b,c,d,f) = (x_left, y_right, y_left, x_right, prss_right)
         // e = x_left · y_left ⊕ z_left ⊕ prss_left
@@ -601,17 +567,59 @@ mod tests {
         // h4=1-2f,
         let h4 = one_minus_two_f;
 
+        ([g1, g2, g3, g4], [h1, h2, h3, h4])
+    }
+
+    #[allow(clippy::fn_params_excessive_bools)]
+    fn correctness_prover_values(
+        x_left: bool,
+        x_right: bool,
+        y_left: bool,
+        y_right: bool,
+        prss_left: bool,
+        prss_right: bool,
+    ) {
+        let mut array_x_left = BitArray::<[u8; 32]>::ZERO;
+        let mut array_x_right = BitArray::<[u8; 32]>::ZERO;
+        let mut array_y_left = BitArray::<[u8; 32]>::ZERO;
+        let mut array_y_right = BitArray::<[u8; 32]>::ZERO;
+        let mut array_prss_left = BitArray::<[u8; 32]>::ZERO;
+        let mut array_prss_right = BitArray::<[u8; 32]>::ZERO;
+
+        // initialize bits
+        array_x_left.set(0, x_left);
+        array_x_right.set(0, x_right);
+        array_y_left.set(0, y_left);
+        array_y_right.set(0, y_right);
+        array_prss_left.set(0, prss_left);
+        array_prss_right.set(0, prss_right);
+
+        let block = MultiplicationInputsBlock {
+            x_left: array_x_left,
+            x_right: array_x_right,
+            y_left: array_y_left,
+            y_right: array_y_right,
+            prss_left: array_prss_left,
+            prss_right: array_prss_right,
+            z_right: BitArray::ZERO,
+        };
+
+        let prover = block.table_indices_prover()[0];
+
+        let ([g1, g2, g3, g4], [h1, h2, h3, h4]) =
+            reference_convert(x_left, x_right, y_left, y_right, prss_left, prss_right);
+
         // check expected == computed
         // g polynomial
-        assert_eq!(g1, prover.0[0]);
-        assert_eq!(g2, prover.0[1]);
-        assert_eq!(g3, prover.0[2]);
-        assert_eq!(g4, prover.0[3]);
+        assert_eq!(g1, TABLE_U[prover.0][0]);
+        assert_eq!(g2, TABLE_U[prover.0][1]);
+        assert_eq!(g3, TABLE_U[prover.0][2]);
+        assert_eq!(g4, TABLE_U[prover.0][3]);
 
         // h polynomial
-        assert_eq!(h1, prover.1[0]);
-        assert_eq!(h2, prover.1[1]);
-        assert_eq!(h3, prover.1[2]);
-        assert_eq!(h4, prover.1[3]);
+        assert_eq!(h1, TABLE_V[prover.1][0]);
+        assert_eq!(h2, TABLE_V[prover.1][1]);
+        assert_eq!(h3, TABLE_V[prover.1][2]);
+        assert_eq!(h4, TABLE_V[prover.1][3]);
     }
 }

--- a/ipa-core/src/protocol/context/dzkp_field.rs
+++ b/ipa-core/src/protocol/context/dzkp_field.rs
@@ -214,7 +214,6 @@ pub static TABLE_V: LazyLock<UVTable<Fp61BitPrime>> = LazyLock::new(|| {
 /// as the same order is used on all three helpers. We preserve the order anyways
 /// to simplify the end-to-end dataflow, even though it makes this routine slightly
 /// more complicated.
-#[allow(clippy::missing_panics_doc)]
 fn intermediates_to_table_indices<'a>(
     i0: &Array256Bit,
     i1: &Array256Bit,
@@ -271,13 +270,13 @@ impl MultiplicationInputsBlock {
     //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
-    // Prover and left compute:
+    // Prover and the verifier on its left compute:
     // g1=-2ac(1-2e),
     // g2=c(1-2e),
     // g3=a(1-2e),
     // g4=-1/2(1-2e),
     //
-    // Prover and right compute:
+    // Prover and the verifier on its right compute:
     // h1=bd(1-2f),
     // h2=d(1-2f),
     // h3=b(1-2f),
@@ -316,7 +315,7 @@ impl MultiplicationInputsBlock {
     //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
-    // Prover and left can compute:
+    // Prover and the verifier on its left compute:
     // g1=-2ac(1-2e),
     // g2=c(1-2e),
     // g3=a(1-2e),
@@ -346,7 +345,7 @@ impl MultiplicationInputsBlock {
     //
     // We use the conversion logic from https://eprint.iacr.org/2023/909.pdf
     //
-    // The prover and the verifier on its left compute:
+    // The prover and the verifier on its right compute:
     // h1=bd(1-2f),
     // h2=d(1-2f),
     // h3=b(1-2f),

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -166,7 +166,7 @@ impl MultiplicationInputsBlock {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "enable-benches"))]
 impl rand::prelude::Distribution<MultiplicationInputsBlock> for rand::distributions::Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> MultiplicationInputsBlock {
         // Generate a random valid block of muliplication intermediates. "Valid" means

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -12,7 +12,7 @@ use crate::{
     protocol::{
         context::{
             batcher::Batcher,
-            dzkp_field::{DZKPBaseField, UVTupleBlock},
+            dzkp_field::{DZKPBaseField, TABLE_U, TABLE_V},
             dzkp_malicious::DZKPUpgraded as MaliciousDZKPUpgraded,
             dzkp_semi_honest::DZKPUpgraded as SemiHonestDZKPUpgraded,
             step::DzkpValidationProtocolStep as Step,
@@ -20,7 +20,8 @@ use crate::{
         },
         ipa_prf::{
             validation_protocol::{proof_generation::ProofBatch, validation::BatchToVerify},
-            CompressedProofGenerator, FirstProofGenerator,
+            CompressedProofGenerator, FirstProofGenerator, ProverTableIndices,
+            VerifierTableIndices,
         },
         Gate, RecordId, RecordIdRange,
     },
@@ -33,7 +34,7 @@ pub type Array256Bit = BitArray<[u8; 32], Lsb0>;
 
 type BitSliceType = BitSlice<u8, Lsb0>;
 
-const BIT_ARRAY_LEN: usize = 256;
+pub const BIT_ARRAY_LEN: usize = 256;
 const BIT_ARRAY_MASK: usize = BIT_ARRAY_LEN - 1;
 const BIT_ARRAY_SHIFT: usize = BIT_ARRAY_LEN.ilog2() as usize;
 
@@ -58,6 +59,12 @@ pub const TARGET_PROOF_SIZE: usize = 8192;
 #[cfg(not(test))]
 pub const TARGET_PROOF_SIZE: usize = 50_000_000;
 
+/// Minimum proof recursion depth.
+///
+/// This minimum avoids special cases in the implementation that would be otherwise
+/// required when the initial and final recursion steps overlap.
+pub const MIN_PROOF_RECURSION: usize = 3;
+
 /// Maximum proof recursion depth.
 //
 // This is a hard limit. Each GF(2) multiply generates four G values and four H values,
@@ -74,8 +81,6 @@ pub const TARGET_PROOF_SIZE: usize = 50_000_000;
 // Because the number of records in a proof batch is often rounded up to a power of two
 // (and less significantly, because multiplication intermediate storage gets rounded up
 // to blocks of 256), leaving some margin is advised.
-//
-// The implementation requires that MAX_PROOF_RECURSION is at least 2.
 pub const MAX_PROOF_RECURSION: usize = 14;
 
 /// `MultiplicationInputsBlock` is a block of fixed size of intermediate values
@@ -159,34 +164,30 @@ impl MultiplicationInputsBlock {
 
         Ok(())
     }
+}
 
-    /// `Convert` allows to convert `MultiplicationInputs` into a format compatible with DZKPs
-    /// This is the convert function called by the prover.
-    fn convert_prover<DF: DZKPBaseField>(&self) -> Vec<UVTupleBlock<DF>> {
-        DF::convert_prover(
-            &self.x_left,
-            &self.x_right,
-            &self.y_left,
-            &self.y_right,
-            &self.prss_right,
-        )
-    }
-
-    /// `convert_values_from_right_prover` allows to convert `MultiplicationInputs` into a format compatible with DZKPs
-    /// This is the convert function called by the verifier on the left.
-    fn convert_values_from_right_prover<DF: DZKPBaseField>(&self) -> Vec<DF> {
-        DF::convert_value_from_right_prover(
-            &self.x_right,
-            &self.y_right,
-            &self.prss_right,
-            &self.z_right,
-        )
-    }
-
-    /// `convert_values_from_left_prover` allows to convert `MultiplicationInputs` into a format compatible with DZKPs
-    /// This is the convert function called by the verifier on the right.
-    fn convert_values_from_left_prover<DF: DZKPBaseField>(&self) -> Vec<DF> {
-        DF::convert_value_from_left_prover(&self.x_left, &self.y_left, &self.prss_left)
+#[cfg(test)]
+impl rand::prelude::Distribution<MultiplicationInputsBlock> for rand::distributions::Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> MultiplicationInputsBlock {
+        // Generate a random valid block of muliplication intermediates. "Valid" means
+        // that the _z_ intermediate is computed from the other intermediates as an
+        // honest helper would.
+        let sample = <Self as rand::prelude::Distribution<[u8; 32]>>::sample;
+        let mut block = MultiplicationInputsBlock {
+            x_left: sample(self, rng).into(),
+            x_right: sample(self, rng).into(),
+            y_left: sample(self, rng).into(),
+            y_right: sample(self, rng).into(),
+            prss_left: sample(self, rng).into(),
+            prss_right: sample(self, rng).into(),
+            z_right: [0u8; 32].into(),
+        };
+        block.z_right = (block.x_left & block.y_left)
+            ^ (block.x_left & block.y_right)
+            ^ (block.x_right & block.y_left)
+            ^ block.prss_left
+            ^ block.prss_right;
+        block
     }
 }
 
@@ -472,34 +473,30 @@ impl MultiplicationInputsBatch {
         }
     }
 
-    /// `get_field_values_prover` converts a `MultiplicationInputsBatch` into an iterator over `field`
-    /// values used by the prover of the DZKPs
-    fn get_field_values_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = UVTupleBlock<DF>> + Clone + '_ {
+    /// `get_field_values_prover` converts a `MultiplicationInputsBatch` into an
+    /// iterator over pairs of indices for `TABLE_U` and `TABLE_V`.
+    fn get_field_values_prover(&self) -> impl Iterator<Item = (u8, u8)> + Clone + '_ {
         self.vec
             .iter()
-            .flat_map(MultiplicationInputsBlock::convert_prover::<DF>)
+            .flat_map(MultiplicationInputsBlock::table_indices_prover)
     }
 
-    /// `get_field_values_from_right_prover` converts a `MultiplicationInputsBatch` into an iterator over `field`
-    /// values used by the verifier of the DZKPs on the left side of the prover, i.e. the `u` values.
-    fn get_field_values_from_right_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = DF> + '_ {
+    /// `get_field_values_from_right_prover` converts a `MultiplicationInputsBatch` into
+    /// an iterator over table indices for `TABLE_U`, which is used by the verifier of
+    /// the DZKPs on the left side of the prover.
+    fn get_field_values_from_right_prover(&self) -> impl Iterator<Item = u8> + '_ {
         self.vec
             .iter()
-            .flat_map(MultiplicationInputsBlock::convert_values_from_right_prover::<DF>)
+            .flat_map(MultiplicationInputsBlock::table_indices_from_right_prover)
     }
 
-    /// `get_field_values_from_left_prover` converts a `MultiplicationInputsBatch` into an iterator over `field`
-    /// values used by the verifier of the DZKPs on the right side of the prover, i.e. the `v` values.
-    fn get_field_values_from_left_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = DF> + '_ {
+    /// `get_field_values_from_left_prover` converts a `MultiplicationInputsBatch` into
+    /// an iterator over table indices for `TABLE_V`, which is used by the verifier of
+    /// the DZKPs on the right side of the prover.
+    fn get_field_values_from_left_prover(&self) -> impl Iterator<Item = u8> + '_ {
         self.vec
             .iter()
-            .flat_map(MultiplicationInputsBlock::convert_values_from_left_prover::<DF>)
+            .flat_map(MultiplicationInputsBlock::table_indices_from_left_prover)
     }
 }
 
@@ -565,36 +562,30 @@ impl Batch {
             .sum()
     }
 
-    /// `get_field_values_prover` converts a `Batch` into an iterator over field values
-    /// which is used by the prover of the DZKP
-    fn get_field_values_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = UVTupleBlock<DF>> + Clone + '_ {
+    /// `get_field_values_prover` converts a `Batch` into an iterator over pairs of
+    /// indices for `TABLE_U` and `TABLE_V`.
+    fn get_field_values_prover(&self) -> impl Iterator<Item = (u8, u8)> + Clone + '_ {
         self.inner
             .values()
-            .flat_map(MultiplicationInputsBatch::get_field_values_prover::<DF>)
+            .flat_map(MultiplicationInputsBatch::get_field_values_prover)
     }
 
-    /// `get_field_values_from_right_prover` converts a `Batch` into an iterator over field values
-    /// which is used by the verifier of the DZKP on the left side of the prover.
-    /// This produces the `u` values.
-    fn get_field_values_from_right_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = DF> + '_ {
+    /// `get_field_values_from_right_prover` converts a `Batch` into an iterator over
+    /// table indices for `TABLE_U`, which is used by the verifier of the DZKP on the
+    /// left side of the prover.
+    fn get_field_values_from_right_prover(&self) -> impl Iterator<Item = u8> + '_ {
         self.inner
             .values()
-            .flat_map(MultiplicationInputsBatch::get_field_values_from_right_prover::<DF>)
+            .flat_map(MultiplicationInputsBatch::get_field_values_from_right_prover)
     }
 
-    /// `get_field_values_from_left_prover` converts a `Batch` into an iterator over field values
-    /// which is used by the verifier of the DZKP on the right side of the prover.
-    /// This produces the `v` values.
-    fn get_field_values_from_left_prover<DF: DZKPBaseField>(
-        &self,
-    ) -> impl Iterator<Item = DF> + '_ {
+    /// `get_field_values_from_left_prover` converts a `Batch` into an iterator over
+    /// table indices for `TABLE_V`, which is used by the verifier of the DZKP on the
+    /// right side of the prover.
+    fn get_field_values_from_left_prover(&self) -> impl Iterator<Item = u8> + '_ {
         self.inner
             .values()
-            .flat_map(MultiplicationInputsBatch::get_field_values_from_left_prover::<DF>)
+            .flat_map(MultiplicationInputsBatch::get_field_values_from_left_prover)
     }
 
     /// ## Panics
@@ -626,7 +617,11 @@ impl Batch {
             q_mask_from_left_prover,
         ) = {
             // generate BatchToVerify
-            ProofBatch::generate(&proof_ctx, prss_record_ids, self.get_field_values_prover())
+            ProofBatch::generate(
+                &proof_ctx,
+                prss_record_ids,
+                ProverTableIndices(self.get_field_values_prover()),
+            )
         };
 
         let chunk_batch = BatchToVerify::generate_batch_to_verify(
@@ -650,12 +645,7 @@ impl Batch {
             tracing::info!("validating {m} multiplications");
             debug_assert_eq!(
                 m,
-                self.get_field_values_prover::<Fp61BitPrime>()
-                    .flat_map(|(u_array, v_array)| {
-                        u_array.into_iter().zip(v_array).map(|(u, v)| u * v)
-                    })
-                    .count()
-                    / 4,
+                self.get_field_values_prover().count(),
                 "Number of multiplications is counted incorrectly"
             );
             let sum_of_uv = Fp61BitPrime::truncate_from(u128::try_from(m).unwrap())
@@ -664,8 +654,14 @@ impl Batch {
             let (p_r_right_prover, q_r_left_prover) = chunk_batch.compute_p_and_q_r(
                 &challenges_for_left_prover,
                 &challenges_for_right_prover,
-                self.get_field_values_from_right_prover(),
-                self.get_field_values_from_left_prover(),
+                VerifierTableIndices {
+                    input: self.get_field_values_from_right_prover(),
+                    table: &TABLE_U,
+                },
+                VerifierTableIndices {
+                    input: self.get_field_values_from_left_prover(),
+                    table: &TABLE_V,
+                },
             );
 
             (sum_of_uv, p_r_right_prover, q_r_left_prover)
@@ -965,12 +961,11 @@ mod tests {
         ff::{
             boolean::Boolean,
             boolean_array::{BooleanArray, BA16, BA20, BA256, BA3, BA32, BA64, BA8},
-            Fp61BitPrime,
         },
         protocol::{
             basics::{select, BooleanArrayMul, SecureMul},
             context::{
-                dzkp_field::{DZKPCompatibleField, BLOCK_SIZE},
+                dzkp_field::DZKPCompatibleField,
                 dzkp_validator::{
                     Batch, DZKPValidator, Segment, SegmentEntry, BIT_ARRAY_LEN, TARGET_PROOF_SIZE,
                 },
@@ -1814,16 +1809,16 @@ mod tests {
 
     fn assert_batch_convert(batch_prover: &Batch, batch_left: &Batch, batch_right: &Batch) {
         batch_prover
-            .get_field_values_prover::<Fp61BitPrime>()
+            .get_field_values_prover()
             .zip(
                 batch_left
-                    .get_field_values_from_right_prover::<Fp61BitPrime>()
-                    .collect::<Vec<[Fp61BitPrime; BLOCK_SIZE]>>(),
+                    .get_field_values_from_right_prover()
+                    .collect::<Vec<_>>(),
             )
             .zip(
                 batch_right
-                    .get_field_values_from_left_prover::<Fp61BitPrime>()
-                    .collect::<Vec<[Fp61BitPrime; BLOCK_SIZE]>>(),
+                    .get_field_values_from_left_prover()
+                    .collect::<Vec<_>>(),
             )
             .for_each(|((prover, verifier_left), verifier_right)| {
                 assert_eq!(prover.0, verifier_left);

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -63,7 +63,7 @@ pub const TARGET_PROOF_SIZE: usize = 50_000_000;
 ///
 /// This minimum avoids special cases in the implementation that would be otherwise
 /// required when the initial and final recursion steps overlap.
-pub const MIN_PROOF_RECURSION: usize = 3;
+pub const MIN_PROOF_RECURSION: usize = 2;
 
 /// Maximum proof recursion depth.
 //

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -169,25 +169,16 @@ impl MultiplicationInputsBlock {
 #[cfg(any(test, feature = "enable-benches"))]
 impl rand::prelude::Distribution<MultiplicationInputsBlock> for rand::distributions::Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> MultiplicationInputsBlock {
-        // Generate a random valid block of muliplication intermediates. "Valid" means
-        // that the _z_ intermediate is computed from the other intermediates as an
-        // honest helper would.
         let sample = <Self as rand::prelude::Distribution<[u8; 32]>>::sample;
-        let mut block = MultiplicationInputsBlock {
+        MultiplicationInputsBlock {
             x_left: sample(self, rng).into(),
             x_right: sample(self, rng).into(),
             y_left: sample(self, rng).into(),
             y_right: sample(self, rng).into(),
             prss_left: sample(self, rng).into(),
             prss_right: sample(self, rng).into(),
-            z_right: [0u8; 32].into(),
-        };
-        block.z_right = (block.x_left & block.y_left)
-            ^ (block.x_left & block.y_right)
-            ^ (block.x_right & block.y_left)
-            ^ block.prss_left
-            ^ block.prss_right;
-        block
+            z_right: sample(self, rng).into(),
+        }
     }
 }
 

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
@@ -86,7 +86,7 @@ where
     /// The "x coordinate" of the output point is `x_output`.
     pub fn new(denominator: &CanonicalLagrangeDenominator<F, N>, x_output: &F) -> Self {
         // assertion that table is not too large for the stack
-        assert!(<F as Serializable>::Size::USIZE * N < 2024);
+        debug_assert!(<F as Serializable>::Size::USIZE * N < 2024);
 
         let table = Self::compute_table_row(x_output, denominator);
         LagrangeTable::<F, N, 1> { table: [table; 1] }

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/mod.rs
@@ -1,3 +1,11 @@
 pub mod lagrange;
 pub mod prover;
 pub mod verifier;
+
+pub type FirstProofGenerator = prover::SmallProofGenerator;
+pub type CompressedProofGenerator = prover::SmallProofGenerator;
+pub use lagrange::{CanonicalLagrangeDenominator, LagrangeTable};
+pub use prover::ProverTableIndices;
+pub use verifier::VerifierTableIndices;
+
+pub const FIRST_RECURSION_FACTOR: usize = FirstProofGenerator::RECURSION_FACTOR;

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -815,8 +815,6 @@ mod test {
             const FPL: usize = FirstProofGenerator::PROOF_LENGTH;
             const FLL: usize = FirstProofGenerator::LAGRANGE_LENGTH;
 
-            // This generates all the intermediates except _z_ randomly, and calculates
-            // _z_ from the others.
             let block = rng.gen::<MultiplicationInputsBlock>();
 
             // Test equivalence for extrapolate_y_values

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -106,7 +106,7 @@ where
 ///
 /// Lagrange interpolation is used in the prover in two ways:
 ///
-/// 1. To extrapolate an additional λ - 1 y-values of degree-λ polynomials so that the
+/// 1. To extrapolate an additional λ - 1 y-values of degree-(λ-1) polynomials so that the
 ///    total 2λ - 1 y-values can be multiplied to obtain a representation of the product of
 ///    the polynomials.
 /// 2. To evaluate polynomials at the randomly chosen challenge point _r_.
@@ -122,9 +122,9 @@ where
 /// `ProverValues` implementation, which represents actual _u_ and _v_ values, is used
 /// by the remaining recursive proofs.
 ///
-/// There is a similar trait `VerifierLagrangeInput` in `verifier.rs`. The prover
-/// operates on _u_ and _v_ values simultaneously (i.e. iterators of tuples). The
-/// verifier operates on only one of _u_ or _v_ at a time.
+/// There is a similar trait `VerifierLagrangeInput` in `verifier.rs`. The difference is
+/// that the prover operates on _u_ and _v_ values simultaneously (i.e. iterators of
+/// tuples). The verifier operates on only one of _u_ or _v_ at a time.
 pub trait ProverLagrangeInput<F: PrimeField, const L: usize> {
     fn extrapolate_y_values<'a, const P: usize, const M: usize>(
         self,
@@ -145,7 +145,7 @@ pub trait ProverLagrangeInput<F: PrimeField, const L: usize> {
 #[derive(Clone)]
 pub struct ProverTableIndices<I: Iterator<Item = (u8, u8)>>(pub I);
 
-/// Iterator producted by `ProverTableIndices::extrapolate_y_values` and
+/// Iterator returned by `ProverTableIndices::extrapolate_y_values` and
 /// `ProverTableIndices::eval_at_r`.
 struct TableIndicesIterator<T, I: Iterator<Item = (u8, u8)>> {
     input: I,

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/prover.rs
@@ -1,18 +1,25 @@
-use std::{borrow::Borrow, iter::zip, marker::PhantomData};
+use std::{array, borrow::Borrow, marker::PhantomData};
 
 use crate::{
     error::Error::{self, DZKPMasks},
-    ff::{Fp61BitPrime, PrimeField},
+    ff::{Fp61BitPrime, MultiplyAccumulate, MultiplyAccumulatorArray, PrimeField},
     helpers::hashing::{compute_hash, hash_to_field},
     protocol::{
-        context::Context,
+        context::{
+            dzkp_field::{TABLE_U, TABLE_V},
+            Context,
+        },
         ipa_prf::{
-            malicious_security::lagrange::{CanonicalLagrangeDenominator, LagrangeTable},
+            malicious_security::{
+                lagrange::{CanonicalLagrangeDenominator, LagrangeTable},
+                FIRST_RECURSION_FACTOR as FRF,
+            },
             CompressedProofGenerator,
         },
         prss::SharedRandomness,
         RecordId, RecordIdRange,
     },
+    secret_sharing::SharedValue,
 };
 
 /// This struct stores intermediate `uv` values.
@@ -95,6 +102,213 @@ where
     }
 }
 
+/// Trait for inputs to Lagrange interpolation on the prover.
+///
+/// Lagrange interpolation is used in the prover in two ways:
+///
+/// 1. To extrapolate an additional λ - 1 y-values of degree-λ polynomials so that the
+///    total 2λ - 1 y-values can be multiplied to obtain a representation of the product of
+///    the polynomials.
+/// 2. To evaluate polynomials at the randomly chosen challenge point _r_.
+///
+/// The two methods in this trait correspond to those two uses.
+///
+/// There are two implementations of this trait: `ProverTableIndices`, and
+/// `ProverValues`. `ProverTableIndices` is used for the input to the first proof.  Each
+/// set of 4 _u_ or _v_ values input to the first proof has one of eight possible
+/// values, determined by the values of the 3 associated multiplication intermediates.
+/// The `ProverTableIndices` implementation uses a lookup table containing the output of
+/// the Lagrange interpolation for each of these eight possible values. The
+/// `ProverValues` implementation, which represents actual _u_ and _v_ values, is used
+/// by the remaining recursive proofs.
+///
+/// There is a similar trait `VerifierLagrangeInput` in `verifier.rs`. The prover
+/// operates on _u_ and _v_ values simultaneously (i.e. iterators of tuples). The
+/// verifier operates on only one of _u_ or _v_ at a time.
+pub trait ProverLagrangeInput<F: PrimeField, const L: usize> {
+    fn extrapolate_y_values<'a, const P: usize, const M: usize>(
+        self,
+        lagrange_table: &'a LagrangeTable<F, L, M>,
+    ) -> impl Iterator<Item = ([F; P], [F; P])> + 'a
+    where
+        Self: 'a;
+
+    fn eval_at_r<'a>(
+        self,
+        lagrange_table: &'a LagrangeTable<F, L, 1>,
+    ) -> impl Iterator<Item = (F, F)> + 'a
+    where
+        Self: 'a;
+}
+
+/// Implementation of `ProverLagrangeInput` for table indices, used for the first proof.
+#[derive(Clone)]
+pub struct ProverTableIndices<I: Iterator<Item = (u8, u8)>>(pub I);
+
+/// Iterator producted by `ProverTableIndices::extrapolate_y_values` and
+/// `ProverTableIndices::eval_at_r`.
+struct TableIndicesIterator<T, I: Iterator<Item = (u8, u8)>> {
+    input: I,
+    u_table: [T; 8],
+    v_table: [T; 8],
+}
+
+impl<I: Iterator<Item = (u8, u8)>> ProverLagrangeInput<Fp61BitPrime, FRF>
+    for ProverTableIndices<I>
+{
+    fn extrapolate_y_values<'a, const P: usize, const M: usize>(
+        self,
+        lagrange_table: &'a LagrangeTable<Fp61BitPrime, FRF, M>,
+    ) -> impl Iterator<Item = ([Fp61BitPrime; P], [Fp61BitPrime; P])> + 'a
+    where
+        Self: 'a,
+    {
+        TableIndicesIterator {
+            input: self.0,
+            u_table: array::from_fn(|i| {
+                let mut result = [Fp61BitPrime::ZERO; P];
+                let u = &TABLE_U[i];
+                result[0..FRF].copy_from_slice(u);
+                result[FRF..].copy_from_slice(&lagrange_table.eval(u));
+                result
+            }),
+            v_table: array::from_fn(|i| {
+                let mut result = [Fp61BitPrime::ZERO; P];
+                let v = &TABLE_V[i];
+                result[0..FRF].copy_from_slice(v);
+                result[FRF..].copy_from_slice(&lagrange_table.eval(v));
+                result
+            }),
+        }
+    }
+
+    fn eval_at_r<'a>(
+        self,
+        lagrange_table: &'a LagrangeTable<Fp61BitPrime, FRF, 1>,
+    ) -> impl Iterator<Item = (Fp61BitPrime, Fp61BitPrime)> + 'a
+    where
+        Self: 'a,
+    {
+        TableIndicesIterator {
+            input: self.0,
+            u_table: array::from_fn(|i| lagrange_table.eval(&TABLE_U[i])[0]),
+            v_table: array::from_fn(|i| lagrange_table.eval(&TABLE_V[i])[0]),
+        }
+    }
+}
+
+impl<T: Clone, I: Iterator<Item = (u8, u8)>> Iterator for TableIndicesIterator<T, I> {
+    type Item = (T, T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.input.next().map(|(u_index, v_index)| {
+            (
+                self.u_table[usize::from(u_index)].clone(),
+                self.v_table[usize::from(v_index)].clone(),
+            )
+        })
+    }
+}
+
+/// Implementation of `ProverLagrangeInput` for _u_ and _v_ values, used for subsequent
+/// recursive proofs.
+#[derive(Clone)]
+pub struct ProverValues<F: PrimeField, const L: usize, I: Iterator<Item = ([F; L], [F; L])>>(pub I);
+
+/// Iterator returned by `ProverValues::extrapolate_y_values`.
+struct ValuesExtrapolateIterator<
+    'a,
+    F: PrimeField,
+    const L: usize,
+    const P: usize,
+    const M: usize,
+    I: Iterator<Item = ([F; L], [F; L])>,
+> {
+    input: I,
+    lagrange_table: &'a LagrangeTable<F, L, M>,
+}
+
+impl<
+        'a,
+        F: PrimeField,
+        const L: usize,
+        const P: usize,
+        const M: usize,
+        I: Iterator<Item = ([F; L], [F; L])>,
+    > Iterator for ValuesExtrapolateIterator<'a, F, L, P, M, I>
+{
+    type Item = ([F; P], [F; P]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.input.next().map(|(u_values, v_values)| {
+            let mut u = [F::ZERO; P];
+            u[0..L].copy_from_slice(&u_values);
+            u[L..].copy_from_slice(&self.lagrange_table.eval(&u_values));
+            let mut v = [F::ZERO; P];
+            v[0..L].copy_from_slice(&v_values);
+            v[L..].copy_from_slice(&self.lagrange_table.eval(&v_values));
+            (u, v)
+        })
+    }
+}
+
+/// Iterator returned by `ProverValues::eval_at_r`.
+struct ValuesEvalAtRIterator<
+    'a,
+    F: PrimeField,
+    const L: usize,
+    I: Iterator<Item = ([F; L], [F; L])>,
+> {
+    input: I,
+    lagrange_table: &'a LagrangeTable<F, L, 1>,
+}
+
+impl<'a, F: PrimeField, const L: usize, I: Iterator<Item = ([F; L], [F; L])>> Iterator
+    for ValuesEvalAtRIterator<'a, F, L, I>
+{
+    type Item = (F, F);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.input.next().map(|(u_values, v_values)| {
+            (
+                self.lagrange_table.eval(&u_values)[0],
+                self.lagrange_table.eval(&v_values)[0],
+            )
+        })
+    }
+}
+
+impl<F: PrimeField, const L: usize, I: Iterator<Item = ([F; L], [F; L])>> ProverLagrangeInput<F, L>
+    for ProverValues<F, L, I>
+{
+    fn extrapolate_y_values<'a, const P: usize, const M: usize>(
+        self,
+        lagrange_table: &'a LagrangeTable<F, L, M>,
+    ) -> impl Iterator<Item = ([F; P], [F; P])> + 'a
+    where
+        Self: 'a,
+    {
+        debug_assert_eq!(L + M, P);
+        ValuesExtrapolateIterator {
+            input: self.0,
+            lagrange_table,
+        }
+    }
+
+    fn eval_at_r<'a>(
+        self,
+        lagrange_table: &'a LagrangeTable<F, L, 1>,
+    ) -> impl Iterator<Item = (F, F)> + 'a
+    where
+        Self: 'a,
+    {
+        ValuesEvalAtRIterator {
+            input: self.0,
+            lagrange_table,
+        }
+    }
+}
+
 /// This struct sets up the parameter for the proof generation
 /// and provides several functions to generate zero knowledge proofs.
 ///
@@ -119,40 +333,47 @@ impl<F: PrimeField, const L: usize, const P: usize, const M: usize> ProofGenerat
     pub const PROOF_LENGTH: usize = P;
     pub const LAGRANGE_LENGTH: usize = M;
 
+    pub fn compute_proof_from_uv<J>(uv: J, lagrange_table: &LagrangeTable<F, L, M>) -> [F; P]
+    where
+        J: Iterator,
+        J::Item: Borrow<([F; L], [F; L])>,
+    {
+        Self::compute_proof(uv.map(|uv| {
+            let (u, v) = uv.borrow();
+            let mut u_ex = [F::ZERO; P];
+            let mut v_ex = [F::ZERO; P];
+            u_ex[0..L].copy_from_slice(u);
+            v_ex[0..L].copy_from_slice(v);
+            u_ex[L..].copy_from_slice(&lagrange_table.eval(u));
+            v_ex[L..].copy_from_slice(&lagrange_table.eval(v));
+            (u_ex, v_ex)
+        }))
+    }
+
     ///
     /// Distributed Zero Knowledge Proofs algorithm drawn from
     /// `https://eprint.iacr.org/2023/909.pdf`
-    pub fn compute_proof<J>(uv_iterator: J, lagrange_table: &LagrangeTable<F, L, M>) -> [F; P]
+    pub fn compute_proof<J>(pq_iterator: J) -> [F; P]
     where
         J: Iterator,
-        J::Item: Borrow<([F; L], [F; L])>,
+        J::Item: Borrow<([F; P], [F; P])>,
     {
-        let mut proof = [F::ZERO; P];
-        for uv_polynomial in uv_iterator {
-            for (i, proof_part) in proof.iter_mut().enumerate().take(L) {
-                *proof_part += uv_polynomial.borrow().0[i] * uv_polynomial.borrow().1[i];
-            }
-            let p_extrapolated = lagrange_table.eval(&uv_polynomial.borrow().0);
-            let q_extrapolated = lagrange_table.eval(&uv_polynomial.borrow().1);
-
-            for (i, (x, y)) in
-                zip(p_extrapolated.into_iter(), q_extrapolated.into_iter()).enumerate()
-            {
-                proof[L + i] += x * y;
-            }
-        }
-        proof
+        pq_iterator
+            .fold(
+                <F as MultiplyAccumulate>::AccumulatorArray::<P>::new(),
+                |mut proof, pq| {
+                    proof.multiply_accumulate(&pq.borrow().0, &pq.borrow().1);
+                    proof
+                },
+            )
+            .take()
     }
 
-    fn gen_challenge_and_recurse<J, const N: usize>(
+    fn gen_challenge_and_recurse<I: ProverLagrangeInput<F, L>, const N: usize>(
         proof_left: &[F; P],
         proof_right: &[F; P],
-        uv_iterator: J,
-    ) -> UVValues<F, N>
-    where
-        J: Iterator,
-        J::Item: Borrow<([F; L], [F; L])>,
-    {
+        uv_iterator: I,
+    ) -> UVValues<F, N> {
         let r: F = hash_to_field(
             &compute_hash(proof_left),
             &compute_hash(proof_right),
@@ -162,17 +383,8 @@ impl<F: PrimeField, const L: usize, const P: usize, const M: usize> ProofGenerat
         let denominator = CanonicalLagrangeDenominator::<F, L>::new();
         let lagrange_table_r = LagrangeTable::<F, L, 1>::new(&denominator, &r);
 
-        // iter and interpolate at x coordinate r
         uv_iterator
-            .map(|polynomial| {
-                let (u_chunk, v_chunk) = polynomial.borrow();
-                (
-                    // new u value
-                    lagrange_table_r.eval(u_chunk)[0],
-                    // new v value
-                    lagrange_table_r.eval(v_chunk)[0],
-                )
-            })
+            .eval_at_r(&lagrange_table_r)
             .collect::<UVValues<F, N>>()
     }
 
@@ -202,29 +414,23 @@ impl<F: PrimeField, const L: usize, const P: usize, const M: usize> ProofGenerat
         proof_other_share
     }
 
-    /// This function is a helper function that computes the next proof
-    /// from an iterator over uv values
-    /// It also computes the next uv values
+    /// This function is a helper function that, given the computed proof, computes the shares of
+    /// the proof, the challenge, and the next uv values.
     ///
     /// It output `(uv values, share_of_proof_from_prover_left, my_proof_left_share)`
     /// where
     /// `share_of_proof_from_prover_left` from left has type `Vec<[F; P]>`,
     /// `my_proof_left_share` has type `Vec<[F; P]>`,
-    pub fn gen_artefacts_from_recursive_step<C, J, const N: usize>(
+    pub fn gen_artefacts_from_recursive_step<C, I, const N: usize>(
         ctx: &C,
         record_ids: &mut RecordIdRange,
-        lagrange_table: &LagrangeTable<F, L, M>,
-        uv_iterator: J,
+        my_proof: [F; P],
+        uv_iterator: I,
     ) -> (UVValues<F, N>, [F; P], [F; P])
     where
         C: Context,
-        J: Iterator + Clone,
-        J::Item: Borrow<([F; L], [F; L])>,
+        I: ProverLagrangeInput<F, L>,
     {
-        // generate next proof
-        // from iterator
-        let my_proof = Self::compute_proof(uv_iterator.clone(), lagrange_table);
-
         // generate proof shares from prss
         let (share_of_proof_from_prover_left, my_proof_right_share) =
             Self::gen_proof_shares_from_prss(ctx, record_ids);
@@ -254,20 +460,26 @@ mod test {
     use std::iter::zip;
 
     use futures::future::try_join;
+    use rand::Rng;
 
+    use super::*;
     use crate::{
         ff::{Fp31, Fp61BitPrime, PrimeField, U128Conversions},
         helpers::{Direction, Role},
         protocol::{
-            context::Context,
-            ipa_prf::malicious_security::{
-                lagrange::{CanonicalLagrangeDenominator, LagrangeTable},
-                prover::{ProofGenerator, SmallProofGenerator, UVValues},
+            context::{
+                dzkp_field::tests::reference_convert,
+                dzkp_validator::{MultiplicationInputsBlock, BIT_ARRAY_LEN},
+                Context,
+            },
+            ipa_prf::{
+                malicious_security::lagrange::{CanonicalLagrangeDenominator, LagrangeTable},
+                FirstProofGenerator,
             },
             RecordId, RecordIdRange,
         },
         seq_join::SeqJoin,
-        test_executor::run,
+        test_executor::{run, run_random},
         test_fixture::{Runner, TestWorld},
     };
 
@@ -316,7 +528,7 @@ mod test {
         let uv_1 = zip_chunks(U_1, V_1);
 
         // first iteration
-        let proof_1 = TestProofGenerator::compute_proof(uv_1.iter(), &lagrange_table);
+        let proof_1 = TestProofGenerator::compute_proof_from_uv(uv_1.iter(), &lagrange_table);
         assert_eq!(
             proof_1.iter().map(Fp31::as_u128).collect::<Vec<_>>(),
             PROOF_1,
@@ -335,12 +547,12 @@ mod test {
         let uv_2 = TestProofGenerator::gen_challenge_and_recurse(
             &proof_left_1,
             &proof_right_1,
-            uv_1.iter(),
+            ProverValues(uv_1.iter().copied()),
         );
         assert_eq!(uv_2, zip_chunks(U_2, V_2));
 
         // next iteration
-        let proof_2 = TestProofGenerator::compute_proof(uv_2.iter(), &lagrange_table);
+        let proof_2 = TestProofGenerator::compute_proof_from_uv(uv_2.iter(), &lagrange_table);
         assert_eq!(
             proof_2.iter().map(Fp31::as_u128).collect::<Vec<_>>(),
             PROOF_2,
@@ -359,7 +571,7 @@ mod test {
         let uv_3 = TestProofGenerator::gen_challenge_and_recurse::<_, 4>(
             &proof_left_2,
             &proof_right_2,
-            uv_2.iter(),
+            ProverValues(uv_2.iter().copied()),
         );
         assert_eq!(uv_3, zip_chunks(U_3, V_3));
 
@@ -369,7 +581,8 @@ mod test {
         );
 
         // final iteration
-        let proof_3 = TestProofGenerator::compute_proof(masked_uv_3.iter(), &lagrange_table);
+        let proof_3 =
+            TestProofGenerator::compute_proof_from_uv(masked_uv_3.iter(), &lagrange_table);
         assert_eq!(
             proof_3.iter().map(Fp31::as_u128).collect::<Vec<_>>(),
             PROOF_3,
@@ -397,11 +610,12 @@ mod test {
             // first iteration
             let world = TestWorld::default();
             let mut record_ids = RecordIdRange::ALL;
+            let proof = TestProofGenerator::compute_proof_from_uv(uv_1.iter(), &lagrange_table);
             let (uv_values, _, _) = TestProofGenerator::gen_artefacts_from_recursive_step::<_, _, 4>(
                 &world.contexts()[0],
                 &mut record_ids,
-                &lagrange_table,
-                uv_1.iter(),
+                proof,
+                ProverValues(uv_1.iter().copied()),
             );
 
             assert_eq!(7, uv_values.len());
@@ -436,14 +650,14 @@ mod test {
         >::from(denominator);
 
         // compute proof
-        let proof = SmallProofGenerator::compute_proof(uv_before.iter(), &lagrange_table);
+        let proof = SmallProofGenerator::compute_proof_from_uv(uv_before.iter(), &lagrange_table);
 
         assert_eq!(proof.len(), SmallProofGenerator::PROOF_LENGTH);
 
         let uv_after = SmallProofGenerator::gen_challenge_and_recurse::<_, 8>(
             &proof,
             &proof,
-            uv_before.iter(),
+            ProverValues(uv_before.iter().copied()),
         );
 
         assert_eq!(
@@ -472,14 +686,14 @@ mod test {
         >::from(denominator);
 
         // compute proof
-        let proof = LargeProofGenerator::compute_proof(uv_before.iter(), &lagrange_table);
+        let proof = LargeProofGenerator::compute_proof_from_uv(uv_before.iter(), &lagrange_table);
 
         assert_eq!(proof.len(), LargeProofGenerator::PROOF_LENGTH);
 
         let uv_after = LargeProofGenerator::gen_challenge_and_recurse::<_, 8>(
             &proof,
             &proof,
-            uv_before.iter(),
+            ProverValues(uv_before.iter().copied()),
         );
 
         assert_eq!(
@@ -593,5 +807,54 @@ mod test {
         assert_two_part_secret_sharing(PROOF_1, h3_proof_right, h2_proof_left);
         assert_two_part_secret_sharing(PROOF_2, h1_proof_right, h3_proof_left);
         assert_two_part_secret_sharing(PROOF_3, h2_proof_right, h1_proof_left);
+    }
+
+    #[test]
+    fn prover_table_indices_equivalence() {
+        run_random(|mut rng| async move {
+            const FPL: usize = FirstProofGenerator::PROOF_LENGTH;
+            const FLL: usize = FirstProofGenerator::LAGRANGE_LENGTH;
+
+            // This generates all the intermediates except _z_ randomly, and calculates
+            // _z_ from the others.
+            let block = rng.gen::<MultiplicationInputsBlock>();
+
+            // Test equivalence for extrapolate_y_values
+            let denominator = CanonicalLagrangeDenominator::new();
+            let lagrange_table = LagrangeTable::from(denominator);
+
+            assert!(ProverTableIndices(block.table_indices_prover().into_iter())
+                .extrapolate_y_values::<FPL, FLL>(&lagrange_table)
+                .eq(ProverValues((0..BIT_ARRAY_LEN).map(|i| {
+                    reference_convert(
+                        block.x_left[i],
+                        block.x_right[i],
+                        block.y_left[i],
+                        block.y_right[i],
+                        block.prss_left[i],
+                        block.prss_right[i],
+                    )
+                }))
+                .extrapolate_y_values::<FPL, FLL>(&lagrange_table)));
+
+            // Test equivalence for eval_at_r
+            let denominator = CanonicalLagrangeDenominator::new();
+            let r = rng.gen();
+            let lagrange_table_r = LagrangeTable::new(&denominator, &r);
+
+            assert!(ProverTableIndices(block.table_indices_prover().into_iter())
+                .eval_at_r(&lagrange_table_r)
+                .eq(ProverValues((0..BIT_ARRAY_LEN).map(|i| {
+                    reference_convert(
+                        block.x_left[i],
+                        block.x_right[i],
+                        block.y_left[i],
+                        block.y_right[i],
+                        block.prss_left[i],
+                        block.prss_right[i],
+                    )
+                }))
+                .eval_at_r(&lagrange_table_r)));
+        });
     }
 }

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -562,8 +562,6 @@ mod test {
     #[test]
     fn verifier_table_indices_equivalence() {
         run_random(|mut rng| async move {
-            // This generates all the intermediates except _z_ randomly, and calculates
-            // _z_ from the others.
             let block = rng.gen::<MultiplicationInputsBlock>();
 
             let denominator = CanonicalLagrangeDenominator::new();

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/verifier.rs
@@ -122,7 +122,7 @@ pub fn recursively_compute_final_check<F: PrimeField, const L: usize>(
     challenges: &[F],
     p_or_q_0: F,
 ) -> F {
-    // This function requires MIN_PROOF_RECURSION be at least 3.
+    // This function requires MIN_PROOF_RECURSION be at least 2.
     assert!(challenges.len() >= MIN_PROOF_RECURSION && challenges.len() <= MAX_PROOF_RECURSION);
     let recursions_after_first = challenges.len() - 1;
 
@@ -179,9 +179,9 @@ pub fn recursively_compute_final_check<F: PrimeField, const L: usize>(
 /// `VerifierValues` implementation, which represents actual _u_ and _v_ values, is used
 /// by the remaining recursive proofs.
 ///
-/// There is a similar trait `ProverLagrangeInput` in `prover.rs`. The prover operates
-/// on _u_ and _v_ values simultaneously (i.e. iterators of tuples). The verifier
-/// operates on only one of _u_ or _v_ at a time.
+/// There is a similar trait `ProverLagrangeInput` in `prover.rs`. The difference is
+/// that the prover operates on _u_ and _v_ values simultaneously (i.e. iterators of
+/// tuples). The verifier operates on only one of _u_ or _v_ at a time.
 pub trait VerifierLagrangeInput<F: PrimeField, const L: usize> {
     fn eval_at_r<'a>(
         self,
@@ -197,7 +197,7 @@ pub struct VerifierTableIndices<'a, F: PrimeField, I: Iterator<Item = u8>> {
     pub table: &'a UVTable<F>,
 }
 
-/// Iterator producted by `VerifierTableIndices::eval_at_r`.
+/// Iterator returned by `VerifierTableIndices::eval_at_r`.
 struct TableIndicesIterator<F: PrimeField, I: Iterator<Item = u8>> {
     input: I,
     table: [F; 8],

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -59,9 +59,10 @@ pub(crate) mod shuffle;
 pub(crate) mod step;
 pub mod validation_protocol;
 
-pub type FirstProofGenerator = malicious_security::prover::SmallProofGenerator;
-pub type CompressedProofGenerator = malicious_security::prover::SmallProofGenerator;
-
+pub use malicious_security::{
+    CompressedProofGenerator, FirstProofGenerator, LagrangeTable, ProverTableIndices,
+    VerifierTableIndices,
+};
 pub use shuffle::Shuffle;
 
 /// Match key type

--- a/ipa-core/src/protocol/ipa_prf/validation_protocol/validation.rs
+++ b/ipa-core/src/protocol/ipa_prf/validation_protocol/validation.rs
@@ -535,7 +535,7 @@ pub mod test {
 
         // check for consistency
         // only check first R::USIZE field elements
-        assert_eq!(simple_proof.to_vec(), proof_computed[0..FRF].to_vec(),);
+        assert_eq!(simple_proof.to_vec(), proof_computed[0..FRF].to_vec());
     }
 
     #[test]
@@ -949,9 +949,8 @@ pub mod test {
         // `verify_batch` to generate test data, generates `len` chunks of u/v values of
         // length `FRF`. We want the input u/v values to compress to exactly one
         // u/v pair after some number of proof steps.
-        let num_inputs = FirstProofGenerator::RECURSION_FACTOR
-            * CompressedProofGenerator::RECURSION_FACTOR
-            * CompressedProofGenerator::RECURSION_FACTOR;
+        let num_inputs =
+            FirstProofGenerator::RECURSION_FACTOR * CompressedProofGenerator::RECURSION_FACTOR;
         assert!(num_inputs % FRF == 0);
         verify_batch(num_inputs / FRF);
     }

--- a/ipa-core/src/secret_sharing/vector/transpose.rs
+++ b/ipa-core/src/secret_sharing/vector/transpose.rs
@@ -100,7 +100,7 @@ pub trait TransposeFrom<T> {
 //
 // From Hacker's Delight (2nd edition), Figure 7-6.
 //
-// There are comments on `dzkp_field::convert_values_table_indices`, which implements a
+// There are comments on `dzkp_field::bits_to_table_indices`, which implements a
 // similar transformation, that may help to understand how this works.
 #[inline]
 pub fn transpose_8x8<B: Borrow<[u8; 8]>>(x: B) -> [u8; 8] {
@@ -125,7 +125,7 @@ pub fn transpose_8x8<B: Borrow<[u8; 8]>>(x: B) -> [u8; 8] {
 //
 // Loosely based on Hacker's Delight (2nd edition), Figure 7-6.
 //
-// There are comments on `dzkp_field::convert_values_table_indices`, which implements a
+// There are comments on `dzkp_field::bits_to_table_indices`, which implements a
 // similar transformation, that may help to understand how this works.
 #[inline]
 pub fn transpose_16x16(src: &[u8; 32]) -> [u8; 32] {


### PR DESCRIPTION
As coded, this change only works when the first recursion has λ = 4. I also have a hacked up version with λ = 8, but it's not as optimized as it could be. For a comparison of the different choices for λ with or without this optimization, see https://github.com/private-attribution/ipa/pull/1440#issuecomment-2480801696.

Unfortunately this change has grown quite large. I may be able to split it up if needed, but I'll also offer the following breakdown of the changes to possibly simplify reviewing:

* In `dzkp_field.rs`:
  * Change the verifier routines to use table indices like the prover routines.
  * Change the table index generation to write to an output iterator instead of producing a vector that may need to be repacked.
  * Some cleanup and renaming.
* In `prover.rs` and `verifier.rs`:
  * Add new `ProverLagrangeInput` and `VerifierLagrangeInput` traits. These traits enable some proof routines to take as input either table indices (for the first proof) or U/V values (for subsequent proofs).
  * `compute_proof` no longer does the Lagrange interpolation, it just does the summation of the Lagrange output into a proof. `compute_proof_from_uv` is a wrapper that is more similar to what `compute_proof` used to do. The call to `compute_proof` moves out of `gen_artefacts_from_recursive_step`, which now takes the proof as an argument. (These changes were made in an earlier version that didn't have the Lagrange input traits, could be undone now if desired.)
  * Other changes to adopt the Lagrange input traits.
* In `dzkp_validator.rs`:
  * Use the table index versions of the conversion routines.
  * Use the `LagrangeInput` traits.
* Most tests are updated to use the `Values` versions of the input traits. There are two new tests that verify the `Values` and `TableIndices` versions produce the same output.

<details>
<summary>Older draft runs</summary>

Draft run at 1ec8962 (included a bunch of changes that are related but not essential to the optimization here): https://draft-mpc.vercel.app/query/view/droll-dill2024-11-14T0030, 2:09.

Draft run at 5e1a5a1 (cleaned up version): https://draft-mpc.vercel.app/query/view/batty-issue2024-11-14T2003, 2:11.

Draft run at a00d566 (added lookup tables for "evaluate at r" operations): https://draft-mpc.vercel.app/query/view/void-job2024-11-19T0059, 2:01.

</details>

Draft run at 825441e (uses multiply-accumulate trait from #1448): https://draft-mpc.vercel.app/query/view/busty-poor2024-11-19T1758, 1:56.

Draft run at 5f9675a: https://draft-mpc.vercel.app/query/view/swish-tape2024-11-20T2217, 1:54.