### PR TITLE
New HTTP handler for query status status requests

### DIFF
--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -562,7 +562,7 @@ pub(crate) mod tests {
         ff::{FieldType, Fp31},
         helpers::{
             make_owned_handler, query::QueryType::TestMultiply, BytesStream, HelperIdentity,
-            HelperResponse, RequestHandler, RoleAssignment, Transport, MESSAGE_PAYLOAD_SIZE_BYTES,
+            HelperResponse, RequestHandler, RoleAssignment, MESSAGE_PAYLOAD_SIZE_BYTES,
         },
         net::test::TestServer,
         protocol::step::TestExecutionStep,
@@ -759,7 +759,7 @@ pub(crate) mod tests {
         resp_ok(resp).await.unwrap();
 
         let mut stream = transport
-            .receive(HelperIdentity::ONE, (QueryId, expected_step.clone()))
+            .receive(HelperIdentity::ONE, &(QueryId, expected_step.clone()))
             .into_bytes_stream();
 
         assert_eq!(

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -33,10 +33,10 @@ use crate::{
     },
     executor::IpaRuntime,
     helpers::{
-        query::{PrepareQuery, QueryConfig, QueryInput},
+        query::{CompareStatusRequest, PrepareQuery, QueryConfig, QueryInput},
         TransportIdentity,
     },
-    net::{http_serde, Error, CRYPTO_PROVIDER},
+    net::{error::ShardQueryStatusMismatchError, http_serde, Error, CRYPTO_PROVIDER},
     protocol::{Gate, QueryId},
 };
 
@@ -383,6 +383,31 @@ impl<F: ConnectionFlavor> IpaHttpClient<F> {
         let req = req.try_into_http_request(self.scheme.clone(), self.authority.clone())?;
         let resp = self.request(req).await?;
         resp_ok(resp).await
+    }
+
+    /// This API is used by leader shards in MPC to request query status information on peers.
+    /// If a given peer has status that doesn't match the one provided by the leader, it responds
+    /// with 412 error and encodes its status inside the response body. Otherwise, 200 is returned.
+    ///
+    /// # Errors
+    /// If the request has illegal arguments, or fails to be delivered
+    pub async fn status_match(&self, data: CompareStatusRequest) -> Result<(), Error> {
+        let req = http_serde::query::status_match::try_into_http_request(
+            &data,
+            self.scheme.clone(),
+            self.authority.clone(),
+        )?;
+        let resp = self.request(req).await?;
+
+        match resp.status() {
+            StatusCode::OK => Ok(()),
+            StatusCode::PRECONDITION_FAILED => {
+                let bytes = response_to_bytes(resp).await?;
+                let err = serde_json::from_slice::<ShardQueryStatusMismatchError>(&bytes)?;
+                Err(err.into())
+            }
+            _ => Err(Error::from_failed_resp(resp).await),
+        }
     }
 }
 

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -384,31 +384,6 @@ impl<F: ConnectionFlavor> IpaHttpClient<F> {
         let resp = self.request(req).await?;
         resp_ok(resp).await
     }
-
-    /// This API is used by leader shards in MPC to request query status information on peers.
-    /// If a given peer has status that doesn't match the one provided by the leader, it responds
-    /// with 412 error and encodes its status inside the response body. Otherwise, 200 is returned.
-    ///
-    /// # Errors
-    /// If the request has illegal arguments, or fails to be delivered
-    pub async fn status_match(&self, data: CompareStatusRequest) -> Result<(), Error> {
-        let req = http_serde::query::status_match::try_into_http_request(
-            &data,
-            self.scheme.clone(),
-            self.authority.clone(),
-        )?;
-        let resp = self.request(req).await?;
-
-        match resp.status() {
-            StatusCode::OK => Ok(()),
-            StatusCode::PRECONDITION_FAILED => {
-                let bytes = response_to_bytes(resp).await?;
-                let err = serde_json::from_slice::<ShardQueryStatusMismatchError>(&bytes)?;
-                Err(err.into())
-            }
-            _ => Err(Error::from_failed_resp(resp).await),
-        }
-    }
 }
 
 impl IpaHttpClient<Helper> {
@@ -533,6 +508,31 @@ impl IpaHttpClient<Shard> {
                 )
             })
             .collect()
