### PR TITLE
Fix Cargo.toml for panic=abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,11 @@ members = ["ipa-core", "ipa-step", "ipa-step-derive", "ipa-step-test", "ipa-metr
 [profile.release]
 incremental = true
 lto = "thin"
+# The reason for this is that we are moving towards the direction when helper processes are created per query
+# in this case there is no reason to try and preserve the helper instance to serve other queries. Aborting
+# makes dealing with the corrupted state easier
+panic = 'abort'
+
 
 [profile.release-max]
 inherits = "release"

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -177,12 +177,6 @@ tempfile = "3"
 ipa-metrics-tracing = { path = "../ipa-metrics-tracing" }
 ipa-metrics = { path = "../ipa-metrics", features = ["partitions"] }
 
-[profile.release]
-# The reason for this is that we are moving towards the direction when helper processes are created per query
-# in this case there is no reason to try and preserve the helper instance to serve other queries. Aborting
-# makes dealing with the corrupted state easier
-panic = 'abort'
-
 [lib]
 path = "src/lib.rs"
 bench = false


### PR DESCRIPTION
This must be specified in workplace Cargo as it was pointed in the warning