### PR TITLE
Fixes for security audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,3 +41,8 @@ jobs:
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Tracked by [#1527](https://github.com/private-attribution/ipa/issues/1527)
+          # RUSTSEC-2024-0436: paste crate is unmaintained
+          # RUSTSEC-2024-0437: crash due to uncontrolled recursion in protobuf crate
+          # RUSTSEC-2025-0014: humantime crate is unmaintained
+          ignore: RUSTSEC-2024-0436,RUSTSEC-2024-0437,RUSTSEC-2025-0014

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
+      issues: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
 

--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -128,7 +128,7 @@ once_cell = "1.18"
 pin-project = "1.0"
 rand = "0.8"
 rand_core = "0.6"
-rcgen = { version = "0.11.3", optional = true }
+rcgen = { version = "0.13", optional = true }
 rustls = { version = "0.23", optional = true }
 rustls-pemfile = { version = "2.1.2", optional = true }
 rustls-pki-types = "1.4.1"


### PR DESCRIPTION
* Grant additional permissions to the job
* Update rcgen to 0.13
* Waive several vulnerabilities that are not critical and cannot immediately be fixed. Tracked by #1527.