### PR TITLE
Remove Info from plaintext Hybrid Reports

### DIFF
--- a/ipa-core/src/cli/crypto/hybrid_decrypt.rs
+++ b/ipa-core/src/cli/crypto/hybrid_decrypt.rs
@@ -14,7 +14,10 @@ use crate::{
         U128Conversions,
     },
     hpke::{KeyRegistry, PrivateKeyOnly},
-    report::hybrid::{EncryptedHybridReport, HybridReport},
+    report::{
+        hybrid::{EncryptedHybridReport, HybridReport},
+        hybrid_info::HybridInfo,
+    },
     test_fixture::Reconstruct,
 };
 
@@ -104,7 +107,7 @@ impl HybridDecryptArgs {
         for (dec_report1, (dec_report2, dec_report3)) in
             decrypted_reports1.zip(decrypted_reports2.zip(decrypted_reports3))
         {
-            match (dec_report1, dec_report2, dec_report3) {
+            match (dec_report1.0, dec_report2.0, dec_report3.0) {
                 (
                     HybridReport::Impression(impression_report1),
                     HybridReport::Impression(impression_report2),
@@ -125,8 +128,9 @@ impl HybridDecryptArgs {
                     ]
                     .reconstruct()
                     .as_u128();
+                    let key_id = dec_report1.1.impression.key_id;
 
-                    writeln!(writer, "i,{match_key},{breakdown_key}")?;
+                    writeln!(writer, "i,{match_key},{breakdown_key},{key_id}")?;
                 }
                 (
                     HybridReport::Conversion(conversion_report1),
@@ -148,7 +152,14 @@ impl HybridDecryptArgs {
                     ]
                     .reconstruct()
                     .as_u128();
-                    writeln!(writer, "c,{match_key},{value}")?;
+
+                    let key_id = dec_report1.1.conversion.key_id;
+                    let conversion_site_domain = dec_report1.1.conversion.conversion_site_domain;
+                    let timestamp = dec_report1.1.conversion.timestamp;
+                    let epsilon = dec_report1.1.conversion.epsilon;
+                    let sensitivity = dec_report1.1.conversion.sensitivity;
+
+                    writeln!(writer, "c,{match_key},{value},{key_id},{conversion_site_domain},{timestamp},{epsilon},{sensitivity}")?;
                 }
                 _ => {
                     panic!("Reports are not all the same type");
@@ -166,7 +177,7 @@ struct DecryptedHybridReports {
 }
 
 impl Iterator for DecryptedHybridReports {
-    type Item = HybridReport<BA8, BA3>;
+    type Item = (HybridReport<BA8, BA3>, HybridInfo);
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut line = String::new();
@@ -174,9 +185,10 @@ impl Iterator for DecryptedHybridReports {
             let encrypted_report_bytes = hex::decode(line.trim()).unwrap();
             let enc_report =
                 EncryptedHybridReport::from_bytes(encrypted_report_bytes.into()).unwrap();
-            let dec_report: HybridReport<BA8, BA3> =
-                enc_report.decrypt(&self.key_registry).unwrap();
-            Some(dec_report)
+            let (dec_report, info) = enc_report
+                .decrypt_and_return_info(&self.key_registry)
+                .unwrap();
+            Some((dec_report, info))
         } else {
             None
         }

--- a/ipa-core/src/cli/crypto/hybrid_decrypt.rs
+++ b/ipa-core/src/cli/crypto/hybrid_decrypt.rs
@@ -125,9 +125,8 @@ impl HybridDecryptArgs {
                     ]
                     .reconstruct()
                     .as_u128();
-                    let key_id = impression_report1.info.key_id;
 
-                    writeln!(writer, "i,{match_key},{breakdown_key},{key_id}")?;
+                    writeln!(writer, "i,{match_key},{breakdown_key}")?;
                 }
                 (
                     HybridReport::Conversion(conversion_report1),
@@ -149,12 +148,7 @@ impl HybridDecryptArgs {
                     ]
                     .reconstruct()
                     .as_u128();
-                    let key_id = conversion_report1.info.key_id;
-                    let conversion_site_domain = conversion_report1.info.conversion_site_domain;
-                    let timestamp = conversion_report1.info.timestamp;
-                    let epsilon = conversion_report1.info.epsilon;
-                    let sensitivity = conversion_report1.info.sensitivity;
-                    writeln!(writer, "c,{match_key},{value},{key_id},{conversion_site_domain},{timestamp},{epsilon},{sensitivity}")?;
+                    writeln!(writer, "c,{match_key},{value}")?;
                 }
                 _ => {
                     panic!("Reports are not all the same type");

--- a/ipa-core/src/cli/crypto/hybrid_encrypt.rs
+++ b/ipa-core/src/cli/crypto/hybrid_encrypt.rs
@@ -29,8 +29,8 @@ use crate::{
     test_fixture::hybrid::TestHybridRecord,
 };
 
-/// Encryptor takes 3 arguments: `report_id`, helper that the shares must be encrypted towards
-/// and the actual share ([`HybridReport`]) to encrypt.
+/// Encryptor takes 4 arguments: `report_id`, helper that the shares must be encrypted towards,
+/// AAD info, and the actual share ([`HybridReport`]) to encrypt.
 type EncryptorInput = (
     usize,
     usize,

--- a/ipa-core/src/query/runner/hybrid.rs
+++ b/ipa-core/src/query/runner/hybrid.rs
@@ -242,8 +242,15 @@ mod tests {
         let shares: [Vec<HybridReport<BA8, BA3>>; 3] = records.iter().cloned().share();
         for (buf, shares) in zip(&mut buffers, shares) {
             for (i, share) in shares.into_iter().enumerate() {
+                let info = records[i].create_hybrid_info();
                 share
-                    .delimited_encrypt_to(key_id, key_registry.as_ref(), &mut rng, &mut buf[i % s])
+                    .delimited_encrypt_to(
+                        key_id,
+                        key_registry.as_ref(),
+                        &info,
+                        &mut rng,
+                        &mut buf[i % s],
+                    )
                     .unwrap();
             }
         }

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -141,7 +141,6 @@ where
 
         buf.put_slice(&plaintext_mk);
         buf.put_slice(&plaintext_bk);
-        //buf.put_slice(&self.info.to_bytes());
     }
 
     /// # Errors
@@ -292,7 +291,6 @@ where
 
         buf.put_slice(&plaintext_mk);
         buf.put_slice(&plaintext_v);
-        //buf.put_slice(&self.info.to_bytes());
     }
 
     /// # Errors
@@ -305,7 +303,6 @@ where
         let value =
             Replicated::<V>::deserialize(GenericArray::from_slice(&buf[mk_sz..mk_sz + v_sz]))
             .map_err(|e| InvalidHybridReportError::DeserializationError("breakdown_key", e.into()))?;
-        // let info = HybridConversionInfo::from_bytes(&buf[mk_sz + v_sz..])?;
         Ok(Self { match_key, value })
     }
 
@@ -334,7 +331,7 @@ where
     /// # Panics
     /// If report length does not fit in `u16`.
     pub fn encrypted_len(&self) -> u16 {
-        self.ciphertext_len() //+ usize::try_from(self.info.byte_len()).unwrap()
+        self.ciphertext_len()
     }
 
     /// # Errors
@@ -616,7 +613,6 @@ where
                 .map_err(|e| {
                     InvalidHybridReportError::DeserializationError("is_trigger", e.into())
                 })?,
-                //info,
             },
             info,
         ))
@@ -737,7 +733,6 @@ where
                     .map_err(|e| {
                         InvalidHybridReportError::DeserializationError("trigger_value", e.into())
                     })?,
-                //info,
             },
             info,
         ))
