### PR TITLE
Fix input_from_url test

### DIFF
--- a/ipa-core/src/net/error.rs
+++ b/ipa-core/src/net/error.rs
@@ -54,7 +54,7 @@ pub enum Error {
         status: hyper::StatusCode,
         reason: String,
     },
-    #[error("Failed to connect to {dest}: {inner}")]
+    #[error("Failed to connect to {dest}: {inner:?}")]
     ConnectError {
         dest: String,
         #[source]

--- a/ipa-core/src/net/query_input.rs
+++ b/ipa-core/src/net/query_input.rs
@@ -26,7 +26,7 @@ pub async fn stream_query_input_from_url(uri: &Uri) -> Result<BodyStream, Error>
         HttpsConnectorBuilder::default()
             .with_native_roots()
             .expect("System truststore is required")
-            .https_only()
+            .https_or_http()
             .enable_all_versions()
             .build(),
     );

--- a/ipa-core/src/net/server/handlers/query/input.rs
+++ b/ipa-core/src/net/server/handlers/query/input.rs
@@ -98,7 +98,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn input_from_url() {
         const QUERY_ID: QueryId = QueryId;
-        const DATA: &str = "input records";
+        const DATA: &str = "<input records>";
 
         let server = tiny_http::Server::http("localhost:0").unwrap();
         let addr = server.server_addr();
@@ -124,9 +124,8 @@ mod tests {
             .await;
 
         let url = format!(
-            "http://localhost:{}{}/{QUERY_ID}/input",
+            "http://localhost:{}/input-data",
             addr.to_ip().unwrap().port(),
-            http_serde::query::BASE_AXUM_PATH,
         );
         let req = http_serde::query::input::Request::new(QueryInput::FromUrl {
             query_id: QUERY_ID,


### PR DESCRIPTION
Enforcement of `https_only` in `hyper-rustls` had been broken 🫠 and was fixed in the past ~24 hours.

I don't really think it's a good idea to allow http here, but for expediency, I did intend to use it when I made the change. I guess my better self wrote `https_only` despite my intentions. I will file an issue about disallowing http (which is mostly a pain because it will require generating certificates for the test).