### PR TITLE
Use validator-adjusted active work for seq_join

### DIFF
--- a/ipa-core/src/protocol/hybrid/oprf.rs
+++ b/ipa-core/src/protocol/hybrid/oprf.rs
@@ -37,7 +37,7 @@ use crate::{
         replicated::{malicious, semi_honest::AdditiveShare as Replicated},
         BitDecomposed, FieldSimd, TransposeFrom, Vectorizable,
     },
-    seq_join::seq_join,
+    seq_join::{seq_join, SeqJoin},
     utils::non_zero_prev_power_of_two,
 };
 
@@ -130,7 +130,7 @@ where
     let m_ctx = validator.context();
 
     let curve_pts = seq_join(
-        ctx.active_work(),
+        m_ctx.active_work(),
         process_slice_by_chunks(
             &input_rows,
             move |idx, records: ChunkData<_, CONV_CHUNK>| {


### PR DESCRIPTION
In this case the adjustment reduces active_work from 32,768 to 256. Using the larger value results in many proofs being active concurrently.

Draft run: https://draft-mpc.vercel.app/query/view/pied-salon2024-12-14T1951