@@ -1333,21 +1328,12 @@ mod test {
                 HybridReport::Impression(HybridImpressionReport::<BA8> {
                     match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                     breakdown_key: AdditiveShare::new(rng.gen(), rng.gen()),
-                    //info: HybridImpressionInfo::new(0),
                 })
             }
             HybridEventType::Conversion => {
                 HybridReport::Conversion(HybridConversionReport::<BA3> {
                     match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                     value: AdditiveShare::new(rng.gen(), rng.gen()),
-                    /*info: HybridConversionInfo::new(
-                        0,
-                        "https://www.example2.com",
-                        rng.gen(),
-                        0.0,
-                        0.0,
-                    )
-                    .unwrap(),*/
                 })
             }
         }
@@ -1374,8 +1360,6 @@ mod test {
             let conversion_report = HybridConversionReport::<BA3> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 value: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridConversionInfo::new(0, "https://www.example2.com", 1_234_567, 0.0, 0.0)
-                //    .unwrap(),
             };
             let indistinguishable_report: IndistinguishableHybridReport<BA8, BA3> =
                 conversion_report.clone().into();
@@ -1405,7 +1389,6 @@ mod test {
             let impression_report = HybridImpressionReport::<BA8> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 breakdown_key: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridImpressionInfo::new(0),
             };
             let indistinguishable_report: IndistinguishableHybridReport<BA8, BA3> =
                 impression_report.clone().into();
