### PR TITLE
Breakdown key reveal

### DIFF
--- a/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
@@ -4,14 +4,9 @@ use futures::stream;
 use futures_util::{StreamExt, TryStreamExt};
 use tracing::{info_span, Instrument};
 
-use super::aggregate_values;
 use crate::{
     error::{Error, UnwrapInfallible},
-    ff::{
-        boolean::Boolean,
-        boolean_array::{BooleanArray, BooleanArrayReader, BooleanArrayWriter, BA32},
-        U128Conversions,
-    },
+    ff::{boolean::Boolean, boolean_array::BooleanArray, U128Conversions},
     helpers::TotalRecords,
     protocol::{
         basics::{reveal, Reveal},
@@ -21,83 +16,21 @@ use crate::{
         },
         ipa_prf::{
             aggregation::{
-                aggregate_values_proof_chunk, step::AggregationStep as Step, AGGREGATE_DEPTH,
+                aggregate_values, aggregate_values_proof_chunk, step::AggregationStep as Step,
+                AGGREGATE_DEPTH,
             },
             oprf_padding::{apply_dp_padding, PaddingParameters},
-            prf_sharding::{AttributionOutputs, SecretSharedAttributionOutputs},
-            shuffle::{Shuffle, Shuffleable},
-            BreakdownKey,
+            shuffle::Shuffle,
         },
         BooleanProtocols, RecordId,
     },
+    report::hybrid::AggregateableHybridReport,
     secret_sharing::{
-        replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},
-        BitDecomposed, FieldSimd, SharedValue, TransposeFrom, Vectorizable,
+        replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, FieldSimd,
+        TransposeFrom, Vectorizable,
     },
     seq_join::seq_join,
 };
-
-impl<BK, TV> AttributionOutputs<Replicated<BK>, Replicated<TV>>
-where
-    BK: BooleanArray,
-    TV: BooleanArray,
-{
-    fn join_fields(breakdown_key: BK, trigger_value: TV) -> <Self as Shuffleable>::Share {
-        let mut share = <Self as Shuffleable>::Share::ZERO;
-
-        BooleanArrayWriter::new(&mut share)
-            .write(&breakdown_key)
-            .write(&trigger_value);
-
-        share
-    }
-
-    fn split_fields(share: &<Self as Shuffleable>::Share) -> (BK, TV) {
-        let bits = BooleanArrayReader::new(share);
-        let (breakdown_key, bits) = bits.read();
-        let (trigger_value, _bits) = bits.read();
-        (breakdown_key, trigger_value)
-    }
-}
-
-impl<BK, TV> Shuffleable for AttributionOutputs<Replicated<BK>, Replicated<TV>>
-where
-    BK: BooleanArray,
-    TV: BooleanArray,
-{
-    /// TODO: Use a smaller BA type to contain BK and TV
-    type Share = BA32;
-
-    fn left(&self) -> Self::Share {
-        Self::join_fields(
-            ReplicatedSecretSharing::left(&self.attributed_breakdown_key_bits),
-            ReplicatedSecretSharing::left(&self.capped_attributed_trigger_value),
-        )
-    }
-
-    fn right(&self) -> Self::Share {
-        Self::join_fields(
-            ReplicatedSecretSharing::right(&self.attributed_breakdown_key_bits),
-            ReplicatedSecretSharing::right(&self.capped_attributed_trigger_value),
-        )
-    }
-
-    fn new(l: Self::Share, r: Self::Share) -> Self {
-        debug_assert!(
-            BK::BITS + TV::BITS <= Self::Share::BITS,
-            "share type {} is too small",
-            std::any::type_name::<Self::Share>(),
-        );
-
-        let left = Self::split_fields(&l);
-        let right = Self::split_fields(&r);
-
-        Self {
-            attributed_breakdown_key_bits: ReplicatedSecretSharing::new(left.0, right.0),
-            capped_attributed_trigger_value: ReplicatedSecretSharing::new(left.1, right.1),
-        }
-    }
-}
 
 /// Improved Aggregation a.k.a Aggregation revealing breakdown.
 ///
