### PR TITLE
add dp_for_histogram to hybrid, complete unit test

### DIFF
--- a/ipa-core/src/protocol/hybrid/step.rs
+++ b/ipa-core/src/protocol/hybrid/step.rs
@@ -3,7 +3,7 @@ use ipa_step_derive::CompactStep;
 #[derive(CompactStep)]
 pub(crate) enum HybridStep {
     ReshardByTag,
-    #[step(child = crate::protocol::ipa_prf::oprf_padding::step::PaddingDpStep, name="padding_dp")]
+    #[step(child = crate::protocol::ipa_prf::oprf_padding::step::PaddingDpStep, name="report_padding_dp")]
     PaddingDp,
     #[step(child = crate::protocol::ipa_prf::shuffle::step::OPRFShuffleStep)]
     InputShuffle,

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -1,9 +1,13 @@
-use std::{convert::Into, marker::PhantomData, sync::Arc};
+use std::{
+    convert::{Infallible, Into},
+    marker::PhantomData,
+    sync::Arc,
+};
 
 use futures::{stream::iter, StreamExt, TryStreamExt};
 
 use crate::{
-    error::Error,
+    error::{Error, LengthError},
     ff::{
         boolean::Boolean,
         boolean_array::{BooleanArray, BA3, BA8},
@@ -35,7 +39,10 @@ use crate::{
         },
         hybrid_info::HybridInfo,
     },
-    secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, Vectorizable},
+    secret_sharing::{
+        replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
+        Vectorizable,
+    },
 };
 
 #[allow(dead_code)]
@@ -75,6 +82,10 @@ where
     Replicated<Boolean>: BooleanProtocols<DZKPUpgraded<C>>,
     Replicated<BA8>: BooleanArrayMul<DZKPUpgraded<C>>
         + Reveal<DZKPUpgraded<C>, Output = <BA8 as Vectorizable<1>>::Array>,
