### PR TITLE
add flag to encrypt_util for length delimited binary format

### DIFF
--- a/ipa-core/src/cli/crypto/hybrid_decrypt.rs
+++ b/ipa-core/src/cli/crypto/hybrid_decrypt.rs
@@ -226,9 +226,14 @@ mod tests {
 
         let output_dir = tempdir().unwrap();
         let network_file = hybrid_sample_data::test_keys().network_config();
-        HybridEncryptArgs::new(input_file.path(), output_dir.path(), network_file.path())
-            .encrypt()
-            .unwrap();
+        HybridEncryptArgs::new(
+            input_file.path(),
+            output_dir.path(),
+            network_file.path(),
+            false,
+        )
+        .encrypt()
+        .unwrap();
 
         let decrypt_output = output_dir.path().join("output");
         let enc1 = output_dir.path().join("DOES_NOT_EXIST.enc");
@@ -258,9 +263,14 @@ mod tests {
 
         let network_file = hybrid_sample_data::test_keys().network_config();
         let output_dir = tempdir().unwrap();
-        HybridEncryptArgs::new(input_file.path(), output_dir.path(), network_file.path())
-            .encrypt()
-            .unwrap();
+        HybridEncryptArgs::new(
+            input_file.path(),
+            output_dir.path(),
+            network_file.path(),
+            false,
+        )
+        .encrypt()
+        .unwrap();
 
         let decrypt_output = output_dir.path().join("output");
         let enc1 = output_dir.path().join("helper1.enc");

--- a/ipa-core/src/cli/crypto/mod.rs
+++ b/ipa-core/src/cli/crypto/mod.rs
@@ -345,9 +345,14 @@ mod tests {
         let input = hybrid_sample_data::test_hybrid_data().take(10);
         let input_file = hybrid_sample_data::write_csv(input).unwrap();
         let network_file = hybrid_sample_data::test_keys().network_config();
-        HybridEncryptArgs::new(input_file.path(), output_dir.path(), network_file.path())
-            .encrypt()
-            .unwrap();
+        HybridEncryptArgs::new(
+            input_file.path(),
+            output_dir.path(),
+            network_file.path(),
+            false,
+        )
+        .encrypt()
+        .unwrap();
 
         let decrypt_output = output_dir.path().join("output");
         let enc1 = output_dir.path().join("helper1.enc");


### PR DESCRIPTION
In order to support the new ability for helpers to load data from a file/url, we need the ability to produce length delimited encrypted data for testing. This adds a flag to the `crypto_util` called `--length-delimited` which will produce length delimited binary instead of newline delimited hex.

The next step is to use this with the integration test. The flow will be

1. generate raw input data files (one for each shard)
2. use `crypto_util` to encrypt each of these for each shard (and each helper)
3. pass these files into the report collector (is this implemented yet @akoshelev ?)
4. cat all input data files together and run `in-the-clear`
5. compare results