@@ -127,30 +60,29 @@ where
 ///     record. This is currently ensured by the serial operation of the aggregation
 ///     protocol (i.e. by not using `seq_join`).
 #[tracing::instrument(name = "breakdown_reveal_aggregation", skip_all, fields(total = attributed_values.len()))]
-pub async fn breakdown_reveal_aggregation<C, BK, TV, HV, const B: usize>(
+pub async fn breakdown_reveal_aggregation<C, BK, V, HV, const B: usize>(
     ctx: C,
-    attributed_values: Vec<SecretSharedAttributionOutputs<BK, TV>>,
+    attributed_values: Vec<AggregateableHybridReport<BK, V>>,
     padding_params: &PaddingParameters,
 ) -> Result<BitDecomposed<Replicated<Boolean, B>>, Error>
 where
     C: UpgradableContext + Shuffle,
     Boolean: FieldSimd<B>,
     Replicated<Boolean, B>: BooleanProtocols<DZKPUpgraded<C>, B>,
-    BK: BreakdownKey<B>,
+    BK: BooleanArray + U128Conversions,
     Replicated<BK>: Reveal<DZKPUpgraded<C>, Output = <BK as Vectorizable<1>>::Array>,
-    TV: BooleanArray + U128Conversions,
+    V: BooleanArray + U128Conversions,
     HV: BooleanArray + U128Conversions,
     BitDecomposed<Replicated<Boolean, B>>:
-        for<'a> TransposeFrom<&'a [Replicated<TV>; B], Error = Infallible>,
+        for<'a> TransposeFrom<&'a [Replicated<V>; B], Error = Infallible>,
 {
     // Apply DP padding for Breakdown Reveal Aggregation
-    let attributed_values_padded =
-        apply_dp_padding::<_, AttributionOutputs<Replicated<BK>, Replicated<TV>>, B>(
-            ctx.narrow(&Step::PaddingDp),
-            attributed_values,
-            padding_params,
-        )
-        .await?;
+    let attributed_values_padded = apply_dp_padding::<_, AggregateableHybridReport<BK, V>, B>(
+        ctx.narrow(&Step::PaddingDp),
+        attributed_values,
+        padding_params,
+    )
+    .await?;
 
     let attributions = ctx
         .narrow(&Step::Shuffle)
@@ -176,7 +108,7 @@ where
     // may exceed that.
     let mut chunk_counter = 0;
     let mut depth = 0;
-    let agg_proof_chunk = aggregate_values_proof_chunk(B, usize::try_from(TV::BITS).unwrap());
+    let agg_proof_chunk = aggregate_values_proof_chunk(B, usize::try_from(V::BITS).unwrap());
 
     while intermediate_results.len() > 1 {
         let mut record_ids = [RecordId::FIRST; AGGREGATE_DEPTH];
@@ -220,34 +152,33 @@ where
 #[tracing::instrument(name = "reveal_breakdowns", skip_all, fields(
     total = attributions.len(),
 ))]
-async fn reveal_breakdowns<C, BK, TV, const B: usize>(
+async fn reveal_breakdowns<C, BK, V, const B: usize>(
     parent_ctx: &C,
-    attributions: Vec<SecretSharedAttributionOutputs<BK, TV>>,
-) -> Result<GroupedTriggerValues<TV, B>, Error>
+    attributions: Vec<AggregateableHybridReport<BK, V>>,
+) -> Result<ValueHistogram<V, B>, Error>
 where
     C: Context,
     Replicated<Boolean, B>: BooleanProtocols<C, B>,
     Boolean: FieldSimd<B>,
-    BK: BreakdownKey<B>,
+    BK: BooleanArray + U128Conversions,
     Replicated<BK>: Reveal<C, Output = <BK as Vectorizable<1>>::Array>,