+    BitDecomposed<Replicated<Boolean, 256>>:
+        for<'b> TransposeFrom<&'b [Replicated<HV>; 256], Error = Infallible>,
+    Vec<Replicated<HV>>:
+        for<'b> TransposeFrom<&'b BitDecomposed<Replicated<Boolean, 256>>, Error = LengthError>,
 {
     #[tracing::instrument("hybrid_query", skip_all, fields(sz=%query_size))]
     pub async fn execute(
@@ -144,7 +155,7 @@ where
         #[cfg(not(feature = "relaxed-dp"))]
         let padding_params = PaddingParameters::default();
 
-        hybrid_protocol::<_, BA8, BA3, HV, 256>(
+        hybrid_protocol::<_, BA8, BA3, HV, 3, 256>(
             ctx,
             indistinguishable_reports,
             dp_params,
@@ -156,7 +167,10 @@ where
 
 #[cfg(all(test, unit_test, feature = "in-memory-infra"))]
 mod tests {
-    use std::{iter::zip, sync::Arc};
+    use std::{
+        iter::{repeat, zip},
+        sync::Arc,
+    };
 
     use rand::rngs::StdRng;
     use rand_core::SeedableRng;
@@ -173,44 +187,14 @@ mod tests {
         hpke::{KeyPair, KeyRegistry},
         query::runner::hybrid::Query as HybridQuery,
         report::{hybrid::HybridReport, hybrid_info::HybridInfo, DEFAULT_KEY_ID},
-        secret_sharing::{replicated::semi_honest::AdditiveShare, IntoShares},
+        secret_sharing::IntoShares,
         test_executor::run,
         test_fixture::{
-            flatten3v, hybrid::TestHybridRecord, Reconstruct, RoundRobinInputDistribution,
-            TestWorld, TestWorldConfig, WithShards,
+            flatten3v,
+            hybrid::{build_hybrid_records_and_expectation, TestHybridRecord},
+            Reconstruct, RoundRobinInputDistribution, TestWorld, TestWorldConfig, WithShards,
         },
     };
-
-    const EXPECTED: &[u128] = &[0, 8, 5];
-
-    fn build_records() -> Vec<TestHybridRecord> {
-        vec![
-            TestHybridRecord::TestImpression {
-                match_key: 12345,
-                breakdown_key: 2,
-            },
-            TestHybridRecord::TestImpression {
-                match_key: 68362,
-                breakdown_key: 1,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 12345,
-                value: 5,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 68362,
-                value: 2,
-            },
-            TestHybridRecord::TestImpression {
-                match_key: 68362,
-                breakdown_key: 1,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 68362,
-                value: 7,
-            },
-        ]
-    }
 
     struct BufferAndKeyRegistry {
         buffers: [Vec<Vec<u8>>; 3],
@@ -265,17 +249,22 @@ mod tests {
     }
 
     #[test]
-    // placeholder until the protocol is complete. can be updated to make sure we
-    // get to the unimplemented() call
-    #[should_panic(
-        expected = "not implemented: protocol::hybrid::hybrid_protocol is not fully implemented"
-    )]
     fn encrypted_hybrid_reports_happy() {
         // While this test currently checks for an unimplemented panic it is
         // designed to test for a correct result for a complete implementation.
         run(|| async {
             const SHARDS: usize = 2;
-            let records = build_records();
+            let (test_hybrid_records, mut expected) = build_hybrid_records_and_expectation();
+
+            match expected.len() {
+                len if len < 256 => {
+                    expected.extend(repeat(0).take(256 - len));
+                }
+                len if len > 256 => {
+                    panic!("no support for more than 256 breakdown_keys");
+                }
+                _ => {}
+            }
 
             let hybrid_info =
                 HybridInfo::new(0, "HELPER_ORIGIN", "meta.com", 1_729_707_432, 5.0, 1.1).unwrap();
@@ -284,7 +273,7 @@ mod tests {
                 buffers,
                 key_registry,
                 query_sizes,
-            } = build_buffers_from_records(&records, SHARDS, &hybrid_info);
+            } = build_buffers_from_records(&test_hybrid_records, SHARDS, &hybrid_info);
 
             let world = TestWorld::<WithShards<SHARDS>>::with_shards(TestWorldConfig::default());
             let contexts = world.malicious_contexts();
@@ -297,7 +286,10 @@ mod tests {
                         .zip(helper_ctxs)
                         .zip(query_sizes.clone())
                         .map(|((buffer, ctx), query_size)| {
-                            let query_params = HybridQueryParams::default();
+                            let query_params = HybridQueryParams {
+                                with_dp: 0,
+                                ..Default::default()
+                            };
                             let input = BodyStream::from(buffer);
 
                             HybridQuery::<_, BA16, KeyRegistry<KeyPair>>::new(
@@ -311,7 +303,9 @@ mod tests {
             ))
             .await;
 
-            let results: Vec<[Vec<AdditiveShare<BA16>>; 3]> = results
+            // TODO: after landing #1446, refactor this to only take the first 3
+            // vectors, then validate that all other vectors reconstruct to 0.
+            let results: Vec<u128> = results
                 .chunks(3)
                 .map(|chunk| {
                     [
@@ -319,15 +313,21 @@ mod tests {
                         chunk[1].as_ref().unwrap().clone(),
                         chunk[2].as_ref().unwrap().clone(),
                     ]
-                })
-                .collect();
-
-            assert_eq!(
-                results.into_iter().next().unwrap().reconstruct()[0..3]
+                    .reconstruct()
                     .iter()
                     .map(U128Conversions::as_u128)
-                    .collect::<Vec<u128>>(),
-                EXPECTED
+                    .collect::<Vec<u128>>()
+                })
+                .fold(([0_u128; 256]).to_vec(), |acc, v| {
+                    acc.into_iter().zip(v).map(|(a, b)| a + b).collect()
+                });
+
+            assert_eq!(
+                results
+                    .iter()
+                    .map(|&x| u32::try_from(x).expect("test values should fit in u32"))
+                    .collect::<Vec<u32>>(),
+                expected
             );
         });
     }
@@ -337,7 +337,7 @@ mod tests {
     #[should_panic(expected = "DuplicateBytes")]
     async fn duplicate_encrypted_hybrid_reports() {
         const SHARDS: usize = 2;
-        let records = build_records();
+        let (test_hybrid_records, _expected) = build_hybrid_records_and_expectation();
 
         let hybrid_info =
             HybridInfo::new(0, "HELPER_ORIGIN", "meta.com", 1_729_707_432, 5.0, 1.1).unwrap();
@@ -346,7 +346,7 @@ mod tests {
             mut buffers,
             key_registry,
             query_sizes,
-        } = build_buffers_from_records(&records, SHARDS, &hybrid_info);
+        } = build_buffers_from_records(&test_hybrid_records, SHARDS, &hybrid_info);
 
         // this is double, since we duplicate the data below
         let query_sizes = query_sizes
@@ -406,7 +406,7 @@ mod tests {
     )]
     async fn unsupported_plaintext_match_keys_hybrid_query() {
         const SHARDS: usize = 2;
-        let records = build_records();
+        let (test_hybrid_records, _expected) = build_hybrid_records_and_expectation();
 
         let hybrid_info =
             HybridInfo::new(0, "HELPER_ORIGIN", "meta.com", 1_729_707_432, 5.0, 1.1).unwrap();
@@ -415,7 +415,7 @@ mod tests {
             buffers,
             key_registry,
             query_sizes,
-        } = build_buffers_from_records(&records, SHARDS, &hybrid_info);
+        } = build_buffers_from_records(&test_hybrid_records, SHARDS, &hybrid_info);
 
         let world: TestWorld<WithShards<SHARDS, RoundRobinInputDistribution>> =
             TestWorld::with_shards(TestWorldConfig::default());

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    iter::zip,
-};
+use std::{collections::HashMap, iter::zip};
 
 use crate::{
     ff::{
@@ -159,16 +156,40 @@ where
     }
 }
 
-struct HashmapEntry {
-    breakdown_key: u32,
-    total_value: u32,
+enum MatchEntry {
+    Single(TestHybridRecord),
+    Pair(TestHybridRecord, TestHybridRecord),
+    MoreThanTwo,
 }
 
-impl HashmapEntry {
-    pub fn new(breakdown_key: u32, value: u32) -> Self {
-        Self {
-            breakdown_key,
-            total_value: value,
+impl MatchEntry {
+    pub fn add_record(&mut self, new_record: TestHybridRecord) {
+        match self {
+            Self::Single(old_record) => {
+                *self = Self::Pair(old_record.clone(), new_record);
+            }
+            Self::Pair { .. } | Self::MoreThanTwo => *self = Self::MoreThanTwo,
+        }
+    }
+
+    pub fn into_breakdown_key_and_value_tuple(self) -> Option<(u32, u32)> {
+        match self {
+            Self::Pair(imp, conv) => match (imp, conv) {
+                (
+                    TestHybridRecord::TestImpression { breakdown_key, .. },
+                    TestHybridRecord::TestConversion { value, .. },
+                )
+                | (
+                    TestHybridRecord::TestConversion { value, .. },
+                    TestHybridRecord::TestImpression { breakdown_key, .. },
+                ) => Some((breakdown_key, value)),
+                (
+                    TestHybridRecord::TestConversion { value: value1, .. },
+                    TestHybridRecord::TestConversion { value: value2, .. },
+                ) => Some((0, value1 + value2)),
+                _ => None,
+            },
+            _ => None,
         }
     }
 }
@@ -177,127 +198,114 @@ impl HashmapEntry {
 /// It won't, so long as you can convert a u32 to a usize
 #[must_use]
 pub fn hybrid_in_the_clear(input_rows: &[TestHybridRecord], max_breakdown: usize) -> Vec<u32> {
-    let mut conversion_match_keys = HashSet::new();
-    let mut impression_match_keys = HashSet::new();
-
+    let mut attributed_conversions = HashMap::<u64, MatchEntry>::new();
     for input in input_rows {
         match input {
-            TestHybridRecord::TestImpression { match_key, .. } => {
-                impression_match_keys.insert(*match_key);
-            }
-            TestHybridRecord::TestConversion { match_key, .. } => {
-                conversion_match_keys.insert(*match_key);
+            TestHybridRecord::TestConversion { match_key, .. }
+            | TestHybridRecord::TestImpression { match_key, .. } => {
+                attributed_conversions
+                    .entry(*match_key)
+                    .and_modify(|e| e.add_record(input.clone()))
+                    .or_insert(MatchEntry::Single(input.clone()));
             }
         }
     }
 
-    // The key is the "match key" and the value stores both the breakdown and total attributed value
-    let mut attributed_conversions = HashMap::new();
-
-    for input in input_rows {
-        match input {
-            TestHybridRecord::TestImpression {
-                match_key,
-                breakdown_key,
-            } => {
-                if conversion_match_keys.contains(match_key) {
-                    let v = attributed_conversions
-                        .entry(*match_key)
-                        .or_insert(HashmapEntry::new(*breakdown_key, 0));
-                    v.breakdown_key = *breakdown_key;
-                }
-            }
-            TestHybridRecord::TestConversion { match_key, value } => {
-                if impression_match_keys.contains(match_key) {
-                    attributed_conversions
-                        .entry(*match_key)
-                        .and_modify(|e| e.total_value += value)
-                        .or_insert(HashmapEntry::new(0, *value));
-                }
-            }
-        }
-    }
+    let pairs = attributed_conversions
+        .into_values()
+        .filter_map(MatchEntry::into_breakdown_key_and_value_tuple)
+        .collect::<Vec<_>>();
 
     let mut output = vec![0; max_breakdown];
-    for (_, entry) in attributed_conversions {
-        output[usize::try_from(entry.breakdown_key).unwrap()] += entry.total_value;
+    for (breakdown_key, value) in pairs {
+        output[usize::try_from(breakdown_key).unwrap()] += value;
     }
 
     output
+}
+
+#[must_use]
+pub fn build_hybrid_records_and_expectation() -> (Vec<TestHybridRecord>, Vec<u32>) {
+    let test_hybrid_records = vec![
+        TestHybridRecord::TestConversion {
+            match_key: 12345,
+            value: 2,
+        }, // malicious client attributed to breakdown 0
+        TestHybridRecord::TestConversion {
+            match_key: 12345,
+            value: 5,
+        }, // malicious client attributed to breakdown 0
+        TestHybridRecord::TestImpression {
+            match_key: 23456,
+            breakdown_key: 4,
+        }, // attributed
+        TestHybridRecord::TestConversion {
+            match_key: 23456,
+            value: 7,
+        }, // attributed
+        TestHybridRecord::TestImpression {
+            match_key: 34567,
+            breakdown_key: 1,
+        }, // no conversion
+        TestHybridRecord::TestImpression {
+            match_key: 45678,
+            breakdown_key: 3,
+        }, // attributed
+        TestHybridRecord::TestConversion {
+            match_key: 45678,
+            value: 5,
+        }, // attributed
+        TestHybridRecord::TestImpression {
+            match_key: 56789,
+            breakdown_key: 5,
+        }, // no conversion
+        TestHybridRecord::TestConversion {
+            match_key: 67890,
+            value: 2,
+        }, // NOT attributed
+        TestHybridRecord::TestImpression {
+            match_key: 78901,
+            breakdown_key: 2,
+        }, // too many reports
+        TestHybridRecord::TestConversion {
+            match_key: 78901,
+            value: 3,
+        }, // not attributed, too many reports
+        TestHybridRecord::TestConversion {
+            match_key: 78901,
+            value: 4,
+        }, // not attributed, too many reports
+        TestHybridRecord::TestImpression {
+            match_key: 89012,
+            breakdown_key: 4,
+        }, // attributed
+        TestHybridRecord::TestConversion {
+            match_key: 89012,
+            value: 6,
+        }, // attributed
+    ];
+
+    let expected = vec![
+        7, // two conversions goes to bucket 0: 2 + 5
+        0, 0, 5, 13, // 4: 7 + 6
+        0,
+    ];
+
+    (test_hybrid_records, expected)
 }
 
 #[cfg(all(test, unit_test))]
 mod tests {
     use rand::{seq::SliceRandom, thread_rng};
 
-    use super::TestHybridRecord;
-    use crate::test_fixture::hybrid::hybrid_in_the_clear;
+    use crate::test_fixture::hybrid::{build_hybrid_records_and_expectation, hybrid_in_the_clear};
 
     #[test]
-    fn basic() {
-        let mut test_data = vec![
-            TestHybridRecord::TestImpression {
-                match_key: 12345,
-                breakdown_key: 2,
-            },
-            TestHybridRecord::TestImpression {
-                match_key: 23456,
-                breakdown_key: 4,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 23456,
-                value: 25,
-            }, // attributed
-            TestHybridRecord::TestImpression {
-                match_key: 34567,
-                breakdown_key: 1,
-            },
-            TestHybridRecord::TestImpression {
-                match_key: 45678,
-                breakdown_key: 3,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 45678,
-                value: 13,
-            }, // attributed
-            TestHybridRecord::TestImpression {
-                match_key: 56789,
-                breakdown_key: 5,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 67890,
-                value: 14,
-            }, // NOT attributed
-            TestHybridRecord::TestImpression {
-                match_key: 78901,
-                breakdown_key: 2,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 78901,
-                value: 12,
-            }, // attributed
-            TestHybridRecord::TestConversion {
-                match_key: 78901,
-                value: 31,
-            }, // attributed
-            TestHybridRecord::TestImpression {
-                match_key: 89012,
-                breakdown_key: 4,
-            },
-            TestHybridRecord::TestConversion {
-                match_key: 89012,
-                value: 8,
-            }, // attributed
-        ];
-
+    fn hybrid_basic() {
+        let (mut test_hybrid_records, expected) = build_hybrid_records_and_expectation();
         let mut rng = thread_rng();
-        test_data.shuffle(&mut rng);
-        let expected = vec![
-            0, 0, 43, // 12 + 31
-            13, 33, // 25 + 8
-            0,
-        ];
-        let result = hybrid_in_the_clear(&test_data, 6);
+        test_hybrid_records.shuffle(&mut rng);
+        let result = hybrid_in_the_clear(&test_hybrid_records, 6);
         assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
this adds DP noise to the histogram (only on the leader shard.) it also allows for a proper unit test of hybrid end-to-end.

note there are a few changes to be made after landing #1446.