### PR TITLE
Update tokio version

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -146,7 +146,7 @@ shuttle-crate = { package = "shuttle", version = "0.6.1", optional = true }
 subtle = "2.6"
 thiserror = "1.0"
 time = { version = "0.3", optional = true }
-tokio = { version = "1.35", features = ["fs", "rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.42", features = ["fs", "rt", "rt-multi-thread", "macros"] }
 tokio-rustls = { version = "0.26", optional = true }
 tokio-stream = "0.1.14"
 toml = { version = "0.8", optional = true }


### PR DESCRIPTION
The signature of `tokio::time::timeout` changed in v1.39 (https://github.com/tokio-rs/tokio/commit/6e845b794d53443c81b33e7dbe2e7bcf58863793), but updating to the latest.

Started a draft run: https://draft-mpc.vercel.app/query/view/feral-flux2024-12-04T0049