-    TV: BooleanArray + U128Conversions,
+    V: BooleanArray + U128Conversions,
 {
     let reveal_ctx = parent_ctx.set_total_records(TotalRecords::specified(attributions.len())?);
 
-    let reveal_work = stream::iter(attributions).enumerate().map(|(i, ao)| {
+    let reveal_work = stream::iter(attributions).enumerate().map(|(i, report)| {
         let record_id = RecordId::from(i);
         let reveal_ctx = reveal_ctx.clone();
         async move {
-            let revealed_bk =
-                reveal(reveal_ctx, record_id, &ao.attributed_breakdown_key_bits).await?;
+            let revealed_bk = reveal(reveal_ctx, record_id, &report.breakdown_key).await?;
             let revealed_bk = BK::from_array(&revealed_bk);
             let Ok(bk) = usize::try_from(revealed_bk.as_u128()) else {
                 return Err(Error::Internal);
             };
-            Ok::<_, Error>((bk, ao.capped_attributed_trigger_value))
+            Ok::<_, Error>((bk, report.value))
         }
     });
-    let mut grouped_tvs = GroupedTriggerValues::<TV, B>::new();
+    let mut grouped_tvs = ValueHistogram::<V, B>::new();
     let mut stream = pin!(seq_join(reveal_ctx.active_work(), reveal_work));
     while let Some((bk, tv)) = stream.try_next().await? {
         grouped_tvs.push(bk, tv);
@@ -259,12 +190,12 @@ where
 /// Helper type that hold all the Trigger Values, grouped by their Breakdown
 /// Key. The main functionality is to turn into a stream that can be given to
 /// [`aggregate_values`].
-struct GroupedTriggerValues<TV: BooleanArray, const B: usize> {
-    tvs: [Vec<Replicated<TV>>; B],
+struct ValueHistogram<V: BooleanArray, const B: usize> {
+    tvs: [Vec<Replicated<V>>; B],
     max_len: usize,
 }
 
-impl<TV: BooleanArray, const B: usize> GroupedTriggerValues<TV, B> {
+impl<V: BooleanArray, const B: usize> ValueHistogram<V, B> {
     fn new() -> Self {
         Self {
             tvs: std::array::from_fn(|_| vec![]),
@@ -272,7 +203,7 @@ impl<TV: BooleanArray, const B: usize> GroupedTriggerValues<TV, B> {
         }
     }
 
-    fn push(&mut self, bk: usize, value: Replicated<TV>) {
+    fn push(&mut self, bk: usize, value: Replicated<V>) {
         self.tvs[bk].push(value);
         if self.tvs[bk].len() > self.max_len {
             self.max_len = self.tvs[bk].len();
@@ -280,18 +211,16 @@ impl<TV: BooleanArray, const B: usize> GroupedTriggerValues<TV, B> {
     }
 }
 
-impl<TV: BooleanArray, const B: usize> From<GroupedTriggerValues<TV, B>>
+impl<V: BooleanArray, const B: usize> From<ValueHistogram<V, B>>
     for Vec<BitDecomposed<Replicated<Boolean, B>>>
 where
     Boolean: FieldSimd<B>,
     BitDecomposed<Replicated<Boolean, B>>:
-        for<'a> TransposeFrom<&'a [Replicated<TV>; B], Error = Infallible>,
+        for<'a> TransposeFrom<&'a [Replicated<V>; B], Error = Infallible>,
 {
-    fn from(
-        mut grouped_tvs: GroupedTriggerValues<TV, B>,
-    ) -> Vec<BitDecomposed<Replicated<Boolean, B>>> {
+    fn from(mut grouped_tvs: ValueHistogram<V, B>) -> Vec<BitDecomposed<Replicated<Boolean, B>>> {
         let iter = (0..grouped_tvs.max_len).map(move |_| {
-            let slice: [Replicated<TV>; B] = grouped_tvs
+            let slice: [Replicated<V>; B] = grouped_tvs
                 .tvs
                 .each_mut()
                 .map(|tv| tv.pop().unwrap_or(Replicated::ZERO));
@@ -302,98 +231,38 @@ where
     }
 }
 
-#[cfg(all(test, any(unit_test, feature = "shuttle")))]
+#[cfg(all(test, unit_test, not(feature = "shuttle")))]
 pub mod tests {
     use futures::TryFutureExt;
     use rand::seq::SliceRandom;
 
-    #[cfg(not(feature = "shuttle"))]
-    use crate::{ff::boolean_array::BA16, test_executor::run};
     use crate::{
         ff::{
             boolean::Boolean,
-            boolean_array::{BA3, BA5, BA8},
+            boolean_array::{BA16, BA3, BA5},
             U128Conversions,
         },
-        protocol::ipa_prf::{
-            aggregation::breakdown_reveal::breakdown_reveal_aggregation,
-            oprf_padding::PaddingParameters,
-            prf_sharding::{AttributionOutputsTestInput, SecretSharedAttributionOutputs},
+        protocol::{
+            hybrid::breakdown_reveal_aggregation, ipa_prf::oprf_padding::PaddingParameters,
         },
         rand::Rng,
         secret_sharing::{
             replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
         },
-        test_executor::run_with,
-        test_fixture::{Reconstruct, Runner, TestWorld},
+        test_executor::run,
+        test_fixture::{hybrid::TestAggregateableHybridReport, Reconstruct, Runner, TestWorld},
     };
 
-    fn input_row(bk: usize, tv: u128) -> AttributionOutputsTestInput<BA5, BA3> {
-        let bk: u128 = bk.try_into().unwrap();
-        AttributionOutputsTestInput {
-            bk: BA5::truncate_from(bk),
-            tv: BA3::truncate_from(tv),
+    fn input_row(breakdown_key: usize, value: u128) -> TestAggregateableHybridReport {
+        TestAggregateableHybridReport {
+            match_key: (),
+            value: value.try_into().unwrap(),
+            breakdown_key: breakdown_key.try_into().unwrap(),
         }
     }
 
     #[test]
-    fn semi_honest_happy_path() {
-        // if shuttle executor is enabled, run this test only once.
-        // it is a very expensive test to explore all possible states,
-        // sometimes github bails after 40 minutes of running it
-        // (workers there are really slow).
-        run_with::<_, _, 3>(|| async {
-            let world = TestWorld::default();
-            let mut rng = world.rng();
-            let mut expectation = Vec::new();
-            for _ in 0..32 {
-                expectation.push(rng.gen_range(0u128..256));
-            }
-            let expectation = expectation; // no more mutability for safety
-            let mut inputs = Vec::new();
-            for (bk, expected_hv) in expectation.iter().enumerate() {
-                let mut remainder = *expected_hv;
-                while remainder > 7 {
-                    let tv = rng.gen_range(0u128..8);
-                    remainder -= tv;
-                    inputs.push(input_row(bk, tv));
-                }
-                inputs.push(input_row(bk, remainder));
-            }
-            inputs.shuffle(&mut rng);
-            let result: Vec<_> = world
-                .semi_honest(inputs.into_iter(), |ctx, input_rows| async move {
-                    let aos = input_rows
-                        .into_iter()
-                        .map(|ti| SecretSharedAttributionOutputs {
-                            attributed_breakdown_key_bits: ti.0,
-                            capped_attributed_trigger_value: ti.1,
-                        })
-                        .collect();
-                    let r: Vec<Replicated<BA8>> =
-                        breakdown_reveal_aggregation::<_, BA5, BA3, BA8, 32>(
-                            ctx,
-                            aos,
-                            &PaddingParameters::relaxed(),
-                        )
-                        .map_ok(|d: BitDecomposed<Replicated<Boolean, 32>>| {
-                            Vec::transposed_from(&d).unwrap()
-                        })
-                        .await
-                        .unwrap();
-                    r
-                })
-                .await
-                .reconstruct();
-            let result = result.iter().map(|&v| v.as_u128()).collect::<Vec<_>>();
-            assert_eq!(32, result.len());
-            assert_eq!(result, expectation);
-        });
-    }
-
-    #[test]
-    #[cfg(not(feature = "shuttle"))] // too slow
-    fn malicious_happy_path() {
+    fn breakdown_reveal_malicious_happy_path() {
         type HV = BA16;
         run(|| async {
             let world = TestWorld::default();
@@ -407,28 +276,25 @@ pub mod tests {
             // depends on `TARGET_PROOF_SIZE`.
             let expectation = expectation; // no more mutability for safety
             let mut inputs = Vec::new();
-            for (bk, expected_hv) in expectation.iter().enumerate() {
-                let mut remainder = *expected_hv;
+            // Builds out inputs with values for each breakdown_key that add up to
+            // the expectation. Expectation is ranomg (0..512). Each iteration
+            // generates a value (0..8) and subtracts from the expectation until a final
+            // remaninder in (0..8) remains to be added to the vec.
+            for (breakdown_key, expected_value) in expectation.iter().enumerate() {
+                let mut remainder = *expected_value;
                 while remainder > 7 {
-                    let tv = rng.gen_range(0u128..8);
-                    remainder -= tv;
-                    inputs.push(input_row(bk, tv));
+                    let value = rng.gen_range(0u128..8);
+                    remainder -= value;
+                    inputs.push(input_row(breakdown_key, value));
                 }
-                inputs.push(input_row(bk, remainder));
+                inputs.push(input_row(breakdown_key, remainder));
             }
             inputs.shuffle(&mut rng);
             let result: Vec<_> = world
-                .malicious(inputs.into_iter(), |ctx, input_rows| async move {
-                    let aos = input_rows
-                        .into_iter()
-                        .map(|ti| SecretSharedAttributionOutputs {
-                            attributed_breakdown_key_bits: ti.0,
-                            capped_attributed_trigger_value: ti.1,
-                        })
-                        .collect();
+                .malicious(inputs.into_iter(), |ctx, reports| async move {
                     breakdown_reveal_aggregation::<_, BA5, BA3, HV, 32>(
                         ctx,
-                        aos,
+                        reports,
                         &PaddingParameters::relaxed(),
                     )
                     .map_ok(|d: BitDecomposed<Replicated<Boolean, 32>>| {

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     hpke::PrivateKeyRegistry,
     protocol::{
-        basics::{BooleanProtocols, Reveal},
+        basics::{BooleanArrayMul, BooleanProtocols, Reveal},
         context::{DZKPUpgraded, MacUpgraded, ShardedContext, UpgradableContext},
         hybrid::{
             hybrid_protocol,
@@ -73,6 +73,8 @@ where
     Replicated<RP25519, PRF_CHUNK>:
         Reveal<MacUpgraded<C, Fp25519>, Output = <RP25519 as Vectorizable<PRF_CHUNK>>::Array>,
     Replicated<Boolean>: BooleanProtocols<DZKPUpgraded<C>>,
+    Replicated<BA8>: BooleanArrayMul<DZKPUpgraded<C>>
+        + Reveal<DZKPUpgraded<C>, Output = <BA8 as Vectorizable<1>>::Array>,
 {
     #[tracing::instrument("hybrid_query", skip_all, fields(sz=%query_size))]
     pub async fn execute(

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -40,7 +40,7 @@ use crate::{
     error::{BoxError, Error},
     ff::{
         boolean_array::{
-            BooleanArray, BooleanArrayReader, BooleanArrayWriter, BA112, BA3, BA64, BA8,
+            BooleanArray, BooleanArrayReader, BooleanArrayWriter, BA112, BA3, BA32, BA64, BA8,
         },
         Serializable,
     },
@@ -685,6 +685,35 @@ pub type PrfHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, u64>;
 /// that OPRF value is no longer required.
 pub type AggregateableHybridReport<BK, V> = IndistinguishableHybridReport<BK, V, ()>;
 
+impl<BK, V> IndistinguishableHybridReport<BK, V, ()>
+where
+    BK: BooleanArray,
+    V: BooleanArray,
+{
+    pub const ZERO: Self = Self {
+        match_key: (),
+        value: Replicated::<V>::ZERO,
+        breakdown_key: Replicated::<BK>::ZERO,
+    };
+
+    fn join_fields(value: V, breakdown_key: BK) -> <Self as Shuffleable>::Share {
+        let mut share = <Self as Shuffleable>::Share::ZERO;
+
+        BooleanArrayWriter::new(&mut share)
+            .write(&value)
+            .write(&breakdown_key);
+
+        share
+    }
+
+    fn split_fields(share: &<Self as Shuffleable>::Share) -> (V, BK) {
+        let bits = BooleanArrayReader::new(share);
+        let (value, bits) = bits.read();
+        let (breakdown_key, _) = bits.read();
+        (value, breakdown_key)
+    }
+}
+
 /// When aggregating reports, we need to lift the value from `V` to `HV`.
 impl<BK, V, HV> From<PrfHybridReport<BK, V>> for AggregateableHybridReport<BK, HV>
 where
@@ -848,6 +877,41 @@ where
             match_key: ReplicatedSecretSharing::new(left.0, right.0),
             value: ReplicatedSecretSharing::new(left.1, right.1),
             breakdown_key: ReplicatedSecretSharing::new(left.2, right.2),
+        }
+    }
+}
+
+impl<BK, V> Shuffleable for IndistinguishableHybridReport<BK, V, ()>
+where
+    BK: BooleanArray,
+    V: BooleanArray,
+{
+    // this requires BK:BAXX + V:BAYY  such that XX + YY <= 32
+    // this is checked in a debud_assert call in ::new below
+    type Share = BA32;
+
+    fn left(&self) -> Self::Share {
+        Self::join_fields(self.value.left(), self.breakdown_key.left())
+    }
+
+    fn right(&self) -> Self::Share {
+        Self::join_fields(self.value.right(), self.breakdown_key.right())
+    }
+
+    fn new(l: Self::Share, r: Self::Share) -> Self {
+        debug_assert!(
+            BK::BITS + V::BITS <= Self::Share::BITS,
+            "share type {} is too small",
+            std::any::type_name::<Self::Share>(),
+        );
+
+        let left = Self::split_fields(&l);
+        let right = Self::split_fields(&r);
+
+        Self {
+            match_key: (),
+            value: ReplicatedSecretSharing::new(left.0, right.0),
+            breakdown_key: ReplicatedSecretSharing::new(left.1, right.1),
         }
     }
 }

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -10,7 +10,8 @@ use crate::{
     },
     rand::Rng,
     report::hybrid::{
-        HybridConversionReport, HybridImpressionReport, HybridReport, IndistinguishableHybridReport,
+        AggregateableHybridReport, HybridConversionReport, HybridImpressionReport, HybridReport,
+        IndistinguishableHybridReport,
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::sharing::Reconstruct,
@@ -85,6 +86,28 @@ where
             breakdown_key: breakdown_key.try_into().unwrap(),
             value: value.try_into().unwrap(),
         }
+    }
+}
+
+impl<BK, V> IntoShares<AggregateableHybridReport<BK, V>> for TestAggregateableHybridReport
+where
+    BK: BooleanArray + U128Conversions + IntoShares<Replicated<BK>>,
+    V: BooleanArray + U128Conversions + IntoShares<Replicated<V>>,
+{
+    fn share_with<R: Rng>(self, rng: &mut R) -> [AggregateableHybridReport<BK, V>; 3] {
+        let ba_breakdown_key = BK::try_from(u128::from(self.breakdown_key))
+            .unwrap()
+            .share_with(rng);
+        let ba_value = V::try_from(u128::from(self.value)).unwrap().share_with(rng);
+        zip(ba_breakdown_key, ba_value)
+            .map(|(breakdown_key, value)| AggregateableHybridReport {
+                match_key: (),
+                breakdown_key,
+                value,
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap()
     }
 }
 

--- a/ipa-core/src/test_fixture/sharing.rs
+++ b/ipa-core/src/test_fixture/sharing.rs
@@ -155,6 +155,15 @@ where
     }
 }
 
+impl<I, T> Reconstruct<Vec<Vec<T>>> for Vec<[Vec<I>; 3]>
+where
+    for<'i> [&'i [I]; 3]: Reconstruct<Vec<T>>,
+{
+    fn reconstruct(&self) -> Vec<Vec<T>> {
+        self.iter().map(Reconstruct::reconstruct).collect()
+    }
+}
+
 impl<I, T> Reconstruct<BitDecomposed<T>> for [BitDecomposed<I>; 3]
 where
     for<'i> [&'i [I]; 3]: Reconstruct<Vec<T>>,


### PR DESCRIPTION
This implements `breakdown_reveal` for hybrid, which covers padding reports, shuffling them, revealing the breakdown key, and then adding the secret shares of the values into histograms.

Note that this is stacked on top of #1444, but in the meantime, you can look just at commit `5dbaa63` to highlight the changes.