### PR TITLE
Add a timeout to TestWorld

### DIFF
--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -116,6 +116,7 @@ async fn run(args: Args) -> Result<(), Error> {
             ..Default::default()
         },
         initial_gate: Some(Gate::default().narrow(&IpaPrf)),
+        timeout: None,
         ..TestWorldConfig::default()
     };
     // Construct TestWorld early to initialize logging.

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -1162,9 +1162,9 @@ mod tests {
         let a: Vec<V> = repeat_with(|| rng.gen()).take(count).collect();
         let b: Vec<V> = repeat_with(|| rng.gen()).take(count).collect();
 
-        // Timeout is 20 seconds plus count * (5 ms).
+        // Timeout is 10 seconds plus count * (3 ms).
         let config = TestWorldConfig::default()
-            .with_timeout_secs(20 + 5 * u64::try_from(count).unwrap() / 1000);
+            .with_timeout_secs(10 + 3 * u64::try_from(count).unwrap() / 1000);
 
         let [ab0, ab1, ab2]: [Vec<Replicated<V>>; 3] =
             TestWorld::<NotSharded>::with_config(&config)
@@ -1360,7 +1360,11 @@ mod tests {
         }
     }
 
+    // This test is much slower in the multi-threading config, perhaps because the
+    // amount of work it does for each record is very small compared to the overhead of
+    // spawning tasks.
     #[tokio::test]
+    #[cfg(not(feature = "multi-threading"))]
     async fn large_batch() {
         multi_select_malicious::<BA8>(2 * TARGET_PROOF_SIZE, 2 * TARGET_PROOF_SIZE).await;
     }

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -1162,9 +1162,9 @@ mod tests {
         let a: Vec<V> = repeat_with(|| rng.gen()).take(count).collect();
         let b: Vec<V> = repeat_with(|| rng.gen()).take(count).collect();
 
-        // Timeout is 10 seconds plus count * (3 ms).
+        // Timeout is 20 seconds plus count * (5 ms).
         let config = TestWorldConfig::default()
-            .with_timeout_secs(10 + 3 * u64::try_from(count).unwrap() / 1000);
+            .with_timeout_secs(20 + 5 * u64::try_from(count).unwrap() / 1000);
 
         let [ab0, ab1, ab2]: [Vec<Replicated<V>>; 3] =
             TestWorld::<NotSharded>::with_config(&config)

--- a/ipa-core/src/protocol/dp/mod.rs
+++ b/ipa-core/src/protocol/dp/mod.rs
@@ -619,6 +619,7 @@ mod test {
             replicated::{semi_honest::AdditiveShare as Replicated, ReplicatedSecretSharing},
             BitDecomposed, SharedValue, TransposeFrom,
         },
+        sharding::NotSharded,
         telemetry::metrics::BYTES_SENT,
         test_fixture::{Reconstruct, Runner, TestWorld, TestWorldConfig},
     };