@@ -1455,7 +1438,6 @@ mod test {
             let hybrid_impression_report = HybridImpressionReport::<BA8> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 breakdown_key: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridImpressionInfo::new(0),
             };
             let mut hybrid_impression_report_bytes =
                 Vec::with_capacity(HybridImpressionReport::<BA8>::serialized_len());
@@ -1474,8 +1456,6 @@ mod test {
             let hybrid_conversion_report = HybridConversionReport::<BA3> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 value: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridConversionInfo::new(0, "https://www.example2.com", 1_234_567, 0.0, 0.0)
-                //    .unwrap(),
             };
             let mut hybrid_conversion_report_bytes =
                 Vec::with_capacity(HybridImpressionReport::<BA8>::serialized_len());
@@ -1497,7 +1477,6 @@ mod test {
             let hybrid_impression_report = HybridImpressionReport::<BA8> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 breakdown_key: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridImpressionInfo::new(key_id),
             };
             let impression_info = HybridImpressionInfo::new(key_id);
 
@@ -1521,7 +1500,6 @@ mod test {
             let hybrid_conversion_report = HybridConversionReport::<BA3> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 value: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridConversionInfo::new(0, "meta.com", 1_729_707_432, 5.0, 1.1).unwrap(),
             };
 
             let key_registry = KeyRegistry::<KeyPair>::random(1, &mut rng);
