### PR TITLE
add scalar batch invert

### DIFF
--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -276,11 +276,15 @@ pub fn batch_invert<const N: usize>(
 where
     Fp25519: Vectorizable<N>,
 {
+    // TODO: This can be made more memory-efficient if we can manage to pass
+    // the input as a mutable reference to `Scalar::batch_invert`
+    // We can also create our own version of `Scalar::batch_invert` that avoids Vecs,
+    // but this would require forking the crate.
     let mut inverted: [Scalar; N] = inputs
         .clone()
         .into_iter()
         .map(|x| x.0)
-        .collect::<Vec<Scalar>>()
+        .collect::<Vec<Scalar>>() // Relying on the compiler to optimize this out
         .try_into()
         .unwrap(); // Safe, the length will always be N
     Scalar::batch_invert(&mut inverted);

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::{malicious::ExtendableField, semi_honest::AdditiveShare},
-        Block, FieldVectorizable, SharedValue, StdArray, Vectorizable,
+        Block, FieldVectorizable, SharedValue, StdArray, Vectorizable, SharedValueArray,
     },
 };
 
@@ -266,6 +266,30 @@ macro_rules! impl_share_from_random {
 }
 
 impl_share_from_random!(PRF_CHUNK);
+
+/*pub fn batch_invert<const N: usize>(inputs: &mut [Fp25519; N]){
+    let mut conv_input = inputs.iter().map(|x| x.0).collect::<Vec<Scalar>>();
+    Scalar::batch_invert(&mut conv_input);
+    for i in 0..N{
+        inputs[i] = Fp25519(conv_input[i]);
+    }
+}*/
+
+/*pub fn batch_invert(inputs: &mut [Fp25519]){
+    let mut conv_input = inputs.iter().map(|x| x.0).collect::<Vec<Scalar>>();
+    Scalar::batch_invert(&mut conv_input);
+    for i in 0..inputs.len(){
+        inputs[i] = Fp25519(conv_input[i]);
+    }
+}*/
+
+pub fn batch_invert<const N: usize>(inputs: &<Fp25519 as Vectorizable<N>>::Array) -> <Fp25519 as Vectorizable<N>>::Array
+where Fp25519: Vectorizable<N>,{
+    let mut inverted = inputs.clone().into_iter().map(|x| x.0).collect::<Vec<Scalar>>();
+    Scalar::batch_invert(&mut inverted);
+    <Fp25519 as Vectorizable<N>>::Array::from_fn(|i| Fp25519(inverted[i]))
+}
+
 
 #[cfg(all(test, unit_test))]
 mod test {

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     secret_sharing::{
         replicated::{malicious::ExtendableField, semi_honest::AdditiveShare},
-        Block, FieldVectorizable, SharedValue, StdArray, Vectorizable, SharedValueArray,
+        Block, FieldVectorizable, SharedValue, SharedValueArray, StdArray, Vectorizable,
     },
 };
 
@@ -283,13 +283,20 @@ impl_share_from_random!(PRF_CHUNK);
     }
 }*/
 