+    }
+
+    /// This API is used by leader shards in MPC to request query status information on peers.
+    /// If a given peer has status that doesn't match the one provided by the leader, it responds
+    /// with 412 error and encodes its status inside the response body. Otherwise, 200 is returned.
+    ///
+    /// # Errors
+    /// If the request has illegal arguments, or fails to be delivered
+    pub async fn status_match(&self, data: CompareStatusRequest) -> Result<(), Error> {
+        let req = http_serde::query::status_match::try_into_http_request(
+            &data,
+            self.scheme.clone(),
+            self.authority.clone(),
+        )?;
+        let resp = self.request(req).await?;
+
+        match resp.status() {
+            StatusCode::OK => Ok(()),
+            StatusCode::PRECONDITION_FAILED => {
+                let bytes = response_to_bytes(resp).await?;
+                let err = serde_json::from_slice::<ShardQueryStatusMismatchError>(&bytes)?;
+                Err(err.into())
+            }
+            _ => Err(Error::from_failed_resp(resp).await),
+        }
     }
 }
 

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -608,4 +608,48 @@ pub mod query {
 
         pub const AXUM_PATH: &str = "/:query_id/kill";
     }
+
+    pub mod status_match {
+        use serde::{Deserialize, Serialize};
+
+        use crate::{helpers::query::CompareStatusRequest, query::QueryStatus};
+
+        #[derive(Serialize, Deserialize)]
+        pub struct StatusQueryString {
+            pub status: QueryStatus,
+        }
+
+        impl StatusQueryString {
+            fn url_encode(&self) -> String {
+                // todo: serde urlencoded
+                format!("status={}", self.status)
+            }
+        }
+
+        impl From<QueryStatus> for StatusQueryString {
+            fn from(value: QueryStatus) -> Self {
+                Self { status: value }
+            }
+        }
+
+        pub fn try_into_http_request(
+            req: &CompareStatusRequest,
+            scheme: axum::http::uri::Scheme,
+            authority: axum::http::uri::Authority,
+        ) -> crate::net::http_serde::OutgoingRequest {
+            let uri = axum::http::uri::Uri::builder()
+                .scheme(scheme)
+                .authority(authority)
+                .path_and_query(format!(
+                    "{}/{}/status-match?{}",
+                    crate::net::http_serde::query::BASE_AXUM_PATH,
+                    req.query_id.as_ref(),
+                    StatusQueryString::from(req.status).url_encode(),
+                ))
+                .build()?;
+            Ok(hyper::Request::get(uri).body(axum::body::Body::empty())?)
+        }
+
+        pub const AXUM_PATH: &str = "/:query_id/status-match";
+    }
 }

--- a/ipa-core/src/net/server/handlers/mod.rs
+++ b/ipa-core/src/net/server/handlers/mod.rs
@@ -3,18 +3,21 @@ mod query;
 
 use axum::Router;
 
-use crate::net::{http_serde, transport::MpcHttpTransport, ShardHttpTransport};
+use crate::{
+    net::{http_serde, transport::MpcHttpTransport, HttpTransport, Shard},
+    sync::Arc,
+};
 
 pub fn mpc_router(transport: MpcHttpTransport) -> Router {
     echo::router().nest(
         http_serde::query::BASE_AXUM_PATH,
         Router::new()
             .merge(query::query_router(transport.clone()))
-            .merge(query::h2h_router(transport)),
+            .merge(query::h2h_router(transport.inner_transport)),
     )
 }
 
