### PR TITLE
Query input from URL

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -172,6 +172,7 @@ rustls = { version = "0.23" }
 tempfile = "3"
 ipa-metrics-tracing = { path = "../ipa-metrics-tracing" }
 ipa-metrics = { path = "../ipa-metrics", features = ["partitions"] }
+tiny_http = "0.12"
 
 [lib]
 path = "src/lib.rs"

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -41,6 +41,7 @@ web-app = [
     "rustls",
     "rustls-pemfile",
     "time",
+    "tiny_http",
     "tokio-rustls",
     "toml",
     "tower",
@@ -140,6 +141,7 @@ thiserror = "1.0"
 tikv-jemallocator = { version = "0.6", optional = true, features = ["profiling"] }
 tikv-jemalloc-ctl = { version = "0.6", optional = true, features = ["stats"] }
 time = { version = "0.3", optional = true }
+tiny_http = { version = "0.12", optional = true }
 tokio = { version = "1.42", features = ["fs", "rt", "rt-multi-thread", "macros"] }
 tokio-rustls = { version = "0.26", optional = true }
 tokio-stream = "0.1.14"
@@ -172,7 +174,6 @@ rustls = { version = "0.23" }
 tempfile = "3"
 ipa-metrics-tracing = { path = "../ipa-metrics-tracing" }
 ipa-metrics = { path = "../ipa-metrics", features = ["partitions"] }
-tiny_http = "0.12"
 
 [lib]
 path = "src/lib.rs"

--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -139,12 +139,19 @@ impl HelperApp {
     pub fn execute_query(&self, input: QueryInput) -> Result<(), ApiError> {
         let mpc_transport = self.inner.mpc_transport.clone_ref();
         let shard_transport = self.inner.shard_transport.clone_ref();
-        let QueryInput::Inline { query_id, input_stream } = input else {
+        let QueryInput::Inline {
+            query_id,
+            input_stream,
+        } = input
+        else {
             panic!("this client does not support pulling query input from a URL");
         };
-        self.inner
-            .query_processor
-            .receive_inputs(mpc_transport, shard_transport, query_id, input_stream)?;
+        self.inner.query_processor.receive_inputs(
+            mpc_transport,
+            shard_transport,
+            query_id,
+            input_stream,
+        )?;
         Ok(())
     }
 

--- a/ipa-core/src/app.rs
+++ b/ipa-core/src/app.rs
@@ -136,6 +136,8 @@ impl HelperApp {
     ///
     /// ## Errors
     /// Propagates errors from the helper.
+    /// ## Panics
+    /// If `input` asks to obtain query input from a remote URL.
     pub fn execute_query(&self, input: QueryInput) -> Result<(), ApiError> {
         let mpc_transport = self.inner.mpc_transport.clone_ref();
         let shard_transport = self.inner.shard_transport.clone_ref();

--- a/ipa-core/src/cli/playbook/add.rs
+++ b/ipa-core/src/cli/playbook/add.rs
@@ -47,7 +47,7 @@ where
             .into_iter()
             .zip(clients)
             .map(|(input_stream, client)| {
-                client.query_input(QueryInput {
+                client.query_input(QueryInput::Inline {
                     query_id,
                     input_stream,
                 })

--- a/ipa-core/src/cli/playbook/hybrid.rs
+++ b/ipa-core/src/cli/playbook/hybrid.rs
@@ -44,7 +44,7 @@ where
         |(shard_clients, shard_inputs)| {
             try_join_all(shard_clients.iter().zip(shard_inputs.into_iter()).map(
                 |(client, input)| {
-                    client.query_input(QueryInput {
+                    client.query_input(QueryInput::Inline {
                         query_id,
                         input_stream: input,
                     })

--- a/ipa-core/src/cli/playbook/ipa.rs
+++ b/ipa-core/src/cli/playbook/ipa.rs
@@ -115,7 +115,7 @@ where
             .into_iter()
             .zip(clients)
             .map(|(input_stream, client)| {
-                client.query_input(QueryInput {
+                client.query_input(QueryInput::Inline {
                     query_id,
                     input_stream,
                 })

--- a/ipa-core/src/cli/playbook/multiply.rs
+++ b/ipa-core/src/cli/playbook/multiply.rs
@@ -55,7 +55,7 @@ where
             .into_iter()
             .zip(clients)
             .map(|(input_stream, client)| {
-                client.query_input(QueryInput {
+                client.query_input(QueryInput::Inline {
                     query_id,
                     input_stream,
                 })

--- a/ipa-core/src/cli/playbook/sharded_shuffle.rs
+++ b/ipa-core/src/cli/playbook/sharded_shuffle.rs
@@ -45,7 +45,7 @@ where
                 let shared = chunk.iter().copied().share();
                 try_join_all(mpc_clients.each_ref().iter().zip(shared).map(
                     |(mpc_client, input)| {
-                        mpc_client.query_input(QueryInput {
+                        mpc_client.query_input(QueryInput::Inline {
                             query_id,
                             input_stream: BodyStream::from_serializable_iter(input),
                         })

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -186,18 +186,6 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
     }
 }
 
-/*
-pub enum QueryInputRequest {
-    FromUrl {
-        query_id: QueryId,
-        url: Uri,
-    },
-    Inline {
-        query_id: QueryId,
-    },
-}
-*/
-
 pub enum QueryInput {
     FromUrl {
         query_id: QueryId,
@@ -229,37 +217,7 @@ impl QueryInput {
             Self::Inline { .. } => None,
         }
     }
-
-    // It would be better to return an error here, but `helpers::error::Error` doesn't
-    // have the variants we need.
-    //
-    // When handling actual requests, the request is parsed once and then stuffed into
-    // `Addr` before it gets here, so parsing shouldn't fail at this point. Some of
-    // this stuff is in need of a refactor (see #994).
-    pub fn from_addr(addr: Addr<HelperIdentity>, input_stream: BodyStream) -> Option<Self> {
-        let query_id = addr.query_id?;
-
-        if addr.params.is_empty() {
-            Some(Self::Inline {
-                query_id,
-                input_stream,
-            })
-        } else {
-            let url = addr.params.parse().ok()?;
-            Some(Self::FromUrl { query_id, url })
-        }
-    }
 }
-
-/*
-impl QueryInputRequest {
-    pub fn query_id(&self) -> QueryId {
-        match self {
-            Self::FromUrl { query_id, .. } | Self::Inline { query_id, ..} => *query_id,
-        }
-    }
-}
-*/
 
 impl Debug for QueryInput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -279,32 +237,6 @@ impl Debug for QueryInput {
         }
     }
 }
-
-/*
-impl RouteParams<RouteId, QueryId, NoStep> for QueryInputRequest {
-    type Params = String;
-
-    fn resource_identifier(&self) -> RouteId {
-        RouteId::QueryInput
-    }
-
-    fn query_id(&self) -> QueryId {
-        self.query_id()
-    }
-
-    fn gate(&self) -> NoStep {
-        NoStep
-    }
-
-    fn extra(&self) -> Self::Params {
-        use QueryInputRequest::*;
-        match self {
-            FromUrl { url, .. } => url.to_string(),
-            Inline { .. } => String::new(),
-        }
-    }
-}
-*/
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     ff::FieldType,
     helpers::{
-        routing::Addr, transport::{routing::RouteId, BodyStream, NoQueryId, NoStep}, HelperIdentity, RoleAssignment, RouteParams
+        routing::Addr,
+        transport::{routing::RouteId, BodyStream, NoQueryId, NoStep},
+        HelperIdentity, RoleAssignment, RouteParams,
     },
     protocol::QueryId,
     query::QueryStatus,
@@ -184,7 +186,6 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
     }
 }
 
-
 /*
 pub enum QueryInputRequest {
     FromUrl {
@@ -211,7 +212,7 @@ pub enum QueryInput {
 impl QueryInput {
     pub fn query_id(&self) -> QueryId {
         match self {
-            Self::FromUrl { query_id, .. } | Self::Inline { query_id, ..} => *query_id,
+            Self::FromUrl { query_id, .. } | Self::Inline { query_id, .. } => *query_id,
         }
     }
 
@@ -239,7 +240,10 @@ impl QueryInput {
         let query_id = addr.query_id?;
 
         if addr.params.is_empty() {
-            Some(Self::Inline { query_id, input_stream })
+            Some(Self::Inline {
+                query_id,
+                input_stream,
+            })
         } else {
             let url = addr.params.parse().ok()?;
             Some(Self::FromUrl { query_id, url })
@@ -260,17 +264,18 @@ impl QueryInputRequest {
 impl Debug for QueryInput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            QueryInput::Inline { query_id, input_stream: _ } => {
-                f.debug_struct("QueryInput::Inline")
-                    .field("query_id", query_id)
-                    .finish()
-            }
-            QueryInput::FromUrl { query_id, url } => {
-                f.debug_struct("QueryInput::FromUrl")
-                    .field("query_id", query_id)
-                    .field("url", url)
-                    .finish()
-            }
+            QueryInput::Inline {
+                query_id,
+                input_stream: _,
+            } => f
+                .debug_struct("QueryInput::Inline")
+                .field("query_id", query_id)
+                .finish(),
+            QueryInput::FromUrl { query_id, url } => f
+                .debug_struct("QueryInput::FromUrl")
+                .field("query_id", query_id)
+                .field("url", url)
+                .finish(),
         }
     }
 }

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 pub use hybrid::HybridQueryParams;
-use hyper::Uri;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
@@ -188,7 +187,7 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
 pub enum QueryInput {
     FromUrl {
         query_id: QueryId,
-        url: Uri,
+        url: String,
     },
     Inline {
         query_id: QueryId,
@@ -197,12 +196,14 @@ pub enum QueryInput {
 }
 
 impl QueryInput {
+    #[must_use]
     pub fn query_id(&self) -> QueryId {
         match self {
             Self::FromUrl { query_id, .. } | Self::Inline { query_id, .. } => *query_id,
         }
     }
 
+    #[must_use]
     pub fn input_stream(self) -> Option<BodyStream> {
         match self {
             Self::Inline { input_stream, .. } => Some(input_stream),
@@ -210,7 +211,8 @@ impl QueryInput {
         }
     }
 
-    pub fn url(&self) -> Option<&Uri> {
+    #[must_use]
+    pub fn url(&self) -> Option<&str> {
         match self {
             Self::FromUrl { url, .. } => Some(url),
             Self::Inline { .. } => None,

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -213,10 +213,10 @@ impl QueryInput {
         }
     }
 
-    pub fn input_stream(self) -> BodyStream {
+    pub fn input_stream(self) -> Option<BodyStream> {
         match self {
-            Self::FromUrl { .. } => BodyStream::empty(),
-            Self::Inline { input_stream, .. } => input_stream,
+            Self::Inline { input_stream, .. } => Some(input_stream),
+            Self::FromUrl { .. } => None,
         }
     }
 

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -220,6 +220,13 @@ impl QueryInput {
         }
     }
 
+    pub fn url(&self) -> Option<&Uri> {
+        match self {
+            Self::FromUrl { url, .. } => Some(url),
+            Self::Inline { .. } => None,
+        }
+    }
+
     // It would be better to return an error here, but `helpers::error::Error` doesn't
     // have the variants we need.
     //

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -12,9 +12,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     ff::FieldType,
     helpers::{
-        routing::Addr,
         transport::{routing::RouteId, BodyStream, NoQueryId, NoStep},
-        HelperIdentity, RoleAssignment, RouteParams,
+        RoleAssignment, RouteParams,
     },
     protocol::QueryId,
     query::QueryStatus,

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -185,6 +185,7 @@ impl RouteParams<RouteId, QueryId, NoStep> for &PrepareQuery {
 }
 
 
+/*
 pub enum QueryInputRequest {
     FromUrl {
         query_id: QueryId,
@@ -194,6 +195,7 @@ pub enum QueryInputRequest {
         query_id: QueryId,
     },
 }
+*/
 
 pub enum QueryInput {
     FromUrl {
@@ -245,6 +247,7 @@ impl QueryInput {
     }
 }
 
+/*
 impl QueryInputRequest {
     pub fn query_id(&self) -> QueryId {
         match self {
@@ -252,6 +255,7 @@ impl QueryInputRequest {
         }
     }
 }
+*/
 
 impl Debug for QueryInput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -271,6 +275,7 @@ impl Debug for QueryInput {
     }
 }
 
+/*
 impl RouteParams<RouteId, QueryId, NoStep> for QueryInputRequest {
     type Params = String;
 
@@ -294,6 +299,7 @@ impl RouteParams<RouteId, QueryId, NoStep> for QueryInputRequest {
         }
     }
 }
+*/
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]

--- a/ipa-core/src/helpers/transport/query/mod.rs
+++ b/ipa-core/src/helpers/transport/query/mod.rs
@@ -246,22 +246,21 @@ impl QueryInputRequest {
     }
 }
 
-/*
-impl From<(Addr<HelperIdentity>, BodyStream)> for QueryInput {
-    fn from((addr, body): (Addr<HelperIdentity>, BodyStream)) -> Self {
-        if addr.params.is_empty() {
-            QueryInput::Inline { addr.query_id, input_stream: body },
-        } else {
-            QueryInput::FromUrl { query_id, url },
-        }
-    }
-}
-*/
-
 impl Debug for QueryInput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
-        //write!(f, "query_inputs[{:?}]", self.query_id)
+        match self {
+            QueryInput::Inline { query_id, input_stream: _ } => {
+                f.debug_struct("QueryInput::Inline")
+                    .field("query_id", query_id)
+                    .finish()
+            }
+            QueryInput::FromUrl { query_id, url } => {
+                f.debug_struct("QueryInput::FromUrl")
+                    .field("query_id", query_id)
+                    .field("url", url)
+                    .finish()
+            }
+        }
     }
 }
 

--- a/ipa-core/src/net/client/mod.rs
+++ b/ipa-core/src/net/client/mod.rs
@@ -726,7 +726,7 @@ pub(crate) mod tests {
         };
         test_query_command(
             |client| async move {
-                let data = QueryInput {
+                let data = QueryInput::Inline {
                     query_id: expected_query_id,
                     input_stream: expected_input.to_vec().into(),
                 };

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -312,16 +312,23 @@ pub mod query {
     }
 
     pub mod input {
-        use axum::async_trait;
-        use axum::{body::Body, http::uri};
-        use axum::{extract::FromRequestParts, http::request::Parts};
-        use hyper::header::{CONTENT_TYPE, HeaderValue};
-        use hyper::Uri;
+        use axum::{
+            async_trait,
+            body::Body,
+            extract::FromRequestParts,
+            http::{request::Parts, uri},
+        };
+        use hyper::{
+            header::{HeaderValue, CONTENT_TYPE},
+            Uri,
+        };
 
-        use crate::net::{Error, HTTP_QUERY_INPUT_URL_HEADER};
         use crate::{
             helpers::query::QueryInput,
-            net::{http_serde::query::BASE_AXUM_PATH, APPLICATION_OCTET_STREAM},
+            net::{
+                http_serde::query::BASE_AXUM_PATH, Error, APPLICATION_OCTET_STREAM,
+                HTTP_QUERY_INPUT_URL_HEADER,
+            },
         };
 
         #[derive(Debug)]
@@ -349,13 +356,18 @@ pub mod query {
                     ))
                     .build()?;
                 let query_input_url = self.query_input.url().cloned();
-                let body = self.query_input.input_stream()
+                let body = self
+                    .query_input
+                    .input_stream()
                     .map(Body::from_stream)
                     .unwrap_or_else(Body::empty);
-                let mut request = hyper::Request::post(uri)
-                    .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
+                let mut request =
+                    hyper::Request::post(uri).header(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
                 if let Some(url) = query_input_url {
-                    request.headers_mut().unwrap().insert(&HTTP_QUERY_INPUT_URL_HEADER, HeaderValue::try_from(url.to_string()).unwrap());
+                    request.headers_mut().unwrap().insert(
+                        &HTTP_QUERY_INPUT_URL_HEADER,
+                        HeaderValue::try_from(url.to_string()).unwrap(),
+                    );
                 }
                 Ok(request.body(body)?)
             }
@@ -369,7 +381,10 @@ pub mod query {
         impl<S: Send + Sync> FromRequestParts<S> for QueryInputUrl {
             type Rejection = Error;
 
-            async fn from_request_parts(req: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+            async fn from_request_parts(
+                req: &mut Parts,
+                _state: &S,
+            ) -> Result<Self, Self::Rejection> {
                 match req.headers.get(&HTTP_QUERY_INPUT_URL_HEADER) {
                     None => Ok(QueryInputUrl(None)),
                     Some(value) => {

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -355,7 +355,7 @@ pub mod query {
                         self.query_input.query_id().as_ref(),
                     ))
                     .build()?;
-                let query_input_url = self.query_input.url().cloned();
+                let query_input_url = self.query_input.url().map(ToOwned::to_owned);
                 let body = self
                     .query_input
                     .input_stream()
@@ -365,7 +365,7 @@ pub mod query {
                 if let Some(url) = query_input_url {
                     request.headers_mut().unwrap().insert(
                         &HTTP_QUERY_INPUT_URL_HEADER,
-                        HeaderValue::try_from(url.to_string()).unwrap(),
+                        HeaderValue::try_from(url).unwrap(),
                     );
                 }
                 Ok(request.body(body)?)

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -359,8 +359,7 @@ pub mod query {
                 let body = self
                     .query_input
                     .input_stream()
-                    .map(Body::from_stream)
-                    .unwrap_or_else(Body::empty);
+                    .map_or_else(Body::empty, Body::from_stream);
                 let mut request =
                     hyper::Request::post(uri).header(CONTENT_TYPE, APPLICATION_OCTET_STREAM);
                 if let Some(url) = query_input_url {
@@ -396,9 +395,9 @@ pub mod query {
             }
         }
 
-        impl Into<Option<Uri>> for QueryInputUrl {
-            fn into(self) -> Option<Uri> {
-                self.0
+        impl From<QueryInputUrl> for Option<Uri> {
+            fn from(value: QueryInputUrl) -> Self {
+                value.0
             }
         }
     }

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -382,13 +382,6 @@ pub mod query {
                 self.0
             }
         }
-
-        // TODO: remove this if unused
-        impl QueryInputUrl {
-            pub fn as_ref(&self) -> Option<&Uri> {
-                self.0.as_ref()
-            }
-        }
     }
 
     pub mod step {

--- a/ipa-core/src/net/http_serde.rs
+++ b/ipa-core/src/net/http_serde.rs
@@ -348,7 +348,9 @@ pub mod query {
                         self.query_input.query_id().as_ref(),
                     ))
                     .build()?;
-                let body = Body::from_stream(self.query_input.input_stream);
+                let body = self.query_input.input_stream()
+                    .map(Body::from_stream)
+                    .unwrap_or_else(Body::empty);
                 Ok(hyper::Request::post(uri)
                     .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
                     .body(body)?)

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -32,6 +32,7 @@ const APPLICATION_JSON: &str = "application/json";
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
 static HTTP_HELPER_ID_HEADER: HeaderName = HeaderName::from_static("x-unverified-helper-identity");
 static HTTP_SHARD_INDEX_HEADER: HeaderName = HeaderName::from_static("x-unverified-shard-index");
+static HTTP_QUERY_INPUT_URL_HEADER: HeaderName = HeaderName::from_static("x-query-input-url");
 
 /// This has the same meaning as const defined in h2 crate, but we don't import it directly.
 /// According to the [`spec`] it cannot exceed 2^31 - 1.

--- a/ipa-core/src/net/mod.rs
+++ b/ipa-core/src/net/mod.rs
@@ -18,6 +18,7 @@ use crate::{
 mod client;
 mod error;
 mod http_serde;
+pub mod query_input;
 mod server;
 #[cfg(all(test, not(feature = "shuttle")))]
 pub mod test;

--- a/ipa-core/src/net/query_input.rs
+++ b/ipa-core/src/net/query_input.rs
@@ -1,0 +1,51 @@
+use axum::{body::Body, BoxError};
+use http_body_util::BodyExt;
+use hyper::Uri;
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::{client::legacy::Client, rt::{TokioExecutor, TokioTimer}};
+
+use crate::{helpers::{query::QueryInput, BodyStream}, net::Error};
+
+/// Download query input from a remote URL.
+async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error> {
+    let mut builder = Client::builder(TokioExecutor::new());
+    // the following timer is necessary for http2, in particular for any timeouts
+    // and waits the clients will need to make
+    // TODO: implement IpaTimer to allow wrapping other than Tokio runtimes
+    builder.timer(TokioTimer::new());
+    let client = builder.build::<_, Body>(
+        HttpsConnectorBuilder::default()
+            .with_native_roots()
+            .expect("System truststore is required")
+            .https_only()
+            .enable_all_versions()
+            .build()
+    );
+
+    let resp = client.get(uri.clone())
+        .await
+        .map_err(|inner| Error::ConnectError { dest: uri.to_string(), inner })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        assert!(status.is_client_error() || status.is_server_error()); // must be failure
+        return Err(
+            axum::body::to_bytes(Body::new(resp.into_body()), 36_000_000) // Roughly 36mb
+                .await
+                .map_or_else(Into::into, |reason_bytes| Error::FailedHttpRequest {
+                    dest: uri.to_string(),
+                    status,
+                    reason: String::from_utf8_lossy(&reason_bytes).to_string(),
+                })
+        );
+    }
+
+    Ok(BodyStream::from_bytes_stream(resp.into_body().map_err(BoxError::from).into_data_stream()))
+}
+
+pub async fn stream_query_input(query_input: QueryInput) -> Result<BodyStream, Error> {
+    match query_input {
+        QueryInput::Inline { input_stream, .. } => Ok(input_stream),
+        QueryInput::FromUrl { url, .. } => stream_query_input_from_url(&url).await,
+    }
+}

--- a/ipa-core/src/net/query_input.rs
+++ b/ipa-core/src/net/query_input.rs
@@ -9,7 +9,13 @@ use hyper_util::{
 
 use crate::{helpers::BodyStream, net::Error};
 
-/// Download query input from a remote URL.
+/// Connect to a remote URL to download query input.
+///
+/// # Errors
+/// If the connection to the remote URL fails or returns an HTTP error.
+///
+/// # Panics
+/// If unable to create an HTTPS client using the system truststore.
 pub async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error> {
     let mut builder = Client::builder(TokioExecutor::new());
     // the following timer is necessary for http2, in particular for any timeouts

--- a/ipa-core/src/net/query_input.rs
+++ b/ipa-core/src/net/query_input.rs
@@ -4,10 +4,10 @@ use hyper::Uri;
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::{TokioExecutor, TokioTimer}};
 
-use crate::{helpers::{query::QueryInput, BodyStream}, net::Error};
+use crate::{helpers::BodyStream, net::Error};
 
 /// Download query input from a remote URL.
-async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error> {
+pub async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error> {
     let mut builder = Client::builder(TokioExecutor::new());
     // the following timer is necessary for http2, in particular for any timeouts
     // and waits the clients will need to make
@@ -43,9 +43,11 @@ async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error> {
     Ok(BodyStream::from_bytes_stream(resp.into_body().map_err(BoxError::from).into_data_stream()))
 }
 
+/*
 pub async fn stream_query_input(query_input: QueryInput) -> Result<BodyStream, Error> {
     match query_input {
         QueryInput::Inline { input_stream, .. } => Ok(input_stream),
         QueryInput::FromUrl { url, .. } => stream_query_input_from_url(&url).await,
     }
 }
+*/

--- a/ipa-core/src/net/query_input.rs
+++ b/ipa-core/src/net/query_input.rs
@@ -51,12 +51,3 @@ pub async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error>
         resp.into_body().map_err(BoxError::from).into_data_stream(),
     ))
 }
-
-/*
-pub async fn stream_query_input(query_input: QueryInput) -> Result<BodyStream, Error> {
-    match query_input {
-        QueryInput::Inline { input_stream, .. } => Ok(input_stream),
-        QueryInput::FromUrl { url, .. } => stream_query_input_from_url(&url).await,
-    }
-}
-*/

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -127,9 +127,7 @@ mod tests {
             "http://localhost:{}{}/{QUERY_ID}/input",
             addr.to_ip().unwrap().port(),
             http_serde::query::BASE_AXUM_PATH,
-        )
-        .parse()
-        .unwrap();
+        );
         let req = http_serde::query::input::Request::new(QueryInput::FromUrl {
             query_id: QUERY_ID,
             url,

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -98,7 +98,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn input_from_url() {
         const QUERY_ID: QueryId = QueryId;
-        const DATA: &'static str = "input records";
+        const DATA: &str = "input records";
 
         let server = tiny_http::Server::http("localhost:0").unwrap();
         let addr = server.server_addr();

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -2,7 +2,7 @@ use axum::{extract::Path, routing::post, Extension, Router};
 use hyper::StatusCode;
 
 use crate::{
-    helpers::{query::QueryInputRequest, routing::RouteId, BodyStream},
+    helpers::{query::QueryInputRequest, BodyStream},
     net::{http_serde::{self, query::input::QueryInputUrl}, transport::MpcHttpTransport, Error},
     protocol::QueryId,
 };
@@ -56,7 +56,7 @@ mod tests {
     async fn input_test() {
         let expected_query_id = QueryId;
         let expected_input = &[4u8; 4];
-        let req = http_serde::query::input::Request::new(QueryInput {
+        let req = http_serde::query::input::Request::new(QueryInput::Inline {
             query_id: expected_query_id,
             input_stream: expected_input.to_vec().into(),
         });

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -3,7 +3,12 @@ use hyper::StatusCode;
 
 use crate::{
     helpers::{routing::RouteId, BodyStream},
-    net::{http_serde::{self, query::input::QueryInputUrl}, query_input::stream_query_input_from_url, transport::MpcHttpTransport, Error},
+    net::{
+        http_serde::{self, query::input::QueryInputUrl},
+        query_input::stream_query_input_from_url,
+        transport::MpcHttpTransport,
+        Error,
+    },
     protocol::QueryId,
 };
 
@@ -52,7 +57,8 @@ mod tests {
         },
         net::{
             http_serde,
-            server::handlers::query::test_helpers::{assert_fails_with, assert_success_with}, test::TestServer,
+            server::handlers::query::test_helpers::{assert_fails_with, assert_success_with},
+            test::TestServer,
         },
         protocol::QueryId,
     };
@@ -128,10 +134,9 @@ mod tests {
             query_id: QUERY_ID,
             url,
         });
-        let hyper_req = req.try_into_http_request(
-            Scheme::HTTP,
-            Authority::from_static("localhost"),
-        ).unwrap();
+        let hyper_req = req
+            .try_into_http_request(Scheme::HTTP, Authority::from_static("localhost"))
+            .unwrap();
 
         let resp = test_server.server.handle_req(hyper_req).await;
         if !resp.status().is_success() {

--- a/ipa-core/src/net/transport.rs
+++ b/ipa-core/src/net/transport.rs
@@ -574,7 +574,7 @@ mod tests {
 
         let mut handle_resps = Vec::with_capacity(helper_shares.len());
         for (i, input_stream) in helper_shares.into_iter().enumerate() {
-            let data = QueryInput {
+            let data = QueryInput::Inline {
                 query_id,
                 input_stream,
             };
@@ -586,7 +586,7 @@ mod tests {
         // convention - first client is shard leader, and we submitted the inputs to it.
         try_join_all(clients.iter().skip(1).map(|ring| {
             try_join_all(ring.each_ref().map(|shard_client| {
-                shard_client.query_input(QueryInput {
+                shard_client.query_input(QueryInput::Inline {
                     query_id,
                     input_stream: BodyStream::empty(),
                 })
@@ -638,7 +638,7 @@ mod tests {
                 |(helper, shard_streams)| async move {
                     try_join_all(shard_streams.into_iter().enumerate().map(
                         |(shard, input_stream)| {
-                            clients[shard][helper].query_input(QueryInput {
+                            clients[shard][helper].query_input(QueryInput::Inline {
                                 query_id,
                                 input_stream,
                             })

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -106,8 +106,6 @@ pub enum QueryInputError {
         #[from]
         source: StateError,
     },
-    #[error("Bad request")]
-    BadRequest,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -306,8 +304,6 @@ impl Processor {
         input_stream: BodyStream,
     ) -> Result<(), QueryInputError> {
         let mut queries = self.queries.inner.lock().unwrap();
-        //let query_id = input.query_id();
-        //let input_stream = input.input_stream().unwrap_or_else(|| BodyStream::empty());
         match queries.entry(query_id) {
             Entry::Occupied(entry) => {
                 let state = entry.remove();

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -11,10 +11,7 @@ use crate::{
     error::Error as ProtocolError,
     executor::IpaRuntime,
     helpers::{
-        query::{CompareStatusRequest, PrepareQuery, QueryConfig, QueryInput},
-        routing::RouteId,
-        BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role,
-        RoleAssignment, ShardTransportError, ShardTransportImpl, Transport,
+        query::{CompareStatusRequest, PrepareQuery, QueryConfig, QueryInput}, routing::RouteId, BodyStream, BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment, ShardTransportError, ShardTransportImpl, Transport
     },
     hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
@@ -306,7 +303,7 @@ impl Processor {
     ) -> Result<(), QueryInputError> {
         let mut queries = self.queries.inner.lock().unwrap();
         let query_id = input.query_id();
-        let input_stream = input.input_stream();
+        let input_stream = input.input_stream().unwrap_or_else(|| BodyStream::empty());
         match queries.entry(query_id) {
             Entry::Occupied(entry) => {
                 let state = entry.remove();

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -11,7 +11,7 @@ use crate::{
     error::Error as ProtocolError,
     executor::IpaRuntime,
     helpers::{
-        query::{CompareStatusRequest, PrepareQuery, QueryConfig, QueryInput}, routing::RouteId, BodyStream, BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment, ShardTransportError, ShardTransportImpl, Transport
+        query::{CompareStatusRequest, PrepareQuery, QueryConfig}, routing::RouteId, BodyStream, BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment, ShardTransportError, ShardTransportImpl, Transport
     },
     hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
@@ -299,11 +299,12 @@ impl Processor {
         &self,
         mpc_transport: MpcTransportImpl,
         shard_transport: ShardTransportImpl,
-        input: QueryInput,
+        query_id: QueryId,
+        input_stream: BodyStream,
     ) -> Result<(), QueryInputError> {
         let mut queries = self.queries.inner.lock().unwrap();
-        let query_id = input.query_id();
-        let input_stream = input.input_stream().unwrap_or_else(|| BodyStream::empty());
+        //let query_id = input.query_id();
+        //let input_stream = input.input_stream().unwrap_or_else(|| BodyStream::empty());
         match queries.entry(query_id) {
             Entry::Occupied(entry) => {
                 let state = entry.remove();

--- a/ipa-core/src/query/processor.rs
+++ b/ipa-core/src/query/processor.rs
@@ -11,7 +11,10 @@ use crate::{
     error::Error as ProtocolError,
     executor::IpaRuntime,
     helpers::{
-        query::{CompareStatusRequest, PrepareQuery, QueryConfig}, routing::RouteId, BodyStream, BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl, Role, RoleAssignment, ShardTransportError, ShardTransportImpl, Transport
+        query::{CompareStatusRequest, PrepareQuery, QueryConfig},
+        routing::RouteId,
+        BodyStream, BroadcastError, Gateway, GatewayConfig, MpcTransportError, MpcTransportImpl,
+        Role, RoleAssignment, ShardTransportError, ShardTransportImpl, Transport,
     },
     hpke::{KeyRegistry, PrivateKeyOnly},
     protocol::QueryId,
@@ -309,10 +312,7 @@ impl Processor {
             Entry::Occupied(entry) => {
                 let state = entry.remove();
                 if let QueryState::AwaitingInputs(query_id, config, role_assignment) = state {
-                    assert_eq!(
-                        query_id, query_id,
-                        "received inputs for a different query"
-                    );
+                    assert_eq!(query_id, query_id, "received inputs for a different query");
                     let mut gateway_config = GatewayConfig::default();
                     if let Some(active_work) = self.active_work {
                         gateway_config.active = active_work;

--- a/ipa-core/src/query/state.rs
+++ b/ipa-core/src/query/state.rs
@@ -46,7 +46,7 @@ impl From<&QueryState> for QueryStatus {
         match source {
             QueryState::Empty => panic!("Query cannot be in the empty state"),
             QueryState::Preparing(_) => QueryStatus::Preparing,
-            QueryState::AwaitingInputs(_, _, _) => QueryStatus::AwaitingInputs,
+            QueryState::AwaitingInputs(_, _) => QueryStatus::AwaitingInputs,
             QueryState::Running(_) => QueryStatus::Running,
             QueryState::AwaitingCompletion => QueryStatus::AwaitingCompletion,
             QueryState::Completed(_) => QueryStatus::Completed,
@@ -78,7 +78,7 @@ pub fn min_status(a: QueryStatus, b: QueryStatus) -> QueryStatus {
 pub enum QueryState {
     Empty,
     Preparing(QueryConfig),
-    AwaitingInputs(QueryId, QueryConfig, RoleAssignment),
+    AwaitingInputs(QueryConfig, RoleAssignment),
     Running(RunningQuery),
     AwaitingCompletion,
     Completed(QueryResult),
@@ -91,9 +91,9 @@ impl QueryState {
         match (cur_state, &new_state) {
             // If query is not running, coordinator initial state is preparing
             // and followers initial state is awaiting inputs
-            (Empty, Preparing(_) | AwaitingInputs(_, _, _))
-            | (Preparing(_), AwaitingInputs(_, _, _))
-            | (AwaitingInputs(_, _, _), Running(_)) => Ok(new_state),
+            (Empty, Preparing(_) | AwaitingInputs(_, _))
+            | (Preparing(_), AwaitingInputs(_, _))
+            | (AwaitingInputs(_, _), Running(_)) => Ok(new_state),
             (_, Preparing(_)) => Err(StateError::AlreadyRunning),
             (_, _) => Err(StateError::InvalidState {
                 from: cur_state.into(),

--- a/ipa-core/src/test_fixture/app.rs
+++ b/ipa-core/src/test_fixture/app.rs
@@ -104,7 +104,7 @@ impl TestApp {
             .into_iter()
             .enumerate()
             .map(|(i, input)| {
-                self.drivers[i].execute_query(QueryInput {
+                self.drivers[i].execute_query(QueryInput::Inline {
                     query_id,
                     input_stream: input.into(),
                 })


### PR DESCRIPTION
Support for helper to pull query input from a URL, rather than receiving it directly from the client in an HTTP request body.

Also adds a simple HTTP server in test_mpc to serve local files, for testing purposes.