### PR TITLE
Improve memory usage for computing hybrid results in the clear

### DIFF
--- a/ipa-core/src/bin/in_the_clear.rs
+++ b/ipa-core/src/bin/in_the_clear.rs
@@ -49,9 +49,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let input = InputSource::from(&args.input);
 
-    let input_rows = input.iter::<TestHybridRecord>().collect::<Vec<_>>();
+    let input_rows = input.iter::<TestHybridRecord>();
     let expected = hybrid_in_the_clear(
-        &input_rows,
+        input_rows,
         usize::try_from(args.max_breakdown_key.get()).unwrap(),
     );
 

--- a/ipa-core/src/test_fixture/hybrid.rs
+++ b/ipa-core/src/test_fixture/hybrid.rs
@@ -256,14 +256,7 @@ pub fn hybrid_in_the_clear<I: IntoIterator<Item: Borrow<TestHybridRecord>>>(
     max_breakdown: usize,
 ) -> Vec<u32> {
     let mut attributed_conversions = HashMap::<u64, MatchEntry>::new();
-    for (cnt, input) in input_rows.into_iter().enumerate() {
-        if cnt % 1_000_000 == 0 {
-            tracing::info!(
-                "processed another 1M rows: {}, size of conversions: {}",
-                cnt / 1_000_000,
-                attributed_conversions.len()
-            );
-        }
+    for input in input_rows {
         match input.borrow() {
             r @ (TestHybridRecord::TestConversion { match_key, .. }
             | TestHybridRecord::TestImpression { match_key, .. }) => {
@@ -274,15 +267,8 @@ pub fn hybrid_in_the_clear<I: IntoIterator<Item: Borrow<TestHybridRecord>>>(
             }
         }
     }
-    tracing::info!("done attribution phase");
-
-    // let pairs = attributed_conversions
-    //     .into_values()
-    //     .filter_map(MatchEntry::into_breakdown_key_and_value_tuple)
-    //     .collect::<Vec<_>>();
 
     let mut output = vec![0; max_breakdown];
-    // for (breakdown_key, value) in attributed_conversions.into_values() {
     for entry in attributed_conversions.into_values() {
         if let Some((breakdown_key, value)) = entry.into_breakdown_key_and_value_tuple() {
             output[usize::try_from(breakdown_key).unwrap()] += value;


### PR DESCRIPTION
This operation was OOMing on 500M inputs

```
memory allocation of 73551314960 bytes failed
Aborted
```

The reason for that was that we were keeping all the information from original reports, including AAD and match key. 
The improved algorithm only keeps breakdown keys and values to perform attribution.

My back of the envelope calculation says that this improvement is enough to get us to 1 billion reports. Each entry would take ~8 bytes and for 1B entries we are looking at 8Gb memory consumption which should be doable

I ran it on 500M and it finished successfully.