### PR TITLE
Add proptest for breakdown-reveal aggregation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -172,6 +172,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
+      - name: Slow Unit Tests
+        run: cargo test -p ipa-core --lib -- mpc_proptest semi_honest_with_dp_slow gen_binomial_noise_16_breakdowns
+
       - name: Integration Tests - Compact Gate
         run: cargo test --release --test "compact_gate" --no-default-features --features "cli web-app real-world-infra test-fixture compact-gate"
 

--- a/ipa-core/src/protocol/context/dzkp_validator.rs
+++ b/ipa-core/src/protocol/context/dzkp_validator.rs
@@ -1332,7 +1332,7 @@ mod tests {
     proptest! {
         #![proptest_config(mpc_proptest_config())]
         #[test]
-        fn batching_proptest(
+        fn batching_mpc_proptest(
             (record_count, max_multiplications_per_gate) in batching(),
             protocol in 0..8,
         ) {

--- a/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
@@ -584,7 +584,7 @@ mod proptests {
     prop_compose! {
         fn inputs(max_len: usize)
                  (
-                     len in 1..=max_len,
+                     len in 0..=max_len,
                  )
                  (
                      len in Just(len),

--- a/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, pin::pin};
+use std::{convert::Infallible, iter::repeat, pin::pin};
 
 use futures::stream;
 use futures_util::{StreamExt, TryStreamExt};
@@ -76,6 +76,14 @@ where
     BitDecomposed<Replicated<Boolean, B>>:
         for<'a> TransposeFrom<&'a [Replicated<V>; B], Error = Infallible>,
 {
+    // This was checked early in the protocol, but we need to check again here, in case
+    // there were no matching pairs of reports.
+    if attributed_values.is_empty() {
+        return Ok(BitDecomposed::new(
+            repeat(Replicated::<Boolean, B>::ZERO).take(usize::try_from(HV::BITS).unwrap()),
+        ));
+    }
+
     // Apply DP padding for Breakdown Reveal Aggregation
     let attributed_values_padded = apply_dp_padding::<_, AggregateableHybridReport<BK, V>, B>(
         ctx.narrow(&Step::PaddingDp),
@@ -291,6 +299,78 @@ pub mod tests {
     }
 
     #[test]
+    fn empty() {
+        run_with::<_, _, 3>(|| async {
+            let world = TestWorld::<WithShards<1>>::with_shards(TestWorldConfig::default());
+            let expectation = vec![0; 32];
+            let inputs: Vec<TestAggregateableHybridReport> = vec![];
+            let result: Vec<_> = world
+                .semi_honest(inputs.into_iter(), |ctx, input_rows| async move {
+                    let r: Vec<Replicated<BA8>> =
+                        breakdown_reveal_aggregation::<_, BA5, BA3, BA8, 32>(
+                            ctx,
+                            input_rows,
+                            &PaddingParameters::no_padding(),
+                        )
+                        .map_ok(|d: BitDecomposed<Replicated<Boolean, 32>>| {
+                            Vec::transposed_from(&d).unwrap()
+                        })
+                        .await
+                        .unwrap();
+                    r
+                })
+                .await
+                .reconstruct();
+            let result = result
+                .first()
+                .unwrap()
+                .iter()
+                .map(|&v| v.as_u128())
+                .collect::<Vec<_>>();
+            assert_eq!(32, result.len());
+            assert_eq!(result, expectation);
+        });
+    }
+
+    #[test]
+    fn single() {
+        // Test that the output is padded to the full size, when there are not enough inputs
+        // for the computation to naturally grow to the full size.
+        run_with::<_, _, 3>(|| async {
+            let world = TestWorld::<WithShards<1>>::with_shards(TestWorldConfig::default());
+            let mut expectation = vec![0; 32];
+            expectation[0] = 7;
+            let expectation = expectation; // no more mutability for safety
+            let inputs = vec![input_row(0, 7)];
+            let result: Vec<_> = world
+                .semi_honest(inputs.into_iter(), |ctx, input_rows| async move {
+                    let r: Vec<Replicated<BA8>> =
+                        breakdown_reveal_aggregation::<_, BA5, BA3, BA8, 32>(
+                            ctx,
+                            input_rows,
+                            &PaddingParameters::no_padding(),
+                        )
+                        .map_ok(|d: BitDecomposed<Replicated<Boolean, 32>>| {
+                            Vec::transposed_from(&d).unwrap()
+                        })
+                        .await
+                        .unwrap();
+                    r
+                })
+                .await
+                .reconstruct();
+            let result = result
+                .first()
+                .unwrap()
+                .iter()
+                .map(|&v| v.as_u128())
+                .collect::<Vec<_>>();
+            assert_eq!(32, result.len());
+            assert_eq!(result, expectation);
+        });
+    }
+
+    #[test]
     fn breakdown_reveal_semi_honest_happy_path() {
         // if shuttle executor is enabled, run this test only once.
         // it is a very expensive test to explore all possible states,
@@ -431,5 +511,166 @@ pub mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(result, expectation);
         });
+    }
+}
+
+#[cfg(all(test, unit_test))]
+mod proptests {
+    use std::{cmp::min, time::Duration};
+
+    use futures::TryFutureExt;
+    use proptest::{prelude::*, prop_compose};
+
+    use crate::{
+        const_assert,
+        ff::{
+            boolean::Boolean,
+            boolean_array::{BA3, BA32, BA5, BA8},
+            U128Conversions,
+        },
+        protocol::{
+            hybrid::breakdown_reveal::breakdown_reveal_aggregation,
+            ipa_prf::oprf_padding::PaddingParameters,
+        },
+        secret_sharing::{
+            replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, SharedValue,
+            TransposeFrom,
+        },
+        test_fixture::{
+            hybrid::{TestAggregateableHybridReport, TestIndistinguishableHybridReport},
+            mpc_proptest_config_with_cases, Reconstruct, Runner, TestWorld, TestWorldConfig,
+            WithShards,
+        },
+    };
+
+    type PropBreakdownKey = BA5;
+    type PropTriggerValue = BA3;
+    type PropHistogramValue = BA8;
+    type PropBucketsBitVec = BA32;
+    const PROP_MAX_INPUT_LEN: usize = 2500;
+    const PROP_BUCKETS: usize = PropBucketsBitVec::BITS as usize;
+    const PROP_SHARDS: usize = 2;
+
+    // We want to capture everything in this struct for visibility in the output of failing runs,
+    // even if it isn't used by the test.
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct AggregatePropTestInputs {
+        inputs: Vec<TestAggregateableHybridReport>,
+        expected: Vec<u32>,
+        len: usize,
+    }
+
+    const_assert!(
+        PropHistogramValue::BITS < u32::BITS,
+        "(1 << PropHistogramValue::BITS) must fit in u32",
+    );
+
+    const_assert!(
+        PROP_BUCKETS <= 1 << PropBreakdownKey::BITS,
+        "PROP_BUCKETS must fit in PropBreakdownKey",
+    );
+
+    impl From<(u32, u32)> for TestAggregateableHybridReport {
+        fn from(value: (u32, u32)) -> Self {
+            TestAggregateableHybridReport {
+                match_key: (),
+                breakdown_key: value.0,
+                value: value.1,
+            }
+        }
+    }
+
+    prop_compose! {
+        fn inputs(max_len: usize)
+                 (
+                     len in 1..=max_len,
+                 )
+                 (
+                     len in Just(len),
+                     inputs in prop::collection::vec((
+                        0u32..u32::try_from(PROP_BUCKETS).unwrap(),
+                        0u32..1 << PropTriggerValue::BITS,
+                    ).prop_map(Into::into), len),
+                 )
+        -> AggregatePropTestInputs {
+            let mut expected = vec![0; PROP_BUCKETS];
+            for input in &inputs {
+                let TestIndistinguishableHybridReport {
+                    match_key: (),
+                    breakdown_key: bk,
+                    value: tv,
+                } = *input;
+                let bk = usize::try_from(bk).unwrap();
+                expected[bk] = min(expected[bk] + tv, (1 << PropHistogramValue::BITS) - 1);
+            }
+
+            AggregatePropTestInputs {
+                inputs,
+                expected,
+                len,
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(mpc_proptest_config_with_cases(100))]
+        #[test]
+        fn breakdown_reveal_proptest(
+            input_struct in inputs(PROP_MAX_INPUT_LEN),
+            seed in any::<u64>(),
+        ) {
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let AggregatePropTestInputs {
+                    inputs,
+                    expected,
+                    ..
+                } = input_struct;
+                let config = TestWorldConfig {
+                    seed,
+                    timeout: Some(Duration::from_secs(20)),
+                    ..Default::default()
+                };
+                let result = TestWorld::<WithShards<PROP_SHARDS>>::with_config(&config)
+                    .malicious(inputs.into_iter(), |ctx, inputs| async move {
+                        breakdown_reveal_aggregation::<
+                            _,
+                            PropBreakdownKey,
+                            PropTriggerValue,
+                            PropHistogramValue,
+                            {PropBucketsBitVec::BITS as usize},
+                        >(
+                            ctx,
+                            inputs,
+                            &PaddingParameters::no_padding(),
+                        )
+                        .map_ok(|d: BitDecomposed<Replicated<Boolean, PROP_BUCKETS>>| {
+                            Vec::transposed_from(&d).unwrap()
+                        })
+                        .await
+                        .unwrap()
+                    })
+                    .await
+                    .reconstruct();
+
+                let initial = vec![0; PROP_BUCKETS];
+                let result = result
+                    .iter()
+                    .fold(initial, |mut acc, vec: &Vec<PropHistogramValue>| {
+                        acc.iter_mut()
+                            .zip(vec)
+                            .for_each(|(a, &b)| {
+                                *a = min(
+                                    *a + u32::try_from(b.as_u128()).unwrap(),
+                                    (1 << PropHistogramValue::BITS) - 1,
+                                );
+                            });
+                        acc
+                    })
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                assert_eq!(result, expected);
+            });
+        }
     }
 }

--- a/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/hybrid/breakdown_reveal.rs
@@ -616,7 +616,7 @@ mod proptests {
     proptest! {
         #![proptest_config(mpc_proptest_config_with_cases(100))]
         #[test]
-        fn breakdown_reveal_proptest(
+        fn breakdown_reveal_mpc_proptest(
             input_struct in inputs(PROP_MAX_INPUT_LEN),
             seed in any::<u64>(),
         ) {

--- a/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
@@ -598,7 +598,7 @@ pub mod tests {
         #[test]
         #[ignore] // This test is similar enough to the one in hybrid::breakdown_reveal
                   // that it is not worth running both.
-        fn breakdown_reveal_proptest(
+        fn breakdown_reveal_mpc_proptest(
             input_struct in inputs(PROP_MAX_INPUT_LEN),
             seed in any::<u64>(),
         ) {

--- a/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
@@ -566,7 +566,10 @@ pub mod tests {
                  )
                  (
                      len in Just(len),
-                     inputs in prop::collection::vec((0..PROP_BUCKETS, 0u32..1 << PropTriggerValue::BITS).prop_map(Into::into), len),
+                     inputs in prop::collection::vec((
+                        0..PROP_BUCKETS,
+                        0u32..1 << PropTriggerValue::BITS,
+                    ).prop_map(Into::into), len),
                  )
         -> AggregatePropTestInputs {
             let mut expected = [0; PROP_BUCKETS];
@@ -593,7 +596,8 @@ pub mod tests {
     proptest! {
         #![proptest_config(mpc_proptest_config_with_cases(100))]
         #[test]
-        #[ignore] // this test is redundant with the version in hybrid::breakdown_reveal.
+        #[ignore] // This test is similar enough to the one in hybrid::breakdown_reveal
+                  // that it is not worth running both.
         fn breakdown_reveal_proptest(
             input_struct in inputs(PROP_MAX_INPUT_LEN),
             seed in any::<u64>(),
@@ -606,7 +610,11 @@ pub mod tests {
                 } = input_struct;
                 let result = TestWorld::with_seed(seed)
                     .malicious(inputs.into_iter(), |ctx, inputs| async move {
-                        breakdown_reveal_aggregation::<_, _, _, PropHistogramValue, {PropBucketsBitVec::BITS as usize}>(
+                        breakdown_reveal_aggregation::<
+                            _, _, _,
+                            PropHistogramValue,
+                            {PropBucketsBitVec::BITS as usize},
+                        >(
                             ctx,
                             inputs,
                             &PaddingParameters::no_padding(),

--- a/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/breakdown_reveal.rs
@@ -203,10 +203,19 @@ where
         intermediate_results = next_intermediate_results;
     }
 
-    Ok(intermediate_results
+    let mut result = intermediate_results
         .into_iter()
         .next()
-        .expect("aggregation input must not be empty"))
+        .expect("aggregation input must not be empty");
+
+    // If there were less than 2^(|ov| - |tv|) inputs, then we didn't add enough carries to produce
+    // a full-length output, so pad the output now.
+    result.resize(
+        usize::try_from(HV::BITS).unwrap(),
+        Replicated::<Boolean, B>::ZERO,
+    );
+
+    Ok(result)
 }
 
 /// Transforms the Breakdown key from a secret share into a revealed `usize`.
@@ -302,29 +311,38 @@ where
 
 #[cfg(all(test, any(unit_test, feature = "shuttle")))]
 pub mod tests {
+    use std::cmp::min;
+
     use futures::TryFutureExt;
+    use proptest::{prelude::*, prop_compose};
     use rand::seq::SliceRandom;
 
-    #[cfg(not(feature = "shuttle"))]
-    use crate::{ff::boolean_array::BA16, test_executor::run};
     use crate::{
+        const_assert,
         ff::{
             boolean::Boolean,
-            boolean_array::{BA3, BA5, BA8},
+            boolean_array::{BA3, BA32, BA5, BA8},
             U128Conversions,
         },
         protocol::ipa_prf::{
             aggregation::breakdown_reveal::breakdown_reveal_aggregation,
             oprf_padding::PaddingParameters,
-            prf_sharding::{AttributionOutputsTestInput, SecretSharedAttributionOutputs},
+            prf_sharding::{
+                AttributionOutputs, AttributionOutputsTestInput, SecretSharedAttributionOutputs,
+            },
         },
         rand::Rng,
         secret_sharing::{
-            replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, TransposeFrom,
+            replicated::semi_honest::AdditiveShare as Replicated, BitDecomposed, IntoShares,
+            SharedValue, TransposeFrom,
         },
         test_executor::run_with,
-        test_fixture::{Reconstruct, Runner, TestWorld},
+        test_fixture::{
+            mpc_proptest_config_with_cases, Reconstruct, ReconstructArr, Runner, TestWorld,
+        },
     };
+    #[cfg(not(feature = "shuttle"))]
+    use crate::{ff::boolean_array::BA16, test_executor::run};
 
     fn input_row(bk: usize, tv: u128) -> AttributionOutputsTestInput<BA5, BA3> {
         let bk: u128 = bk.try_into().unwrap();
@@ -444,5 +462,120 @@ pub mod tests {
             assert_eq!(32, result.len());
             assert_eq!(result, expectation);
         });
+    }
+
+    type PropBreakdownKey = BA5;
+    type PropTriggerValue = BA3;
+    type PropHistogramValue = BA8;
+    type PropBucketsBitVec = BA32;
+    const PROP_MAX_INPUT_LEN: usize = 2500;
+    const PROP_BUCKETS: usize = PropBucketsBitVec::BITS as usize;
+
+    // We want to capture everything in this struct for visibility in the output of failing runs,
+    // even if it isn't used by the test.
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct AggregatePropTestInputs {
+        inputs: Vec<AttributionOutputs<usize, u32>>,
+        expected: BitDecomposed<PropBucketsBitVec>,
+        len: usize,
+    }
+
+    const_assert!(
+        PropHistogramValue::BITS < u32::BITS,
+        "(1 << PropHistogramValue::BITS) must fit in u32",
+    );
+
+    const_assert!(
+        PROP_BUCKETS <= 1 << PropBreakdownKey::BITS,
+        "PROP_BUCKETS must fit in PropBreakdownKey",
+    );
+
+    impl<BK, TV> From<(BK, TV)> for AttributionOutputs<BK, TV> {
+        fn from(value: (BK, TV)) -> Self {
+            AttributionOutputs {
+                attributed_breakdown_key_bits: value.0,
+                capped_attributed_trigger_value: value.1,
+            }
+        }
+    }
+
+    impl IntoShares<SecretSharedAttributionOutputs<PropBreakdownKey, PropTriggerValue>>
+        for AttributionOutputs<usize, u32>
+    {
+        fn share_with<R: Rng>(
+            self,
+            rng: &mut R,
+        ) -> [SecretSharedAttributionOutputs<PropBreakdownKey, PropTriggerValue>; 3] {
+            let [bk_0, bk_1, bk_2] = PropBreakdownKey::truncate_from(
+                u128::try_from(self.attributed_breakdown_key_bits).unwrap(),
+            )
+            .share_with(rng);
+            let [tv_0, tv_1, tv_2] =
+                PropTriggerValue::truncate_from(u128::from(self.capped_attributed_trigger_value))
+                    .share_with(rng);
+            [(bk_0, tv_0), (bk_1, tv_1), (bk_2, tv_2)].map(Into::into)
+        }
+    }
+
+    prop_compose! {
+        fn inputs(max_len: usize)
+                 (
+                     len in 1..=max_len,
+                 )
+                 (
+                     len in Just(len),
+                     inputs in prop::collection::vec((0..PROP_BUCKETS, 0u32..1 << PropTriggerValue::BITS).prop_map(Into::into), len),
+                 )
+        -> AggregatePropTestInputs {
+            let mut expected = [0; PROP_BUCKETS];
+            for input in &inputs {
+                let AttributionOutputs {
+                    attributed_breakdown_key_bits: bk,
+                    capped_attributed_trigger_value: tv,
+                } = *input;
+                expected[bk] = min(expected[bk] + tv, (1 << PropHistogramValue::BITS) - 1);
+            }
+
+            let expected = BitDecomposed::decompose(PropHistogramValue::BITS, |i| {
+                expected.iter().map(|v| Boolean::from((v >> i) & 1 == 1)).collect()
+            });
+
+            AggregatePropTestInputs {
+                inputs,
+                expected,
+                len,
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(mpc_proptest_config_with_cases(100))]
+        #[test]
+        fn breakdown_reveal_proptest(
+            input_struct in inputs(PROP_MAX_INPUT_LEN),
+            seed in any::<u64>(),
+        ) {
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let AggregatePropTestInputs {
+                    inputs,
+                    expected,
+                    ..
+                } = input_struct;
+                let result = TestWorld::with_seed(seed)
+                    .malicious(inputs.into_iter(), |ctx, inputs| async move {
+                        breakdown_reveal_aggregation::<_, _, _, PropHistogramValue, {PropBucketsBitVec::BITS as usize}>(
+                            ctx,
+                            inputs,
+                            &PaddingParameters::no_padding(),
+                        ).await
+                    })
+                    .await
+                    .map(Result::unwrap)
+                    .reconstruct_arr();
+
+                assert_eq!(result, expected);
+            });
+        }
     }
 }

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -537,7 +537,7 @@ pub mod tests {
     proptest! {
         #![proptest_config(mpc_proptest_config())]
         #[test]
-        fn aggregate_values_proptest(
+        fn aggregate_values_mpc_proptest(
             input_struct in arb_aggregate_values_inputs(PROP_MAX_INPUT_LEN),
             seed in any::<u64>(),
         ) {

--- a/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
+++ b/ipa-core/src/protocol/ipa_prf/aggregation/mod.rs
@@ -257,7 +257,7 @@ pub mod tests {
         helpers::Role,
         secret_sharing::{BitDecomposed, SharedValue},
         test_executor::run,
-        test_fixture::{ReconstructArr, Runner, TestWorld},
+        test_fixture::{mpc_proptest_config, ReconstructArr, Runner, TestWorld},
     };
 
     fn input_row<const B: usize>(tv_bits: usize, values: &[u32]) -> BitDecomposed<[Boolean; B]> {
@@ -482,7 +482,7 @@ pub mod tests {
     // Any of the supported aggregation configs can be used here (search for "aggregation output" in
     // transpose.rs). This small config keeps CI runtime within reason, however, it does not exercise
     // saturated addition at the output.
-    const PROP_MAX_INPUT_LEN: usize = 10;
+    const PROP_MAX_INPUT_LEN: usize = 100;
     const PROP_MAX_TV_BITS: usize = 3; // Limit: (1 << TV_BITS) must fit in u32
     const PROP_BUCKETS: usize = 8;
     type PropHistogramValue = BA8;
@@ -535,6 +535,7 @@ pub mod tests {
     }
 
     proptest! {
+        #![proptest_config(mpc_proptest_config())]
         #[test]
         fn aggregate_values_proptest(
             input_struct in arb_aggregate_values_inputs(PROP_MAX_INPUT_LEN),

--- a/ipa-core/src/test_fixture/mod.rs
+++ b/ipa-core/src/test_fixture/mod.rs
@@ -197,3 +197,31 @@ pub fn bits_to_value<F: Field + U128Conversions>(x: &[F]) -> u128 {
 pub fn bits_to_field<F: Field + U128Conversions>(x: &[F]) -> F {
     F::try_from(bits_to_value(x)).unwrap()
 }
+
+/// Useful proptest configuration when testing MPC protocols.
+#[cfg(test)]
+#[must_use]
+pub fn mpc_proptest_config() -> proptest::prelude::ProptestConfig {
+    mpc_proptest_config_with_cases(proptest::prelude::ProptestConfig::default().cases)
+}
+
+#[cfg(test)]
+#[must_use]
+pub fn mpc_proptest_config_with_cases(cases: u32) -> proptest::prelude::ProptestConfig {
+    use std::cmp::max;
+
+    // TestWorld imposes a per-iteration timeout. In addition to that, we want to limit
+    // the shrinking time, since most of the shrinking attempts for a timeout case, are
+    // likely to also time out. Proptest also has a timeout mechanism, but it interacts
+    // badly with max_shrink_time, and is mostly redundant with the TestWorld timeout.
+    let mut config = proptest::prelude::ProptestConfig {
+        max_shrink_time: 60_000,
+        cases,
+        ..Default::default()
+    };
+    if std::env::var("EXEC_SLOW_TESTS").is_err() {
+        // Reduce the number of cases when not in slow-tests mode.
+        config.cases = max(cases / 20, 1);
+    }
+    config
+}

--- a/ipa-core/src/test_fixture/mod.rs
+++ b/ipa-core/src/test_fixture/mod.rs
@@ -199,6 +199,9 @@ pub fn bits_to_field<F: Field + U128Conversions>(x: &[F]) -> F {
 }
 
 /// Useful proptest configuration when testing MPC protocols.
+///
+/// If you are using this config in a test, consider putting `mpc_proptest` in the name
+/// of the test, so it is included in the CI run of slow tests.
 #[cfg(test)]
 #[must_use]
 pub fn mpc_proptest_config() -> proptest::prelude::ProptestConfig {

--- a/ipa-core/src/test_fixture/world.rs
+++ b/ipa-core/src/test_fixture/world.rs
@@ -396,8 +396,8 @@ impl<S: ShardingScheme> TestWorld<S> {
         };
         if let Some(timeout) = timeout {
             let Ok(output) = tokio::time::timeout(timeout, fut).await else {
-                tracing::error!("timed out after {:?}", self.timeout);
-                panic!("timed out after {:?}", self.timeout);
+                tracing::error!("timed out after {timeout:?}");
+                panic!("timed out after {timeout:?}");
             };
             output
         } else {


### PR DESCRIPTION
And some general proptest cleanup and improvements. Run longer versions of the MPC proptests when EXEC_SLOW_TESTS is set.

Prompted by #1463.