@@ -863,7 +864,8 @@ mod test {
         if std::env::var("EXEC_SLOW_TESTS").is_err() {
             return;
         }
-        let world = TestWorld::default();
+        let config = TestWorldConfig::default().with_timeout_secs(60);
+        let world = TestWorld::<NotSharded>::with_config(&config);
         let result: [Vec<Replicated<OutputValue>>; 3] = world
             .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
@@ -898,7 +900,8 @@ mod test {
         type OutputValue = BA16;
         const NUM_BREAKDOWNS: u32 = 32;
         let num_bernoulli: u32 = 2000;
-        let world = TestWorld::default();
+        let config = TestWorldConfig::default().with_timeout_secs(60);
+        let world = TestWorld::<NotSharded>::with_config(&config);
         let result: [Vec<Replicated<OutputValue>>; 3] = world
             .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(
@@ -933,7 +936,8 @@ mod test {
         type OutputValue = BA16;
         const NUM_BREAKDOWNS: u32 = 256;
         let num_bernoulli: u32 = 1000;
-        let world = TestWorld::default();
+        let config = TestWorldConfig::default().with_timeout_secs(60);
+        let world = TestWorld::<NotSharded>::with_config(&config);
         let result: [Vec<Replicated<OutputValue>>; 3] = world
             .dzkp_semi_honest((), |ctx, ()| async move {
                 Vec::transposed_from(

--- a/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
@@ -336,10 +336,13 @@ pub mod tests {
     #[test]
     #[cfg(not(feature = "shuttle"))] // too slow
     fn breakdown_reveal_malicious_happy_path() {
+        use crate::test_fixture::TestWorldConfig;
+
         type HV = BA16;
         const SHARDS: usize = 2;
         run(|| async {
-            let world = TestWorld::<WithShards<SHARDS>>::with_shards(TestWorldConfig::default());
+            let config = TestWorldConfig::default().with_timeout_secs(60);
+            let world = TestWorld::<WithShards<SHARDS>>::with_shards(&config);
             let (inputs, expectation) = inputs_and_expectation(world.rng());
 
             let result: Vec<_> = world

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -221,7 +221,7 @@ mod test {
             const SHARDS: usize = 2;
             let world: TestWorld<WithShards<SHARDS>> = TestWorld::with_shards(TestWorldConfig {
                 initial_gate: Some(Gate::default().narrow(&ProtocolStep::Hybrid)),
-                timeout: Duration::from_secs(60),
+                timeout: Some(Duration::from_secs(60)),
                 ..Default::default()
             });
 

--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -200,7 +200,10 @@ where
 
 #[cfg(all(test, unit_test, feature = "in-memory-infra"))]
 mod test {
-    use std::collections::{HashMap, HashSet};
+    use std::{
+        collections::{HashMap, HashSet},
+        time::Duration,
+    };
 
     use ipa_step::StepNarrow;
 
@@ -218,6 +221,7 @@ mod test {
             const SHARDS: usize = 2;
             let world: TestWorld<WithShards<SHARDS>> = TestWorld::with_shards(TestWorldConfig {
                 initial_gate: Some(Gate::default().narrow(&ProtocolStep::Hybrid)),
+                timeout: Duration::from_secs(60),
                 ..Default::default()
             });
 

--- a/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
@@ -392,9 +392,12 @@ pub mod tests {
     #[test]
     #[cfg(not(feature = "shuttle"))] // too slow
     fn malicious_happy_path() {
+        use crate::{sharding::NotSharded, test_fixture::TestWorldConfig};
+
         type HV = BA16;
         run(|| async {
-            let world = TestWorld::default();
+            let config = TestWorldConfig::default().with_timeout_secs(60);
+            let world = TestWorld::<NotSharded>::with_config(&config);
             let mut rng = world.rng();
             let mut expectation = Vec::new();
             for _ in 0..32 {

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -536,7 +536,7 @@ pub mod tests {
 
     proptest! {
         #[test]
-        fn aggregate_proptest(
+        fn aggregate_values_proptest(
             input_struct in arb_aggregate_values_inputs(PROP_MAX_INPUT_LEN),
             seed in any::<u64>(),
         ) {

--- a/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
+++ b/ipa-core/src/protocol/ipa_prf/boolean_ops/share_conversion_aby.rs
@@ -386,8 +386,9 @@ mod tests {
         rand::thread_rng,
         secret_sharing::SharedValue,
         seq_join::{seq_join, SeqJoin},
+        sharding::NotSharded,
         test_executor::run,
-        test_fixture::{ReconstructArr, Runner, TestWorld},
+        test_fixture::{ReconstructArr, Runner, TestWorld, TestWorldConfig},
     };
 
     #[test]
@@ -457,7 +458,8 @@ mod tests {
             const COUNT: usize = CONV_CHUNK * PROOF_CHUNK * 2 + 1;
             const TOTAL_RECORDS: usize = COUNT.div_ceil(CONV_CHUNK);
 
-            let world = TestWorld::default();
+            let config = TestWorldConfig::default().with_timeout_secs(60);
+            let world = TestWorld::<NotSharded>::with_config(&config);
 
             let mut rng = thread_rng();
 

--- a/ipa-core/src/protocol/ipa_prf/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/mod.rs
@@ -527,8 +527,9 @@ pub mod tests {
             dp::NoiseParams,
             ipa_prf::{oprf_ipa, oprf_padding::PaddingParameters},
         },
+        sharding::NotSharded,
         test_executor::run,
-        test_fixture::{ipa::TestRawDataRecord, Reconstruct, Runner, TestWorld},
+        test_fixture::{ipa::TestRawDataRecord, Reconstruct, Runner, TestWorld, TestWorldConfig},
     };
 
     fn test_input(
@@ -660,7 +661,8 @@ pub mod tests {
             let dp_params = DpMechanism::Binomial { epsilon };
             let per_user_credit_cap = 2_f64.powi(i32::try_from(SS_BITS).unwrap());
             let padding_params = PaddingParameters::relaxed();
-            let world = TestWorld::default();
+            let config = TestWorldConfig::default().with_timeout_secs(60);
+            let world = TestWorld::<NotSharded>::with_config(&config);
 
             let records: Vec<TestRawDataRecord> = vec![
                 test_input(0, 12345, false, 1, 0),

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -387,11 +387,15 @@ impl<S: ShardingScheme> TestWorld<S> {
     }
 
     async fn with_timeout<F: IntoFuture>(&self, fut: F) -> F::Output {
-        let Ok(output) = tokio::time::timeout(self.timeout, fut).await else {
-            tracing::error!("timed out after {:?}", self.timeout);
-            panic!("timed out after {:?}", self.timeout);
-        };
-        output
+        if cfg!(feature = "shuttle") {
+            fut.await
+        } else {
+            let Ok(output) = tokio::time::timeout(self.timeout, fut).await else {
+                tracing::error!("timed out after {:?}", self.timeout);
+                panic!("timed out after {:?}", self.timeout);
+            };
+            output
+        }
     }
 }
 

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -4,10 +4,12 @@ use std::{
     array::from_fn,
     borrow::Borrow,
     fmt::Debug,
+    future::IntoFuture,
     io::stdout,
     iter::{self, zip},
     marker::PhantomData,
     sync::Mutex,
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -108,6 +110,7 @@ pub struct TestWorld<S: ShardingScheme = NotSharded> {
     rng: Mutex<StdRng>,
     gate_vendor: Box<dyn TestGateVendor>,
     _shard_network: InMemoryShardNetwork,
+    timeout: Duration,
 }
 
 #[derive(Clone)]
@@ -155,6 +158,12 @@ pub struct TestWorldConfig {
     /// [`MaliciousHelper`]: crate::helpers::in_memory_config::MaliciousHelper
     /// [`passthrough`]: crate::helpers::in_memory_config::passthrough
     pub stream_interceptor: DynStreamInterceptor,
+
+    /// Timeout for tests run by this `TestWorld`.
+    ///
+    /// This timeout is implement using tokio, so it will only be able to terminate the test if the
+    /// futures are yielding periodically.
+    pub timeout: Duration,
 }
 
 impl ShardingScheme for NotSharded {
@@ -347,6 +356,7 @@ impl<S: ShardingScheme> TestWorld<S> {
             rng: Mutex::new(rng),
             gate_vendor: gate_vendor(config.initial_gate.clone()),
             _shard_network: shard_network,
+            timeout: config.timeout,
         }
     }
 
@@ -375,6 +385,14 @@ impl<S: ShardingScheme> TestWorld<S> {
         // unfortunately take `&self`.
         StdRng::from_seed(self.rng.lock().unwrap().gen())
     }
+
+    async fn with_timeout<F: IntoFuture>(&self, fut: F) -> F::Output {
+        let Ok(output) = tokio::time::timeout(self.timeout, fut).await else {
+            tracing::error!("timed out after {:?}", self.timeout);
+            panic!("timed out after {:?}", self.timeout);
+        };
+        output
+    }
 }
 
 impl Default for TestWorldConfig {
@@ -392,6 +410,7 @@ impl Default for TestWorldConfig {
             seed: thread_rng().next_u64(),
             initial_gate: None,
             stream_interceptor: passthrough(),
+            timeout: Duration::from_secs(10),
         }
     }
 }
@@ -406,6 +425,12 @@ impl TestWorldConfig {
     #[must_use]
     pub fn with_seed(mut self, seed: u64) -> Self {
         self.seed = seed;
+        self
+    }
+
+    #[must_use]
+    pub fn with_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.timeout = Duration::from_secs(timeout_secs);
         self
     }
 
@@ -538,18 +563,20 @@ impl<const SHARDS: usize, D: Distribute> Runner<WithShards<SHARDS, D>>
         // No clippy, you're wrong, it is not redundant, it allows shard_fn to be `Copy`
         #[allow(clippy::redundant_closure)]
         let shard_fn = |ctx, input| helper_fn(ctx, input);
-        zip(shards.into_iter(), zip(zip(h1, h2), h3))
-            .map(|(shard, ((h1, h2), h3))| {
-                ShardWorld::<WithShards<SHARDS, D>>::run_either(
-                    shard.contexts(&gate),
-                    self.metrics_handle.span(),
-                    [h1, h2, h3],
-                    shard_fn,
-                )
-            })
-            .collect::<FuturesOrdered<_>>()
-            .collect::<Vec<_>>()
-            .await
+        self.with_timeout(
+            zip(shards.into_iter(), zip(zip(h1, h2), h3))
+                .map(|(shard, ((h1, h2), h3))| {
+                    ShardWorld::<WithShards<SHARDS, D>>::run_either(
+                        shard.contexts(&gate),
+                        self.metrics_handle.span(),
+                        [h1, h2, h3],
+                        shard_fn,
+                    )
+                })
+                .collect::<FuturesOrdered<_>>()
+                .collect::<Vec<_>>(),
+        )
+        .await
     }
 
     async fn malicious<'a, I, A, O, H, R>(&'a self, input: I, helper_fn: H) -> Vec<[O; 3]>
@@ -573,18 +600,20 @@ impl<const SHARDS: usize, D: Distribute> Runner<WithShards<SHARDS, D>>
         // No clippy, you're wrong, it is not redundant, it allows shard_fn to be `Copy`
         #[allow(clippy::redundant_closure)]
         let shard_fn = |ctx, input| helper_fn(ctx, input);
-        zip(shards.into_iter(), zip(zip(h1, h2), h3))
-            .map(|(shard, ((h1, h2), h3))| {
-                ShardWorld::<WithShards<SHARDS, D>>::run_either(
-                    shard.malicious_contexts(&gate),
-                    self.metrics_handle.span(),
-                    [h1, h2, h3],
-                    shard_fn,
-                )
-            })
-            .collect::<FuturesOrdered<_>>()
-            .collect::<Vec<_>>()
-            .await
+        self.with_timeout(
+            zip(shards.into_iter(), zip(zip(h1, h2), h3))
+                .map(|(shard, ((h1, h2), h3))| {
+                    ShardWorld::<WithShards<SHARDS, D>>::run_either(
+                        shard.malicious_contexts(&gate),
+                        self.metrics_handle.span(),
+                        [h1, h2, h3],
+                        shard_fn,
+                    )
+                })
+                .collect::<FuturesOrdered<_>>()
+                .collect::<Vec<_>>(),
+        )
+        .await
     }
 
     async fn upgraded_malicious<'a, F, I, A, M, O, H, R, P>(
@@ -645,12 +674,12 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         H: Fn(Self::SemiHonestContext<'a>, A) -> R + Send + Sync,
         R: Future<Output = O> + Send,
     {
-        ShardWorld::<NotSharded>::run_either(
+        self.with_timeout(ShardWorld::<NotSharded>::run_either(
             self.contexts(),
             self.metrics_handle.span(),
             input.share_with(&mut self.rng()),
             helper_fn,
-        )
+        ))
         .await
     }
 
@@ -662,12 +691,12 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         H: Fn(Self::MaliciousContext<'a>, A) -> R + Send + Sync,
         R: Future<Output = O> + Send,
     {
-        ShardWorld::<NotSharded>::run_either(
+        self.with_timeout(ShardWorld::<NotSharded>::run_either(
             self.malicious_contexts(),
             self.metrics_handle.span(),
             input.share_with(&mut self.rng()),
             helper_fn,
-        )
+        ))
         .await
     }
 
@@ -747,7 +776,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
         H: Fn(DZKPUpgradedSemiHonestContext<'a, NotSharded>, A) -> R + Send + Sync,
         R: Future<Output = O> + Send,
     {
-        ShardWorld::<NotSharded>::run_either(
+        self.with_timeout(ShardWorld::<NotSharded>::run_either(
             self.contexts(),
             self.metrics_handle.span(),
             input.share(),
@@ -758,7 +787,7 @@ impl Runner<NotSharded> for TestWorld<NotSharded> {
                 v.validate().await.unwrap();
                 m_result
             },
-        )
+        ))
         .await
     }
 
@@ -852,6 +881,7 @@ impl<S: ShardingScheme> ShardWorld<S> {
         }))
         .instrument(span)
         .await;
+
         <[_; 3]>::try_from(output).unwrap()
     }
 


### PR DESCRIPTION
There is a risk that this will introduce flakiness, if there are tests where the tail of the runtime distribution exceeds the timeout. On the other hand, we know that stalls are a predominant failure mode of our protocols, and a clear failure message is a lot nicer than a test job that hangs until somebody notices and kills it.