### PR TITLE
Remove RUSTSEC-2025-0014 audit lint suppression

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -44,5 +44,4 @@ jobs:
           # Tracked by [#1527](https://github.com/private-attribution/ipa/issues/1527)
           # RUSTSEC-2024-0436: paste crate is unmaintained
           # RUSTSEC-2024-0437: crash due to uncontrolled recursion in protobuf crate
-          # RUSTSEC-2025-0014: humantime crate is unmaintained
-          ignore: RUSTSEC-2024-0436,RUSTSEC-2024-0437,RUSTSEC-2025-0014
+          ignore: RUSTSEC-2024-0436,RUSTSEC-2024-0437


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0014

> This advisory has been withdrawn and should be ignored. It is kept only for reference.

https://github.com/tailhook/humantime/issues/31