### PR TITLE
use BA32 instead of BA16 for hybrid histogram values

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -21,10 +21,7 @@ use ipa_core::{
         CsvSerializer, IpaQueryResult, Verbosity,
     },
     config::{KeyRegistries, NetworkConfig},
-    ff::{
-        boolean_array::{BA16, BA32},
-        FieldType,
-    },
+    ff::{boolean_array::BA32, FieldType},
     helpers::{
         query::{
             DpMechanism, HybridQueryParams, IpaQueryConfig, QueryConfig, QuerySize, QueryType,
@@ -465,10 +462,10 @@ async fn hybrid(
 
     tracing::info!("Starting query for OPRF");
 
-    // the value for histogram values (BA16) must be kept in sync with the server-side
+    // the value for histogram values (BA32) must be kept in sync with the server-side
     // implementation, otherwise a runtime reconstruct error will be generated.
     // see ipa-core/src/query/executor.rs
-    let actual = run_hybrid_query_and_validate::<BA16>(
+    let actual = run_hybrid_query_and_validate::<BA32>(
         submissions,
         count,
         helper_clients,

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -13,7 +13,7 @@ use crate::{
     error::{Error, LengthError},
     ff::{
         boolean::Boolean,
-        boolean_array::{BooleanArray, BA16, BA3, BA8},
+        boolean_array::{BooleanArray, BA3, BA32, BA8},
         curve_points::RP25519,
         ec_prime_field::Fp25519,
         Serializable, U128Conversions,
@@ -190,7 +190,7 @@ pub async fn execute_hybrid_protocol<'a, R: PrivateKeyRegistry>(
     let ctx = ShardedMaliciousContext::new_with_gate(prss, gateway, gate, sharded);
 
     Ok(Box::new(
-        Query::<_, BA16, R>::new(ipa_config, key_registry)
+        Query::<_, BA32, R>::new(ipa_config, key_registry)
             .execute(ctx, config.size, input)
             .await?,
     ))
@@ -208,7 +208,7 @@ mod tests {
 
     use crate::{
         ff::{
-            boolean_array::{BA16, BA3, BA8},
+            boolean_array::{BA3, BA32, BA8},
             U128Conversions,
         },
         helpers::{
@@ -310,7 +310,7 @@ mod tests {
                             };
                             let input = BodyStream::from(buffer);
 
-                            HybridQuery::<_, BA16, KeyRegistry<KeyPair>>::new(
+                            HybridQuery::<_, BA32, KeyRegistry<KeyPair>>::new(
                                 query_params,
                                 Arc::clone(&key_registry),
                             )
@@ -393,7 +393,7 @@ mod tests {
                         let query_params = HybridQueryParams::default();
                         let input = BodyStream::from(buffer);
 
-                        HybridQuery::<_, BA16, KeyRegistry<KeyPair>>::new(
+                        HybridQuery::<_, BA32, KeyRegistry<KeyPair>>::new(
                             query_params,
                             Arc::clone(&key_registry),
                         )
@@ -439,7 +439,7 @@ mod tests {
                         };
                         let input = BodyStream::from(buffer);
 
-                        HybridQuery::<_, BA16, KeyRegistry<KeyPair>>::new(
+                        HybridQuery::<_, BA32, KeyRegistry<KeyPair>>::new(
                             query_params,
                             Arc::clone(&key_registry),
                         )

--- a/ipa-core/src/secret_sharing/vector/transpose.rs
+++ b/ipa-core/src/secret_sharing/vector/transpose.rs
@@ -674,9 +674,6 @@ macro_rules! impl_transpose_shares_ba_to_bool {
 // Usage: Share conversion input (convert_to_fp25519 test). M = CONV_CHUNK, N = MK_BITS.
 impl_transpose_shares_ba_to_bool!(BA64, 256, 64, test_transpose_shares_ba_to_bool_256x64);
 
-// Usage: Quicksort. M = SORT_CHUNK, N = sort key bits.
-impl_transpose_shares_ba_to_bool!(BA32, 256, 32, test_transpose_shares_ba_to_bool_256x32);
-
 /// Implement a transpose of a MxN matrix of secret-shared bits accessed via
 /// `Fn(usize) -> AdditiveShare<BA{N}>` into a NxM bit matrix represented as `[AdditiveShare<Boolean, M>; N]`.
 ///
@@ -786,6 +783,7 @@ macro_rules! impl_transpose_shares_ba_to_bool_small {
 // Dimensions: Arbitrary (rows are padded to whole bytes).
 
 // Usage: Aggregation input. M = AGG_CHUNK, N = BK or TV bits.
+impl_transpose_shares_ba_to_bool_small!(BA32, 256, 32, test_transpose_shares_ba_to_bool_256x32); // Addtional Usage: Quicksort. M = SORT_CHUNK, N = sort key bits.
 impl_transpose_shares_ba_to_bool_small!(BA16, 256, 16, test_transpose_shares_ba_to_bool_256x16);
 impl_transpose_shares_ba_to_bool_small!(BA8, 256, 8, test_transpose_shares_ba_to_bool_256x8);
 impl_transpose_shares_ba_to_bool_small!(BA5, 256, 5, test_transpose_shares_ba_to_bool_256x5);


### PR DESCRIPTION
As we scale up to 1B rows, the saturated_add results in all histogram values saturating at `2^16 - 1` (e.g. `65_535`) with `BA16`. Increasing this to `BA32` will move the saturation point up to `4_294_967_295`. 

Our current data generator has a 20% match rate. With a max_value of 7 (and thus expected value of 3.5), we'd expect histograms to have values around `(1B * 0.2 * 3.5) / 256 = 2_734_375`, safely under the saturation point.