### PR TITLE
Create an abstraction for multiply-accumulate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Add Rust sources
         run: rustup component add rust-src
       - name: Run tests with sanitizer
-        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test -Z build-std -p ipa-core --target $TARGET --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate ${{ matrix.features }}"
+        run: RUSTFLAGS="-Z sanitizer=${{ matrix.sanitizer }} -Z sanitizer-memory-track-origins" cargo test -Z build-std -p ipa-core --all-targets --target $TARGET --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate ${{ matrix.features }}"
 
   miri:
     runs-on: ubuntu-latest

--- a/ipa-core/src/ff/accumulator.rs
+++ b/ipa-core/src/ff/accumulator.rs
@@ -1,0 +1,430 @@
+//! Optimized multiply-accumulate for field elements.
+//!
+//! An add or multiply operation in a prime field can be implemented as the
+//! corresponding operation over the integers, followed by a reduction modulo the prime.
+//!
+//! In the case of several arithmetic operations performed in sequence, it is not
+//! necessary to perform the reduction after every operation. As long as an exact
+//! integer result is maintained up until reducing, the reduction can be performed once
+//! at the end of the sequence.
+//!
+//! The reduction is usually the most expensive part of a multiplication operation, even
+//! when using special primes like Mersenne primes that have an efficient reduction
+//! operation.
+//!
+//! This module implements an optimized multiply-accumulate operation for field elements
+//! that defers reduction.
+//!
+//! To enable this optimized implementation for a field, it is necessary to (1) select
+//! an accumulator type, (2) calculate the number of multiply-accumulate operations
+//! that can be performed without overflowing the accumulator. Record these values
+//! in an implementation of the `MultiplyAccumulate` trait.
+//!
+//! This module also provides a generic implementation of `MultiplyAccumulate` that
+//! reduces after every operation. To use the generic implementation for `MyField`:
+//!
+//! ```ignore
+//! impl MultiplyAccumulate for MyField {
+//!     type Accumulator = MyField;
+//!     type AccumulatorArray<const N: usize> = [MyField; N];
+//! }
+//! ```
+//!
+//! Currently, an optimized implementation is supplied only for `Fp61BitPrime`, which is
+//! used _extensively_ in DZKP-based malicious security. All other fields use a naive
+//! implementation. (The implementation of DZKPs is also the only place that the traits
+//! in this module are used; there is no reason to adopt them if not trying to access
+//! the optimized implementation, or at least trying to be easily portable to an
+//! optimized implementation.)
+//!
+//! To perform multiply-accumulate operations using this API:
+//! ```
+//! use ipa_core::ff::{PrimeField, MultiplyAccumulate, MultiplyAccumulator};
+//! fn dot_product<F: PrimeField, const N: usize>(a: &[F; N], b: &[F; N]) -> F {
+//!     let mut acc = <F as MultiplyAccumulate>::Accumulator::new();
+//!     for i in 0..N {
+//!         acc.multiply_accumulate(a[i], b[i]);
+//!     }
+//!     acc.take()
+//! }
+//! ```
+
+use std::{
+    array,
+    marker::PhantomData,
+    ops::{AddAssign, Mul},
+};
+
+use crate::{
+    ff::{Field, U128Conversions},
+    secret_sharing::SharedValue,
+};
+
+/// Trait for multiply-accumulate operations on.
+///
+/// See the module-level documentation for usage.
+pub trait MultiplyAccumulator<F>: Clone {
+    /// Create a new accumulator with a value of zero.
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    /// Performs _accumulator <- accumulator + lhs * rhs_.
+    fn multiply_accumulate(&mut self, lhs: F, rhs: F);
+
+    /// Consume the accumulator and return its value.
+    fn take(self) -> F;
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize;
+}
+
+/// Trait for multiply-accumulate operations on vectors.
+///
+/// See the module-level documentation for usage.
+pub trait MultiplyAccumulatorArray<F, const N: usize>: Clone {
+    /// Create a new accumulator with a value of zero.
+    fn new() -> Self
+    where
+        Self: Sized;
+
+    /// Performs _accumulator <- accumulator + lhs * rhs_.
+    ///
+    /// Each of _accumulator_, _lhs_, and _rhs_ is a vector of length `N`, and _lhs *
+    /// rhs_ is an element-wise product.
+    fn multiply_accumulate(&mut self, lhs: &[F; N], rhs: &[F; N]);
+
+    /// Consume the accumulator and return its value.
+    fn take(self) -> [F; N];
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize;
+}
+
+/// Trait for values (e.g. `Field`s) that support multiply-accumulate operations.
+///
+/// See the module-level documentation for usage.
+pub trait MultiplyAccumulate: Sized {
+    type Accumulator: MultiplyAccumulator<Self>;
+    type AccumulatorArray<const N: usize>: MultiplyAccumulatorArray<Self, N>;
+}
+
+#[derive(Clone, Default)]
+pub struct Accumulator<F, A, const REDUCE_INTERVAL: usize> {
+    value: A,
+    count: usize,
+    phantom_data: PhantomData<F>,
+}
+
+#[cfg(test)]
+impl<F, A, const REDUCE_INTERVAL: usize> Accumulator<F, A, REDUCE_INTERVAL> {
+    /// Return the raw accumulator value, which may not directly correspond to
+    /// a valid value for `F`. This is intended for tests.
+    fn into_raw(self) -> A {
+        self.value
+    }
+}
+
+impl<F, A, const REDUCE_INTERVAL: usize> From<F> for Accumulator<F, A, REDUCE_INTERVAL>
+where
+    A: Default + From<u128>,
+    F: U128Conversions,
+{
+    fn from(value: F) -> Self {
+        Self {
+            value: value.as_u128().into(),
+            count: 0,
+            phantom_data: PhantomData,
+        }
+    }
+}
+/// Optimized multiply-accumulate implementation that adds `REDUCE_INTERVAL` products
+/// into an accumulator before reducing.
+///
+/// Note that the accumulator must be large enough to hold `REDUCE_INTERVAL` products,
+/// plus one additional field element. The additional field element represents the
+/// output of the previous reduction, or an initial value of the accumulator.
+impl<F, A, const REDUCE_INTERVAL: usize> MultiplyAccumulator<F>
+    for Accumulator<F, A, REDUCE_INTERVAL>
+where
+    A: AddAssign + Copy + Default + Mul<Output = A> + From<u128> + Into<u128>,
+    F: SharedValue + U128Conversions + MultiplyAccumulate<Accumulator = Self>,
+{
+    #[inline]
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Self::default()
+    }
+
+    #[inline]
+    fn multiply_accumulate(&mut self, lhs: F, rhs: F) {
+        self.value += A::from(lhs.as_u128()) * A::from(rhs.as_u128());
+        self.count += 1;
+        if self.count == REDUCE_INTERVAL {
+            // Modulo, not really a truncation.
+            self.value = A::from(F::truncate_from(self.value).as_u128());
+            self.count = 0;
+        }
+    }
+
+    #[inline]
+    fn take(self) -> F {
+        // Modulo, not really a truncation.
+        F::truncate_from(self.value)
+    }
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize {
+        REDUCE_INTERVAL
+    }
+}
+
+/// Optimized multiply-accumulate implementation that adds `REDUCE_INTERVAL` products
+/// into an accumulator before reducing. This version operates on arrays.
+impl<F, A, const N: usize, const REDUCE_INTERVAL: usize> MultiplyAccumulatorArray<F, N>
+    for Accumulator<F, [A; N], REDUCE_INTERVAL>
+where
+    A: AddAssign + Copy + Default + Mul<Output = A> + From<u128> + Into<u128>,
+    F: SharedValue + U128Conversions + MultiplyAccumulate<AccumulatorArray<N> = Self>,
+{
+    #[inline]
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Accumulator {
+            value: [A::default(); N],
+            count: 0,
+            phantom_data: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn multiply_accumulate(&mut self, lhs: &[F; N], rhs: &[F; N]) {
+        for i in 0..N {
+            self.value[i] += A::from(lhs[i].as_u128()) * A::from(rhs[i].as_u128());
+        }
+        self.count += 1;
+        if self.count == REDUCE_INTERVAL {
+            // Modulo, not really a truncation.
+            self.value = array::from_fn(|i| A::from(F::truncate_from(self.value[i]).as_u128()));
+            self.count = 0;
+        }
+    }
+
+    #[inline]
+    fn take(self) -> [F; N] {
+        // Modulo, not really a truncation.
+        array::from_fn(|i| F::truncate_from(self.value[i]))
+    }
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize {
+        REDUCE_INTERVAL
+    }
+}
+
+// Unoptimized implementation usable for any field.
+impl<F: Field> MultiplyAccumulator<F> for F {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        F::ZERO
+    }
+
+    fn multiply_accumulate(&mut self, lhs: F, rhs: F) {
+        *self += lhs * rhs;
+    }
+
+    fn take(self) -> F {
+        self
+    }
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize {
+        1
+    }
+}
+
+// Unoptimized implementation usable for any field. This version operates on arrays.
+impl<F: Field, const N: usize> MultiplyAccumulatorArray<F, N> for [F; N] {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        [F::ZERO; N]
+    }
+
+    fn multiply_accumulate(&mut self, lhs: &[F; N], rhs: &[F; N]) {
+        for i in 0..N {
+            self[i] += lhs[i] * rhs[i];
+        }
+    }
+
+    fn take(self) -> [F; N] {
+        self
+    }
+
+    #[cfg(test)]
+    fn reduce_interval() -> usize {
+        1
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod test {
+    use crate::ff::{Fp61BitPrime, MultiplyAccumulate, MultiplyAccumulator, U128Conversions};
+
+    // If adding optimized multiply-accumulate for an additional field, it would make
+    // sense to convert the freestanding `fp61bit_*` tests here to a macro and replicate
+    // them for the new field.
+
+    #[test]
+    fn fp61bit_accum_size() {
+        // Test that the accumulator does not overflow before reaching REDUCE_INTERVAL.
+        type Accumulator = <Fp61BitPrime as MultiplyAccumulate>::Accumulator;
+        let max = -Fp61BitPrime::from_bit(true);
+        let mut acc = Accumulator::from(max);
+        for _ in 0..Accumulator::reduce_interval() - 1 {
+            acc.multiply_accumulate(max, max);
+        }
+
+        let expected = max.as_u128()
+            + u128::try_from(Accumulator::reduce_interval() - 1).unwrap()
+                * (max.as_u128() * max.as_u128());
+        assert_eq!(acc.clone().into_raw(), expected);
+
+        assert_eq!(acc.take(), Fp61BitPrime::truncate_from(expected));
+
+        // Test that the largest value the accumulator should ever hold (which is not
+        // visible through the API, because it will be reduced immediately) does not
+        // overflow.
+        let _ = max.as_u128()
+            + u128::try_from(Accumulator::reduce_interval()).unwrap()
+                * (max.as_u128() * max.as_u128());
+    }
+
+    #[test]
+    fn fp61bit_accum_reduction() {
+        // Test that the accumulator reduces after reaching the specified interval.
+        // (This test assumes that the implementation (1) sets REDUCE_INTERVAL as large
+        // as possible, and (2) fully reduces upon reaching REDUCE_INTERVAL. It is
+        // possible for a correct implementation not to have these properties. If
+        // adding such an implementation, this test will need to be adjusted.)
+        type Accumulator = <Fp61BitPrime as MultiplyAccumulate>::Accumulator;
+        let max = -Fp61BitPrime::from_bit(true);
+        let mut acc = Accumulator::new();
+        for _ in 0..Accumulator::reduce_interval() {
+            acc.multiply_accumulate(max, max);
+        }
+
+        let expected = Fp61BitPrime::truncate_from(
+            u128::try_from(Accumulator::reduce_interval()).unwrap()
+                * (max.as_u128() * max.as_u128()),
+        );
+        assert_eq!(acc.clone().into_raw(), expected.as_u128());
+        assert_eq!(acc.take(), expected);
+    }
+
+    #[macro_export]
+    macro_rules! accum_tests {
+        ($field:ty) => {
+            mod accum_tests {
+                use std::iter::zip;
+
+                use proptest::prelude::*;
+
+                use $crate::{
+                    ff::{MultiplyAccumulate, MultiplyAccumulator, MultiplyAccumulatorArray},
+                    test_executor::run_random,
+                };
+                use super::*;
+
+                const SZ: usize = 2;
+
+                #[test]
+                fn accum_simple() {
+                    run_random(|mut rng| async move {
+                        let a = rng.gen();
+                        let b = rng.gen();
+                        let c = rng.gen();
+                        let d = rng.gen();
+
+                        let mut acc = <$field as MultiplyAccumulate>::Accumulator::new();
+                        acc.multiply_accumulate(a, b);
+                        acc.multiply_accumulate(c, d);
+
+                        assert_eq!(acc.take(), a * b + c * d);
+                    });
+                }
+
+                prop_compose! {
+                    fn arb_inputs(max_len: usize)
+                                 (len in 0..max_len)
+                                 (
+                                     lhs in prop::collection::vec(any::<$field>(), len),
+                                     rhs in prop::collection::vec(any::<$field>(), len),
+                                 )
+                    -> (Vec<$field>, Vec<$field>) {
+                        (lhs, rhs)
+                    }
+                }
+
+                proptest::proptest! {
+                    #[test]
+                    fn accum_proptest((lhs, rhs) in arb_inputs(
+                        10 * <$field as MultiplyAccumulate>::Accumulator::reduce_interval()
+                    )) {
+                        type Accumulator = <$field as MultiplyAccumulate>::Accumulator;
+                        let mut acc = Accumulator::new();
+                        let mut expected = <$field>::ZERO;
+                        for (lhs_term, rhs_term) in zip(lhs, rhs) {
+                            acc.multiply_accumulate(lhs_term, rhs_term);
+                            expected += lhs_term * rhs_term;
+                        }
+                        assert_eq!(acc.take(), expected);
+                    }
+                }
+
+                prop_compose! {
+                    fn arb_array_inputs(max_len: usize)
+                                       (len in 0..max_len)
+                                       (
+                                           lhs in prop::collection::vec(
+                                               prop::array::uniform(any::<$field>()),
+                                               len,
+                                           ),
+                                           rhs in prop::collection::vec(
+                                               prop::array::uniform(any::<$field>()),
+                                               len,
+                                           ),
+                                       )
+                    -> (Vec<[$field; SZ]>, Vec<[$field; SZ]>) {
+                        (lhs, rhs)
+                    }
+                }
+
+                proptest::proptest! {
+                    #[test]
+                    fn accum_array_proptest((lhs, rhs) in arb_array_inputs(
+                        10 * <$field as MultiplyAccumulate>::AccumulatorArray::<SZ>::reduce_interval()
+                    )) {
+                        type Accumulator = <$field as MultiplyAccumulate>::AccumulatorArray::<SZ>;
+                        let mut acc = Accumulator::new();
+                        let mut expected = [<$field>::ZERO; SZ];
+                        for (lhs_arr, rhs_arr) in zip(lhs, rhs) {
+                            acc.multiply_accumulate(&lhs_arr, &rhs_arr);
+                            for i in 0..SZ {
+                                expected[i] += lhs_arr[i] * rhs_arr[i];
+                            }
+                        }
+                        assert_eq!(acc.take(), expected);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ipa-core/src/ff/accumulator.rs
+++ b/ipa-core/src/ff/accumulator.rs
@@ -116,7 +116,7 @@ pub struct Accumulator<F, A, const REDUCE_INTERVAL: usize> {
     phantom_data: PhantomData<F>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, unit_test))]
 impl<F, A, const REDUCE_INTERVAL: usize> Accumulator<F, A, REDUCE_INTERVAL> {
     /// Return the raw accumulator value, which may not directly correspond to
     /// a valid value for `F`. This is intended for tests.

--- a/ipa-core/src/ff/accumulator.rs
+++ b/ipa-core/src/ff/accumulator.rs
@@ -125,6 +125,12 @@ impl<F, A, const REDUCE_INTERVAL: usize> Accumulator<F, A, REDUCE_INTERVAL> {
     }
 }
 
+/// Create a new accumulator containing the specified value.
+///
+/// This is currently used only by tests, and for that purpose it is sufficient to
+/// access it via the concrete `Accumulator` type. To use it more generally, it would
+/// need to be made part of the trait (either by adding a `From` supertrait bound, or by
+/// adding a method in the trait to perform the operation).
 impl<F, A, const REDUCE_INTERVAL: usize> From<F> for Accumulator<F, A, REDUCE_INTERVAL>
 where
     A: Default + From<u128>,
@@ -228,6 +234,7 @@ where
 
 // Unoptimized implementation usable for any field.
 impl<F: Field> MultiplyAccumulator<F> for F {
+    #[inline]
     fn new() -> Self
     where
         Self: Sized,
@@ -235,10 +242,12 @@ impl<F: Field> MultiplyAccumulator<F> for F {
         F::ZERO
     }
 
+    #[inline]
     fn multiply_accumulate(&mut self, lhs: F, rhs: F) {
         *self += lhs * rhs;
     }
 
+    #[inline]
     fn take(self) -> F {
         self
     }
@@ -251,6 +260,7 @@ impl<F: Field> MultiplyAccumulator<F> for F {
 
 // Unoptimized implementation usable for any field. This version operates on arrays.
 impl<F: Field, const N: usize> MultiplyAccumulatorArray<F, N> for [F; N] {
+    #[inline]
     fn new() -> Self
     where
         Self: Sized,
@@ -258,12 +268,14 @@ impl<F: Field, const N: usize> MultiplyAccumulatorArray<F, N> for [F; N] {
         [F::ZERO; N]
     }
 
+    #[inline]
     fn multiply_accumulate(&mut self, lhs: &[F; N], rhs: &[F; N]) {
         for i in 0..N {
             self[i] += lhs[i] * rhs[i];
         }
     }
 
+    #[inline]
     fn take(self) -> [F; N] {
         self
     }

--- a/ipa-core/src/ff/boolean.rs
+++ b/ipa-core/src/ff/boolean.rs
@@ -5,7 +5,7 @@ use generic_array::GenericArray;
 use typenum::U1;
 
 use crate::{
-    ff::{ArrayAccess, Field, PrimeField, Serializable, U128Conversions},
+    ff::{ArrayAccess, Field, MultiplyAccumulate, PrimeField, Serializable, U128Conversions},
     impl_shared_value_common,
     protocol::{
         context::{dzkp_field::DZKPCompatibleField, dzkp_validator::SegmentEntry},
@@ -56,6 +56,13 @@ impl ArrayAccess for Boolean {
 impl PrimeField for Boolean {
     type PrimeInteger = u8;
     const PRIME: Self::PrimeInteger = 2;
+}
+
+// Note: The multiply-accumulate tests are not currently instantiated for `Boolean`.
+impl MultiplyAccumulate for Boolean {
+    type Accumulator = Boolean;
+    // This could be specialized with a bit vector type if it ever mattered.
+    type AccumulatorArray<const N: usize> = [Boolean; N];
 }
 
 impl SharedValue for Boolean {

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -6,7 +6,7 @@ use subtle::{Choice, ConstantTimeEq};
 use typenum::{U2, U32};
 
 use crate::{
-    ff::{boolean_array::BA256, Field, Serializable},
+    ff::{boolean_array::BA256, Field, MultiplyAccumulate, Serializable},
     impl_shared_value_common,
     protocol::{
         ipa_prf::PRF_CHUNK,
@@ -224,6 +224,12 @@ impl ExtendableField for Fp25519 {
     fn to_extended(&self) -> Self::ExtendedField {
         *self
     }
+}
+
+// Note: The multiply-accumulate tests are not currently instantiated for `Boolean`.
+impl MultiplyAccumulate for Fp25519 {
+    type Accumulator = Fp25519;
+    type AccumulatorArray<const N: usize> = [Fp25519; N];
 }
 
 impl FromRandom for Fp25519 {

--- a/ipa-core/src/ff/field.rs
+++ b/ipa-core/src/ff/field.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use typenum::{U1, U4, U8};
 
 use crate::{
+    ff::MultiplyAccumulate,
     protocol::prss::FromRandom,
     secret_sharing::{Block, FieldVectorizable, SharedValue, Vectorizable},
 };
@@ -30,6 +31,7 @@ pub trait Field:
     SharedValue
     + Mul<Self, Output = Self>
     + MulAssign<Self>
+    + MultiplyAccumulate
     + FromRandom
     + Into<Self::Storage>
     + Vectorizable<1>

--- a/ipa-core/src/ff/galois_field.rs
+++ b/ipa-core/src/ff/galois_field.rs
@@ -13,7 +13,7 @@ use typenum::{Unsigned, U1, U2, U3, U4, U5};
 
 use crate::{
     error::LengthError,
-    ff::{boolean_array::NonZeroPadding, Field, Serializable, U128Conversions},
+    ff::{boolean_array::NonZeroPadding, Field, MultiplyAccumulate, Serializable, U128Conversions},
     impl_serializable_trait, impl_shared_value_common,
     protocol::prss::FromRandomU128,
     secret_sharing::{Block, FieldVectorizable, SharedValue, StdArray, Vectorizable},
@@ -178,6 +178,12 @@ macro_rules! bit_array_impl {
                 const NAME: &'static str = stringify!($field);
 
                 const ONE: Self = Self($one);
+            }
+
+            // Note: The multiply-accumulate tests are not currently instantiated for Galois fields.
+            impl MultiplyAccumulate for $name {
+                type Accumulator = $name;
+                type AccumulatorArray<const N: usize> = [$name; N];
             }
 
             impl U128Conversions for $name {

--- a/ipa-core/src/ff/mod.rs
+++ b/ipa-core/src/ff/mod.rs
@@ -2,6 +2,7 @@
 //
 // This is where we store arithmetic shared secret data models.
 
+mod accumulator;
 pub mod boolean;
 pub mod boolean_array;
 pub mod curve_points;
@@ -15,6 +16,7 @@ use std::{
     ops::{Add, AddAssign, Sub, SubAssign},
 };
 
+pub use accumulator::{MultiplyAccumulate, MultiplyAccumulator, MultiplyAccumulatorArray};
 pub use field::{Field, FieldType};
 pub use galois_field::{GaloisField, Gf2, Gf20Bit, Gf32Bit, Gf3Bit, Gf40Bit, Gf8Bit, Gf9Bit};
 use generic_array::{ArrayLength, GenericArray};

--- a/ipa-core/src/ff/prime_field.rs
+++ b/ipa-core/src/ff/prime_field.rs
@@ -6,7 +6,10 @@ use subtle::{Choice, ConstantTimeEq};
 use super::Field;
 use crate::{
     const_assert,
-    ff::{Serializable, U128Conversions},
+    ff::{
+        accumulator::{Accumulator, MultiplyAccumulate},
+        Serializable, U128Conversions,
+    },
     impl_shared_value_common,
     protocol::prss::FromRandomU128,
     secret_sharing::{Block, FieldVectorizable, SharedValue, StdArray, Vectorizable},
@@ -437,9 +440,17 @@ mod fp31 {
     field_impl! { Fp31, u8, u16, 8, 31 }
     rem_modulo_impl! { Fp31, u16 }
 
+    impl MultiplyAccumulate for Fp31 {
+        type Accumulator = Fp31;
+        type AccumulatorArray<const N: usize> = [Fp31; N];
+    }
+
     #[cfg(all(test, unit_test))]
     mod specialized_tests {
         use super::*;
+        use crate::accum_tests;
+
+        accum_tests!(Fp31);
 
         #[test]
         fn fp31() {
@@ -469,9 +480,17 @@ mod fp32bit {
         type ArrayAlias = StdArray<Fp32BitPrime, 32>;
     }
 
+    impl MultiplyAccumulate for Fp32BitPrime {
+        type Accumulator = Fp32BitPrime;
+        type AccumulatorArray<const N: usize> = [Fp32BitPrime; N];
+    }
+
     #[cfg(all(test, unit_test))]
     mod specialized_tests {
         use super::*;
+        use crate::accum_tests;
+
+        accum_tests!(Fp32BitPrime);
 
         #[test]
         fn thirty_two_bit_prime() {
@@ -517,6 +536,14 @@ mod fp32bit {
 
 mod fp61bit {
     field_impl! { Fp61BitPrime, u64, u128, 61, 2_305_843_009_213_693_951 }
+
+    // For multiply-accumulate of `Fp61BitPrime` using `u128` as the accumulator, we can add 64
+    // products onto an original field element before reduction is necessary. i.e., 64 * (2^61 - 2)^2 +
+    // (2^61 - 2) < 2^128.
+    impl MultiplyAccumulate for Fp61BitPrime {
+        type Accumulator = Accumulator<Fp61BitPrime, u128, 64>;
+        type AccumulatorArray<const N: usize> = Accumulator<Fp61BitPrime, [u128; N], 64>;
+    }
 
     impl Fp61BitPrime {
         #[must_use]
@@ -565,6 +592,12 @@ mod fp61bit {
         use proptest::proptest;
 
         use super::*;
+        use crate::accum_tests;
+
+        // Note: besides the tests generated with this macro, there are some additional
+        // tests for the optimized accumulator for `Fp61BitPrime` in the `accumulator`
+        // module.
+        accum_tests!(Fp61BitPrime);
 
         // copied from 32 bit prime field, adjusted wrap arounds, computed using wolframalpha.com
         #[test]

--- a/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
+++ b/ipa-core/src/protocol/ipa_prf/malicious_security/lagrange.rs
@@ -2,7 +2,9 @@ use std::{array::from_fn, fmt::Debug};
 
 use typenum::Unsigned;
 
-use crate::ff::{batch_invert, Field, PrimeField, Serializable};
+use crate::ff::{
+    batch_invert, Field, MultiplyAccumulate, MultiplyAccumulator, PrimeField, Serializable,
+};
 
 /// The Canonical Lagrange denominator is defined as the denominator of the Lagrange base polynomials
 /// `https://en.wikipedia.org/wiki/Lagrange_polynomial`
@@ -162,23 +164,14 @@ where
 /// Computes the dot product of two arrays of the same size.
 /// It is isolated from Lagrange because there could be potential SIMD optimizations used
 fn dot_product<F: PrimeField, const N: usize>(a: &[F; N], b: &[F; N]) -> F {
-    // Staying in integers allows rustc to optimize this code properly, but puts a restriction
-    // on how large the prime field can be
-    debug_assert!(
-        2 * F::BITS + N.next_power_of_two().ilog2() <= 128,
-        "The prime field {} is too large for this dot product implementation",
-        F::PRIME.into()
-    );
-
-    let mut sum = 0;
-
     // I am cautious about using zip in hot code
     // https://github.com/rust-lang/rust/issues/103555
-    for i in 0..N {
-        sum += a[i].as_u128() * b[i].as_u128();
-    }
 
-    F::truncate_from(sum)
+    let mut acc = <F as MultiplyAccumulate>::Accumulator::new();
+    for i in 0..N {
+        acc.multiply_accumulate(a[i], b[i]);
+    }
+    acc.take()
 }
 
 #[cfg(all(test, unit_test))]


### PR DESCRIPTION
Create an abstraction for multiply-accumulate and provide an optimized implementation for `Fp61BitPrime`. Currently it is still used only in `lagrange::dot_product`, but it will soon be used in `compute_proof` as well.

This change by itself is not meant to affect performance (up or down), it is meant to encapsulate the optimized implementation so that we don't need similar code working with field internals in both `dot_product` and `compute_proof` (and anywhere else we might use it in the future).

Without the `#[inline]` directives, this seemed to hurt performance in my local testing. After adding the `#[inline]` directives, I do not see a significant performance impact either locally or in draft ([before](https://draft-mpc.vercel.app/query/view/void-job2024-11-19T0059) / [after](https://draft-mpc.vercel.app/query/view/busty-poor2024-11-19T1758)) (these runs do include other changes not part of this PR).

Draft: https://draft-mpc.vercel.app/query/view/each-hurt2024-11-20T0056, 2:30.
The runs in #1440 were 2:27 and 2:23.