-pub fn shard_router(transport: ShardHttpTransport) -> Router {
+pub fn shard_router(transport: Arc<HttpTransport<Shard>>) -> Router {
     echo::router().nest(
         http_serde::query::BASE_AXUM_PATH,
         Router::new().merge(query::s2s_router(transport)),

--- a/ipa-core/src/net/server/handlers/query/mod.rs
+++ b/ipa-core/src/net/server/handlers/query/mod.rs
@@ -4,6 +4,7 @@ mod kill;
 mod prepare;
 mod results;
 mod status;
+mod status_match;
 mod step;
 
 use std::marker::PhantomData;
@@ -21,8 +22,8 @@ use tower::{layer::layer_fn, Service};
 
 use crate::{
     net::{
-        server::ClientIdentity, transport::MpcHttpTransport, ConnectionFlavor, Helper, Shard,
-        ShardHttpTransport,
+        server::ClientIdentity, transport::MpcHttpTransport, ConnectionFlavor, Helper,
+        HttpTransport, Shard,
     },
     sync::Arc,
 };
@@ -48,19 +49,20 @@ pub fn query_router(transport: MpcHttpTransport) -> Router {
 /// particular query, to coordinate servicing that query.
 //
 // It might make sense to split the query and h2h handlers into two modules.
-pub fn h2h_router(transport: MpcHttpTransport) -> Router {
+pub fn h2h_router(transport: Arc<HttpTransport<Helper>>) -> Router {
     Router::new()
-        .merge(step::router(Arc::clone(&transport.inner_transport)))
-        .merge(prepare::router(transport.inner_transport))
+        .merge(step::router(Arc::clone(&transport)))
+        .merge(prepare::router(transport))
         .layer(layer_fn(HelperAuthentication::<_, Helper>::new))
 }
 
 /// Construct router for shard-to-shard communications similar to [`h2h_router`].
-pub fn s2s_router(transport: ShardHttpTransport) -> Router {
+pub fn s2s_router(transport: Arc<HttpTransport<Shard>>) -> Router {
     Router::new()
-        .merge(step::router(Arc::clone(&transport.inner_transport)))
-        .merge(prepare::router(Arc::clone(&transport.inner_transport)))
-        .merge(results::router(transport.inner_transport))
+        .merge(step::router(Arc::clone(&transport)))
+        .merge(prepare::router(Arc::clone(&transport)))
+        .merge(results::router(Arc::clone(&transport)))
+        .merge(status_match::router(transport))
         .layer(layer_fn(HelperAuthentication::<_, Shard>::new))
 }
 
@@ -125,12 +127,11 @@ pub mod test_helpers {
     use std::{any::Any, sync::Arc};
 
     use axum::body::Body;
-    use http_body_util::BodyExt;
     use hyper::{http::request, StatusCode};
 
     use crate::{
         helpers::{HelperIdentity, RequestHandler},
-        net::test::TestServer,
+        net::{test::TestServer, Helper},
     };
 
     /// Helper trait for optionally adding an extension to a request.
@@ -178,14 +179,6 @@ pub mod test_helpers {
         req: hyper::Request<Body>,
         handler: Arc<dyn RequestHandler<HelperIdentity>>,
     ) -> bytes::Bytes {
-        let test_server = TestServer::builder()
-            .with_request_handler(handler)
-            .build()
-            .await;
-        let resp = test_server.server.handle_req(req).await;
-        let status = resp.status();
-        assert_eq!(StatusCode::OK, status);
-
-        resp.into_body().collect().await.unwrap().to_bytes()
+        TestServer::<Helper>::oneshot_success(req, handler).await
     }
 }

--- a/ipa-core/src/net/server/handlers/query/status_match.rs
+++ b/ipa-core/src/net/server/handlers/query/status_match.rs
@@ -1,0 +1,160 @@
+use axum::{
+    extract::{Path, Query},
+    routing::get,
+    Extension, Router,
+};
+use hyper::StatusCode;
+
+use crate::{
+    helpers::{query::CompareStatusRequest, ApiError, BodyStream},
+    net::{
+        http_serde::query::status_match::{
+            StatusQueryString, {self},
+        },
+        server::Error,
+        HttpTransport, Shard,
+    },
+    protocol::QueryId,
+    sync::Arc,
+};
+
+async fn handler(
+    transport: Extension<Arc<HttpTransport<Shard>>>,
+    Path(query_id): Path<QueryId>,
+    Query(StatusQueryString { status }): Query<StatusQueryString>,
+) -> Result<(), Error> {
+    let req = CompareStatusRequest { query_id, status };
+    match Arc::clone(&transport)
+        .dispatch(req, BodyStream::empty())
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(ApiError::QueryStatus(status)) => {
+            Err(Error::application(StatusCode::PRECONDITION_FAILED, status))
+        }
+        Err(e) => Err(Error::application(StatusCode::INTERNAL_SERVER_ERROR, e)),
+    }
+}
+
+pub fn router(transport: Arc<HttpTransport<Shard>>) -> Router {
+    Router::new()
+        .route(status_match::AXUM_PATH, get(handler))
+        .layer(Extension(transport))
+}
+
+#[cfg(all(test, unit_test))]
+mod tests {
+    use std::borrow::Borrow;
+
+    use axum::{
+        body::Body,
+        http::uri::{Authority, Scheme},
+    };
+    use hyper::StatusCode;
+
+    use crate::{
+        helpers::{
+            make_owned_handler,
+            query::CompareStatusRequest,
+            routing::{Addr, RouteId},
+            ApiError, BodyStream, HelperResponse,
+        },
+        net::{
+            http_serde::query::status_match::try_into_http_request, server::ClientIdentity,
+            test::TestServer, Shard,
+        },
+        protocol::QueryId,
+        query::{QueryStatus, QueryStatusError},
+        sharding::ShardIndex,
+    };
+
+    fn for_status(status: QueryStatus) -> CompareStatusRequest {
+        CompareStatusRequest {
+            query_id: QueryId,
+            status,
+        }
+    }
+
+    fn http_request<B: Borrow<CompareStatusRequest>>(req: B) -> hyper::Request<axum::body::Body> {
+        try_into_http_request(
+            req.borrow(),
+            Scheme::HTTP,
+            Authority::from_static("localhost"),
+        )
+        .unwrap()
+    }
+
+    fn authenticated(mut req: hyper::Request<Body>) -> hyper::Request<Body> {
+        req.extensions_mut()
+            .insert(ClientIdentity(ShardIndex::from(2)));
+        req
+    }
+
+    #[tokio::test]
+    async fn status_success() {
+        let expected_status = QueryStatus::Running;
+        let expected_query_id = QueryId;
+
+        let handler = make_owned_handler(
+            move |addr: Addr<ShardIndex>, _data: BodyStream| async move {
+                let RouteId::QueryStatus = addr.route else {
+                    panic!("unexpected call");
+                };
+                let req = addr.into::<CompareStatusRequest>().unwrap();
+                assert_eq!(req.query_id, expected_query_id);
+                assert_eq!(req.status, expected_status);
+                Ok(HelperResponse::ok())
+            },
+        );
+        let req = authenticated(http_request(for_status(expected_status)));
+
+        TestServer::<Shard>::oneshot_success(req, handler).await;
+    }
+
+    #[tokio::test]
+    async fn status_mismatch() {
+        let req_status = QueryStatus::Completed;
+        let handler = make_owned_handler(
+            move |addr: Addr<ShardIndex>, _data: BodyStream| async move {
+                let RouteId::QueryStatus = addr.route else {
+                    panic!("unexpected call");
+                };
+                Err(ApiError::QueryStatus(QueryStatusError::DifferentStatus {
+                    query_id: QueryId,
+                    my_status: QueryStatus::Running,
+                    other_status: req_status,
+                }))
+            },
+        );
+        let req = authenticated(http_request(for_status(req_status)));
+
+        let resp = TestServer::<Shard>::oneshot(req, handler).await;
+        assert_eq!(StatusCode::PRECONDITION_FAILED, resp.status());
+    }
+
+    #[tokio::test]
+    async fn unauthenticated() {
+        assert_eq!(
+            StatusCode::UNAUTHORIZED,
+            TestServer::<Shard>::oneshot(
+                http_request(for_status(QueryStatus::Running)),
+                make_owned_handler(|_, _| async move { unimplemented!() }),
+            )
+            .await
+            .status()
+        );
+    }
+
+    #[tokio::test]
+    async fn server_error() {
+        assert_eq!(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            TestServer::<Shard>::oneshot(
+                authenticated(http_request(for_status(QueryStatus::Running))),
+                make_owned_handler(|_, _| async move { Err(ApiError::BadRequest("".into())) }),
+            )
+            .await
+            .status()
+        );
+    }
+}

--- a/ipa-core/src/net/server/handlers/query/status_match.rs
+++ b/ipa-core/src/net/server/handlers/query/status_match.rs
@@ -136,7 +136,7 @@ mod tests {
     #[tokio::test]
     async fn other_query_error() {
         let handler = make_owned_handler(
-            move |addr: Addr<ShardIndex>, _data: BodyStream| async move {
+            move |_addr: Addr<ShardIndex>, _data: BodyStream| async move {
                 Err(ApiError::QueryStatus(QueryStatusError::NoSuchQuery(
                     QueryId,
                 )))

--- a/ipa-core/src/net/server/handlers/query/step.rs
+++ b/ipa-core/src/net/server/handlers/query/step.rs
@@ -40,7 +40,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        helpers::{HelperIdentity, Transport, MESSAGE_PAYLOAD_SIZE_BYTES},
+        helpers::{HelperIdentity, MESSAGE_PAYLOAD_SIZE_BYTES},
         net::{
             server::handlers::query::test_helpers::{assert_fails_with, MaybeExtensionExt},
             test::TestServer,
@@ -66,7 +66,7 @@ mod tests {
 
         let mut stream = test_server
             .transport
-            .receive(HelperIdentity::TWO, (QueryId, step))
+            .receive(HelperIdentity::TWO, &(QueryId, step))
             .into_bytes_stream();
 
         assert_eq!(

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -15,7 +15,9 @@ use std::{
     ops::Index,
 };
 
+#[cfg(all(test, unit_test))]
 use http_body_util::BodyExt;
+#[cfg(all(test, unit_test))]
 use hyper::StatusCode;
 use once_cell::sync::Lazy;
 use rustls_pki_types::CertificateDer;
@@ -231,7 +233,7 @@ impl TestApp {
             &self.mpc_network_config,
             &identities.helper,
         );
-        let (transport, server) = MpcHttpTransport::new(
+        let (transport, server) = crate::net::MpcHttpTransport::new(
             IpaRuntime::current(),
             sid.helper_identity,
             self.mpc_server.config,
@@ -509,6 +511,7 @@ impl TestServer<Helper> {
         TestServerBuilder::default()
     }
 
+    #[cfg(all(test, unit_test))]
     pub async fn oneshot_success(
         req: hyper::Request<axum::body::Body>,
         handler: Arc<dyn RequestHandler<HelperIdentity>>,
@@ -526,6 +529,7 @@ impl TestServer<Helper> {
 }
 
 impl TestServer<Shard> {
+    #[cfg(all(test, unit_test))]
     pub async fn oneshot(
         req: hyper::Request<axum::body::Body>,
         handler: Arc<dyn RequestHandler<ShardIndex>>,
@@ -537,6 +541,7 @@ impl TestServer<Shard> {
         test_server.server.handle_req(req).await
     }
 
+    #[cfg(all(test, unit_test))]
     pub async fn oneshot_success(
         req: hyper::Request<axum::body::Body>,
         handler: Arc<dyn RequestHandler<ShardIndex>>,

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -28,11 +28,11 @@ use crate::{
 
 /// Shared implementation used by [`MpcHttpTransport`] and [`ShardHttpTransport`]
 pub struct HttpTransport<F: ConnectionFlavor> {
-    http_runtime: IpaRuntime,
-    identity: F::Identity,
-    clients: Vec<IpaHttpClient<F>>,
-    record_streams: StreamCollection<F::Identity, BodyStream>,
-    handler: Option<HandlerRef<F::Identity>>,
+    pub(super) http_runtime: IpaRuntime,
+    pub(super) identity: F::Identity,
+    pub(super) clients: Vec<IpaHttpClient<F>>,
+    pub(super) record_streams: StreamCollection<F::Identity, BodyStream>,
+    pub(super) handler: Option<HandlerRef<F::Identity>>,
 }
 
 /// HTTP transport for helper to helper traffic.
@@ -122,7 +122,7 @@ impl<F: ConnectionFlavor> HttpTransport<F> {
         }
     }
 
-    fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
+    pub(crate) fn receive<R: RouteParams<NoResourceIdentifier, QueryId, Gate>>(
         &self,
         from: F::Identity,
         route: &R,
@@ -218,18 +218,17 @@ impl MpcHttpTransport {
         clients: &[IpaHttpClient<Helper>; 3],
         handler: Option<HandlerRef<HelperIdentity>>,
     ) -> (Self, IpaHttpServer<Helper>) {
-        let transport = Self {
-            inner_transport: Arc::new(HttpTransport {
-                http_runtime,
-                identity,
-                clients: clients.to_vec(),
-                handler,
-                record_streams: StreamCollection::default(),
-            }),
-        };
+        let inner_transport = Arc::new(HttpTransport {
+            http_runtime,
+            identity,
+            clients: clients.to_vec(),
+            handler,
+            record_streams: StreamCollection::default(),
+        });
 
-        let server = IpaHttpServer::new_mpc(&transport, server_config, network_config);
-        (transport, server)
+        let server =
+            IpaHttpServer::new_mpc(Arc::clone(&inner_transport), server_config, network_config);
+        (Self { inner_transport }, server)
     }
 
     /// Connect an inbound stream of record data.
@@ -326,19 +325,23 @@ impl ShardHttpTransport {
         clients: Vec<IpaHttpClient<Shard>>,
         handler: Option<HandlerRef<ShardIndex>>,
     ) -> (Self, IpaHttpServer<Shard>) {
-        let transport = Self {
-            inner_transport: Arc::new(HttpTransport {
-                http_runtime,
-                identity: shard_id,
-                clients,
-                handler,
-                record_streams: StreamCollection::default(),
-            }),
-            shard_count,
-        };
+        let inner_transport = Arc::new(HttpTransport {
+            http_runtime,
+            identity: shard_id,
+            clients,
+            handler,
+            record_streams: StreamCollection::default(),
+        });
 
-        let server = IpaHttpServer::new_shards(&transport, server_config, network_config);
-        (transport, server)
+        let server =
+            IpaHttpServer::new_shards(Arc::clone(&inner_transport), server_config, network_config);
+        (
+            Self {
+                inner_transport,
+                shard_count,
+            },
+            server,
+        )
     }
 }
 

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -442,18 +442,18 @@ mod tests {
             .build()
             .await;
 
-        transport.inner_transport.record_streams.add_stream(
+        transport.record_streams.add_stream(
             (QueryId, HelperIdentity::ONE, Gate::default()),
             BodyStream::empty(),
         );
-        assert_eq!(1, transport.inner_transport.record_streams.len());
+        assert_eq!(1, transport.record_streams.len());
 
-        Transport::clone_ref(&transport)
+        Arc::clone(&transport)
             .dispatch((RouteId::KillQuery, QueryId), BodyStream::empty())
             .await
             .unwrap();
 
-        assert!(transport.inner_transport.record_streams.is_empty());
+        assert!(transport.record_streams.is_empty());
     }
 
     #[tokio::test]
@@ -471,7 +471,7 @@ mod tests {
 
         // Request step data reception (normally called by protocol)
         let mut stream = transport
-            .receive(HelperIdentity::TWO, (QueryId, STEP.clone()))
+            .receive(HelperIdentity::TWO, &(QueryId, STEP.clone()))
             .into_bytes_stream();
 
         // make sure it is not ready as it hasn't received any data yet.

--- a/ipa-core/src/query/state.rs
+++ b/ipa-core/src/query/state.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fmt::{Debug, Formatter},
+    fmt::{Debug, Display, Formatter},
     future::Future,
     task::Poll,
 };
@@ -33,6 +33,12 @@ pub enum QueryStatus {
     AwaitingCompletion,
     /// Query has finished and results are available.
     Completed,
+}
+
+impl Display for QueryStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
 }
 
 impl From<&QueryState> for QueryStatus {


### PR DESCRIPTION
Quite a bit of changes here, mostly because of a need to have test server for shard endpoint.
This endpoint is required for shards to be able to communicate query status updates to each other.