### PR TITLE
Add an option to put helper logs into a file

### DIFF
--- a/ipa-core/src/cli/verbosity.rs
+++ b/ipa-core/src/cli/verbosity.rs
@@ -25,8 +25,6 @@ pub struct Verbosity {
     #[arg(short, long, action = clap::ArgAction::Count, global = true)]
     verbose: u8,
 
-    /// This option is mutually exclusive with console logging. If set,
-    /// no console output will be produced
     #[arg(long, help = "Specify the output file for logs")]
     log_file: Option<PathBuf>,
 }

--- a/ipa-core/tests/helper_networks.rs
+++ b/ipa-core/tests/helper_networks.rs
@@ -123,13 +123,13 @@ fn keygen_confgen() {
     }
 
     exec_conf_gen(false);
-    let helpers = spawn_helpers(path, &sockets, true);
+    let helpers = spawn_helpers(path, &sockets, true, None);
     test_multiply(path, true);
     drop(helpers);
 
     // now overwrite the configuration file and try again
     exec_conf_gen(true);
-    let helpers = spawn_helpers(path, &sockets, true);
+    let helpers = spawn_helpers(path, &sockets, true, None);
     test_multiply(path, true);
     drop(helpers);
 }


### PR DESCRIPTION
We need it because stderr is often dropped by the external services (like Kubernetes)

This also adds some verification for our e2e tests to make sure we write something into them