### PR TITLE
Periodically report memory usage

### DIFF
--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -14,7 +14,6 @@ use ipa_core::{
         ipa::{ipa_in_the_clear, test_oprf_ipa, CappingOrder, IpaSecurityModel},
         EventGenerator, EventGeneratorConfig, TestWorld, TestWorldConfig,
     },
-    use_jemalloc,
 };
 use ipa_step::StepNarrow;
 use rand::{random, rngs::StdRng, SeedableRng};
@@ -159,7 +158,7 @@ async fn run(args: Args) -> Result<(), Error> {
 
 fn main() -> Result<(), Error> {
     #[cfg(jemalloc)]
-    use_jemalloc!();
+    ipa_core::use_jemalloc!();
 
     #[cfg(feature = "dhat-heap")]
     #[global_allocator]

--- a/ipa-core/benches/oneshot/ipa.rs
+++ b/ipa-core/benches/oneshot/ipa.rs
@@ -14,18 +14,11 @@ use ipa_core::{
         ipa::{ipa_in_the_clear, test_oprf_ipa, CappingOrder, IpaSecurityModel},
         EventGenerator, EventGeneratorConfig, TestWorld, TestWorldConfig,
     },
+    use_jemalloc,
 };
 use ipa_step::StepNarrow;
 use rand::{random, rngs::StdRng, SeedableRng};
 use tokio::runtime::Builder;
-
-#[cfg(jemalloc)]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(feature = "dhat-heap")]
-#[global_allocator]
-static ALLOC: dhat::Alloc = dhat::Alloc;
 
 /// A benchmark for the full IPA protocol.
 #[derive(Parser)]
@@ -165,6 +158,13 @@ async fn run(args: Args) -> Result<(), Error> {
 }
 
 fn main() -> Result<(), Error> {
+    #[cfg(jemalloc)]
+    use_jemalloc!();
+
+    #[cfg(feature = "dhat-heap")]
+    #[global_allocator]
+    static ALLOC: dhat::Alloc = dhat::Alloc;
+
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
 

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -25,18 +25,10 @@ use ipa_core::{
         ShardHttpTransport,
     },
     sharding::ShardIndex,
-    AppConfig, AppSetup, NonZeroU32PowerOfTwo,
+    use_jemalloc, AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tokio::runtime::Runtime;
 use tracing::{error, info};
-
-#[cfg(jemalloc)]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(feature = "dhat-heap")]
-#[global_allocator]
-static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[derive(Debug, Parser)]
 #[clap(
@@ -369,6 +361,13 @@ fn new_query_runtime(logging_handle: &LoggingHandle) -> Runtime {
 /// runtimes to use in MPC queries and HTTP.
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() {
+    #[cfg(jemalloc)]
+    use_jemalloc!();
+
+    #[cfg(feature = "dhat-heap")]
+    #[global_allocator]
+    static ALLOC: dhat::Alloc = dhat::Alloc;
+
     let args = Args::parse();
     let handle = args.logging.setup_logging();
 

--- a/ipa-core/src/bin/helper.rs
+++ b/ipa-core/src/bin/helper.rs
@@ -25,7 +25,7 @@ use ipa_core::{
         ShardHttpTransport,
     },
     sharding::ShardIndex,
-    use_jemalloc, AppConfig, AppSetup, NonZeroU32PowerOfTwo,
+    AppConfig, AppSetup, NonZeroU32PowerOfTwo,
 };
 use tokio::runtime::Runtime;
 use tracing::{error, info};
@@ -362,7 +362,7 @@ fn new_query_runtime(logging_handle: &LoggingHandle) -> Runtime {
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() {
     #[cfg(jemalloc)]
-    use_jemalloc!();
+    ipa_core::use_jemalloc!();
 
     #[cfg(feature = "dhat-heap")]
     #[global_allocator]

--- a/ipa-core/src/lib.rs
+++ b/ipa-core/src/lib.rs
@@ -32,6 +32,7 @@ mod seq_join;
 mod serde;
 pub mod sharding;
 pub mod utils;
+
 pub use app::{AppConfig, HelperApp, Setup as AppSetup};
 pub use utils::NonZeroU32PowerOfTwo;
 
@@ -347,6 +348,21 @@ pub(crate) mod test_executor {
 }
 
 pub const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+
+/// This macro should be called in a binary that uses `ipa_core`, if that binary wishes
+/// to use jemalloc.
+///
+/// Besides declaring the `#[global_allocator]`, the macro also activates some memory
+/// reporting.
+#[macro_export]
+macro_rules! use_jemalloc {
+    () => {
+        #[global_allocator]
+        static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+        $crate::telemetry::memory::jemalloc::activate();
+    };
+}
 
 #[macro_export]
 macro_rules! const_assert {

--- a/ipa-core/src/seq_join/multi_thread.rs
+++ b/ipa-core/src/seq_join/multi_thread.rs
@@ -134,6 +134,7 @@ where
                 None => None,
             })
         } else if this.source.is_done() {
+            periodic_memory_report(*this.spawned);
             Poll::Ready(None)
         } else {
             Poll::Pending

--- a/ipa-core/src/seq_join/multi_thread.rs
+++ b/ipa-core/src/seq_join/multi_thread.rs
@@ -9,6 +9,8 @@ use futures::{stream::Fuse, Stream, StreamExt};
 use pin_project::pin_project;
 use tracing::{Instrument, Span};
 
+use crate::telemetry::memory::periodic_memory_report;
+
 #[cfg(feature = "shuttle")]
 mod shuttle_spawner {
     use std::future::Future;
@@ -62,6 +64,7 @@ where
     #[pin]
     source: Fuse<S>,
     capacity: usize,
+    spawned: usize,
 }
 
 impl<S, F> SequentialFutures<'_, S, F>
@@ -75,6 +78,7 @@ where
             spawner: unsafe { create_spawner() },
             source: source.fuse(),
             capacity: active.get(),
+            spawned: 0,
         }
     }
 }
@@ -103,11 +107,14 @@ where
                 // a dependency between futures, pending one will never complete.
                 // Cancellable futures will be cancelled when spawner is dropped which is
                 // the behavior we want.
-                let task_index = this.spawner.len();
+                let task_index = *this.spawned;
                 this.spawner
                     .spawn_cancellable(f.into_future().instrument(Span::current()), move || {
                         panic!("SequentialFutures: spawned task {task_index} cancelled")
                     });
+
+                periodic_memory_report(*this.spawned);
+                *this.spawned += 1;
             } else {
                 break;
             }

