### PR TITLE
Use one set of encryption keys on all shards for match key encryption

### DIFF
--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -220,7 +220,6 @@ impl RequestHandler<HelperIdentity> for Inner {
         data: BodyStream,
     ) -> Result<HelperResponse, ApiError> {
         let qp = &self.query_processor;
-
         Ok(match req.route {
             r @ RouteId::Records => {
                 return Err(ApiError::BadRequest(

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -371,7 +371,7 @@ pub async fn main() {
     let res = match args.command {
         None => server(args.server, handle).await,
         Some(HelperCommand::Keygen(args)) => keygen(&args),
-        Some(HelperCommand::TestSetup(args)) => test_setup(args),
+        Some(HelperCommand::TestSetup(args)) => test_setup(&args),
         Some(HelperCommand::Confgen(args)) => client_config_setup(args),
         Some(HelperCommand::ShardedConfgen(args)) => sharded_client_config_setup(args),
     };

--- a/ipa-core/src/cli/clientconf.rs
+++ b/ipa-core/src/cli/clientconf.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     error::BoxError,
     helpers::HelperIdentity,
+    sharding::ShardIndex,
 };
 
 #[derive(Debug, Args)]
@@ -157,7 +158,7 @@ fn create_sharded_conf_from_files(
             let mut shard_dir = base_dir.clone();
             let id_nr: u8 = id.into();
             shard_dir.push(format!("helper{id_nr}"));
-            shard_dir.push(format!("shard{ix}"));
+            shard_dir.push(shard_conf_folder(ix));
 
             let host_name = find_file_with_extension(&shard_dir, "pem").unwrap();
             let tls_cert_file = shard_dir.join(format!("{host_name}.pem"));
@@ -222,4 +223,8 @@ fn gen_conf_from_args(
         conf_file_path.display()
     );
     Ok(())
+}
+
+pub fn shard_conf_folder<I: TryInto<ShardIndex>>(shard_id: I) -> PathBuf {
+    format!("shard{}", shard_id.try_into().ok().unwrap()).into()
 }

--- a/ipa-core/src/cli/config_parse.rs
+++ b/ipa-core/src/cli/config_parse.rs
@@ -123,8 +123,8 @@ fn parse_sharded_network_toml(input: &str) -> Result<ShardedNetworkToml, Error> 
 
 /// Generates client configuration file at the requested destination. The destination must exist
 /// before this function is called
-pub fn gen_client_config(
-    clients_conf: impl Iterator<Item = HelperClientConf>,
+pub fn gen_client_config<I: IntoIterator<Item = HelperClientConf>>(
+    clients_conf: I,
     use_http1: bool,
     conf_file: &mut File,
 ) -> Result<(), BoxError> {
@@ -352,7 +352,7 @@ pub fn sharded_server_from_toml_str(
             identities: shard_count.iter().collect(),
         };
         Ok((mpc_network, shard_network))
-    } else if missing_urls == [0, 1, 2] && shard_count == ShardIndex(1) {
+    } else if missing_urls == [0, 1, 2] && shard_count == ShardIndex::from(1) {
         // This is the special case we're dealing with a non-sharded, single ring MPC.
         // Since the shard network will be of size 1, it can't really communicate with anyone else.
         // Hence we just create a config where I'm the only shard. We take the MPC configuration

--- a/ipa-core/src/config.rs
+++ b/ipa-core/src/config.rs
@@ -602,6 +602,6 @@ mod tests {
         let pc1 = PeerConfig::new(uri1, None);
         let client = ClientConfig::default();
         let conf = NetworkConfig::new_shards(vec![pc1.clone()], client);
-        assert_eq!(conf.peers[ShardIndex(0)].url, pc1.url);
+        assert_eq!(conf.peers[ShardIndex::FIRST].url, pc1.url);
     }
 }

--- a/ipa-core/src/net/test.rs
+++ b/ipa-core/src/net/test.rs
@@ -138,7 +138,7 @@ impl TestNetwork<Shard> {
     /// Creates all the shards for a helper and creates a network.
     fn new_shards(id: HelperIdentity, ports: Vec<Option<u16>>, conf: &TestConfigBuilder) -> Self {
         let servers: Vec<_> = (0..conf.shard_count)
-            .map(ShardIndex)
+            .map(ShardIndex::from)
             .zip(ports)
             .map(|(ix, p)| {
                 let sid = ShardedHelperIdentity::new(id, ix);
@@ -296,7 +296,7 @@ impl TestConfig {
     /// Creates a new [`TestConfig`] using the provided configuration.
     fn new(conf: &TestConfigBuilder) -> Self {
         let rings = (0..conf.shard_count)
-            .map(ShardIndex)
+            .map(ShardIndex::from)
             .map(|s| {
                 let ports = conf.get_ports_for_shard_index(s);
                 TestNetwork::<Helper>::new_mpc(s, ports, conf)
@@ -1049,7 +1049,7 @@ mod tests {
         let builder = TestConfigBuilder::with_http_and_default_test_ports();
         assert_eq!(
             vec![Some(3000), Some(3001), Some(3002)],
-            builder.get_ports_for_shard_index(ShardIndex(0))
+            builder.get_ports_for_shard_index(ShardIndex::FIRST)
         );
         assert_eq!(
             vec![Some(6001)],
@@ -1060,6 +1060,9 @@ mod tests {
     #[test]
     fn get_os_ports() {
         let builder = TestConfigBuilder::default();
-        assert_eq!(3, builder.get_ports_for_shard_index(ShardIndex(0)).len());
+        assert_eq!(
+            3,
+            builder.get_ports_for_shard_index(ShardIndex::FIRST).len()
+        );
     }
 }

--- a/ipa-core/src/protocol/hybrid/agg.rs
+++ b/ipa-core/src/protocol/hybrid/agg.rs
@@ -187,6 +187,7 @@ pub mod test {
     // the inputs are laid out to work with exactly 2 shards
     // as if it we're resharded by match_key/prf
     const SHARDS: usize = 2;
+    const SECOND_SHARD: ShardIndex = ShardIndex::from_u32(1);
 
     // we re-use these as the "prf" of the match_key
     // to avoid needing to actually do the prf here
@@ -374,8 +375,8 @@ pub mod test {
             let results: Vec<[Vec<[AggregateableHybridReport<BA8, BA3>; 2]>; 3]> = world
                 .malicious(records.clone().into_iter(), |ctx, input| {
                     let match_keys = match ctx.shard_id() {
-                        ShardIndex(0) => SHARD1_MKS,
-                        ShardIndex(1) => SHARD2_MKS,
+                        ShardIndex::FIRST => SHARD1_MKS,
+                        SECOND_SHARD => SHARD2_MKS,
                         _ => panic!("invalid shard_id"),
                     };
                     async move {
@@ -446,8 +447,8 @@ pub mod test {
             let results: Vec<[Vec<AggregateableHybridReport<BA8, BA3>>; 3]> = world
                 .malicious(records.clone().into_iter(), |ctx, input| {
                     let match_keys = match ctx.shard_id() {
-                        ShardIndex(0) => SHARD1_MKS,
-                        ShardIndex(1) => SHARD2_MKS,
+                        ShardIndex::FIRST => SHARD1_MKS,
+                        SECOND_SHARD => SHARD2_MKS,
                         _ => panic!("invalid shard_id"),
                     };
                     async move {
@@ -572,8 +573,8 @@ pub mod test {
             let _results: Vec<[Vec<AggregateableHybridReport<BA8, BA3>>; 3]> = world
                 .malicious(records.clone().into_iter(), |ctx, input| {
                     let match_keys = match ctx.shard_id() {
-                        ShardIndex(0) => SHARD1_MKS,
-                        ShardIndex(1) => SHARD2_MKS,
+                        ShardIndex::FIRST => SHARD1_MKS,
+                        SECOND_SHARD => SHARD2_MKS,
                         _ => panic!("invalid shard_id"),
                     };
                     async move {

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -1151,18 +1151,18 @@ mod tests {
         #[tokio::test]
         async fn combined_status_response() {
             fn shard_handle(si: ShardIndex) -> Arc<dyn RequestHandler<ShardIndex>> {
-                const THIRD_SHARD: ShardIndex = ShardIndex::from_u32(3);
-                const SECOND_SHARD: ShardIndex = ShardIndex::from_u32(2);
+                const FOURTH_SHARD: ShardIndex = ShardIndex::from_u32(3);
+                const THIRD_SHARD: ShardIndex = ShardIndex::from_u32(2);
                 create_handler(move |_| async move {
                     match si {
-                        THIRD_SHARD => {
+                        FOURTH_SHARD => {
                             Err(ApiError::QueryStatus(QueryStatusError::DifferentStatus {
                                 query_id: QueryId,
                                 my_status: QueryStatus::Completed,
                                 other_status: QueryStatus::Preparing,
                             }))
                         }
-                        SECOND_SHARD => {
+                        THIRD_SHARD => {
                             Err(ApiError::QueryStatus(QueryStatusError::DifferentStatus {
                                 query_id: QueryId,
                                 my_status: QueryStatus::Running,

--- a/ipa-core/src/sharding.rs
+++ b/ipa-core/src/sharding.rs
@@ -39,8 +39,11 @@ impl ShardedHelperIdentity {
 }
 
 /// A unique zero-based index of the helper shard.
+/// Note to editors - if rustc suggests to make the internal field public,
+/// don't. It breaks the encapsulation constraint. Use `from` or other methods
+/// to convert from or into this struct's instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ShardIndex(pub u32);
+pub struct ShardIndex(u32);
 
 impl ShardIndex {
     pub const FIRST: Self = Self(0);
@@ -49,11 +52,18 @@ impl ShardIndex {
     pub fn iter(self) -> impl Iterator<Item = Self> {
         (0..self.0).map(Self)
     }
+
+    /// Create a valid shard index from its u32 representation.
+    /// The reason it exists is because traits don't exist in const context
+    #[must_use]
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
 }
 
 impl From<u32> for ShardIndex {
     fn from(value: u32) -> Self {
-        Self(value)
+        Self::from_u32(value)
     }
 }
 


### PR DESCRIPTION
This builds on top #1473 and only adds [this commit](https://github.com/private-attribution/ipa/commit/afa5c7273bcebc0591d841539a6cd377bd8ed764)

This takes the simplest approach of overwriting the key files after
creating them. Unfortunately there is no easy way to test this without
writing a new protocol, so we'll wait until Hybrid comes into play.

In the meantime I tested it manually to make sure files get overwritten

```bash
running 1 test
generating configuration for 3 shards in /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb

...
❯ cmp /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h1_mk.key /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard1/h1_mk.key

❯ cmp /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h1_mk.key /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard1/h2_mk.key
/var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h1_mk.key /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard1/h2_mk.key differ: char 1, line 1

❯ cmp /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h1_mk.key /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard2/h1_mk.key

❯ cmp /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h2_mk.key /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard2/h2_mk.key

cmp /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard0/h3_mk.pub /var/folders/n2/wgkrrbd57173j9dvy8bdjcvw0000gn/T/.tmpCMhgQb/shard2/h3_mk.pub
```