-pub fn batch_invert<const N: usize>(inputs: &<Fp25519 as Vectorizable<N>>::Array) -> <Fp25519 as Vectorizable<N>>::Array
-where Fp25519: Vectorizable<N>,{
-    let mut inverted = inputs.clone().into_iter().map(|x| x.0).collect::<Vec<Scalar>>();
+pub fn batch_invert<const N: usize>(
+    inputs: &<Fp25519 as Vectorizable<N>>::Array,
+) -> <Fp25519 as Vectorizable<N>>::Array
+where
+    Fp25519: Vectorizable<N>,
+{
+    let mut inverted = inputs
+        .clone()
+        .into_iter()
+        .map(|x| x.0)
+        .collect::<Vec<Scalar>>();
     Scalar::batch_invert(&mut inverted);
     <Fp25519 as Vectorizable<N>>::Array::from_fn(|i| Fp25519(inverted[i]))
 }
-
 
 #[cfg(all(test, unit_test))]
 mod test {

--- a/ipa-core/src/ff/ec_prime_field.rs
+++ b/ipa-core/src/ff/ec_prime_field.rs
@@ -267,33 +267,22 @@ macro_rules! impl_share_from_random {
 
 impl_share_from_random!(PRF_CHUNK);
 
-/*pub fn batch_invert<const N: usize>(inputs: &mut [Fp25519; N]){
-    let mut conv_input = inputs.iter().map(|x| x.0).collect::<Vec<Scalar>>();
-    Scalar::batch_invert(&mut conv_input);
-    for i in 0..N{
-        inputs[i] = Fp25519(conv_input[i]);
-    }
-}*/
-
-/*pub fn batch_invert(inputs: &mut [Fp25519]){
-    let mut conv_input = inputs.iter().map(|x| x.0).collect::<Vec<Scalar>>();
-    Scalar::batch_invert(&mut conv_input);
-    for i in 0..inputs.len(){
-        inputs[i] = Fp25519(conv_input[i]);
-    }
-}*/
-
+/// Calls the `batch_invert` function for Scalars from the `curve25519_dalek` crate.
+/// # Panics
+/// When N != N (never)
 pub fn batch_invert<const N: usize>(
     inputs: &<Fp25519 as Vectorizable<N>>::Array,
 ) -> <Fp25519 as Vectorizable<N>>::Array
 where
     Fp25519: Vectorizable<N>,
 {
-    let mut inverted = inputs
+    let mut inverted: [Scalar; N] = inputs
         .clone()
         .into_iter()
         .map(|x| x.0)
-        .collect::<Vec<Scalar>>();
+        .collect::<Vec<Scalar>>()
+        .try_into()
+        .unwrap(); // Safe, the length will always be N
     Scalar::batch_invert(&mut inverted);
     <Fp25519 as Vectorizable<N>>::Array::from_fn(|i| Fp25519(inverted[i]))
 }

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -137,7 +137,7 @@ where
 
     // validate everything before reveal
     ctx.validate_record(record_id).await?;
-    let (gr, z): (
+    let (gr, mut z): (
         <RP25519 as Vectorizable<N>>::Array,
         <Fp25519 as Vectorizable<N>>::Array,
     ) = try_join(
@@ -146,12 +146,13 @@ where
     )
     .await?;
 
-    //compute R^(1/z) to u64
-    Ok(zip(gr, z)
-        .map(|(gr, z)| u64::from(gr * z.invert()))
-        .collect::<Vec<_>>()
-        .try_into()
-        .expect("iteration over arrays"))
+     //compute R^(1/z) to u64
+     let inv_z = crate::ff::ec_prime_field::batch_invert::<N>(&mut z);
+     Ok(zip(gr, inv_z)
+         .map(|(gr, inv_z)| u64::from(gr * inv_z))
+         .collect::<Vec<_>>()
+         .try_into()
+         .expect("iteration over arrays"))
 }
 
 #[cfg(all(test, unit_test))]

--- a/ipa-core/src/protocol/ipa_prf/prf_eval.rs
+++ b/ipa-core/src/protocol/ipa_prf/prf_eval.rs
@@ -137,7 +137,7 @@ where
 
     // validate everything before reveal
     ctx.validate_record(record_id).await?;
-    let (gr, mut z): (
+    let (gr, z): (
         <RP25519 as Vectorizable<N>>::Array,
         <Fp25519 as Vectorizable<N>>::Array,
     ) = try_join(
@@ -146,13 +146,13 @@ where
     )
     .await?;
 
-     //compute R^(1/z) to u64
-     let inv_z = crate::ff::ec_prime_field::batch_invert::<N>(&mut z);
-     Ok(zip(gr, inv_z)
-         .map(|(gr, inv_z)| u64::from(gr * inv_z))
-         .collect::<Vec<_>>()
-         .try_into()
-         .expect("iteration over arrays"))
+    //compute R^(1/z) to u64
+    let inv_z = crate::ff::ec_prime_field::batch_invert::<N>(&z);
+    Ok(zip(gr, inv_z)
+        .map(|(gr, inv_z)| u64::from(gr * inv_z))
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("iteration over arrays"))
 }
 
 #[cfg(all(test, unit_test))]


### PR DESCRIPTION
There's one part of the PRF code that can likely be sped up by using batch inversion of Fp25519. This PR adds a function to call the Scalar batch_invert in curve25519-dalek which can be used here.

The function I wrote is not memory efficient at all because I couldn't figure out how to effectively work with <V as Vectorizable<N>>::Array>. I'd appreciate some suggestions here :)
Using Vecs appears to be necessary as it's part of the dalek batch_invert code. To re-implement that code using arrays, we would need to fork dalek to expose UnpackedScalar and the pack/unpack methods.

Even so, this version appears to be faster:
2M records in 6:12 https://draft-mpc.vercel.app/query/view/sore-deal2024-11-21T1848
4M records in 12:12 https://draft-mpc.vercel.app/query/view/roast-loft2024-11-21T2017

Compared to current main:
2M in 6:22 https://draft-mpc.vercel.app/query/view/gaudy-whack2024-11-21T1856
4M in 12:27 https://draft-mpc.vercel.app/query/view/beta-porch2024-11-21T2003