### PR TITLE
Fix build failures

### DIFF
--- a/ipa-core/Cargo.toml
+++ b/ipa-core/Cargo.toml
@@ -147,8 +147,8 @@ tokio = { version = "1.42", features = ["fs", "rt", "rt-multi-thread", "macros"]
 tokio-rustls = { version = "0.26", optional = true }
 tokio-stream = "0.1.14"
 toml = { version = "0.8", optional = true }
-tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.5", optional = true, features = ["trace"] }
+tower = { version = "0.5.2", optional = true, features = ["util"] }
+tower-http = { version = "0.6.2", optional = true, features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 typenum = { version = "1.17", features = ["i128"] }


### PR DESCRIPTION
Failures started to pop up recently:
https://github.com/private-attribution/ipa/actions/runs/13868880764/job/38812864191?pr=1529

I couldn't figure out what caused this. I suspect one of our dependencies stopped using `util` feature from Tower and didn't mark that change as breaking. I checked Axum change log, but couldn't find anything.

Either way, this fixes it and I also bumped up tower dependency version to the latest