@@ -1571,7 +1549,6 @@ mod test {
             let hybrid_conversion_report = HybridConversionReport::<BA3> {
                 match_key: AdditiveShare::new(rng.gen(), rng.gen()),
                 value: AdditiveShare::new(rng.gen(), rng.gen()),
-                //info: HybridConversionInfo::new(0, "meta.com", 1_729_707_432, 5.0, 1.1).unwrap(),
             };
 
             let key_registry = KeyRegistry::<KeyPair>::random(1, &mut rng);

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -187,6 +187,8 @@ where
 
     /// # Errors
     /// If there is a problem encrypting the report.
+    /// # Panics
+    /// If info length + report length does not fit in `u16`.
     pub fn delimited_encrypt_to<R: CryptoRng + RngCore, B: BufMut>(
         &self,
         key_id: KeyIdentifier,
@@ -195,12 +197,14 @@ where
         rng: &mut R,
         out: &mut B,
     ) -> Result<(), InvalidHybridReportError> {
-        out.put_u16_le(self.encrypted_len() + info.byte_len());
+        out.put_u16_le(self.encrypted_len() + u16::try_from(info.byte_len()).unwrap());
         self.encrypt_to(key_id, key_registry, info, rng, out)
     }
 
     /// # Errors
     /// If there is a problem encrypting the report.
+    /// # Panics
+    /// If info length + report length does not fit in `u16`.
     pub fn encrypt<R: CryptoRng + RngCore>(
         &self,
         key_id: KeyIdentifier,
@@ -208,9 +212,9 @@ where
         info: &HybridImpressionInfo,
         rng: &mut R,
     ) -> Result<Vec<u8>, InvalidHybridReportError> {
-        let mut out = Vec::with_capacity(usize::from(self.encrypted_len() + info.byte_len()));
+        let mut out = Vec::with_capacity(usize::from(self.encrypted_len() + u16::try_from(info.byte_len()).unwrap()));
         self.encrypt_to(key_id, key_registry, info, rng, &mut out)?;
-        debug_assert_eq!(out.len(), usize::from(self.encrypted_len() + info.byte_len()));
+        debug_assert_eq!(out.len(), usize::from(self.encrypted_len() + u16::try_from(info.byte_len()).unwrap()));
         Ok(out)
     }
 
@@ -335,6 +339,8 @@ where
 
     /// # Errors
     /// If there is a problem encrypting the report.
+    /// # Panics
+    /// If info length + report length does not fit in `u16`.
     pub fn delimited_encrypt_to<R: CryptoRng + RngCore, B: BufMut>(
         &self,
         key_id: KeyIdentifier,
@@ -343,12 +349,14 @@ where
         rng: &mut R,
         out: &mut B,
     ) -> Result<(), InvalidHybridReportError> {
-        out.put_u16_le(self.encrypted_len() + info.byte_len());
+        out.put_u16_le(self.encrypted_len() + u16::try_from(info.byte_len()).unwrap());
         self.encrypt_to(key_id, key_registry, info, rng, out)
     }
 
     /// # Errors
     /// If there is a problem encrypting the report.
+    /// # Panics
+    /// If info length + report length does not fit in `u16`.
     pub fn encrypt<R: CryptoRng + RngCore>(
         &self,
         key_id: KeyIdentifier,
@@ -356,9 +364,9 @@ where
         info: &HybridConversionInfo,
         rng: &mut R,
     ) -> Result<Vec<u8>, InvalidHybridReportError> {
-        let mut out = Vec::with_capacity(usize::from(self.ciphertext_len() + info.byte_len()));
+        let mut out = Vec::with_capacity(usize::from(self.ciphertext_len() + u16::try_from(info.byte_len()).unwrap()));
         self.encrypt_to(key_id, key_registry, info, rng, &mut out)?;
-        debug_assert_eq!(out.len(), usize::from(self.encrypted_len() + info.byte_len()));
+        debug_assert_eq!(out.len(), usize::from(self.encrypted_len() + u16::try_from(info.byte_len()).unwrap()));
         Ok(out)
     }
 
@@ -448,6 +456,8 @@ where
 
     /// # Errors
     /// If there is a problem encrypting the report.
+    /// # Panics
+    /// If info length + report length does not fit in `u16`.
     pub fn delimited_encrypt_to<R: CryptoRng + RngCore, B: BufMut>(
         &self,
         key_id: KeyIdentifier,
@@ -458,12 +468,12 @@ where
     ) -> Result<(), InvalidHybridReportError> {
         match self {
             HybridReport::Impression(impression_report) => {
-                out.put_u16_le(self.encrypted_len() + info.impression.byte_len());
+                out.put_u16_le(self.encrypted_len() + u16::try_from(info.impression.byte_len()).unwrap());
                 out.put_u8(HybridEventType::Impression as u8);
                 impression_report.encrypt_to(key_id, key_registry, &info.impression, rng, out)
             },
             HybridReport::Conversion(conversion_report) => {
-                out.put_u16_le(self.encrypted_len() + info.conversion.byte_len());
+                out.put_u16_le(self.encrypted_len() + u16::try_from(info.conversion.byte_len()).unwrap());
                 out.put_u8(HybridEventType::Conversion as u8);
                 conversion_report.encrypt_to(key_id, key_registry, &info.conversion, rng, out)
             },

--- a/ipa-core/src/report/hybrid.rs
+++ b/ipa-core/src/report/hybrid.rs
@@ -153,7 +153,6 @@ where
         let breakdown_key =
             Replicated::<BK>::deserialize(GenericArray::from_slice(&buf[mk_sz..mk_sz + bk_sz]))
             .map_err(|e| InvalidHybridReportError::DeserializationError("breakdown_key", e.into()))?;
-        //let info = HybridImpressionInfo::from_bytes(&buf[mk_sz + bk_sz..])?;
 
         Ok(Self { match_key, breakdown_key })
     }
@@ -183,7 +182,7 @@ where
     /// # Panics
     /// If report length does not fit in `u16`.
     pub fn encrypted_len(&self) -> u16 {
-        self.ciphertext_len() //+ u16::try_from(self.info.byte_len()).unwrap()
+        self.ciphertext_len()
     }
 
     /// # Errors

--- a/ipa-core/src/report/hybrid_info.rs
+++ b/ipa-core/src/report/hybrid_info.rs
@@ -18,10 +18,12 @@ impl HybridImpressionInfo {
     }
 
     #[must_use]
-    pub fn byte_len(&self) -> usize {
+    /// # Panics
+    /// If report length does not fit in `u16`.
+    pub fn byte_len(&self) -> u16 {
         let out_len = std::mem::size_of_val(&self.key_id);
         debug_assert_eq!(out_len, self.to_bytes().len(), "Serialization length estimation is incorrect and leads to extra allocation or wasted memory");
-        out_len
+        out_len.try_into().unwrap()
     }
 
     // Converts this instance into an owned byte slice. DO NOT USE AS INPUT TO HPKE
@@ -99,7 +101,9 @@ impl HybridConversionInfo {
     }
 
     #[must_use]
-    pub fn byte_len(&self) -> usize {
+    /// # Panics
+    /// If report length does not fit in `u16`.
+    pub fn byte_len(&self) -> u16 {
         let out_len = std::mem::size_of_val(&self.key_id)
         + 1 // delimiter
         + self.conversion_site_domain.len()
@@ -107,7 +111,7 @@ impl HybridConversionInfo {
         + std::mem::size_of_val(&self.epsilon)
         + std::mem::size_of_val(&self.sensitivity);
         debug_assert_eq!(out_len, self.to_bytes().len(), "Serialization length estimation is incorrect and leads to extra allocation or wasted memory");
-        out_len
+        out_len.try_into().unwrap()
     }
 
     // Converts this instance into an owned byte slice. DO NOT USE AS INPUT TO HPKE

--- a/ipa-core/src/report/hybrid_info.rs
+++ b/ipa-core/src/report/hybrid_info.rs
@@ -254,6 +254,34 @@ impl HybridInfo {
     }
 }
 
+impl From<HybridImpressionInfo> for HybridInfo {
+    fn from(impression: HybridImpressionInfo) -> Self {
+        let conversion = HybridConversionInfo {
+            key_id: impression.key_id,
+            conversion_site_domain: String::new(),
+            timestamp: 0,
+            epsilon: 0.0,
+            sensitivity: 0.0,
+        };
+        Self {
+            impression,
+            conversion,
+        }
+    }
+}
+
+impl From<HybridConversionInfo> for HybridInfo {
+    fn from(conversion: HybridConversionInfo) -> Self {
+        let impression = HybridImpressionInfo {
+            key_id: conversion.key_id,
+        };
+        Self {
+            impression,
+            conversion,
+        }
+    }
+}
+
 #[cfg(all(test, unit_test))]
 mod test {
     use super::*;

--- a/ipa-core/src/report/hybrid_info.rs
+++ b/ipa-core/src/report/hybrid_info.rs
@@ -20,10 +20,10 @@ impl HybridImpressionInfo {
     #[must_use]
     /// # Panics
     /// If report length does not fit in `u16`.
-    pub fn byte_len(&self) -> u16 {
+    pub fn byte_len(&self) -> usize {
         let out_len = std::mem::size_of_val(&self.key_id);
         debug_assert_eq!(out_len, self.to_bytes().len(), "Serialization length estimation is incorrect and leads to extra allocation or wasted memory");
-        out_len.try_into().unwrap()
+        out_len
     }
 
     // Converts this instance into an owned byte slice. DO NOT USE AS INPUT TO HPKE
@@ -101,9 +101,7 @@ impl HybridConversionInfo {
     }
 
     #[must_use]
-    /// # Panics
-    /// If report length does not fit in `u16`.
-    pub fn byte_len(&self) -> u16 {
+    pub fn byte_len(&self) -> usize {
         let out_len = std::mem::size_of_val(&self.key_id)
         + 1 // delimiter
         + self.conversion_site_domain.len()
@@ -111,7 +109,7 @@ impl HybridConversionInfo {
         + std::mem::size_of_val(&self.epsilon)
         + std::mem::size_of_val(&self.sensitivity);
         debug_assert_eq!(out_len, self.to_bytes().len(), "Serialization length estimation is incorrect and leads to extra allocation or wasted memory");
-        out_len.try_into().unwrap()
+        out_len
     }
 
     // Converts this instance into an owned byte slice. DO NOT USE AS INPUT TO HPKE

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -171,14 +171,6 @@ where
                         HybridReport::Conversion::<BK, V>(HybridConversionReport {
                             match_key: match_key_share,
                             value: value_share,
-                            /*info: HybridConversionInfo::new(
-                                key_id,
-                                &conversion_site_domain,
-                                timestamp,
-                                epsilon,
-                                sensitivity,
-                            )
-                            .unwrap(),*/
                         })
                     })
                     .collect::<Vec<_>>()

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -190,6 +190,7 @@ where
 }
 
 impl TestHybridRecord {
+    #[must_use]
     pub fn create_hybrid_info(&self) -> HybridInfo {
         match self {
             TestHybridRecord::TestImpression {
@@ -198,15 +199,13 @@ impl TestHybridRecord {
                 key_id,
             } => {
                 let conversion = HybridConversionInfo {
-                    key_id: key_id.clone(),
-                    conversion_site_domain: "".to_string(),
+                    key_id: *key_id,
+                    conversion_site_domain: String::new(),
                     timestamp: 0,
                     epsilon: 0.0,
                     sensitivity: 0.0,
                 };
-                let impression = HybridImpressionInfo {
-                    key_id: key_id.clone(),
-                };
+                let impression = HybridImpressionInfo { key_id: *key_id };
                 HybridInfo {
                     impression,
                     conversion,
@@ -221,11 +220,11 @@ impl TestHybridRecord {
                 epsilon,
                 sensitivity,
             } => {
-                let key_id = key_id.clone();
-                let conversion_site_domain = conversion_site_domain.clone();
-                let timestamp = timestamp.clone();
-                let epsilon = epsilon.clone();
-                let sensitivity = sensitivity.clone();
+                let key_id = *key_id;
+                let conversion_site_domain = conversion_site_domain.to_string();
+                let timestamp = *timestamp;
+                let epsilon = *epsilon;
+                let sensitivity = *sensitivity;
                 let impression = HybridImpressionInfo { key_id };
                 let conversion = HybridConversionInfo {
                     key_id,

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -11,7 +11,7 @@ use crate::{
             AggregateableHybridReport, HybridConversionReport, HybridImpressionReport,
             HybridReport, IndistinguishableHybridReport, KeyIdentifier,
         },
-        hybrid_info::{HybridConversionInfo, HybridImpressionInfo},
+        hybrid_info::{HybridConversionInfo, HybridImpressionInfo, HybridInfo},
     },
     secret_sharing::{replicated::semi_honest::AdditiveShare as Replicated, IntoShares},
     test_fixture::sharing::Reconstruct,
@@ -133,7 +133,7 @@ where
             TestHybridRecord::TestImpression {
                 match_key,
                 breakdown_key,
-                key_id,
+                key_id: _,
             } => {
                 let ba_match_key = BA64::try_from(u128::from(match_key))
                     .unwrap()
@@ -146,7 +146,7 @@ where
                         HybridReport::Impression::<BK, V>(HybridImpressionReport {
                             match_key: match_key_share,
                             breakdown_key: breakdown_key_share,
-                            info: HybridImpressionInfo::new(key_id),
+                            //info: HybridImpressionInfo::new(key_id),
                         })
                     })
                     .collect::<Vec<_>>()
@@ -156,11 +156,11 @@ where
             TestHybridRecord::TestConversion {
                 match_key,
                 value,
-                key_id,
-                conversion_site_domain,
-                timestamp,
-                epsilon,
-                sensitivity,
+                key_id: _,
+                conversion_site_domain: _,
+                timestamp: _,
+                epsilon: _,
+                sensitivity: _,
             } => {
                 let ba_match_key = BA64::try_from(u128::from(match_key))
                     .unwrap()
@@ -171,19 +171,73 @@ where
                         HybridReport::Conversion::<BK, V>(HybridConversionReport {
                             match_key: match_key_share,
                             value: value_share,
-                            info: HybridConversionInfo::new(
+                            /*info: HybridConversionInfo::new(
                                 key_id,
                                 &conversion_site_domain,
                                 timestamp,
                                 epsilon,
                                 sensitivity,
                             )
-                            .unwrap(),
+                            .unwrap(),*/
                         })
                     })
                     .collect::<Vec<_>>()
                     .try_into()
                     .unwrap()
+            }
+        }
+    }
+}
+
+impl TestHybridRecord {
+    pub fn create_hybrid_info(&self) -> HybridInfo {
+        match self {
+            TestHybridRecord::TestImpression {
+                match_key: _,
+                breakdown_key: _,
+                key_id,
+            } => {
+                let conversion = HybridConversionInfo {
+                    key_id: key_id.clone(),
+                    conversion_site_domain: "".to_string(),
+                    timestamp: 0,
+                    epsilon: 0.0,
+                    sensitivity: 0.0,
+                };
+                let impression = HybridImpressionInfo {
+                    key_id: key_id.clone(),
+                };
+                HybridInfo {
+                    impression,
+                    conversion,
+                }
+            }
+            TestHybridRecord::TestConversion {
+                match_key: _,
+                value: _,
+                key_id,
+                conversion_site_domain,
+                timestamp,
+                epsilon,
+                sensitivity,
+            } => {
+                let key_id = key_id.clone();
+                let conversion_site_domain = conversion_site_domain.clone();
+                let timestamp = timestamp.clone();
+                let epsilon = epsilon.clone();
+                let sensitivity = sensitivity.clone();
+                let impression = HybridImpressionInfo { key_id };
+                let conversion = HybridConversionInfo {
+                    key_id,
+                    conversion_site_domain,
+                    timestamp,
+                    epsilon,
+                    sensitivity,
+                };
+                HybridInfo {
+                    impression,
+                    conversion,
+                }
             }
         }
     }


### PR DESCRIPTION
* Remove HybridInfo from being included in plaintext HybridReports by default.
* HybridInfo is now a required argument for encryption
* Because we want the info in some contexts, adds a function to optionally return both the report and the info when decrypting
* Adds a `create_hybrid_info()` function to TestHybridRecord so that we can do the initial encryption
* Adjusts encryption/decryption scripts to handle refactor. Output format is unchanged.