--- a/ipa-core/src/telemetry/memory.rs
+++ b/ipa-core/src/telemetry/memory.rs
@@ -1,12 +1,14 @@
-#[cfg(not(jemalloc))]
-pub fn periodic_memory_report() { }
+pub fn periodic_memory_report(count: usize) {
+    #[cfg(not(jemalloc))]
+    let _ = count;
+
+    #[cfg(jemalloc)]
+    jemalloc::periodic_memory_report(count);
+}
 
 #[cfg(jemalloc)]
-pub use jemalloc::periodic_memory_report;
-
-#[cfg(jemalloc)]
-mod jemalloc {
-    use std::sync::LazyLock;
+pub mod jemalloc {
+    use std::sync::RwLock;
 
     use tikv_jemalloc_ctl::{epoch_mib, stats::allocated_mib};
 
@@ -16,19 +18,28 @@ mod jemalloc {
     // statistics stands for "Management Information Base", not "mebibytes".
     // The reporting unit is bytes.
 
-    static EPOCH: LazyLock<epoch_mib> = LazyLock::new(|| {
-        tikv_jemalloc_ctl::epoch::mib().unwrap()
-    });
+    struct JemallocControls {
+        epoch: epoch_mib,
+        allocated: allocated_mib,
+    }
 
-    static ALLOCATED: LazyLock<allocated_mib> = LazyLock::new(|| {
-        tikv_jemalloc_ctl::stats::allocated::mib().unwrap()
-    });
+    static CONTROLS: RwLock<Option<JemallocControls>> = RwLock::new(None);
 
-    fn report_memory_usage(count: usize) {
+    /// Activates periodic memory usage reporting during `seq_join`.
+    pub fn activate() {
+        let mut controls = CONTROLS.write().unwrap();
+
+        let epoch = tikv_jemalloc_ctl::epoch::mib().unwrap();
+        let allocated = tikv_jemalloc_ctl::stats::allocated::mib().unwrap();
+
+        *controls = Some(JemallocControls { epoch, allocated });
+    }
+
+    fn report_memory_usage(controls: &JemallocControls, count: usize) {
         // Some of the information jemalloc uses when reporting statistics is cached, and
         // refreshed only upon advancing the epoch.
-        EPOCH.advance().unwrap();
-        let allocated = ALLOCATED.read().unwrap() / MB;
+        controls.epoch.advance().unwrap();
+        let allocated = controls.allocated.read().unwrap() / MB;
         tracing::debug!("i={count}: {allocated} MiB allocated");
     }
 
@@ -38,7 +49,7 @@ mod jemalloc {
         }
 
         let bits = count.ilog2();
-        let report_interval_log2 = std::cmp::max(bits.saturating_sub(2), 8);
+        let report_interval_log2 = std::cmp::max(bits.saturating_sub(1), 8);
         let report_interval_mask = (1 << report_interval_log2) - 1;
         (count & report_interval_mask) == 0
     }
@@ -49,8 +60,11 @@ mod jemalloc {
     /// a tolerable amount of log messages for loops with many iterations,
     /// while still providing some reporting for shorter loops.
     pub fn periodic_memory_report(count: usize) {
-        if should_print_report(count) {
-            report_memory_usage(count);
+        let controls_opt = CONTROLS.read().unwrap();
+        if let Some(controls) = controls_opt.as_ref() {
+            if should_print_report(count) {
+                report_memory_usage(controls, count);
+            }
         }
     }
 }

--- a/ipa-core/src/telemetry/memory.rs
+++ b/ipa-core/src/telemetry/memory.rs
@@ -26,6 +26,9 @@ pub mod jemalloc {
     static CONTROLS: RwLock<Option<JemallocControls>> = RwLock::new(None);
 
     /// Activates periodic memory usage reporting during `seq_join`.
+    ///
+    /// # Panics
+    /// If `RwLock` is poisoned.
     pub fn activate() {
         let mut controls = CONTROLS.write().unwrap();
 
@@ -59,6 +62,9 @@ pub mod jemalloc {
     /// As `count` increases, so does the report interval. This results in
     /// a tolerable amount of log messages for loops with many iterations,
     /// while still providing some reporting for shorter loops.
+    ///
+    /// # Panics
+    /// If `RwLock` is poisoned.
     pub fn periodic_memory_report(count: usize) {
         let controls_opt = CONTROLS.read().unwrap();
         if let Some(controls) = controls_opt.as_ref() {

--- a/ipa-core/src/telemetry/memory.rs
+++ b/ipa-core/src/telemetry/memory.rs
@@ -1,0 +1,56 @@
+#[cfg(not(jemalloc))]
+pub fn periodic_memory_report() { }
+
+#[cfg(jemalloc)]
+pub use jemalloc::periodic_memory_report;
+
+#[cfg(jemalloc)]
+mod jemalloc {
+    use std::sync::LazyLock;
+
+    use tikv_jemalloc_ctl::{epoch_mib, stats::allocated_mib};
+
+    const MB: usize = 2 << 20;
+
+    // In an unfortunate acronym collision, `mib` in the names of the jemalloc
+    // statistics stands for "Management Information Base", not "mebibytes".
+    // The reporting unit is bytes.
+
+    static EPOCH: LazyLock<epoch_mib> = LazyLock::new(|| {
+        tikv_jemalloc_ctl::epoch::mib().unwrap()
+    });
+
+    static ALLOCATED: LazyLock<allocated_mib> = LazyLock::new(|| {
+        tikv_jemalloc_ctl::stats::allocated::mib().unwrap()
+    });
+
+    fn report_memory_usage(count: usize) {
+        // Some of the information jemalloc uses when reporting statistics is cached, and
+        // refreshed only upon advancing the epoch.
+        EPOCH.advance().unwrap();
+        let allocated = ALLOCATED.read().unwrap() / MB;
+        tracing::debug!("i={count}: {allocated} MiB allocated");
+    }
+
+    fn should_print_report(count: usize) -> bool {
+        if count == 0 {
+            return true;
+        }
+
+        let bits = count.ilog2();
+        let report_interval_log2 = std::cmp::max(bits.saturating_sub(2), 8);
+        let report_interval_mask = (1 << report_interval_log2) - 1;
+        (count & report_interval_mask) == 0
+    }
+
+    /// Print a memory report periodically, based on the value of `count`.
+    ///
+    /// As `count` increases, so does the report interval. This results in
+    /// a tolerable amount of log messages for loops with many iterations,
+    /// while still providing some reporting for shorter loops.
+    pub fn periodic_memory_report(count: usize) {
+        if should_print_report(count) {
+            report_memory_usage(count);
+        }
+    }
+}

--- a/ipa-core/src/telemetry/mod.rs
+++ b/ipa-core/src/telemetry/mod.rs
@@ -1,3 +1,4 @@
+pub mod memory;
 pub mod stats;
 mod step_stats;
 


### PR DESCRIPTION
The reporting is wired into seq_join. The reporting interval increases as the record count increases, which results in a tolerable amount of log messages for loops with many iterations, while still providing some reporting for shorter loops. It's still fairly chatty, so I put it at debug level. [Here's a sample](https://github.com/user-attachments/files/18159269/memory-reporting-sample.txt) -- 1141 lines reporting memory usage vs. 583 other log lines -- but I reduced the frequency after generating this, so it's ~half of that now.

Note that the reporting depends on jemalloc. That is the default on linux. It can be activated on other platforms with a feature.