### PR TITLE
Add Fixed-Rate Polling Specifier To ReportCollector

### DIFF
--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -154,8 +154,8 @@ enum ReportCollectorCommand {
 
         // If set, use the specified fixed polling interval when running a query.
         // Otherwise, use exponential backoff.
-        #[arg(long, default_value_t = 0)]
-        set_fixed_polling_ms: u64,
+        #[clap(long)]
+        set_fixed_polling_ms: Option<u64>,
     },
 }
 
@@ -428,7 +428,7 @@ async fn hybrid(
     helper_clients: Vec<[IpaHttpClient<Helper>; 3]>,
     encrypted_inputs: &EncryptedInputs,
     count: usize,
-    set_fixed_polling_ms: u64,
+    set_fixed_polling_ms: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
     let query_type = QueryType::MaliciousHybrid(hybrid_query_config);
 

--- a/ipa-core/src/bin/report_collector.rs
+++ b/ipa-core/src/bin/report_collector.rs
@@ -151,6 +151,11 @@ enum ReportCollectorCommand {
         /// Number of records to aggregate
         #[clap(long, short = 'n')]
         count: u32,
+
+        // If set, use the specified fixed polling interval when running a query.
+        // Otherwise, use exponential backoff.
+        #[arg(long, default_value_t = 0)]
+        set_fixed_polling_ms: u64,
     },
 }
 
@@ -264,6 +269,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             ref encrypted_inputs,
             hybrid_query_config,
             count,
+            set_fixed_polling_ms,
         } => {
             hybrid(
                 &args,
@@ -271,6 +277,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 clients,
                 encrypted_inputs,
                 count.try_into().expect("u32 should fit into usize"),
+                set_fixed_polling_ms,
             )
             .await?
         }
@@ -421,6 +428,7 @@ async fn hybrid(
     helper_clients: Vec<[IpaHttpClient<Helper>; 3]>,
     encrypted_inputs: &EncryptedInputs,
     count: usize,
+    set_fixed_polling_ms: u64,
 ) -> Result<(), Box<dyn Error>> {
     let query_type = QueryType::MaliciousHybrid(hybrid_query_config);
 
@@ -471,6 +479,7 @@ async fn hybrid(
         helper_clients,
         query_id,
         hybrid_query_config,
+        set_fixed_polling_ms,
     )
     .await;
 

--- a/ipa-core/src/cli/playbook/hybrid.rs
+++ b/ipa-core/src/cli/playbook/hybrid.rs
@@ -31,7 +31,7 @@ pub async fn run_hybrid_query_and_validate<HV>(
     clients: Vec<[IpaHttpClient<Helper>; 3]>,
     query_id: QueryId,
     query_config: HybridQueryParams,
-    set_fixed_polling_ms: u64,
+    set_fixed_polling_ms: Option<u64>,
 ) -> HybridQueryResult
 where
     HV: SharedValue + U128Conversions,
@@ -56,11 +56,10 @@ where
     .unwrap();
 
     let leader_clients = &clients[0];
-    let exponential_backoff = set_fixed_polling_ms == 0;
-    let mut delay = if exponential_backoff {
-        Duration::from_millis(125)
-    } else {
-        Duration::from_millis(set_fixed_polling_ms)
+
+    let (exponential_backoff, mut delay) = match set_fixed_polling_ms {
+        Some(specified_delay) => (false, Duration::from_millis(specified_delay)),
+        None => (true, Duration::from_millis(125)),
     };
 
     loop {

--- a/ipa-core/src/cli/playbook/hybrid.rs
+++ b/ipa-core/src/cli/playbook/hybrid.rs
@@ -31,6 +31,7 @@ pub async fn run_hybrid_query_and_validate<HV>(
     clients: Vec<[IpaHttpClient<Helper>; 3]>,
     query_id: QueryId,
     query_config: HybridQueryParams,
+    set_fixed_polling_ms: u64,
 ) -> HybridQueryResult
 where
     HV: SharedValue + U128Conversions,
@@ -55,8 +56,13 @@ where
     .unwrap();
 
     let leader_clients = &clients[0];
+    let exponential_backoff = set_fixed_polling_ms == 0;
+    let mut delay = if exponential_backoff {
+        Duration::from_millis(125)
+    } else {
+        Duration::from_millis(set_fixed_polling_ms)
+    };
 
-    let mut delay = Duration::from_millis(125);
     loop {
         if try_join_all(
             leader_clients
@@ -72,7 +78,9 @@ where
         }
 
         sleep(delay).await;
-        delay = min(Duration::from_secs(5), delay * 2);
+        if exponential_backoff {
+            delay = min(Duration::from_secs(5), delay * 2);
+        }
         // TODO: Add a timeout of some sort. Possibly, add some sort of progress indicator to
         // the status API so we can check whether the query is making progress.
     }


### PR DESCRIPTION
To test this, I added `.args(["--set-fixed-polling-ms", "100"])` before line 93 in the file containing `test_hybrid()`. I also verified that it fails with bad arguments

Test ran with `cargo test --package ipa-core --test hybrid --no-default-features --features "cli compact-gate web-app real-world-infra test-fixture relaxed-dp multi-threading" -- test_hybrid --exact`

I should say this usually passes... I ran it once (with the argument specified) and got
```
Unable to create query!: FailedHttpRequest { dest: "localhost:64473", status: 500, reason: "500 Internal Server Error: One or more peers rejected the request: [(ShardIndex(3), ShardError { shard_index: ShardIndex(0), source: ConnectError { dest: \"localhost:64493\", inner: hyper_util::client::legacy::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: InvalidMessage(InvalidContentType) } }) } })]" }
```
But I don't think that's due to any incorrect logic in this PR